### PR TITLE
feat: library API parity — Config fields, token breakdowns, ValidateSource

### DIFF
--- a/llm/token_tracker.go
+++ b/llm/token_tracker.go
@@ -78,6 +78,17 @@ func (t *TokenTracker) TotalUsage() Usage {
 	return total
 }
 
+// AllProviderUsage returns a copy of the accumulated usage for all providers.
+func (t *TokenTracker) AllProviderUsage() map[string]Usage {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	result := make(map[string]Usage, len(t.usage))
+	for k, v := range t.usage {
+		result[k] = v
+	}
+	return result
+}
+
 // Providers returns a sorted slice of provider names that have recorded usage.
 func (t *TokenTracker) Providers() []string {
 	t.mu.RLock()

--- a/llm/token_tracker_test.go
+++ b/llm/token_tracker_test.go
@@ -120,3 +120,53 @@ func TestTokenTrackerFallsBackToRequestProvider(t *testing.T) {
 		t.Errorf("expected 20 from fallback, got %d", usage.InputTokens)
 	}
 }
+
+func TestTokenTrackerAllProviderUsage(t *testing.T) {
+	tracker := NewTokenTracker()
+
+	for _, tc := range []struct {
+		provider string
+		input    int
+		output   int
+	}{
+		{"anthropic", 100, 50},
+		{"openai", 200, 80},
+		{"gemini", 150, 60},
+	} {
+		p := tc.provider
+		in := tc.input
+		out := tc.output
+		handler := tracker.WrapComplete(func(ctx context.Context, req *Request) (*Response, error) {
+			return &Response{Provider: p, Usage: Usage{InputTokens: in, OutputTokens: out}}, nil
+		})
+		_, _ = handler(context.Background(), &Request{Provider: p})
+	}
+
+	all := tracker.AllProviderUsage()
+	if len(all) != 3 {
+		t.Fatalf("expected 3 providers, got %d", len(all))
+	}
+	if all["anthropic"].InputTokens != 100 {
+		t.Errorf("anthropic InputTokens = %d, want 100", all["anthropic"].InputTokens)
+	}
+	if all["openai"].OutputTokens != 80 {
+		t.Errorf("openai OutputTokens = %d, want 80", all["openai"].OutputTokens)
+	}
+	if all["gemini"].InputTokens != 150 {
+		t.Errorf("gemini InputTokens = %d, want 150", all["gemini"].InputTokens)
+	}
+
+	// Verify returned map is a copy — mutations don't affect the tracker.
+	all["anthropic"] = Usage{InputTokens: 9999}
+	if tracker.ProviderUsage("anthropic").InputTokens != 100 {
+		t.Error("AllProviderUsage should return a copy, not a reference")
+	}
+}
+
+func TestTokenTrackerAllProviderUsageEmpty(t *testing.T) {
+	tracker := NewTokenTracker()
+	all := tracker.AllProviderUsage()
+	if len(all) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(all))
+	}
+}

--- a/pipeline/trace.go
+++ b/pipeline/trace.go
@@ -91,6 +91,20 @@ func (tr *Trace) AggregateUsage() *UsageSummary {
 	return s
 }
 
+// AggregateToolCalls sums tool call counts from all trace entries with session stats.
+func (t *Trace) AggregateToolCalls() map[string]int {
+	calls := make(map[string]int)
+	for _, entry := range t.Entries {
+		if entry.Stats == nil {
+			continue
+		}
+		for name, count := range entry.Stats.ToolCalls {
+			calls[name] += count
+		}
+	}
+	return calls
+}
+
 // Summary returns a human-readable summary of the trace.
 func (tr *Trace) Summary() string {
 	var b strings.Builder

--- a/pipeline/trace.go
+++ b/pipeline/trace.go
@@ -93,6 +93,9 @@ func (tr *Trace) AggregateUsage() *UsageSummary {
 
 // AggregateToolCalls sums tool call counts from all trace entries with session stats.
 func (t *Trace) AggregateToolCalls() map[string]int {
+	if t == nil {
+		return nil
+	}
 	calls := make(map[string]int)
 	for _, entry := range t.Entries {
 		if entry.Stats == nil {

--- a/pipeline/trace_test.go
+++ b/pipeline/trace_test.go
@@ -706,3 +706,74 @@ func TestEngineResultUsageFromTraceStats(t *testing.T) {
 		t.Errorf("SessionCount = %d, want 1", result.Usage.SessionCount)
 	}
 }
+
+func TestTraceAggregateToolCalls(t *testing.T) {
+	t.Run("normal aggregation", func(t *testing.T) {
+		tr := &Trace{
+			RunID: "tool-agg",
+			Entries: []TraceEntry{
+				{NodeID: "s", HandlerName: "start", Status: OutcomeSuccess},
+				{
+					NodeID: "impl1", HandlerName: "codergen", Status: OutcomeSuccess,
+					Stats: &SessionStats{
+						ToolCalls: map[string]int{"bash": 5, "write": 3},
+					},
+				},
+				{
+					NodeID: "impl2", HandlerName: "codergen", Status: OutcomeSuccess,
+					Stats: &SessionStats{
+						ToolCalls: map[string]int{"bash": 2, "read": 4},
+					},
+				},
+				{NodeID: "end", HandlerName: "exit", Status: OutcomeSuccess},
+			},
+		}
+
+		calls := tr.AggregateToolCalls()
+		if calls["bash"] != 7 {
+			t.Errorf("bash = %d, want 7", calls["bash"])
+		}
+		if calls["write"] != 3 {
+			t.Errorf("write = %d, want 3", calls["write"])
+		}
+		if calls["read"] != 4 {
+			t.Errorf("read = %d, want 4", calls["read"])
+		}
+	})
+
+	t.Run("no tool calls", func(t *testing.T) {
+		tr := &Trace{
+			RunID: "no-tools",
+			Entries: []TraceEntry{
+				{NodeID: "s", HandlerName: "start", Status: OutcomeSuccess},
+				{NodeID: "end", HandlerName: "exit", Status: OutcomeSuccess},
+			},
+		}
+		calls := tr.AggregateToolCalls()
+		if len(calls) != 0 {
+			t.Errorf("expected empty map, got %v", calls)
+		}
+	})
+
+	t.Run("entries with nil stats", func(t *testing.T) {
+		tr := &Trace{
+			RunID: "nil-stats",
+			Entries: []TraceEntry{
+				{NodeID: "s", HandlerName: "start", Status: OutcomeSuccess},
+				{
+					NodeID: "impl", HandlerName: "codergen", Status: OutcomeSuccess,
+					Stats: &SessionStats{
+						ToolCalls: map[string]int{"bash": 10},
+					},
+				},
+			},
+		}
+		calls := tr.AggregateToolCalls()
+		if calls["bash"] != 10 {
+			t.Errorf("bash = %d, want 10", calls["bash"])
+		}
+		if len(calls) != 1 {
+			t.Errorf("expected 1 tool, got %d", len(calls))
+		}
+	})
+}

--- a/pipeline/trace_test.go
+++ b/pipeline/trace_test.go
@@ -755,7 +755,7 @@ func TestTraceAggregateToolCalls(t *testing.T) {
 		}
 	})
 
-	t.Run("entries with nil stats", func(t *testing.T) {
+	t.Run("entries with mixed stats", func(t *testing.T) {
 		tr := &Trace{
 			RunID: "nil-stats",
 			Entries: []TraceEntry{

--- a/tracker.go
+++ b/tracker.go
@@ -45,6 +45,9 @@ type Config struct {
 	AgentEvents   agent.EventHandler            // optional: live agent session events
 	LLMClient     agent.Completer               // optional: override auto-created client
 	Context       map[string]string             // optional: initial pipeline context
+	Backend       string                        // "native" (default), "claude-code", "acp"; selects agent backend
+	Autopilot     string                        // "" (interactive), "lax", "mid", "hard", "mentor"; LLM-driven gate decisions
+	AutoApprove   bool                          // auto-approve all human gates with default/first option
 }
 
 // Result contains the outcome of a pipeline execution.
@@ -54,6 +57,7 @@ type Result struct {
 	CompletedNodes []string
 	Context        map[string]string
 	EngineResult   *pipeline.EngineResult
+	Trace          *pipeline.Trace // full execution trace (nodes, timing, stats)
 }
 
 // Engine wraps pipeline.Engine with auto-wired internals.
@@ -117,7 +121,7 @@ func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.
 
 	injectGraphDefaults(graph, cfg)
 
-	registry := buildRegistry(graph, completer, workDir, cfg)
+	registry := buildRegistry(graph, client, completer, workDir, cfg)
 	engineOpts := buildEngineOpts(cfg)
 	inner := pipeline.NewEngine(graph, registry, engineOpts...)
 
@@ -162,7 +166,7 @@ func injectGraphAttrIfAbsent(graph *pipeline.Graph, key, value string) {
 }
 
 // buildRegistry creates a handler registry with all dependencies wired.
-func buildRegistry(graph *pipeline.Graph, completer agent.Completer, workDir string, cfg Config) *pipeline.HandlerRegistry {
+func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Completer, workDir string, cfg Config) *pipeline.HandlerRegistry {
 	env := exec.NewLocalEnvironment(workDir)
 	registryOpts := []handlers.RegistryOption{
 		handlers.WithLLMClient(completer, workDir),
@@ -174,7 +178,35 @@ func buildRegistry(graph *pipeline.Graph, completer agent.Completer, workDir str
 	if cfg.EventHandler != nil {
 		registryOpts = append(registryOpts, handlers.WithPipelineEventHandler(cfg.EventHandler))
 	}
+	if cfg.Backend != "" {
+		registryOpts = append(registryOpts, handlers.WithDefaultBackend(cfg.Backend))
+	}
+	interviewer := resolveInterviewer(cfg, client)
+	if interviewer != nil {
+		registryOpts = append(registryOpts, handlers.WithInterviewer(interviewer, graph))
+	}
 	return handlers.NewDefaultRegistry(graph, registryOpts...)
+}
+
+// resolveInterviewer selects an automated interviewer based on Config.
+// Returns nil if no automation is configured (interactive/default mode).
+func resolveInterviewer(cfg Config, client *llm.Client) handlers.FreeformInterviewer {
+	if cfg.AutoApprove {
+		return &handlers.AutoApproveFreeformInterviewer{}
+	}
+	if cfg.Autopilot != "" {
+		persona, err := handlers.ParsePersona(cfg.Autopilot)
+		if err != nil {
+			log.Printf("WARNING: %v; falling back to auto-approve", err)
+			return &handlers.AutoApproveFreeformInterviewer{}
+		}
+		if client == nil {
+			log.Printf("WARNING: no LLM client for autopilot; falling back to auto-approve")
+			return &handlers.AutoApproveFreeformInterviewer{}
+		}
+		return handlers.NewAutopilotInterviewer(client, persona)
+	}
+	return nil
 }
 
 // buildEngineOpts constructs engine options from Config.
@@ -372,5 +404,6 @@ func resultFromEngine(er *pipeline.EngineResult) *Result {
 		CompletedNodes: er.CompletedNodes,
 		Context:        er.Context,
 		EngineResult:   er,
+		Trace:          er.Trace,
 	}
 }

--- a/tracker.go
+++ b/tracker.go
@@ -52,20 +52,23 @@ type Config struct {
 
 // Result contains the outcome of a pipeline execution.
 type Result struct {
-	RunID          string
-	Status         string
-	CompletedNodes []string
-	Context        map[string]string
-	EngineResult   *pipeline.EngineResult
-	Trace          *pipeline.Trace // full execution trace (nodes, timing, stats)
+	RunID            string
+	Status           string
+	CompletedNodes   []string
+	Context          map[string]string
+	EngineResult     *pipeline.EngineResult
+	Trace            *pipeline.Trace      // full execution trace (nodes, timing, stats)
+	TokensByProvider map[string]llm.Usage // per-provider token totals
+	ToolCallsByName  map[string]int       // tool call counts by name
 }
 
 // Engine wraps pipeline.Engine with auto-wired internals.
 type Engine struct {
-	inner     *pipeline.Engine
-	client    *llm.Client // nil if caller provided their own Completer
-	closeOnce sync.Once
-	closeErr  error
+	inner        *pipeline.Engine
+	client       *llm.Client // nil if caller provided their own Completer
+	tokenTracker *llm.TokenTracker
+	closeOnce    sync.Once
+	closeErr     error
 }
 
 // NewEngine parses a pipeline source (.dip preferred, DOT deprecated),
@@ -121,14 +124,16 @@ func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.
 
 	injectGraphDefaults(graph, cfg)
 
-	registry := buildRegistry(graph, client, completer, workDir, cfg)
+	tokenTracker := llm.NewTokenTracker()
+	registry := buildRegistry(graph, client, completer, workDir, cfg, tokenTracker)
 	engineOpts := buildEngineOpts(cfg)
 	inner := pipeline.NewEngine(graph, registry, engineOpts...)
 
 	built = true
 	return &Engine{
-		inner:  inner,
-		client: client,
+		inner:        inner,
+		client:       client,
+		tokenTracker: tokenTracker,
 	}
 }
 
@@ -166,11 +171,12 @@ func injectGraphAttrIfAbsent(graph *pipeline.Graph, key, value string) {
 }
 
 // buildRegistry creates a handler registry with all dependencies wired.
-func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Completer, workDir string, cfg Config) *pipeline.HandlerRegistry {
+func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Completer, workDir string, cfg Config, tokenTracker *llm.TokenTracker) *pipeline.HandlerRegistry {
 	env := exec.NewLocalEnvironment(workDir)
 	registryOpts := []handlers.RegistryOption{
 		handlers.WithLLMClient(completer, workDir),
 		handlers.WithExecEnvironment(env),
+		handlers.WithTokenTracker(tokenTracker),
 	}
 	if cfg.AgentEvents != nil {
 		registryOpts = append(registryOpts, handlers.WithAgentEventHandler(cfg.AgentEvents))
@@ -368,7 +374,14 @@ func (e *Engine) Run(ctx context.Context) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
-	return resultFromEngine(engineResult), nil
+	result := resultFromEngine(engineResult)
+	if e.tokenTracker != nil {
+		result.TokensByProvider = e.tokenTracker.AllProviderUsage()
+	}
+	if engineResult != nil && engineResult.Trace != nil {
+		result.ToolCallsByName = engineResult.Trace.AggregateToolCalls()
+	}
+	return result, nil
 }
 
 // Close releases resources. Must be called if the engine was created
@@ -380,6 +393,54 @@ func (e *Engine) Close() error {
 		}
 	})
 	return e.closeErr
+}
+
+// ValidationResult contains the outcome of pipeline validation.
+type ValidationResult struct {
+	Graph    *pipeline.Graph
+	Errors   []string
+	Warnings []string
+	Hints    []string
+}
+
+// ValidateOption configures ValidateSource behavior.
+type ValidateOption func(*validateConfig)
+
+type validateConfig struct {
+	format string
+}
+
+// WithValidateFormat sets the pipeline source format ("dip" or "dot").
+func WithValidateFormat(format string) ValidateOption {
+	return func(c *validateConfig) { c.format = format }
+}
+
+// ValidateSource parses and validates a pipeline source string without executing it.
+// Returns a ValidationResult with structured errors, warnings, and hints.
+// An error is returned when the source cannot be parsed or has structural errors.
+func ValidateSource(source string, opts ...ValidateOption) (*ValidationResult, error) {
+	cfg := &validateConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	graph, err := parsePipelineSource(source, cfg.format)
+	if err != nil {
+		return &ValidationResult{Errors: []string{err.Error()}}, err
+	}
+
+	result := &ValidationResult{Graph: graph}
+
+	ve := pipeline.ValidateAll(graph)
+	if ve != nil {
+		result.Errors = append(result.Errors, ve.Errors...)
+		result.Warnings = append(result.Warnings, ve.Warnings...)
+	}
+
+	if len(result.Errors) > 0 {
+		return result, fmt.Errorf("%s", result.Errors[0])
+	}
+	return result, nil
 }
 
 // Run parses a pipeline source, auto-wires all internals, executes, and returns the result.

--- a/tracker.go
+++ b/tracker.go
@@ -126,9 +126,12 @@ func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.
 
 	tokenTracker := llm.NewTokenTracker()
 	// Attach token tracker as middleware to the LLM client so it captures
-	// per-provider usage during native backend runs.
+	// per-provider usage during native backend runs. Works for both
+	// auto-created clients and user-provided *llm.Client via Config.LLMClient.
 	if client != nil {
 		client.AddMiddleware(tokenTracker)
+	} else if lc, ok := completer.(*llm.Client); ok {
+		lc.AddMiddleware(tokenTracker)
 	}
 	registry, err := buildRegistry(graph, client, completer, workDir, cfg, tokenTracker)
 	if err != nil {
@@ -195,7 +198,7 @@ func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Co
 	if cfg.Backend != "" {
 		registryOpts = append(registryOpts, handlers.WithDefaultBackend(cfg.Backend))
 	}
-	interviewer, err := resolveInterviewer(cfg, client)
+	interviewer, err := resolveInterviewer(cfg, client, completer)
 	if err != nil {
 		return nil, err
 	}
@@ -207,21 +210,46 @@ func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Co
 
 // resolveInterviewer selects an automated interviewer based on Config.
 // Returns nil if no automation is configured (interactive/default mode).
-func resolveInterviewer(cfg Config, client *llm.Client) (handlers.FreeformInterviewer, error) {
+// When Backend is "claude-code", prefers ClaudeCodeAutopilotInterviewer.
+func resolveInterviewer(cfg Config, client *llm.Client, completer agent.Completer) (handlers.FreeformInterviewer, error) {
 	if cfg.AutoApprove {
 		return &handlers.AutoApproveFreeformInterviewer{}, nil
 	}
-	if cfg.Autopilot != "" {
-		persona, err := handlers.ParsePersona(cfg.Autopilot)
-		if err != nil {
-			return nil, fmt.Errorf("invalid autopilot persona %q: %w", cfg.Autopilot, err)
-		}
-		if client == nil {
-			return nil, fmt.Errorf("autopilot %q requires an LLM client (set Config.LLMClient or configure API keys)", cfg.Autopilot)
-		}
-		return handlers.NewAutopilotInterviewer(client, persona), nil
+	if cfg.Autopilot == "" {
+		return nil, nil
 	}
-	return nil, nil
+	return resolveAutopilot(cfg, client, completer)
+}
+
+// resolveAutopilot builds an autopilot interviewer for the given persona and backend.
+func resolveAutopilot(cfg Config, client *llm.Client, completer agent.Completer) (handlers.FreeformInterviewer, error) {
+	persona, err := handlers.ParsePersona(cfg.Autopilot)
+	if err != nil {
+		return nil, fmt.Errorf("invalid autopilot persona %q: %w", cfg.Autopilot, err)
+	}
+	if cfg.Backend == "claude-code" {
+		if iv, ccErr := handlers.NewClaudeCodeAutopilotInterviewer(persona); ccErr == nil {
+			return iv, nil
+		}
+		log.Printf("[tracker] claude-code autopilot init failed, trying native")
+	}
+	client = resolveAutopilotClient(client, completer)
+	if client == nil {
+		return nil, fmt.Errorf("autopilot %q requires an LLM client (set Config.LLMClient or configure API keys)", cfg.Autopilot)
+	}
+	return handlers.NewAutopilotInterviewer(client, persona), nil
+}
+
+// resolveAutopilotClient returns the LLM client for native autopilot,
+// trying a type assertion on completer if client is nil.
+func resolveAutopilotClient(client *llm.Client, completer agent.Completer) *llm.Client {
+	if client != nil {
+		return client
+	}
+	if lc, ok := completer.(*llm.Client); ok {
+		return lc
+	}
+	return nil
 }
 
 // buildEngineOpts constructs engine options from Config.

--- a/tracker.go
+++ b/tracker.go
@@ -97,7 +97,7 @@ func NewEngine(source string, cfg Config) (*Engine, error) {
 		return nil, err
 	}
 
-	return buildEngine(graph, cfg, workDir, client, completer), nil
+	return buildEngine(graph, cfg, workDir, client, completer)
 }
 
 // resolveWorkDir returns the working directory, falling back to cwd if empty.
@@ -113,7 +113,7 @@ func resolveWorkDir(workDir string) (string, error) {
 }
 
 // buildEngine assembles the Engine after all dependencies are resolved.
-func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.Client, completer agent.Completer) *Engine {
+func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.Client, completer agent.Completer) (*Engine, error) {
 	// Clean up the auto-created client if anything below fails.
 	built := false
 	defer func() {
@@ -125,7 +125,15 @@ func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.
 	injectGraphDefaults(graph, cfg)
 
 	tokenTracker := llm.NewTokenTracker()
-	registry := buildRegistry(graph, client, completer, workDir, cfg, tokenTracker)
+	// Attach token tracker as middleware to the LLM client so it captures
+	// per-provider usage during native backend runs.
+	if client != nil {
+		client.AddMiddleware(tokenTracker)
+	}
+	registry, err := buildRegistry(graph, client, completer, workDir, cfg, tokenTracker)
+	if err != nil {
+		return nil, err
+	}
 	engineOpts := buildEngineOpts(cfg)
 	inner := pipeline.NewEngine(graph, registry, engineOpts...)
 
@@ -134,7 +142,7 @@ func buildEngine(graph *pipeline.Graph, cfg Config, workDir string, client *llm.
 		inner:        inner,
 		client:       client,
 		tokenTracker: tokenTracker,
-	}
+	}, nil
 }
 
 // resolveCompleter returns the LLM client and completer, building a client from env if needed.
@@ -171,7 +179,7 @@ func injectGraphAttrIfAbsent(graph *pipeline.Graph, key, value string) {
 }
 
 // buildRegistry creates a handler registry with all dependencies wired.
-func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Completer, workDir string, cfg Config, tokenTracker *llm.TokenTracker) *pipeline.HandlerRegistry {
+func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Completer, workDir string, cfg Config, tokenTracker *llm.TokenTracker) (*pipeline.HandlerRegistry, error) {
 	env := exec.NewLocalEnvironment(workDir)
 	registryOpts := []handlers.RegistryOption{
 		handlers.WithLLMClient(completer, workDir),
@@ -187,32 +195,33 @@ func buildRegistry(graph *pipeline.Graph, client *llm.Client, completer agent.Co
 	if cfg.Backend != "" {
 		registryOpts = append(registryOpts, handlers.WithDefaultBackend(cfg.Backend))
 	}
-	interviewer := resolveInterviewer(cfg, client)
+	interviewer, err := resolveInterviewer(cfg, client)
+	if err != nil {
+		return nil, err
+	}
 	if interviewer != nil {
 		registryOpts = append(registryOpts, handlers.WithInterviewer(interviewer, graph))
 	}
-	return handlers.NewDefaultRegistry(graph, registryOpts...)
+	return handlers.NewDefaultRegistry(graph, registryOpts...), nil
 }
 
 // resolveInterviewer selects an automated interviewer based on Config.
 // Returns nil if no automation is configured (interactive/default mode).
-func resolveInterviewer(cfg Config, client *llm.Client) handlers.FreeformInterviewer {
+func resolveInterviewer(cfg Config, client *llm.Client) (handlers.FreeformInterviewer, error) {
 	if cfg.AutoApprove {
-		return &handlers.AutoApproveFreeformInterviewer{}
+		return &handlers.AutoApproveFreeformInterviewer{}, nil
 	}
 	if cfg.Autopilot != "" {
 		persona, err := handlers.ParsePersona(cfg.Autopilot)
 		if err != nil {
-			log.Printf("WARNING: %v; falling back to auto-approve", err)
-			return &handlers.AutoApproveFreeformInterviewer{}
+			return nil, fmt.Errorf("invalid autopilot persona %q: %w", cfg.Autopilot, err)
 		}
 		if client == nil {
-			log.Printf("WARNING: no LLM client for autopilot; falling back to auto-approve")
-			return &handlers.AutoApproveFreeformInterviewer{}
+			return nil, fmt.Errorf("autopilot %q requires an LLM client (set Config.LLMClient or configure API keys)", cfg.Autopilot)
 		}
-		return handlers.NewAutopilotInterviewer(client, persona)
+		return handlers.NewAutopilotInterviewer(client, persona), nil
 	}
-	return nil
+	return nil, nil
 }
 
 // buildEngineOpts constructs engine options from Config.
@@ -431,6 +440,7 @@ func ValidateSource(source string, opts ...ValidateOption) (*ValidationResult, e
 
 	result := &ValidationResult{Graph: graph}
 
+	// Structural + semantic validation (includes warnings).
 	ve := pipeline.ValidateAll(graph)
 	if ve != nil {
 		result.Errors = append(result.Errors, ve.Errors...)
@@ -438,7 +448,7 @@ func ValidateSource(source string, opts ...ValidateOption) (*ValidationResult, e
 	}
 
 	if len(result.Errors) > 0 {
-		return result, fmt.Errorf("%s", result.Errors[0])
+		return result, fmt.Errorf("validation failed: %s", result.Errors[0])
 	}
 	return result, nil
 }

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -361,12 +361,15 @@ func TestValidateSource_ReturnsWarnings(t *testing.T) {
 		gate -> done [label="outcome=success"];
 	}`
 	result, err := ValidateSource(graphWithWarning, WithValidateFormat("dot"))
-	// Errors are not expected here — only a warning about missing fail edge.
-	_ = err
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
 	}
-	// Warnings may or may not be present depending on graph structure; just ensure no panic.
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
 }
 
 func TestRun_WithRetryPolicy(t *testing.T) {

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -305,6 +305,70 @@ func TestNewEngine_InvalidProvider(t *testing.T) {
 	}
 }
 
+func TestValidateSource_ValidDip(t *testing.T) {
+	result, err := ValidateSource(simpleDip)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Errors) > 0 {
+		t.Errorf("unexpected errors: %v", result.Errors)
+	}
+	if result.Graph == nil {
+		t.Error("expected non-nil graph")
+	}
+}
+
+func TestValidateSource_InvalidSyntax(t *testing.T) {
+	result, err := ValidateSource("not valid at all {{{")
+	if err == nil && len(result.Errors) == 0 {
+		t.Fatal("expected errors for invalid syntax")
+	}
+}
+
+func TestValidateSource_WithFormatOption(t *testing.T) {
+	result, err := ValidateSource(simpleDip, WithValidateFormat("dip"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Graph == nil {
+		t.Error("expected non-nil graph")
+	}
+}
+
+func TestValidateSource_StructuralError(t *testing.T) {
+	// DOT graph missing an exit node — should fail validation.
+	badGraph := `digraph test {
+		start [shape=Mdiamond];
+		orphan [shape=box];
+		start -> orphan;
+	}`
+	result, err := ValidateSource(badGraph, WithValidateFormat("dot"))
+	if err == nil {
+		t.Fatal("expected validation error for graph without exit node")
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected at least one error in ValidationResult")
+	}
+}
+
+func TestValidateSource_ReturnsWarnings(t *testing.T) {
+	// A graph with a diamond node missing a fail edge produces a warning.
+	graphWithWarning := `digraph test {
+		start [shape=Mdiamond];
+		gate  [shape=diamond];
+		done  [shape=Msquare];
+		start -> gate;
+		gate -> done [label="outcome=success"];
+	}`
+	result, err := ValidateSource(graphWithWarning, WithValidateFormat("dot"))
+	// Errors are not expected here — only a warning about missing fail edge.
+	_ = err
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Warnings may or may not be present depending on graph structure; just ensure no panic.
+}
+
 func TestRun_WithRetryPolicy(t *testing.T) {
 	client := &stubCompleter{
 		response: &llm.Response{


### PR DESCRIPTION
## Summary

Three library API improvements so consumers (factory worker, Slack bot, etc.) don't need CLI internals:

- **#59** — `Config.Backend` ("native"/"claude-code"/"acp"), `Config.Autopilot` ("lax"/"mid"/"hard"/"mentor"), `Config.AutoApprove` (bool). Threaded through to handler registry. Also exposed `Result.Trace` for full execution trace access.

- **#62** — `Result.TokensByProvider` (map[string]llm.Usage) for per-provider token breakdowns. `Result.ToolCallsByName` (map[string]int) for tool call counts. Added `TokenTracker.AllProviderUsage()` and `Trace.AggregateToolCalls()`. Library Engine now internally creates and wires a TokenTracker.

- **#60** — `ValidateSource(source string, opts ...ValidateOption) (*ValidationResult, error)` validates a pipeline without executing it. Returns structured `Errors`, `Warnings`, `Hints` from both dippin-lang and tracker validators.

## Test plan

- [x] Config fields compile and thread correctly
- [x] `TestAllProviderUsage` / `TestAggregateToolCalls` — breakdown methods work
- [x] `TestValidateSource_ValidDip` — valid pipeline returns no errors
- [x] `TestValidateSource_InvalidSyntax` — invalid input returns errors
- [x] All 15 packages pass, all pre-commit gates pass

Closes #59, #62, #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot-style per-provider token usage reporting.
  * Aggregated tool-call metrics across traces.
  * Source validation API with configurable format.
  * Config options for backend selection, autopilot mode, and auto-approve.
  * Execution results now include trace, tokens-by-provider, and tool-call summaries.

* **Tests**
  * Added unit tests covering token usage reporting, tool-call aggregation, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->