### PR TITLE
feat: token & cost governance (library exposure + pipeline ceilings)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to tracker will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Result.Cost` on the library API with per-provider rollup (`map[string]llm.ProviderCost`) and `TotalUSD`. Populated from the `llm.TokenTracker` middleware and priced via `llm.EstimateCost`. Closes #62.
+- `pipeline.BudgetGuard` enforcing `MaxTotalTokens`, `MaxCostCents`, and `MaxWallTime` limits. Halts the run with `pipeline.OutcomeBudgetExceeded` when any dimension trips. Closes #17.
+- New `tracker.Config.Budget` field (type `pipeline.BudgetLimits`) for library consumers.
+- New CLI flags on `tracker run`: `--max-tokens`, `--max-cost` (cents), `--max-wall-time`.
+- New pipeline events `cost_updated` (streaming per-node cost snapshots) and `budget_exceeded` (fired on halt). Both carry a `CostSnapshot` payload with `TotalTokens`, `TotalCostUSD`, `ProviderTotals`, and `WallElapsed`.
+- `tracker diagnose` surfaces a "Budget halt detected" section when a run halts on budget.
+- `UsageSummary.ProviderTotals` (per-provider token and cost rollup) on `pipeline.Trace.AggregateUsage()` output.
+
+### Notes
+
+- Reading budget limits from `.dip` workflow attrs is blocked on dippin-lang IR support; tracked in #67.
+
 ## [0.16.4] - 2026-04-09
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,20 @@ The CLI summary in `cmd/tracker/summary.go` uses `llm.TokenTracker` for
 per-provider breakdowns (middleware-level) and `EngineResult.Usage` for
 trace-level aggregation. These are independent data sources.
 
+### Cost governance (v0.17.0+)
+
+`UsageSummary.ProviderTotals` carries the per-provider rollup (tokens + cost),
+and `tracker.Result.Cost` on the library API exposes dollar cost via
+`llm.TokenTracker.CostByProvider`. The pipeline engine enforces optional
+ceilings via `pipeline.BudgetGuard`, which is evaluated between nodes
+after every `emitCostUpdate`. A breach halts the run with
+`pipeline.OutcomeBudgetExceeded`, populates `EngineResult.BudgetLimitsHit`,
+and fires `EventBudgetExceeded` carrying the final `CostSnapshot`.
+
+Configure budgets via `tracker.Config.Budget` or the `--max-tokens`,
+`--max-cost` (cents), `--max-wall-time` CLI flags. Reading them from
+`.dip` workflow attrs is blocked on dippin-lang IR support (issue #67).
+
 ### OpenAI returns errors inside 200 SSE streams
 The Responses API returns HTTP 200 and sends `error` / `response.failed`
 as SSE event types. The adapter must handle these — they are NOT reflected

--- a/README.md
+++ b/README.md
@@ -394,10 +394,10 @@ for provider, pc := range result.Cost.ByProvider {
 }
 ```
 
-**CLI users** pass flags on `tracker run`:
+**CLI users** pass flags directly to `tracker`:
 
 ```
-tracker run examples/ask_and_execute.dip \
+tracker examples/ask_and_execute.dip \
     --max-tokens 100000 \
     --max-cost 500 \
     --max-wall-time 30m

--- a/README.md
+++ b/README.md
@@ -371,6 +371,50 @@ tracker audit <run-id>
 | Every milestone needs fixing | known_failures has comments or bad format | Ensure bare test names only, no comments — v0.11.2 strips them automatically |
 | Build loop skips all milestones | Milestone headers don't match expected format | Use `## Milestone N: Title` format — v0.11.2 is flexible + fails loudly |
 
+## Cost Governance
+
+Tracker exposes per-provider token and dollar cost from every run, and can halt
+pipelines that exceed configured ceilings.
+
+**Library consumers** read cost via `Result.Cost`:
+
+```go
+result, _ := tracker.Run(ctx, source, tracker.Config{
+    Budget: pipeline.BudgetLimits{
+        MaxTotalTokens: 100_000,
+        MaxCostCents:   500,           // $5.00
+        MaxWallTime:    30 * time.Minute,
+    },
+})
+if result.Status == pipeline.OutcomeBudgetExceeded {
+    log.Printf("halt: %s, spent $%.4f", result.Cost.LimitsHit, result.Cost.TotalUSD)
+}
+for provider, pc := range result.Cost.ByProvider {
+    log.Printf("%s: %d tokens, $%.4f", provider, pc.Usage.InputTokens+pc.Usage.OutputTokens, pc.USD)
+}
+```
+
+**CLI users** pass flags on `tracker run`:
+
+```
+tracker run examples/ask_and_execute.dip \
+    --max-tokens 100000 \
+    --max-cost 500 \
+    --max-wall-time 30m
+```
+
+A halted run prints a `HALTED: budget exceeded` section naming the dimension
+that tripped. Run `tracker diagnose` to see the per-provider breakdown and
+remediation guidance.
+
+**Streaming consumers** subscribe to `EventCostUpdated` via
+`tracker.Config.EventHandler`. Each terminal-node outcome emits a
+`CostSnapshot` with aggregate tokens, dollar cost, per-provider totals,
+and wall-clock elapsed time.
+
+Reading budget limits directly from `.dip` workflow attrs is a follow-up
+tracked in #67.
+
 ## CLI Reference
 
 ```

--- a/README.md
+++ b/README.md
@@ -397,10 +397,8 @@ for provider, pc := range result.Cost.ByProvider {
 **CLI users** pass flags directly to `tracker`:
 
 ```
-tracker examples/ask_and_execute.dip \
-    --max-tokens 100000 \
-    --max-cost 500 \
-    --max-wall-time 30m
+tracker --max-tokens 100000 --max-cost 500 --max-wall-time 30m \
+    examples/ask_and_execute.dip
 ```
 
 A halted run prints a `HALTED: budget exceeded` section naming the dimension

--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ for provider, pc := range result.Cost.ByProvider {
 
 **CLI users** pass flags directly to `tracker`:
 
-```
+```bash
 tracker --max-tokens 100000 --max-cost 500 --max-wall-time 30m \
     examples/ask_and_execute.dip
 ```

--- a/agent/result.go
+++ b/agent/result.go
@@ -14,6 +14,7 @@ import (
 // SessionResult holds summary statistics and metadata from a completed session.
 type SessionResult struct {
 	SessionID          string
+	Provider           string
 	Duration           time.Duration
 	Turns              int
 	MaxTurnsUsed       bool

--- a/agent/session.go
+++ b/agent/session.go
@@ -153,6 +153,7 @@ func (s *Session) Run(ctx context.Context, userInput string) (SessionResult, err
 
 	result := SessionResult{
 		SessionID: s.id,
+		Provider:  s.config.Provider,
 		ToolCalls: make(map[string]int),
 	}
 

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -93,6 +93,32 @@ func TestSessionTextOnlyResponse(t *testing.T) {
 	}
 }
 
+func TestSessionRunPopulatesProvider(t *testing.T) {
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			{
+				Message:      llm.AssistantMessage("Hello"),
+				FinishReason: llm.FinishReason{Reason: "stop"},
+				Usage:        llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+			},
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.Provider = "openai"
+	cfg.MaxTurns = 1
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Provider != "openai" {
+		t.Errorf("expected result.Provider == \"openai\", got %q", result.Provider)
+	}
+}
+
 func TestSessionToolCallLoop(t *testing.T) {
 	toolCallResp := &llm.Response{
 		Message: llm.Message{

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/2389-research/tracker/pipeline"
 	"github.com/2389-research/tracker/pipeline/handlers"
 	"github.com/joho/godotenv"
 	"github.com/mattn/go-isatty"
@@ -246,6 +247,12 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 
 	// Store autopilot config for chooseInterviewer (called from run/runTUI).
 	activeAutopilotCfg = autopilotCfg{persona: cfg.autopilot, autoApprove: cfg.autoApprove}
+	// Store budget limits for buildEngineOptions (called from run/runTUI).
+	activeBudgetLimits = pipeline.BudgetLimits{
+		MaxTotalTokens: cfg.maxTokens,
+		MaxCostCents:   cfg.maxCostCents,
+		MaxWallTime:    cfg.maxWallTime,
+	}
 
 	if err := printRunPreamble(cfg); err != nil {
 		return err

--- a/cmd/tracker/diagnose.go
+++ b/cmd/tracker/diagnose.go
@@ -84,6 +84,13 @@ func pickLatestRunID(runsDir string, entries []os.DirEntry) string {
 	return latestID
 }
 
+// budgetHalt holds information about a budget halt detected in the activity log.
+type budgetHalt struct {
+	TotalTokens   int
+	TotalCostUSD  float64
+	WallElapsedMs int64
+}
+
 // runDiagnose performs deep failure analysis on a pipeline run.
 func runDiagnose(workdir, runID string) error {
 	runDir, err := resolveRunDir(workdir, runID)
@@ -101,23 +108,41 @@ func runDiagnose(workdir, runID string) error {
 	// Collect node failures from status.json files.
 	failures := collectNodeFailures(runDir)
 
-	// Parse activity log for runtime errors and tool output.
-	enrichFromActivity(runDir, failures)
+	// Parse activity log for runtime errors, tool output, and budget halts.
+	halt := enrichFromActivity(runDir, failures)
 
-	// Print diagnosis.
+	printDiagnoseHeader(cp, halt, failures)
+	return nil
+}
+
+// printDiagnoseHeader renders the diagnose banner, budget halt section (if any),
+// and node failure details.
+func printDiagnoseHeader(cp *pipeline.Checkpoint, halt *budgetHalt, failures map[string]*nodeFailure) {
 	fmt.Println()
 	fmt.Println(bannerStyle.Render("tracker diagnose"))
 	fmt.Println()
 	fmt.Printf("  Run ID:  %s\n", cp.RunID)
 	fmt.Printf("  Nodes:   %d completed\n", len(cp.CompletedNodes))
 
-	if len(failures) == 0 {
+	// Surface budget halt prominently before other sections.
+	if halt != nil {
+		printBudgetHalt(halt)
+	}
+
+	if len(failures) == 0 && halt == nil {
 		fmt.Println()
 		fmt.Println(lipgloss.NewStyle().Foreground(colorNeon).Render("  No failures found — this run completed cleanly."))
 		fmt.Println()
-		return nil
+		return
 	}
 
+	if len(failures) > 0 {
+		printNodeFailures(failures, cp)
+	}
+}
+
+// printNodeFailures prints the failure count, per-node diagnosis, and suggestions.
+func printNodeFailures(failures map[string]*nodeFailure, cp *pipeline.Checkpoint) {
 	fmt.Printf("  Failures: %d\n", len(failures))
 	fmt.Println()
 
@@ -129,14 +154,30 @@ func runDiagnose(workdir, runID string) error {
 	sort.Strings(nodeIDs)
 
 	for _, nodeID := range nodeIDs {
-		f := failures[nodeID]
-		printNodeDiagnosis(f)
+		printNodeDiagnosis(failures[nodeID])
 	}
 
 	// Print suggestions.
 	printDiagnoseSuggestions(failures, cp)
+}
 
-	return nil
+// printBudgetHalt prints a prominent budget halt section.
+func printBudgetHalt(halt *budgetHalt) {
+	w := os.Stdout
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "━━━ Budget halt detected ━━━")
+	if halt.TotalTokens > 0 {
+		fmt.Fprintf(w, "  tokens used:  %d\n", halt.TotalTokens)
+	}
+	if halt.TotalCostUSD > 0 {
+		fmt.Fprintf(w, "  cost:         $%.4f\n", halt.TotalCostUSD)
+	}
+	if halt.WallElapsedMs > 0 {
+		fmt.Fprintf(w, "  wall time:    %dms\n", halt.WallElapsedMs)
+	}
+	fmt.Fprintln(w, "  suggestion:   raise the relevant --max-tokens, --max-cost, or --max-wall-time flag,")
+	fmt.Fprintln(w, "                or remove the Config.Budget value in your pipeline configuration")
+	fmt.Fprintln(w, "")
 }
 
 // collectNodeFailures reads status.json files from each node directory.
@@ -190,31 +231,38 @@ func loadNodeFailure(runDir, nodeID string) *nodeFailure {
 
 // diagnoseEntry is a parsed activity.jsonl line with fields needed for diagnosis.
 type diagnoseEntry struct {
-	Timestamp string `json:"ts"`
-	Type      string `json:"type"`
-	NodeID    string `json:"node_id"`
-	Error     string `json:"error"`
-	ToolErr   string `json:"tool_error"`
-	Handler   string `json:"handler"`
+	Timestamp     string  `json:"ts"`
+	Type          string  `json:"type"`
+	NodeID        string  `json:"node_id"`
+	Error         string  `json:"error"`
+	ToolErr       string  `json:"tool_error"`
+	Handler       string  `json:"handler"`
+	TotalTokens   int     `json:"total_tokens"`
+	TotalCostUSD  float64 `json:"total_cost_usd"`
+	WallElapsedMs int64   `json:"wall_elapsed_ms"`
 }
 
 // enrichFromActivity adds error messages, timing, and retry analysis from activity.jsonl.
-func enrichFromActivity(runDir string, failures map[string]*nodeFailure) {
+// Returns a non-nil *budgetHalt if a budget_exceeded event was found.
+func enrichFromActivity(runDir string, failures map[string]*nodeFailure) *budgetHalt {
 	path := filepath.Join(runDir, "activity.jsonl")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return
+		return nil
 	}
 
 	stageStarts := make(map[string]time.Time)
 	failSignatures := make(map[string][]string)
 
-	parseActivityLines(string(data), failures, stageStarts, failSignatures)
+	halt := parseActivityLines(string(data), failures, stageStarts, failSignatures)
 	applyRetryAnalysis(failures, failSignatures)
+	return halt
 }
 
 // parseActivityLines processes each JSONL line from the activity log.
-func parseActivityLines(data string, failures map[string]*nodeFailure, stageStarts map[string]time.Time, failSignatures map[string][]string) {
+// Returns a non-nil *budgetHalt if a budget_exceeded event was found.
+func parseActivityLines(data string, failures map[string]*nodeFailure, stageStarts map[string]time.Time, failSignatures map[string][]string) *budgetHalt {
+	var halt *budgetHalt
 	for _, line := range strings.Split(data, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -224,8 +272,16 @@ func parseActivityLines(data string, failures map[string]*nodeFailure, stageStar
 		if err := json.Unmarshal([]byte(line), &entry); err != nil {
 			continue
 		}
+		if entry.Type == "budget_exceeded" {
+			halt = &budgetHalt{
+				TotalTokens:   entry.TotalTokens,
+				TotalCostUSD:  entry.TotalCostUSD,
+				WallElapsedMs: entry.WallElapsedMs,
+			}
+		}
 		enrichFromEntry(entry, failures, stageStarts, failSignatures)
 	}
+	return halt
 }
 
 // applyRetryAnalysis updates failure records with retry count and pattern data.

--- a/cmd/tracker/diagnose.go
+++ b/cmd/tracker/diagnose.go
@@ -89,6 +89,7 @@ type budgetHalt struct {
 	TotalTokens   int
 	TotalCostUSD  float64
 	WallElapsedMs int64
+	Message       string // breach description, e.g. "max_total_tokens exceeded"
 }
 
 // runDiagnose performs deep failure analysis on a pipeline run.
@@ -166,6 +167,9 @@ func printBudgetHalt(halt *budgetHalt) {
 	w := os.Stdout
 	fmt.Fprintln(w, "")
 	fmt.Fprintln(w, "━━━ Budget halt detected ━━━")
+	if halt.Message != "" {
+		fmt.Fprintf(w, "  breach:       %s\n", halt.Message)
+	}
 	if halt.TotalTokens > 0 {
 		fmt.Fprintf(w, "  tokens used:  %d\n", halt.TotalTokens)
 	}
@@ -234,6 +238,7 @@ type diagnoseEntry struct {
 	Timestamp     string  `json:"ts"`
 	Type          string  `json:"type"`
 	NodeID        string  `json:"node_id"`
+	Message       string  `json:"message"`
 	Error         string  `json:"error"`
 	ToolErr       string  `json:"tool_error"`
 	Handler       string  `json:"handler"`
@@ -277,6 +282,7 @@ func parseActivityLines(data string, failures map[string]*nodeFailure, stageStar
 				TotalTokens:   entry.TotalTokens,
 				TotalCostUSD:  entry.TotalCostUSD,
 				WallElapsedMs: entry.WallElapsedMs,
+				Message:       entry.Message,
 			}
 		}
 		enrichFromEntry(entry, failures, stageStarts, failSignatures)

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -132,6 +132,9 @@ func newRunFlagSet(progName string, cfg *runConfig) *flag.FlagSet {
 	fs.StringVar(&cfg.backend, "backend", "", "Agent backend: native (default), claude-code, or acp")
 	fs.StringVar(&cfg.autopilot, "autopilot", "", "Replace human gates with LLM judge (lax/mid/hard/mentor)")
 	fs.BoolVar(&cfg.autoApprove, "auto-approve", false, "Auto-approve all human gates (no LLM, deterministic)")
+	fs.IntVar(&cfg.maxTokens, "max-tokens", 0, "Halt if total tokens across the run exceed this value (0 = no limit)")
+	fs.IntVar(&cfg.maxCostCents, "max-cost", 0, "Halt if total cost in cents exceeds this value (0 = no limit)")
+	fs.DurationVar(&cfg.maxWallTime, "max-wall-time", 0, "Halt if pipeline wall time exceeds this duration (0 = no limit)")
 	return fs
 }
 
@@ -187,5 +190,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  --backend string          Agent backend: native (default), claude-code, or acp\n")
 	fmt.Fprintf(w, "  --autopilot <persona>     Replace human gates with LLM judge (lax/mid/hard/mentor)\n")
 	fmt.Fprintf(w, "  --auto-approve            Auto-approve all human gates (deterministic, no LLM)\n")
+	fmt.Fprintf(w, "  --max-tokens int          Halt if total tokens exceed this value (0 = no limit)\n")
+	fmt.Fprintf(w, "  --max-cost int            Halt if total cost in cents exceeds this value (0 = no limit)\n")
+	fmt.Fprintf(w, "  --max-wall-time duration  Halt if pipeline wall time exceeds this duration (0 = no limit)\n")
 	fmt.Fprintf(w, "  --version                 Show version information\n")
 }

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -102,7 +102,18 @@ func parseRunFlags(args []string, cfg runConfig) (runConfig, error) {
 	if err := validateBackend(cfg.backend); err != nil {
 		return cfg, err
 	}
+	if err := validateBudgetLimits(cfg); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
+}
+
+// validateBudgetLimits returns an error if any budget limit is negative.
+func validateBudgetLimits(cfg runConfig) error {
+	if cfg.maxTokens < 0 || cfg.maxCostCents < 0 || cfg.maxWallTime < 0 {
+		return fmt.Errorf("budget limits must be non-negative")
+	}
+	return nil
 }
 
 // isHelpRequest returns true when the second argument is a help flag.

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 )
 
 type runConfig struct {
@@ -19,10 +20,13 @@ type runConfig struct {
 	resumeID     string // run ID to resume (resolved to checkpoint path)
 	noTUI        bool
 	verbose      bool
-	jsonOut      bool   // stream events as NDJSON to stdout
-	backend      string // agent execution backend: "" (default), "native", or "claude-code"
-	autopilot    string // persona name (lax/mid/hard/mentor) or empty
-	autoApprove  bool   // deterministic auto-approve, no LLM
+	jsonOut      bool          // stream events as NDJSON to stdout
+	backend      string        // agent execution backend: "" (default), "native", or "claude-code"
+	autopilot    string        // persona name (lax/mid/hard/mentor) or empty
+	autoApprove  bool          // deterministic auto-approve, no LLM
+	maxTokens    int           // halt if total tokens exceed this value (0 = no limit)
+	maxCostCents int           // halt if total cost in cents exceeds this value (0 = no limit)
+	maxWallTime  time.Duration // halt if wall time exceeds this duration (0 = no limit)
 }
 
 type commandMode string

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -35,6 +35,10 @@ type autopilotCfg struct {
 
 var activeAutopilotCfg autopilotCfg
 
+// activeBudgetLimits holds the budget limits for the current run.
+// Set by executeRun before calling run/runTUI, matching the pattern of activeAutopilotCfg.
+var activeBudgetLimits pipeline.BudgetLimits
+
 // run executes the pipeline in mode 1: BubbleteaInterviewer spins up an inline
 // tea.Program for each human gate, then returns control to the pipeline goroutine.
 func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool, jsonOut bool) error {
@@ -121,6 +125,9 @@ func buildEngineOptions(artifactDir, checkpoint string, evtHandler pipeline.Pipe
 	}
 	if checkpoint != "" {
 		opts = append(opts, pipeline.WithCheckpointPath(checkpoint))
+	}
+	if guard := pipeline.NewBudgetGuard(activeBudgetLimits); guard != nil {
+		opts = append(opts, pipeline.WithBudgetGuard(guard))
 	}
 	return opts
 }
@@ -404,6 +411,9 @@ func buildTUIEngine(graph *pipeline.Graph, registry *pipeline.HandlerRegistry, a
 	engineOpts = append(engineOpts, pipeline.WithStylesheetResolution(true))
 	if checkpoint != "" {
 		engineOpts = append(engineOpts, pipeline.WithCheckpointPath(checkpoint))
+	}
+	if guard := pipeline.NewBudgetGuard(activeBudgetLimits); guard != nil {
+		engineOpts = append(engineOpts, pipeline.WithBudgetGuard(guard))
 	}
 	return pipeline.NewEngine(graph, registry, engineOpts...)
 }

--- a/cmd/tracker/summary.go
+++ b/cmd/tracker/summary.go
@@ -161,7 +161,9 @@ func printRunSummary(result *pipeline.EngineResult, pipelineErr error, tracker *
 	printTokensByProvider(tracker)
 	printPipelineFlow(result)
 
-	if pipelineErr != nil {
+	if result != nil && result.Status == pipeline.OutcomeBudgetExceeded {
+		printBudgetHaltBanner(result, tracker)
+	} else if pipelineErr != nil {
 		fmt.Println()
 		fmt.Printf("  ERROR: %v\n", pipelineErr)
 	}
@@ -368,6 +370,26 @@ func printNodeConnector(entries []pipeline.TraceEntry, i int) {
 		fmt.Printf("  │ → %s\n", entries[i].EdgeTo)
 	}
 	fmt.Println("  │")
+}
+
+// printBudgetHaltBanner prints a prominent halt notice when a budget limit was exceeded.
+func printBudgetHaltBanner(result *pipeline.EngineResult, tracker *llm.TokenTracker) {
+	fmt.Println()
+	fmt.Println("─── HALTED: budget exceeded ───────────────────────────────")
+	if len(result.BudgetLimitsHit) > 0 {
+		fmt.Printf("  reason: %s\n", strings.Join(result.BudgetLimitsHit, ", "))
+	}
+	if tracker != nil {
+		total := tracker.TotalUsage()
+		if total.InputTokens > 0 || total.OutputTokens > 0 {
+			totalToks := total.InputTokens + total.OutputTokens
+			fmt.Printf("  spent:  %s tokens", formatNumber(totalToks))
+			if total.EstimatedCost > 0 {
+				fmt.Printf(", $%.4f", total.EstimatedCost)
+			}
+			fmt.Println()
+		}
+	}
 }
 
 // printResumeHint shows the resume command when the pipeline didn't complete successfully.

--- a/docs/superpowers/plans/2026-04-14-token-cost-governance.md
+++ b/docs/superpowers/plans/2026-04-14-token-cost-governance.md
@@ -1,0 +1,1154 @@
+# Token & Cost Governance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose complete per-provider token/cost data from the tracker library in real time, and enforce configurable pipeline-level token/cost/wall-time ceilings that halt execution when breached.
+
+**Architecture:** Part 1 promotes `llm.TokenTracker` from a CLI-summary helper to a first-class library output by surfacing its per-provider totals on `Result` / `EngineResult`, pricing each provider via `llm.EstimateCost`, and emitting a new `EventCostUpdated` event after every trace entry so consumers see streaming updates. Part 2 adds a `BudgetGuard` evaluated inside the engine loop after each node's outcome is applied; on breach it writes a terminal trace entry, emits `EventBudgetExceeded`, and returns an `EngineResult` with status `OutcomeBudgetExceeded`. Part 3 wires graph attrs (`max_total_tokens`, `max_cost_cents`, `max_wall_time`) and CLI flags that override them.
+
+**Tech Stack:** Go 1.22+, existing `pipeline.Engine`, `llm.TokenTracker`, `llm.pricing`, `pipeline/events.go` event bus.
+
+**Closes:** #62, #17
+
+---
+
+## File Structure
+
+**New files**
+- `llm/pricing.go` — extend (not new) with `EstimateCostDetailed(model, usage) CostBreakdown` and exported `Pricing(model)` lookup.
+- `llm/token_tracker_cost.go` — `(*TokenTracker).CostByProvider(resolver)` helper that maps per-provider `Usage` to dollar cost using a provided model-resolver callback.
+- `pipeline/budget.go` — `BudgetLimits` struct, `BudgetGuard` with `Check(usage *UsageSummary, started time.Time) BudgetBreach`, `BudgetBreach` enum.
+- `pipeline/budget_test.go` — unit tests for guard boundary behavior.
+- `tracker_budget_test.go` — integration test hitting `max_cost_cents: 1`.
+
+**Modified files**
+- `pipeline/trace.go` — add `TotalCacheCreationTokens` (if missing), add `ProviderTotals map[string]ProviderUsage` to `UsageSummary`.
+- `pipeline/engine.go` — thread `BudgetGuard`, add `WithBudgetGuard` option, add `OutcomeBudgetExceeded` constant, add budget check in `processActiveNode` after `applyOutcome`, set `Status` on `EngineResult` accordingly.
+- `pipeline/events.go` — add `EventCostUpdated` and `EventBudgetExceeded` event types; extend `PipelineEvent` with optional `Cost *CostSnapshot` field.
+- `pipeline/engine_run.go` — after every `s.trace.AddEntry(...)` that corresponds to a completed node, emit `EventCostUpdated` with the fresh aggregate (helper `emitCostUpdate`).
+- `tracker.go` — add `Result.Cost` (struct: Total, ByProvider, LimitsHit), add `Config.Budget BudgetLimits`, plumb into `buildEngineOpts`. Populate `result.Cost` in `Run()` from tracker + trace.
+- `pipeline/dippin_adapter.go` — parse graph-level attrs `max_total_tokens`, `max_cost_cents`, `max_wall_time` into `Graph.Attrs` (pass-through — already supported since adapter copies `WorkflowConfig` attrs). Add adapter test for the new keys.
+- `cmd/tracker/run.go` — add `--max-tokens`, `--max-cost` (cents), `--max-wall-time` flags; build `BudgetLimits`; attach via `Config.Budget`.
+- `cmd/tracker/summary.go` — print "HALTED: budget exceeded (reason)" when `Result.Cost.LimitsHit` is non-empty.
+- `cmd/tracker/diagnose.go` — detect `OutcomeBudgetExceeded` status and surface a distinct diagnostic section.
+- `CHANGELOG.md` — Added section.
+- `README.md` — new "Cost governance" subsection.
+- `CLAUDE.md` — add note in "Token usage flows through three layers" about new per-provider breakdown and `BudgetGuard`.
+
+---
+
+## Task 1: Cost snapshot types and per-provider cost resolver
+
+**Files:**
+- Modify: `llm/pricing.go`
+- Create: `llm/token_tracker_cost.go`
+- Test: `llm/token_tracker_cost_test.go`
+
+- [ ] **Step 1: Write failing test for `CostBreakdown` and resolver**
+
+Create `llm/token_tracker_cost_test.go`:
+
+```go
+package llm
+
+import (
+	"testing"
+)
+
+func TestTokenTracker_CostByProvider(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("anthropic", Usage{InputTokens: 1_000_000, OutputTokens: 500_000})
+	tr.AddUsage("openai", Usage{InputTokens: 2_000_000, OutputTokens: 1_000_000})
+
+	// 1M anthropic input @ $3 + 0.5M output @ $15 = 3 + 7.5 = 10.50
+	// 2M openai input @ $2.50 + 1M output @ $10 = 5 + 10 = 15.00
+	resolver := func(provider string) string {
+		switch provider {
+		case "anthropic":
+			return "claude-sonnet-4-6"
+		case "openai":
+			return "gpt-4o"
+		}
+		return ""
+	}
+
+	breakdown := tr.CostByProvider(resolver)
+	if got := breakdown["anthropic"].USD; got < 10.49 || got > 10.51 {
+		t.Errorf("anthropic cost: got %.4f, want 10.50", got)
+	}
+	if got := breakdown["openai"].USD; got < 14.99 || got > 15.01 {
+		t.Errorf("openai cost: got %.4f, want 15.00", got)
+	}
+}
+
+func TestTokenTracker_CostByProvider_UnknownModel(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("mystery", Usage{InputTokens: 10_000, OutputTokens: 5_000})
+
+	breakdown := tr.CostByProvider(func(string) string { return "" })
+	if breakdown["mystery"].USD != 0 {
+		t.Errorf("unknown model should yield $0, got %.4f", breakdown["mystery"].USD)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./llm/ -run TokenTracker_CostByProvider -v`
+Expected: FAIL — `CostByProvider` undefined.
+
+- [ ] **Step 3: Add `ProviderCost` type and `CostByProvider` method**
+
+Create `llm/token_tracker_cost.go`:
+
+```go
+// ABOUTME: Per-provider cost rollup for the TokenTracker middleware.
+// ABOUTME: Maps accumulated Usage to dollar cost using a caller-provided model resolver.
+package llm
+
+// ProviderCost is the per-provider cost rollup returned by TokenTracker.CostByProvider.
+type ProviderCost struct {
+	Usage Usage
+	Model string
+	USD   float64
+}
+
+// ModelResolver returns the model name that should be used for cost estimation
+// for a given provider. Return "" when unknown — the entry will still be
+// included with USD=0.
+type ModelResolver func(provider string) string
+
+// CostByProvider returns a per-provider cost rollup, resolving each provider's
+// model via the caller-supplied resolver and pricing it via EstimateCost.
+func (t *TokenTracker) CostByProvider(resolve ModelResolver) map[string]ProviderCost {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make(map[string]ProviderCost, len(t.usage))
+	for provider, usage := range t.usage {
+		model := ""
+		if resolve != nil {
+			model = resolve(provider)
+		}
+		out[provider] = ProviderCost{
+			Usage: usage,
+			Model: model,
+			USD:   EstimateCost(model, usage),
+		}
+	}
+	return out
+}
+
+// TotalCostUSD is a convenience helper summing CostByProvider to a single dollar
+// figure using the same resolver.
+func (t *TokenTracker) TotalCostUSD(resolve ModelResolver) float64 {
+	var total float64
+	for _, pc := range t.CostByProvider(resolve) {
+		total += pc.USD
+	}
+	return total
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./llm/ -run TokenTracker_CostByProvider -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add llm/token_tracker_cost.go llm/token_tracker_cost_test.go
+git commit -m "feat(llm): add per-provider cost rollup on TokenTracker"
+```
+
+**Acceptance gate:**
+- `go test ./llm/...` passes.
+- `ProviderCost` exported, `CostByProvider` and `TotalCostUSD` callable.
+
+---
+
+## Task 2: Extend `UsageSummary` with per-provider totals
+
+**Files:**
+- Modify: `pipeline/trace.go`
+- Test: `pipeline/trace_test.go`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `pipeline/trace_test.go`:
+
+```go
+func TestAggregateUsage_PerProvider(t *testing.T) {
+	tr := &Trace{Entries: []TraceEntry{
+		{Stats: &SessionStats{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.01, Provider: "anthropic"}},
+		{Stats: &SessionStats{InputTokens: 200, OutputTokens: 75, TotalTokens: 275, CostUSD: 0.02, Provider: "openai"}},
+		{Stats: &SessionStats{InputTokens: 50, OutputTokens: 25, TotalTokens: 75, CostUSD: 0.005, Provider: "anthropic"}},
+	}}
+
+	s := tr.AggregateUsage()
+	if s == nil {
+		t.Fatal("AggregateUsage returned nil")
+	}
+	if s.TotalTokens != 500 {
+		t.Errorf("TotalTokens = %d, want 500", s.TotalTokens)
+	}
+	if got := s.ProviderTotals["anthropic"].InputTokens; got != 150 {
+		t.Errorf("anthropic input = %d, want 150", got)
+	}
+	if got := s.ProviderTotals["anthropic"].CostUSD; got < 0.014 || got > 0.016 {
+		t.Errorf("anthropic cost = %.4f, want 0.015", got)
+	}
+	if got := s.ProviderTotals["openai"].InputTokens; got != 200 {
+		t.Errorf("openai input = %d, want 200", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+Run: `go test ./pipeline/ -run TestAggregateUsage_PerProvider -v`
+Expected: FAIL — `Provider` field and `ProviderTotals` missing.
+
+- [ ] **Step 3: Extend `SessionStats` and `UsageSummary`**
+
+Edit `pipeline/trace.go`:
+
+```go
+// SessionStats ... (add Provider field)
+type SessionStats struct {
+	// ... existing fields ...
+	Provider         string         `json:"provider,omitempty"`
+}
+
+// ProviderUsage is the per-provider rollup embedded in UsageSummary.
+type ProviderUsage struct {
+	InputTokens      int     `json:"input_tokens"`
+	OutputTokens     int     `json:"output_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	CostUSD          float64 `json:"cost_usd"`
+	ReasoningTokens  int     `json:"reasoning_tokens"`
+	CacheReadTokens  int     `json:"cache_read_tokens"`
+	CacheWriteTokens int     `json:"cache_write_tokens"`
+	SessionCount     int     `json:"session_count"`
+}
+
+// UsageSummary ... (add ProviderTotals)
+type UsageSummary struct {
+	// ... existing fields ...
+	ProviderTotals map[string]ProviderUsage `json:"provider_totals,omitempty"`
+}
+```
+
+Update `AggregateUsage` so each trace-entry pass also accumulates into `ProviderTotals[entry.Stats.Provider]` when the provider is non-empty:
+
+```go
+func (tr *Trace) AggregateUsage() *UsageSummary {
+	if tr == nil {
+		return nil
+	}
+	s := &UsageSummary{ProviderTotals: make(map[string]ProviderUsage)}
+	for _, e := range tr.Entries {
+		if e.Stats == nil {
+			continue
+		}
+		s.TotalInputTokens += e.Stats.InputTokens
+		s.TotalOutputTokens += e.Stats.OutputTokens
+		s.TotalTokens += e.Stats.TotalTokens
+		s.TotalCostUSD += e.Stats.CostUSD
+		s.TotalReasoningTokens += e.Stats.ReasoningTokens
+		s.TotalCacheReadTokens += e.Stats.CacheReadTokens
+		s.TotalCacheWriteTokens += e.Stats.CacheWriteTokens
+		s.SessionCount++
+		if p := e.Stats.Provider; p != "" {
+			pt := s.ProviderTotals[p]
+			pt.InputTokens += e.Stats.InputTokens
+			pt.OutputTokens += e.Stats.OutputTokens
+			pt.TotalTokens += e.Stats.TotalTokens
+			pt.CostUSD += e.Stats.CostUSD
+			pt.ReasoningTokens += e.Stats.ReasoningTokens
+			pt.CacheReadTokens += e.Stats.CacheReadTokens
+			pt.CacheWriteTokens += e.Stats.CacheWriteTokens
+			pt.SessionCount++
+			s.ProviderTotals[p] = pt
+		}
+	}
+	if s.SessionCount == 0 {
+		return nil
+	}
+	if len(s.ProviderTotals) == 0 {
+		s.ProviderTotals = nil
+	}
+	return s
+}
+```
+
+- [ ] **Step 4: Populate `SessionStats.Provider` at the transcript site**
+
+Find the `buildSessionStats` function:
+
+Run: `grep -n "buildSessionStats" pipeline/handlers/transcript.go`
+
+Edit it to set `stats.Provider = sessionResult.Provider` (or equivalent — use whatever field the agent's `SessionResult` already exposes; if none, pull from the first LLM trace entry in the session).
+
+- [ ] **Step 5: Run all trace tests**
+
+Run: `go test ./pipeline/ -run TestAggregate -v`
+Expected: PASS (new + existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/trace.go pipeline/trace_test.go pipeline/handlers/transcript.go
+git commit -m "feat(pipeline): per-provider rollup in UsageSummary"
+```
+
+**Acceptance gate:**
+- `go test ./pipeline/...` passes.
+- A trace with two providers yields two entries in `UsageSummary.ProviderTotals`.
+
+---
+
+## Task 3: `Result.Cost` on the library API
+
+**Files:**
+- Modify: `tracker.go`
+- Test: `tracker_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tracker_test.go` a test that runs a trivial passthrough pipeline with a mocked `Completer` returning a `Usage{InputTokens: 1000, OutputTokens: 500}` on a known model, then asserts:
+
+```go
+func TestRun_ResultCost_PopulatesProviderAndTotal(t *testing.T) {
+	// Uses existing test harness — see nearby tests for stub Completer pattern.
+	// Assertion:
+	//   result.Cost.TotalUSD > 0
+	//   result.Cost.ByProvider["anthropic"].USD > 0
+	//   result.Cost.ByProvider["anthropic"].Usage.InputTokens == 1000
+}
+```
+
+Model the stub after the nearest existing `tracker_test.go` test that injects `Config.LLMClient`.
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `go test . -run TestRun_ResultCost -v`
+Expected: FAIL — `Result.Cost` undefined.
+
+- [ ] **Step 3: Add `Cost` type and populate in `Run`**
+
+Edit `tracker.go`:
+
+```go
+// CostReport summarizes spend for a pipeline run.
+type CostReport struct {
+	TotalUSD   float64
+	ByProvider map[string]llm.ProviderCost
+	LimitsHit  []string // populated if BudgetGuard halted the run
+}
+
+// Result — add field:
+type Result struct {
+	// ... existing fields ...
+	Cost *CostReport
+}
+```
+
+In `(*Engine).Run` after `result := resultFromEngine(...)`:
+
+```go
+if e.tokenTracker != nil {
+	resolver := func(provider string) string {
+		return e.defaultModelFor(provider)
+	}
+	byProvider := e.tokenTracker.CostByProvider(resolver)
+	total := 0.0
+	for _, pc := range byProvider {
+		total += pc.USD
+	}
+	result.Cost = &CostReport{
+		TotalUSD:   total,
+		ByProvider: byProvider,
+	}
+}
+if engineResult != nil && engineResult.Status == pipeline.OutcomeBudgetExceeded {
+	if result.Cost == nil {
+		result.Cost = &CostReport{}
+	}
+	result.Cost.LimitsHit = engineResult.BudgetLimitsHit // added in Task 5
+}
+```
+
+Add `defaultModelFor`: look up `graph.Attrs["llm_model"]` as a universal fallback, and optionally a future per-provider map. For this task, returning `graph.Attrs["llm_model"]` for every provider is sufficient.
+
+- [ ] **Step 4: Run test, confirm pass**
+
+Run: `go test . -run TestRun_ResultCost -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tracker.go tracker_test.go
+git commit -m "feat(tracker): expose CostReport on Result"
+```
+
+**Acceptance gate:**
+- `Result.Cost.TotalUSD` and `Result.Cost.ByProvider` populated after every run that had any LLM activity.
+- `go test ./...` passes.
+
+---
+
+## Task 4: Streaming `EventCostUpdated`
+
+**Files:**
+- Modify: `pipeline/events.go`
+- Modify: `pipeline/engine_run.go`
+- Modify: `pipeline/engine.go`
+- Test: `pipeline/engine_test.go` (new test)
+
+- [ ] **Step 1: Add failing test**
+
+Add to `pipeline/engine_test.go` (or nearest engine test file):
+
+```go
+func TestEngine_EmitsCostUpdatedAfterEachNode(t *testing.T) {
+	// Build a 3-node linear graph where each node's handler returns
+	// SessionStats{InputTokens:100, OutputTokens:50, TotalTokens:150, CostUSD: 0.01}
+	// Capture events via a PipelineEventHandlerFunc.
+	// Assert: exactly 3 EventCostUpdated events; each carries a non-nil
+	//         Cost snapshot whose TotalCostUSD is monotonically increasing.
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `go test ./pipeline/ -run TestEngine_EmitsCostUpdated -v`
+Expected: FAIL — `EventCostUpdated` undefined.
+
+- [ ] **Step 3: Add event type and payload**
+
+Edit `pipeline/events.go`:
+
+```go
+const (
+	// ... existing constants ...
+	EventCostUpdated    PipelineEventType = "cost_updated"
+	EventBudgetExceeded PipelineEventType = "budget_exceeded"
+)
+
+// CostSnapshot is the payload of EventCostUpdated/EventBudgetExceeded events.
+type CostSnapshot struct {
+	TotalTokens    int
+	TotalCostUSD   float64
+	ProviderTotals map[string]ProviderUsage
+	WallElapsed    time.Duration
+}
+
+// PipelineEvent — add field:
+type PipelineEvent struct {
+	// ... existing fields ...
+	Cost *CostSnapshot
+}
+```
+
+- [ ] **Step 4: Emit after trace entries**
+
+In `pipeline/engine_run.go` add:
+
+```go
+func (e *Engine) emitCostUpdate(s *runState) {
+	summary := s.trace.AggregateUsage()
+	if summary == nil {
+		return
+	}
+	e.emit(PipelineEvent{
+		Type:      EventCostUpdated,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		Cost: &CostSnapshot{
+			TotalTokens:    summary.TotalTokens,
+			TotalCostUSD:   summary.TotalCostUSD,
+			ProviderTotals: summary.ProviderTotals,
+			WallElapsed:    time.Since(s.trace.StartTime),
+		},
+	})
+}
+```
+
+Find each call site that ends a node's execution successfully and calls `s.trace.AddEntry(...)` for a user-facing node (not retry-bookkeeping entries). Call `e.emitCostUpdate(s)` immediately after. Use the call sites in `engine.go:279, 294, 319` and `engine_run.go:345, 365, 432, 449, 466, 472, 477`. Skip the retry-bookkeeping adds that already have a preceding add for the same node.
+
+Guideline: add `emitCostUpdate` after any `AddEntry` where `traceEntry.Status` is `OutcomeSuccess`, `OutcomeFail`, or `OutcomeEscalate`. Do NOT emit after retry-scheduling entries.
+
+- [ ] **Step 5: Run test, confirm pass**
+
+Run: `go test ./pipeline/ -run TestEngine_EmitsCostUpdated -v`
+Expected: PASS — three events, monotonically increasing cost.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/events.go pipeline/engine.go pipeline/engine_run.go pipeline/engine_test.go
+git commit -m "feat(pipeline): emit EventCostUpdated after each completed node"
+```
+
+**Acceptance gate:**
+- A 3-node run emits exactly 3 `EventCostUpdated` events.
+- `PipelineEvent.Cost` is non-nil on those events; `nil` on all other event types.
+- All existing pipeline tests pass.
+
+---
+
+## Task 5: `BudgetGuard` + `OutcomeBudgetExceeded`
+
+**Files:**
+- Create: `pipeline/budget.go`
+- Create: `pipeline/budget_test.go`
+- Modify: `pipeline/engine.go` (EngineResult, constants, option, Run loop)
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `pipeline/budget_test.go`:
+
+```go
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBudgetGuard_UnderLimits(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000, MaxCostCents: 100, MaxWallTime: time.Minute})
+	breach := g.Check(&UsageSummary{TotalTokens: 500, TotalCostUSD: 0.25}, time.Now())
+	if breach.Kind != BudgetOK {
+		t.Errorf("got breach %v, want BudgetOK", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_TokenCeiling(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000})
+	breach := g.Check(&UsageSummary{TotalTokens: 1001}, time.Now())
+	if breach.Kind != BudgetTokens {
+		t.Errorf("got %v, want BudgetTokens", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_ExactTokenCeiling(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000})
+	if g.Check(&UsageSummary{TotalTokens: 1000}, time.Now()).Kind != BudgetOK {
+		t.Errorf("exact limit should be OK (inclusive)")
+	}
+}
+
+func TestBudgetGuard_CostCeiling(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxCostCents: 50})
+	breach := g.Check(&UsageSummary{TotalCostUSD: 0.51}, time.Now())
+	if breach.Kind != BudgetCost {
+		t.Errorf("got %v, want BudgetCost", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_WallTime(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxWallTime: 10 * time.Millisecond})
+	started := time.Now().Add(-time.Second)
+	breach := g.Check(&UsageSummary{}, started)
+	if breach.Kind != BudgetWallTime {
+		t.Errorf("got %v, want BudgetWallTime", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_NilLimitsNoOp(t *testing.T) {
+	var g *BudgetGuard
+	if g.Check(&UsageSummary{TotalTokens: 999999}, time.Now()).Kind != BudgetOK {
+		t.Errorf("nil guard should always return BudgetOK")
+	}
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `go test ./pipeline/ -run BudgetGuard -v`
+Expected: FAIL — undefined.
+
+- [ ] **Step 3: Implement `BudgetGuard`**
+
+Create `pipeline/budget.go`:
+
+```go
+// ABOUTME: Pipeline-level token, cost, and wall-time ceilings enforced between nodes.
+// ABOUTME: Halts execution with OutcomeBudgetExceeded when any configured limit is breached.
+package pipeline
+
+import "time"
+
+// BudgetLimits configures hard ceilings for a pipeline run.
+// A zero-value field means "no limit" for that dimension.
+type BudgetLimits struct {
+	MaxTotalTokens int
+	MaxCostCents   int
+	MaxWallTime    time.Duration
+}
+
+// IsZero reports whether any limit is configured.
+func (l BudgetLimits) IsZero() bool {
+	return l.MaxTotalTokens == 0 && l.MaxCostCents == 0 && l.MaxWallTime == 0
+}
+
+// BudgetBreachKind classifies which limit was hit.
+type BudgetBreachKind int
+
+const (
+	BudgetOK BudgetBreachKind = iota
+	BudgetTokens
+	BudgetCost
+	BudgetWallTime
+)
+
+// BudgetBreach describes the outcome of a guard check.
+type BudgetBreach struct {
+	Kind    BudgetBreachKind
+	Message string
+}
+
+// BudgetGuard evaluates BudgetLimits against a UsageSummary snapshot.
+type BudgetGuard struct {
+	limits BudgetLimits
+}
+
+// NewBudgetGuard constructs a BudgetGuard with the given limits.
+// If limits.IsZero(), returns nil so callers can skip the check entirely.
+func NewBudgetGuard(limits BudgetLimits) *BudgetGuard {
+	if limits.IsZero() {
+		return nil
+	}
+	return &BudgetGuard{limits: limits}
+}
+
+// Check reports whether the given usage snapshot breaches any configured limit.
+// A nil guard always returns BudgetOK.
+func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach {
+	if g == nil {
+		return BudgetBreach{Kind: BudgetOK}
+	}
+	if g.limits.MaxTotalTokens > 0 && usage != nil && usage.TotalTokens > g.limits.MaxTotalTokens {
+		return BudgetBreach{
+			Kind:    BudgetTokens,
+			Message: "max_total_tokens exceeded",
+		}
+	}
+	if g.limits.MaxCostCents > 0 && usage != nil {
+		cents := int(usage.TotalCostUSD * 100)
+		if cents > g.limits.MaxCostCents {
+			return BudgetBreach{
+				Kind:    BudgetCost,
+				Message: "max_cost_cents exceeded",
+			}
+		}
+	}
+	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
+		return BudgetBreach{
+			Kind:    BudgetWallTime,
+			Message: "max_wall_time exceeded",
+		}
+	}
+	return BudgetBreach{Kind: BudgetOK}
+}
+
+// String returns a human-readable label for a breach kind.
+func (k BudgetBreachKind) String() string {
+	switch k {
+	case BudgetTokens:
+		return "tokens"
+	case BudgetCost:
+		return "cost"
+	case BudgetWallTime:
+		return "wall_time"
+	default:
+		return "ok"
+	}
+}
+```
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `go test ./pipeline/ -run BudgetGuard -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add `OutcomeBudgetExceeded` and engine option**
+
+Edit `pipeline/engine.go`:
+
+```go
+const OutcomeBudgetExceeded = "budget_exceeded"
+
+// EngineResult — add:
+type EngineResult struct {
+	// ... existing fields ...
+	BudgetLimitsHit []string
+}
+
+// WithBudgetGuard attaches a BudgetGuard evaluated between nodes.
+func WithBudgetGuard(guard *BudgetGuard) EngineOption {
+	return func(e *Engine) { e.budgetGuard = guard }
+}
+
+// Engine — add field:
+type Engine struct {
+	// ... existing fields ...
+	budgetGuard *BudgetGuard
+}
+```
+
+- [ ] **Step 6: Enforce in the run loop**
+
+In `pipeline/engine_run.go`, right after each `emitCostUpdate(s)` call (added in Task 4), add:
+
+```go
+if breach := e.budgetGuard.Check(s.trace.AggregateUsage(), s.trace.StartTime); breach.Kind != BudgetOK {
+	return e.haltForBudget(s, breach)
+}
+```
+
+Add helper in `engine_run.go`:
+
+```go
+func (e *Engine) haltForBudget(s *runState, breach BudgetBreach) loopResult {
+	s.trace.EndTime = time.Now()
+	e.emit(PipelineEvent{
+		Type:      EventBudgetExceeded,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		Message:   breach.Message,
+	})
+	return loopResult{
+		action: loopReturn,
+		result: &EngineResult{
+			RunID:           s.runID,
+			Status:          OutcomeBudgetExceeded,
+			CompletedNodes:  s.cp.CompletedNodes,
+			Context:         s.pctx.Snapshot(),
+			Trace:           s.trace,
+			Usage:           s.trace.AggregateUsage(),
+			BudgetLimitsHit: []string{breach.Kind.String()},
+		},
+	}
+}
+```
+
+The return value type of `processNode` / `processActiveNode` / `advanceToNextNode` is `loopResult`, which already supports `loopReturn`. Plumb `haltForBudget` through whichever function you put the check in — if it's in `advanceToNextNode`, return the `loopResult` directly; if it's in a callee, bubble it up.
+
+Concretely: put the check in a new method `checkBudgetAfterNode` called at the top of `advanceToNextNode` *after* `s.trace.AddEntry(*traceEntry)` has run, and return its `loopResult` if non-OK. Because `advanceToNextNode` already adds the entry at line 294 before selecting the next edge, move the emit+check to after that `AddEntry`.
+
+- [ ] **Step 7: Integration test for engine halt**
+
+Add to `pipeline/engine_test.go`:
+
+```go
+func TestEngine_HaltsOnBudgetBreach(t *testing.T) {
+	// 5-node linear graph. Each node's stub handler returns SessionStats{TotalTokens: 300}.
+	// Guard: MaxTotalTokens = 700. Expect halt after node 3 (total 900 > 700), Status OutcomeBudgetExceeded.
+}
+```
+
+- [ ] **Step 8: Run all pipeline tests**
+
+Run: `go test ./pipeline/ -v`
+Expected: PASS — including the new halt test and all existing ones.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pipeline/budget.go pipeline/budget_test.go pipeline/engine.go pipeline/engine_run.go pipeline/engine_test.go
+git commit -m "feat(pipeline): BudgetGuard enforces token/cost/wall-time ceilings"
+```
+
+**Acceptance gate:**
+- Budget tests pass.
+- A deliberately over-budget run halts with `Status == OutcomeBudgetExceeded` and `BudgetLimitsHit` populated.
+- No regressions in existing `./pipeline/...` tests.
+
+---
+
+## Task 6: Adapter passes budget attrs through
+
+**Files:**
+- Modify: `pipeline/dippin_adapter.go`
+- Test: `pipeline/dippin_adapter_test.go`
+
+- [ ] **Step 1: Failing test**
+
+Add:
+
+```go
+func TestAdapter_BudgetAttrsPassThrough(t *testing.T) {
+	src := `
+workflow test {
+	max_total_tokens: 50000
+	max_cost_cents: 250
+	max_wall_time: "10m"
+	start -> done
+	node start { prompt: "hi" }
+	node done { }
+}`
+	// parse via dippin parser, convert, assert graph.Attrs has the three keys verbatim.
+}
+```
+
+- [ ] **Step 2: Confirm fail or pass**
+
+Run: `go test ./pipeline/ -run TestAdapter_BudgetAttrsPassThrough -v`
+Expected: likely already passes if adapter copies all workflow attrs — if so, this test locks behavior. If it fails, add the keys to whatever attr-copy list the adapter uses.
+
+- [ ] **Step 3: If failing, update adapter to copy the three keys into `graph.Attrs`**
+
+(Editing guidance only; the exact location is the workflow-attr loop in `FromDippinIR`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pipeline/dippin_adapter.go pipeline/dippin_adapter_test.go
+git commit -m "feat(adapter): pass through budget attrs (tokens/cost/walltime)"
+```
+
+**Acceptance gate:**
+- Graph from a `.dip` file with budget attrs exposes them on `graph.Attrs` with the exact keys `max_total_tokens`, `max_cost_cents`, `max_wall_time`.
+
+---
+
+## Task 7: Library wiring — `Config.Budget` and graph-attr fallback
+
+**Files:**
+- Modify: `tracker.go`
+- Test: `tracker_budget_test.go` (new)
+
+- [ ] **Step 1: Failing integration test**
+
+Create `tracker_budget_test.go`:
+
+```go
+package tracker
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestRun_BudgetHalt_FromConfig(t *testing.T) {
+	// Minimal .dip with two nodes that each produce stub usage 600 tokens.
+	// Use a stub Completer; see existing tests for the pattern.
+	// Config.Budget = BudgetLimits{MaxTotalTokens: 1000}
+	// Expect: result.Status == "budget_exceeded", result.Cost.LimitsHit contains "tokens".
+}
+
+func TestRun_BudgetHalt_FromGraphAttrs(t *testing.T) {
+	// Same stub, but budget only in the .dip source as max_total_tokens: 1000.
+	// Config.Budget unset. Expect same halt.
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+Run: `go test . -run TestRun_Budget -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Wire through `Config` and graph attrs**
+
+In `tracker.go`:
+
+```go
+type Config struct {
+	// ... existing fields ...
+	Budget pipeline.BudgetLimits
+}
+```
+
+In `buildEngineOpts`:
+
+```go
+limits := resolveBudgetLimits(cfg, graph)
+if !limits.IsZero() {
+	opts = append(opts, pipeline.WithBudgetGuard(pipeline.NewBudgetGuard(limits)))
+}
+```
+
+Note: `buildEngineOpts` currently does not receive `graph`. Thread it: change the signature to `buildEngineOpts(cfg Config, graph *pipeline.Graph)` and update the one caller in `buildEngine`.
+
+Add `resolveBudgetLimits`:
+
+```go
+// resolveBudgetLimits returns Config.Budget merged with graph attrs.
+// Config.Budget wins field-by-field; graph attrs fill in the gaps.
+func resolveBudgetLimits(cfg Config, graph *pipeline.Graph) pipeline.BudgetLimits {
+	limits := cfg.Budget
+	if limits.MaxTotalTokens == 0 {
+		limits.MaxTotalTokens = atoiAttr(graph.Attrs["max_total_tokens"])
+	}
+	if limits.MaxCostCents == 0 {
+		limits.MaxCostCents = atoiAttr(graph.Attrs["max_cost_cents"])
+	}
+	if limits.MaxWallTime == 0 {
+		if d, err := time.ParseDuration(graph.Attrs["max_wall_time"]); err == nil {
+			limits.MaxWallTime = d
+		}
+	}
+	return limits
+}
+
+func atoiAttr(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+```
+
+- [ ] **Step 4: Pass through in `Run`**
+
+After `engineResult, err := e.inner.Run(ctx)`, if `engineResult.Status == pipeline.OutcomeBudgetExceeded`, copy `engineResult.BudgetLimitsHit` into `result.Cost.LimitsHit` (handled in Task 3 — verify the field name matches).
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test . -run TestRun_Budget -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tracker.go tracker_budget_test.go
+git commit -m "feat(tracker): Config.Budget and graph-attr fallback wire BudgetGuard"
+```
+
+**Acceptance gate:**
+- Library consumers can set `Config.Budget = pipeline.BudgetLimits{...}` and see the run halt.
+- A `.dip` file with `max_total_tokens: 1000` halts without any CLI flag or Config field.
+- `Result.Cost.LimitsHit` identifies which limit was hit.
+
+---
+
+## Task 8: CLI flags `--max-tokens --max-cost --max-wall-time`
+
+**Files:**
+- Modify: `cmd/tracker/run.go`
+- Modify: `cmd/tracker/summary.go`
+- Test: `cmd/tracker/main_test.go` (CLI smoke test)
+
+- [ ] **Step 1: Add flags**
+
+In `cmd/tracker/run.go`, add:
+
+```go
+var (
+	maxTokensFlag   int
+	maxCostCents    int
+	maxWallTimeFlag time.Duration
+)
+
+// in flag registration:
+runCmd.Flags().IntVar(&maxTokensFlag, "max-tokens", 0, "halt if total tokens exceed this value")
+runCmd.Flags().IntVar(&maxCostCents, "max-cost", 0, "halt if total cost (cents) exceeds this value")
+runCmd.Flags().DurationVar(&maxWallTimeFlag, "max-wall-time", 0, "halt if pipeline wall time exceeds this duration")
+```
+
+Wire into `Config.Budget` before calling `tracker.Run`.
+
+- [ ] **Step 2: Summary output**
+
+In `cmd/tracker/summary.go`, after the existing totals block, if `result.Cost != nil && len(result.Cost.LimitsHit) > 0`, print:
+
+```
+HALTED: budget exceeded (tokens)
+  spent: 1,250 tokens, $0.04
+  limit: 1,000 tokens
+```
+
+Keep it a single paragraph, styled consistently with existing error sections.
+
+- [ ] **Step 3: Smoke test**
+
+Add to `cmd/tracker/main_test.go` a subtest that invokes the CLI with `--max-tokens=10` against a stub pipeline (or skips if the harness doesn't support stub LLMs — fall back to `go test -run TestRun_Budget` in the library as the authoritative gate).
+
+- [ ] **Step 4: Build and run**
+
+Run: `go build ./... && go test ./cmd/tracker/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/tracker/run.go cmd/tracker/summary.go cmd/tracker/main_test.go
+git commit -m "feat(cli): --max-tokens --max-cost --max-wall-time flags"
+```
+
+**Acceptance gate:**
+- `tracker run foo.dip --max-tokens 10` halts and prints the budget-halt summary.
+- `tracker run foo.dip` unchanged (no flags = no limits).
+
+---
+
+## Task 9: `tracker diagnose` surfaces budget halts
+
+**Files:**
+- Modify: `cmd/tracker/diagnose.go`
+- Test: manual verification (diagnose reads from disk artifacts)
+
+- [ ] **Step 1: Add branch**
+
+In `diagnose.go`, find the status-based branching logic. Add a case for `status == "budget_exceeded"` that prints:
+
+```
+Budget halt detected
+  reason: <first entry of BudgetLimitsHit>
+  suggestion: raise the relevant --max-* flag or remove the graph attr
+```
+
+- [ ] **Step 2: Manual test**
+
+Run: `tracker run examples/ask_and_execute.dip --max-tokens 10 || true` then `tracker diagnose`
+Expected: The diagnose output names the budget halt.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/tracker/diagnose.go
+git commit -m "feat(diagnose): surface budget halts distinctly"
+```
+
+**Acceptance gate:**
+- A run halted by budget yields a diagnose section that names the breach kind.
+
+---
+
+## Task 10: Docs + CHANGELOG + CLAUDE.md
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `README.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: CHANGELOG**
+
+Add under an `## [Unreleased]` → `### Added` section:
+
+```
+### Added
+- `Result.Cost` on the library API with per-provider rollup and total USD (closes #62).
+- `pipeline.BudgetGuard` enforcing `max_total_tokens`, `max_cost_cents`, `max_wall_time`. Configurable via `Config.Budget`, `.dip` graph attrs, or `--max-tokens / --max-cost / --max-wall-time` flags (closes #17).
+- New pipeline events `cost_updated` and `budget_exceeded` for streaming consumers.
+```
+
+- [ ] **Step 2: README section**
+
+Add a "Cost governance" subsection showing both consumer usage of `result.Cost.ByProvider` and a `.dip` snippet with `max_cost_cents: 500`.
+
+- [ ] **Step 3: CLAUDE.md note**
+
+Append to the "Token usage flows through three layers" section:
+
+```
+As of v0.17.0, `UsageSummary.ProviderTotals` carries the per-provider rollup, and `Result.Cost` on the library API exposes dollar cost. A `pipeline.BudgetGuard` evaluated between nodes halts the run with `OutcomeBudgetExceeded` when any configured limit is breached; see `pipeline/budget.go`.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md README.md CLAUDE.md
+git commit -m "docs: cost governance — Result.Cost, BudgetGuard, and flags"
+```
+
+**Acceptance gate:**
+- CHANGELOG entry references both issues.
+- README shows at least one working snippet.
+- CLAUDE.md mentions `BudgetGuard` and `ProviderTotals`.
+
+---
+
+## Task 11: Full pre-PR verification
+
+- [ ] **Step 1: Build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 2: Full test**
+
+Run: `go test ./... -short`
+Expected: all 14+ packages pass.
+
+- [ ] **Step 3: Dippin doctor on all examples**
+
+Run: `dippin doctor examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip`
+Expected: A grade across the board.
+
+- [ ] **Step 4: Smoke test a real run with a low budget**
+
+Run: `tracker run examples/ask_and_execute.dip --max-tokens 1 || true`
+Expected: Exits with budget halt; `tracker diagnose` names it.
+
+- [ ] **Step 5: Smoke test a real run without budget**
+
+Run: `tracker run examples/ask_and_execute.dip`
+Expected: Normal completion; CLI summary shows per-provider cost rollup.
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push -u origin feat/token-cost-governance
+```
+
+**Acceptance gate (hard blockers for PR):**
+1. `go build ./...` — zero errors.
+2. `go test ./... -short` — zero failures.
+3. `dippin doctor` — A on every shipped example.
+4. Hooks pass without `--no-verify`.
+5. A budget-exceeded run halts with `OutcomeBudgetExceeded` and a populated `Result.Cost.LimitsHit`.
+6. A normal run's `Result.Cost.ByProvider` is non-empty and `TotalUSD > 0` whenever any LLM call was made.
+7. Three or more `EventCostUpdated` events are observable on a 3-node pipeline.
+8. CHANGELOG, README, CLAUDE.md all updated.
+
+---
+
+## Task 12: Open the PR
+
+- [ ] **Step 1: Create PR**
+
+```bash
+gh pr create --title "feat: token & cost governance (library exposure + pipeline ceilings)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Expose per-provider token and cost data on `Result.Cost` in the library API (closes #62)
+- Enforce `max_total_tokens`, `max_cost_cents`, `max_wall_time` via `BudgetGuard` (closes #17)
+- Stream `cost_updated` events for real-time consumer dashboards
+- CLI flags `--max-tokens --max-cost --max-wall-time` and graph-attr equivalents
+
+## Test plan
+- [ ] `go test ./... -short`
+- [ ] `dippin doctor` on all shipped examples
+- [ ] Manual: `tracker run examples/ask_and_execute.dip --max-tokens 1` halts with budget error
+- [ ] Manual: `tracker diagnose` after a budget halt surfaces the breach kind
+- [ ] Manual: `tracker run examples/ask_and_execute.dip` prints per-provider cost rollup
+
+Closes #62
+Closes #17
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Report URL to user**
+
+---
+
+## Self-review notes
+
+- Every task ships runnable code with tests and a commit.
+- Types used after Task 2 (`ProviderUsage`, `UsageSummary.ProviderTotals`) are defined there.
+- Types used after Task 5 (`BudgetLimits`, `BudgetGuard`, `OutcomeBudgetExceeded`, `EngineResult.BudgetLimitsHit`) are defined there.
+- `Result.Cost` is introduced in Task 3 and extended in Task 7; field name `LimitsHit` is consistent.
+- `EventCostUpdated` emission (Task 4) and `BudgetGuard` check (Task 5, Step 6) share the same call site — the check runs immediately after the emit to ensure the latest snapshot is evaluated.
+- Pricing comes from `llm.EstimateCost` (already present) — no new pricing table is introduced; if models are missing from `llm/pricing.go`, that's a separate change and out of scope.
+- #62 asked for real-time updates, per-provider breakdowns, and accurate cost; all three are addressed (Tasks 4, 2/3, and the reuse of `EstimateCost`).
+- #17 asked for aggregate token cap, cost ceiling, wall-time timeout, and a circuit breaker; all four are in `BudgetLimits` + `BudgetGuard`.

--- a/llm/token_tracker_cost.go
+++ b/llm/token_tracker_cost.go
@@ -1,0 +1,45 @@
+// ABOUTME: Per-provider cost rollup for the TokenTracker middleware.
+// ABOUTME: Maps accumulated Usage to dollar cost via a caller-supplied model resolver.
+package llm
+
+// ProviderCost is the per-provider cost rollup returned by TokenTracker.CostByProvider.
+type ProviderCost struct {
+	Usage Usage
+	Model string
+	USD   float64
+}
+
+// ModelResolver returns the model name that should be used for cost estimation
+// for a given provider. Return "" when unknown — the entry is still included
+// in the result with USD=0.
+type ModelResolver func(provider string) string
+
+// CostByProvider returns a per-provider cost rollup, resolving each provider's
+// model via the caller-supplied resolver and pricing it via EstimateCost.
+// A nil resolver is treated as one that always returns "".
+func (t *TokenTracker) CostByProvider(resolve ModelResolver) map[string]ProviderCost {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	out := make(map[string]ProviderCost, len(t.usage))
+	for provider, usage := range t.usage {
+		var model string
+		if resolve != nil {
+			model = resolve(provider)
+		}
+		out[provider] = ProviderCost{
+			Usage: usage,
+			Model: model,
+			USD:   EstimateCost(model, usage),
+		}
+	}
+	return out
+}
+
+// TotalCostUSD sums CostByProvider to a single dollar figure using the same resolver.
+func (t *TokenTracker) TotalCostUSD(resolve ModelResolver) float64 {
+	var total float64
+	for _, pc := range t.CostByProvider(resolve) {
+		total += pc.USD
+	}
+	return total
+}

--- a/llm/token_tracker_cost_test.go
+++ b/llm/token_tracker_cost_test.go
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for TokenTracker per-provider cost rollup.
+// ABOUTME: Verifies CostByProvider resolves models via the caller callback and prices via EstimateCost.
+package llm
+
+import (
+	"testing"
+)
+
+func TestTokenTracker_CostByProvider(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("anthropic", Usage{InputTokens: 1_000_000, OutputTokens: 500_000})
+	tr.AddUsage("openai", Usage{InputTokens: 2_000_000, OutputTokens: 1_000_000})
+
+	resolver := func(provider string) string {
+		switch provider {
+		case "anthropic":
+			return "claude-sonnet-4-6"
+		case "openai":
+			return "gpt-4o"
+		}
+		return ""
+	}
+
+	breakdown := tr.CostByProvider(resolver)
+
+	// 1M anthropic input @ $3 + 0.5M output @ $15 = 3 + 7.5 = 10.50
+	if got := breakdown["anthropic"].USD; got < 10.49 || got > 10.51 {
+		t.Errorf("anthropic cost: got %.4f, want 10.50", got)
+	}
+	// 2M openai input @ $2.50 + 1M output @ $10 = 5 + 10 = 15.00
+	if got := breakdown["openai"].USD; got < 14.99 || got > 15.01 {
+		t.Errorf("openai cost: got %.4f, want 15.00", got)
+	}
+	if breakdown["anthropic"].Model != "claude-sonnet-4-6" {
+		t.Errorf("anthropic model = %q", breakdown["anthropic"].Model)
+	}
+	if breakdown["openai"].Usage.InputTokens != 2_000_000 {
+		t.Errorf("openai usage input = %d", breakdown["openai"].Usage.InputTokens)
+	}
+}
+
+func TestTokenTracker_CostByProvider_UnknownModel(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("mystery", Usage{InputTokens: 10_000, OutputTokens: 5_000})
+
+	breakdown := tr.CostByProvider(func(string) string { return "" })
+	if breakdown["mystery"].USD != 0 {
+		t.Errorf("unknown model should yield $0, got %.4f", breakdown["mystery"].USD)
+	}
+	if _, ok := breakdown["mystery"]; !ok {
+		t.Errorf("unknown-model provider should still appear in map")
+	}
+}
+
+func TestTokenTracker_TotalCostUSD(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("anthropic", Usage{InputTokens: 1_000_000, OutputTokens: 500_000})
+	tr.AddUsage("openai", Usage{InputTokens: 2_000_000, OutputTokens: 1_000_000})
+
+	resolver := func(provider string) string {
+		switch provider {
+		case "anthropic":
+			return "claude-sonnet-4-6"
+		case "openai":
+			return "gpt-4o"
+		}
+		return ""
+	}
+
+	total := tr.TotalCostUSD(resolver)
+	// 10.50 + 15.00 = 25.50
+	if total < 25.49 || total > 25.51 {
+		t.Errorf("total = %.4f, want 25.50", total)
+	}
+}
+
+func TestTokenTracker_CostByProvider_NilResolver(t *testing.T) {
+	tr := NewTokenTracker()
+	tr.AddUsage("anthropic", Usage{InputTokens: 1000, OutputTokens: 500})
+
+	breakdown := tr.CostByProvider(nil)
+	if breakdown["anthropic"].USD != 0 {
+		t.Errorf("nil resolver should yield $0, got %.4f", breakdown["anthropic"].USD)
+	}
+}

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -2,7 +2,10 @@
 // ABOUTME: Halts execution with OutcomeBudgetExceeded when any configured limit is breached.
 package pipeline
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // BudgetLimits configures hard ceilings for a pipeline run.
 // A zero-value field means "no limit" for that dimension.
@@ -89,7 +92,7 @@ func (g *BudgetGuard) checkUsage(usage *UsageSummary) BudgetBreach {
 	if g.limits.MaxTotalTokens > 0 && usage.TotalTokens > g.limits.MaxTotalTokens {
 		return BudgetBreach{Kind: BudgetTokens, Message: "max_total_tokens exceeded"}
 	}
-	if g.limits.MaxCostCents > 0 && int(usage.TotalCostUSD*100) > g.limits.MaxCostCents {
+	if g.limits.MaxCostCents > 0 && int(math.Round(usage.TotalCostUSD*100)) > g.limits.MaxCostCents {
 		return BudgetBreach{Kind: BudgetCost, Message: "max_cost_cents exceeded"}
 	}
 	return BudgetBreach{Kind: BudgetOK}

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -1,0 +1,96 @@
+// ABOUTME: Pipeline-level token, cost, and wall-time ceilings enforced between nodes.
+// ABOUTME: Halts execution with OutcomeBudgetExceeded when any configured limit is breached.
+package pipeline
+
+import "time"
+
+// BudgetLimits configures hard ceilings for a pipeline run.
+// A zero-value field means "no limit" for that dimension.
+type BudgetLimits struct {
+	MaxTotalTokens int
+	MaxCostCents   int
+	MaxWallTime    time.Duration
+}
+
+// IsZero reports whether every limit is unset.
+func (l BudgetLimits) IsZero() bool {
+	return l.MaxTotalTokens == 0 && l.MaxCostCents == 0 && l.MaxWallTime == 0
+}
+
+// BudgetBreachKind classifies which limit was hit.
+type BudgetBreachKind int
+
+const (
+	BudgetOK BudgetBreachKind = iota
+	BudgetTokens
+	BudgetCost
+	BudgetWallTime
+)
+
+// String returns a human-readable label for a breach kind.
+// Used as the halt reason in EngineResult.BudgetLimitsHit.
+func (k BudgetBreachKind) String() string {
+	switch k {
+	case BudgetTokens:
+		return "tokens"
+	case BudgetCost:
+		return "cost"
+	case BudgetWallTime:
+		return "wall_time"
+	default:
+		return "ok"
+	}
+}
+
+// BudgetBreach describes the outcome of a guard check.
+type BudgetBreach struct {
+	Kind    BudgetBreachKind
+	Message string
+}
+
+// BudgetGuard evaluates BudgetLimits against a UsageSummary snapshot and a run
+// start time. The zero value is not usable; construct via NewBudgetGuard.
+type BudgetGuard struct {
+	limits BudgetLimits
+}
+
+// NewBudgetGuard constructs a BudgetGuard with the given limits. Returns nil
+// when limits.IsZero() so callers can use the nil-guard pattern to skip checks
+// when no limits are configured.
+func NewBudgetGuard(limits BudgetLimits) *BudgetGuard {
+	if limits.IsZero() {
+		return nil
+	}
+	return &BudgetGuard{limits: limits}
+}
+
+// Check reports whether the given usage snapshot breaches any configured
+// limit. A nil guard and a nil usage are both safe and return BudgetOK.
+// Token and cost ceilings are inclusive — the exact limit is not a breach.
+func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach {
+	if g == nil {
+		return BudgetBreach{Kind: BudgetOK}
+	}
+	if breach := g.checkUsage(usage); breach.Kind != BudgetOK {
+		return breach
+	}
+	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
+		return BudgetBreach{Kind: BudgetWallTime, Message: "max_wall_time exceeded"}
+	}
+	return BudgetBreach{Kind: BudgetOK}
+}
+
+// checkUsage evaluates token and cost limits against a usage snapshot.
+// Returns BudgetOK when usage is nil or no limit is breached.
+func (g *BudgetGuard) checkUsage(usage *UsageSummary) BudgetBreach {
+	if usage == nil {
+		return BudgetBreach{Kind: BudgetOK}
+	}
+	if g.limits.MaxTotalTokens > 0 && usage.TotalTokens > g.limits.MaxTotalTokens {
+		return BudgetBreach{Kind: BudgetTokens, Message: "max_total_tokens exceeded"}
+	}
+	if g.limits.MaxCostCents > 0 && int(usage.TotalCostUSD*100) > g.limits.MaxCostCents {
+		return BudgetBreach{Kind: BudgetCost, Message: "max_cost_cents exceeded"}
+	}
+	return BudgetBreach{Kind: BudgetOK}
+}

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -3,6 +3,7 @@
 package pipeline
 
 import (
+	"math"
 	"testing"
 	"time"
 )
@@ -67,5 +68,17 @@ func TestBudgetGuard_NilUsageHandled(t *testing.T) {
 	breach := g.Check(nil, time.Now())
 	if breach.Kind != BudgetOK {
 		t.Errorf("nil usage should be safe, got %v", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_CostCeiling_RoundsBoundaryValue(t *testing.T) {
+	// The largest float64 strictly less than 0.51, when scaled by 100, yields
+	// 50.9999... which naive truncation would read as 50¢ (missing the breach
+	// on a 50¢ ceiling). Math.Round correctly reads it as 51¢.
+	justBelow := math.Nextafter(0.51, 0)
+	g := NewBudgetGuard(BudgetLimits{MaxCostCents: 50})
+	breach := g.Check(&UsageSummary{TotalCostUSD: justBelow}, time.Now())
+	if breach.Kind != BudgetCost {
+		t.Errorf("cost %.20f should breach 50¢ ceiling after rounding, got %v", justBelow, breach.Kind)
 	}
 }

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -1,0 +1,71 @@
+// ABOUTME: Tests for BudgetGuard — pipeline-level token, cost, and wall-time ceilings.
+// ABOUTME: Verifies each limit dimension fires independently and nil-guard is a no-op.
+package pipeline
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBudgetGuard_UnderLimits(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000, MaxCostCents: 100, MaxWallTime: time.Minute})
+	breach := g.Check(&UsageSummary{TotalTokens: 500, TotalCostUSD: 0.25}, time.Now())
+	if breach.Kind != BudgetOK {
+		t.Errorf("got breach %v, want BudgetOK", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_TokenCeiling(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000})
+	breach := g.Check(&UsageSummary{TotalTokens: 1001}, time.Now())
+	if breach.Kind != BudgetTokens {
+		t.Errorf("got %v, want BudgetTokens", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_ExactTokenCeilingInclusive(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000})
+	breach := g.Check(&UsageSummary{TotalTokens: 1000}, time.Now())
+	if breach.Kind != BudgetOK {
+		t.Errorf("exact limit should be OK (inclusive), got %v", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_CostCeiling(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxCostCents: 50})
+	breach := g.Check(&UsageSummary{TotalCostUSD: 0.51}, time.Now())
+	if breach.Kind != BudgetCost {
+		t.Errorf("got %v, want BudgetCost", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_WallTime(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxWallTime: 10 * time.Millisecond})
+	started := time.Now().Add(-time.Second)
+	breach := g.Check(&UsageSummary{}, started)
+	if breach.Kind != BudgetWallTime {
+		t.Errorf("got %v, want BudgetWallTime", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_NilGuardNoOp(t *testing.T) {
+	var g *BudgetGuard
+	if g.Check(&UsageSummary{TotalTokens: 999_999}, time.Now()).Kind != BudgetOK {
+		t.Errorf("nil guard should always return BudgetOK")
+	}
+}
+
+func TestBudgetGuard_NilLimitsYieldsNilGuard(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{})
+	if g != nil {
+		t.Errorf("NewBudgetGuard with zero limits should return nil")
+	}
+}
+
+func TestBudgetGuard_NilUsageHandled(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000, MaxCostCents: 50})
+	breach := g.Check(nil, time.Now())
+	if breach.Kind != BudgetOK {
+		t.Errorf("nil usage should be safe, got %v", breach.Kind)
+	}
+}

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -508,6 +508,56 @@ func TestFromDippinIR_WorkflowDefaults(t *testing.T) {
 	}
 }
 
+// TestAdapter_BudgetAttrsPassThrough verifies that workflow-level budget attrs
+// (max_total_tokens, max_cost_cents, max_wall_time) are passed through from
+// IR WorkflowDefaults to graph.Attrs when present, enabling Task 7 to read them
+// via graph.Attrs["max_total_tokens"] etc. without further mapping.
+//
+// NOTE: This test documents the expected behavior for when dippin-lang adds
+// these fields to WorkflowDefaults. Currently (v0.18.0), the fields don't exist
+// on the IR struct, so this test uses a manual graph construction to verify the
+// adapter would handle them correctly if they existed.
+func TestAdapter_BudgetAttrsPassThrough(t *testing.T) {
+	// Since ir.WorkflowDefaults doesn't have these fields yet, we directly
+	// construct a Graph as the adapter would produce if they did exist.
+	// This documents the contract: when dippin-lang v0.x+ adds:
+	//   MaxTotalTokens int
+	//   MaxCostCents   int
+	//   MaxWallTime    string
+	// The extractWorkflowDefaults function should map them like:
+	//   attrs["max_total_tokens"] = strconv.Itoa(defaults.MaxTotalTokens)
+	//   attrs["max_cost_cents"] = strconv.Itoa(defaults.MaxCostCents)
+	//   attrs["max_wall_time"] = defaults.MaxWallTime
+
+	// Simulate what the adapter would produce
+	g := &Graph{
+		Name:      "BudgetTest",
+		StartNode: "start",
+		ExitNode:  "exit",
+		Attrs: map[string]string{
+			"max_total_tokens": "50000",
+			"max_cost_cents":   "250",
+			"max_wall_time":    "10m",
+		},
+		Nodes: make(map[string]*Node),
+		Edges: []*Edge{},
+	}
+	g.Nodes["start"] = &Node{ID: "start", Shape: "Mdiamond", Handler: "start", Attrs: make(map[string]string)}
+	g.Nodes["exit"] = &Node{ID: "exit", Shape: "Msquare", Handler: "exit", Attrs: make(map[string]string)}
+	g.Edges = append(g.Edges, &Edge{From: "start", To: "exit"})
+
+	// Verify the attrs land in graph.Attrs with exact keys
+	if g.Attrs["max_total_tokens"] != "50000" {
+		t.Errorf("attrs[max_total_tokens] = %q, want %q", g.Attrs["max_total_tokens"], "50000")
+	}
+	if g.Attrs["max_cost_cents"] != "250" {
+		t.Errorf("attrs[max_cost_cents] = %q, want %q", g.Attrs["max_cost_cents"], "250")
+	}
+	if g.Attrs["max_wall_time"] != "10m" {
+		t.Errorf("attrs[max_wall_time] = %q, want %q", g.Attrs["max_wall_time"], "10m")
+	}
+}
+
 // TestFromDippinIR_EdgeConditions verifies edge conditions are preserved as raw strings.
 func TestFromDippinIR_EdgeConditions(t *testing.T) {
 	workflow := &ir.Workflow{

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -508,56 +508,6 @@ func TestFromDippinIR_WorkflowDefaults(t *testing.T) {
 	}
 }
 
-// TestAdapter_BudgetAttrsPassThrough verifies that workflow-level budget attrs
-// (max_total_tokens, max_cost_cents, max_wall_time) are passed through from
-// IR WorkflowDefaults to graph.Attrs when present, enabling Task 7 to read them
-// via graph.Attrs["max_total_tokens"] etc. without further mapping.
-//
-// NOTE: This test documents the expected behavior for when dippin-lang adds
-// these fields to WorkflowDefaults. Currently (v0.18.0), the fields don't exist
-// on the IR struct, so this test uses a manual graph construction to verify the
-// adapter would handle them correctly if they existed.
-func TestAdapter_BudgetAttrsPassThrough(t *testing.T) {
-	// Since ir.WorkflowDefaults doesn't have these fields yet, we directly
-	// construct a Graph as the adapter would produce if they did exist.
-	// This documents the contract: when dippin-lang v0.x+ adds:
-	//   MaxTotalTokens int
-	//   MaxCostCents   int
-	//   MaxWallTime    string
-	// The extractWorkflowDefaults function should map them like:
-	//   attrs["max_total_tokens"] = strconv.Itoa(defaults.MaxTotalTokens)
-	//   attrs["max_cost_cents"] = strconv.Itoa(defaults.MaxCostCents)
-	//   attrs["max_wall_time"] = defaults.MaxWallTime
-
-	// Simulate what the adapter would produce
-	g := &Graph{
-		Name:      "BudgetTest",
-		StartNode: "start",
-		ExitNode:  "exit",
-		Attrs: map[string]string{
-			"max_total_tokens": "50000",
-			"max_cost_cents":   "250",
-			"max_wall_time":    "10m",
-		},
-		Nodes: make(map[string]*Node),
-		Edges: []*Edge{},
-	}
-	g.Nodes["start"] = &Node{ID: "start", Shape: "Mdiamond", Handler: "start", Attrs: make(map[string]string)}
-	g.Nodes["exit"] = &Node{ID: "exit", Shape: "Msquare", Handler: "exit", Attrs: make(map[string]string)}
-	g.Edges = append(g.Edges, &Edge{From: "start", To: "exit"})
-
-	// Verify the attrs land in graph.Attrs with exact keys
-	if g.Attrs["max_total_tokens"] != "50000" {
-		t.Errorf("attrs[max_total_tokens] = %q, want %q", g.Attrs["max_total_tokens"], "50000")
-	}
-	if g.Attrs["max_cost_cents"] != "250" {
-		t.Errorf("attrs[max_cost_cents] = %q, want %q", g.Attrs["max_cost_cents"], "250")
-	}
-	if g.Attrs["max_wall_time"] != "10m" {
-		t.Errorf("attrs[max_wall_time] = %q, want %q", g.Attrs["max_wall_time"], "10m")
-	}
-}
-
 // TestFromDippinIR_EdgeConditions verifies edge conditions are preserved as raw strings.
 func TestFromDippinIR_EdgeConditions(t *testing.T) {
 	workflow := &ir.Workflow{

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -296,6 +296,7 @@ func (e *Engine) advanceToNextNode(s *runState, currentNodeID string, traceEntry
 
 	traceEntry.EdgeTo = next.To
 	s.trace.AddEntry(*traceEntry)
+	e.emitCostUpdate(s)
 	s.cp.SetEdgeSelection(currentNodeID, next.To)
 
 	if s.cp.IsCompleted(next.To) {

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -13,13 +13,17 @@ import (
 
 // EngineResult holds the final outcome of a pipeline execution run.
 type EngineResult struct {
-	RunID          string
-	Status         string
-	CompletedNodes []string
-	Context        map[string]string
-	Trace          *Trace
-	Usage          *UsageSummary
+	RunID           string
+	Status          string
+	CompletedNodes  []string
+	Context         map[string]string
+	Trace           *Trace
+	Usage           *UsageSummary
+	BudgetLimitsHit []string // populated when a BudgetGuard halted the run
 }
+
+// OutcomeBudgetExceeded signals that a BudgetGuard halted the run.
+const OutcomeBudgetExceeded = "budget_exceeded"
 
 // Engine executes a pipeline graph by traversing nodes, dispatching handlers,
 // selecting edges, and managing retries and checkpoints.
@@ -31,6 +35,7 @@ type Engine struct {
 	resolveStylesheet bool
 	initialContext    map[string]string
 	artifactDir       string
+	budgetGuard       *BudgetGuard
 }
 
 // EngineOption configures optional Engine behavior.
@@ -71,6 +76,12 @@ func WithInitialContext(ctx map[string]string) EngineOption {
 	return func(e *Engine) {
 		e.initialContext = ctx
 	}
+}
+
+// WithBudgetGuard attaches a BudgetGuard evaluated after every terminal
+// node outcome. Nil guards are no-ops.
+func WithBudgetGuard(guard *BudgetGuard) EngineOption {
+	return func(e *Engine) { e.budgetGuard = guard }
 }
 
 // NewEngine creates a pipeline engine for the given graph and handler registry.
@@ -297,6 +308,9 @@ func (e *Engine) advanceToNextNode(s *runState, currentNodeID string, traceEntry
 	traceEntry.EdgeTo = next.To
 	s.trace.AddEntry(*traceEntry)
 	e.emitCostUpdate(s)
+	if lr := e.checkBudgetAfterEmit(s); lr != nil {
+		return *lr
+	}
 	s.cp.SetEdgeSelection(currentNodeID, next.To)
 
 	if s.cp.IsCompleted(next.To) {

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -86,6 +86,10 @@ func NewEngine(graph *Graph, registry *HandlerRegistry, opts ...EngineOption) *E
 	return e
 }
 
+// Graph returns the graph this engine executes. Used by library callers
+// that need to inspect graph attributes after construction.
+func (e *Engine) Graph() *Graph { return e.graph }
+
 // loopAction tells the main loop what to do after processing a node.
 type loopAction int
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -31,6 +31,64 @@ func (e *Engine) emitCostUpdate(s *runState) {
 	})
 }
 
+// haltForBudget produces the terminal loopResult emitted when a BudgetGuard
+// trips. It sets the trace end time, emits EventBudgetExceeded, and packages
+// an EngineResult with Status=OutcomeBudgetExceeded and BudgetLimitsHit.
+func (e *Engine) haltForBudget(s *runState, breach BudgetBreach) loopResult {
+	s.trace.EndTime = time.Now()
+	e.emit(PipelineEvent{
+		Type:      EventBudgetExceeded,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		Message:   breach.Message,
+		Cost: func() *CostSnapshot {
+			summary := s.trace.AggregateUsage()
+			if summary == nil {
+				return nil
+			}
+			return &CostSnapshot{
+				TotalTokens:    summary.TotalTokens,
+				TotalCostUSD:   summary.TotalCostUSD,
+				ProviderTotals: summary.ProviderTotals,
+				WallElapsed:    time.Since(s.trace.StartTime),
+			}
+		}(),
+	})
+	return loopResult{
+		action: loopReturn,
+		result: &EngineResult{
+			RunID:           s.runID,
+			Status:          OutcomeBudgetExceeded,
+			CompletedNodes:  s.cp.CompletedNodes,
+			Context:         s.pctx.Snapshot(),
+			Trace:           s.trace,
+			Usage:           s.trace.AggregateUsage(),
+			BudgetLimitsHit: []string{breach.Kind.String()},
+		},
+	}
+}
+
+// checkBudgetAfterEmit runs the BudgetGuard against the current aggregate
+// usage. Returns a non-nil loopResult when a breach halts the run, or nil
+// to continue.
+func (e *Engine) checkBudgetAfterEmit(s *runState) *loopResult {
+	breach := e.budgetGuard.Check(s.trace.AggregateUsage(), s.trace.StartTime)
+	if breach.Kind == BudgetOK {
+		return nil
+	}
+	lr := e.haltForBudget(s, breach)
+	return &lr
+}
+
+// checkBudgetHaltForExit is a thin wrapper used by handleExitNode, which has
+// a different return signature from advanceToNextNode.
+func (e *Engine) checkBudgetHaltForExit(s *runState) *EngineResult {
+	if lr := e.checkBudgetAfterEmit(s); lr != nil {
+		return lr.result
+	}
+	return nil
+}
+
 // runState holds per-run mutable state threaded through the main loop.
 type runState struct {
 	runID        string
@@ -497,6 +555,9 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 	}
 	s.trace.AddEntry(*traceEntry)
 	e.emitCostUpdate(s)
+	if halt := e.checkBudgetHaltForExit(s); halt != nil {
+		return false, "", halt
+	}
 	return true, "", nil
 }
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -32,9 +32,11 @@ func (e *Engine) emitCostUpdate(s *runState) {
 }
 
 // haltForBudget produces the terminal loopResult emitted when a BudgetGuard
-// trips. It sets the trace end time, emits EventBudgetExceeded, and packages
+// trips. It saves the checkpoint (so restarts skip already-completed nodes),
+// sets the trace end time, emits EventBudgetExceeded, and packages
 // an EngineResult with Status=OutcomeBudgetExceeded and BudgetLimitsHit.
 func (e *Engine) haltForBudget(s *runState, breach BudgetBreach) loopResult {
+	e.saveCheckpoint(s.cp, s.pctx, s.runID)
 	s.trace.EndTime = time.Now()
 	summary := s.trace.AggregateUsage()
 	var costSnap *CostSnapshot
@@ -421,6 +423,10 @@ func (e *Engine) handleRetryWithinBudget(ctx context.Context, s *runState, curre
 	}
 	traceEntry.EdgeTo = target
 	s.trace.AddEntry(*traceEntry)
+	e.emitCostUpdate(s)
+	if lr := e.checkBudgetAfterEmit(s); lr != nil {
+		return "", false, lr.result, nil
+	}
 	e.clearDownstream(target, s.cp)
 	s.cp.CurrentNode = target
 	e.saveCheckpoint(s.cp, s.pctx, s.runID)

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -10,6 +10,27 @@ import (
 	"time"
 )
 
+// emitCostUpdate emits an EventCostUpdated carrying the current aggregate
+// usage from the trace. Safe to call when no LLM activity has occurred yet —
+// AggregateUsage returns nil and the event is suppressed.
+func (e *Engine) emitCostUpdate(s *runState) {
+	summary := s.trace.AggregateUsage()
+	if summary == nil {
+		return
+	}
+	e.emit(PipelineEvent{
+		Type:      EventCostUpdated,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		Cost: &CostSnapshot{
+			TotalTokens:    summary.TotalTokens,
+			TotalCostUSD:   summary.TotalCostUSD,
+			ProviderTotals: summary.ProviderTotals,
+			WallElapsed:    time.Since(s.trace.StartTime),
+		},
+	})
+}
+
 // runState holds per-run mutable state threaded through the main loop.
 type runState struct {
 	runID        string
@@ -475,6 +496,7 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 		return false, "", result
 	}
 	s.trace.AddEntry(*traceEntry)
+	e.emitCostUpdate(s)
 	return true, "", nil
 }
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -36,23 +36,22 @@ func (e *Engine) emitCostUpdate(s *runState) {
 // an EngineResult with Status=OutcomeBudgetExceeded and BudgetLimitsHit.
 func (e *Engine) haltForBudget(s *runState, breach BudgetBreach) loopResult {
 	s.trace.EndTime = time.Now()
+	summary := s.trace.AggregateUsage()
+	var costSnap *CostSnapshot
+	if summary != nil {
+		costSnap = &CostSnapshot{
+			TotalTokens:    summary.TotalTokens,
+			TotalCostUSD:   summary.TotalCostUSD,
+			ProviderTotals: summary.ProviderTotals,
+			WallElapsed:    time.Since(s.trace.StartTime),
+		}
+	}
 	e.emit(PipelineEvent{
 		Type:      EventBudgetExceeded,
 		Timestamp: time.Now(),
 		RunID:     s.runID,
 		Message:   breach.Message,
-		Cost: func() *CostSnapshot {
-			summary := s.trace.AggregateUsage()
-			if summary == nil {
-				return nil
-			}
-			return &CostSnapshot{
-				TotalTokens:    summary.TotalTokens,
-				TotalCostUSD:   summary.TotalCostUSD,
-				ProviderTotals: summary.ProviderTotals,
-				WallElapsed:    time.Since(s.trace.StartTime),
-			}
-		}(),
+		Cost:      costSnap,
 	})
 	return loopResult{
 		action: loopReturn,
@@ -62,7 +61,7 @@ func (e *Engine) haltForBudget(s *runState, breach BudgetBreach) loopResult {
 			CompletedNodes:  s.cp.CompletedNodes,
 			Context:         s.pctx.Snapshot(),
 			Trace:           s.trace,
-			Usage:           s.trace.AggregateUsage(),
+			Usage:           summary,
 			BudgetLimitsHit: []string{breach.Kind.String()},
 		},
 	}

--- a/pipeline/engine_test.go
+++ b/pipeline/engine_test.go
@@ -1248,3 +1248,86 @@ func TestEngine_EmitsCostUpdatedAfterEachNode(t *testing.T) {
 		}
 	}
 }
+
+func TestEngine_HaltsOnBudgetBreach(t *testing.T) {
+	// 5-node linear graph: start -> n1 -> n2 -> n3 -> end
+	// Each handler returns 300 tokens. Guard: MaxTotalTokens=700.
+	// After node n1 completes we have 600 total (start + n1), after n2 we have 900.
+	// The check fires after emitCostUpdate in advanceToNextNode, so halt occurs
+	// after n2's trace entry is committed (total 900 > 700).
+	g := NewGraph("budget_halt_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "n1", Shape: "box", Label: "N1"})
+	g.AddNode(&Node{ID: "n2", Shape: "box", Label: "N2"})
+	g.AddNode(&Node{ID: "n3", Shape: "box", Label: "N3"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+
+	g.AddEdge(&Edge{From: "start", To: "n1"})
+	g.AddEdge(&Edge{From: "n1", To: "n2"})
+	g.AddEdge(&Edge{From: "n2", To: "n3"})
+	g.AddEdge(&Edge{From: "n3", To: "end"})
+
+	nodeStats := &SessionStats{
+		InputTokens:  200,
+		OutputTokens: 100,
+		TotalTokens:  300,
+		CostUSD:      0.01,
+		Provider:     "test-provider",
+	}
+
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		n := name
+		reg.Register(&testHandler{name: n, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{Status: OutcomeSuccess, Stats: nodeStats}, nil
+		}})
+	}
+
+	var mu sync.Mutex
+	var budgetEvents []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		if evt.Type == EventBudgetExceeded {
+			mu.Lock()
+			budgetEvents = append(budgetEvents, evt)
+			mu.Unlock()
+		}
+	})
+
+	guard := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 700})
+	engine := NewEngine(g, reg,
+		WithPipelineEventHandler(handler),
+		WithBudgetGuard(guard),
+	)
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine.Run returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.Status != OutcomeBudgetExceeded {
+		t.Errorf("result.Status = %q, want %q", result.Status, OutcomeBudgetExceeded)
+	}
+
+	if len(result.BudgetLimitsHit) != 1 || result.BudgetLimitsHit[0] != "tokens" {
+		t.Errorf("BudgetLimitsHit = %v, want [\"tokens\"]", result.BudgetLimitsHit)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(budgetEvents) == 0 {
+		t.Error("expected at least one EventBudgetExceeded, got none")
+	}
+
+	// Pipeline must not have run to completion — n3 and end should not be completed.
+	completedSet := make(map[string]bool)
+	for _, n := range result.CompletedNodes {
+		completedSet[n] = true
+	}
+	if completedSet["n3"] || completedSet["end"] {
+		t.Errorf("pipeline should have halted before n3/end, CompletedNodes=%v", result.CompletedNodes)
+	}
+}

--- a/pipeline/engine_test.go
+++ b/pipeline/engine_test.go
@@ -1155,3 +1155,96 @@ func TestEngineResumeLoopingPipelineDoesNotInfiniteLoop(t *testing.T) {
 		t.Error("expected loop nodes to be re-executed, but none were")
 	}
 }
+
+func TestEngine_EmitsCostUpdatedAfterEachNode(t *testing.T) {
+	// 3-node linear graph: start -> middle -> end
+	g := NewGraph("cost_updated_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "middle", Shape: "box", Label: "Middle"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+
+	g.AddEdge(&Edge{From: "start", To: "middle"})
+	g.AddEdge(&Edge{From: "middle", To: "end"})
+
+	// All three nodes return SessionStats so AggregateUsage returns non-nil.
+	nodeStats := &SessionStats{
+		InputTokens:  100,
+		OutputTokens: 50,
+		TotalTokens:  150,
+		CostUSD:      0.01,
+		Provider:     "test-provider",
+	}
+
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		n := name
+		reg.Register(&testHandler{name: n, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{Status: OutcomeSuccess, Stats: nodeStats}, nil
+		}})
+	}
+
+	var mu sync.Mutex
+	var costEvents []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		if evt.Type == EventCostUpdated {
+			mu.Lock()
+			costEvents = append(costEvents, evt)
+			mu.Unlock()
+		}
+	})
+
+	engine := NewEngine(g, reg, WithPipelineEventHandler(handler))
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Fatalf("expected success, got %q", result.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(costEvents) < 3 {
+		t.Errorf("expected at least 3 EventCostUpdated events, got %d", len(costEvents))
+	}
+
+	// Each event must carry a non-nil Cost snapshot.
+	for i, evt := range costEvents {
+		if evt.Cost == nil {
+			t.Errorf("event %d has nil Cost", i)
+			continue
+		}
+		if evt.Cost.TotalTokens <= 0 {
+			t.Errorf("event %d has TotalTokens=%d, want > 0", i, evt.Cost.TotalTokens)
+		}
+	}
+
+	// TotalTokens must be monotonically non-decreasing.
+	for i := 1; i < len(costEvents); i++ {
+		prev := costEvents[i-1].Cost
+		curr := costEvents[i].Cost
+		if prev == nil || curr == nil {
+			continue
+		}
+		if curr.TotalTokens < prev.TotalTokens {
+			t.Errorf("event %d TotalTokens=%d < event %d TotalTokens=%d (not monotonically non-decreasing)",
+				i, curr.TotalTokens, i-1, prev.TotalTokens)
+		}
+	}
+
+	// Final event must have cumulative cost >= 3 * 0.01 = 0.03 (with tolerance).
+	if len(costEvents) > 0 {
+		last := costEvents[len(costEvents)-1]
+		if last.Cost == nil {
+			t.Fatal("last EventCostUpdated has nil Cost")
+		}
+		const wantMinCost = 0.03 - 1e-9
+		if last.Cost.TotalCostUSD < wantMinCost {
+			t.Errorf("final Cost.TotalCostUSD=%.6f, want >= %.6f", last.Cost.TotalCostUSD, wantMinCost)
+		}
+		if last.Cost.WallElapsed <= 0 {
+			t.Errorf("final Cost.WallElapsed=%v, want > 0", last.Cost.WallElapsed)
+		}
+	}
+}

--- a/pipeline/engine_test.go
+++ b/pipeline/engine_test.go
@@ -1331,3 +1331,79 @@ func TestEngine_HaltsOnBudgetBreach(t *testing.T) {
 		t.Errorf("pipeline should have halted before n3/end, CompletedNodes=%v", result.CompletedNodes)
 	}
 }
+
+// TestEngine_HaltsOnBudgetBreachDuringRetry verifies that the BudgetGuard fires
+// on the retry path, not just on normal node advancement. The node returns
+// OutcomeRetry twice, each attempt emitting 500 tokens. The guard limit is 600,
+// so after the first retry's trace entry is committed (total 500 from the initial
+// run + 500 from the retry attempt = 1000 > 600) the pipeline must halt.
+func TestEngine_HaltsOnBudgetBreachDuringRetry(t *testing.T) {
+	g := NewGraph("retry_budget_halt_test")
+	g.Attrs["default_max_retry"] = "5"
+	g.Attrs["default_retry_policy"] = "none"
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "retrying", Shape: "box", Label: "Retrying"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+
+	g.AddEdge(&Edge{From: "start", To: "retrying"})
+	g.AddEdge(&Edge{From: "retrying", To: "end"})
+
+	nodeStats := &SessionStats{
+		InputTokens:  350,
+		OutputTokens: 150,
+		TotalTokens:  500,
+		CostUSD:      0.01,
+		Provider:     "test-provider",
+	}
+
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		n := name
+		reg.Register(&testHandler{name: n, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{Status: OutcomeRetry, Stats: nodeStats}, nil
+		}})
+	}
+
+	var mu sync.Mutex
+	var budgetEvents []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		if evt.Type == EventBudgetExceeded {
+			mu.Lock()
+			budgetEvents = append(budgetEvents, evt)
+			mu.Unlock()
+		}
+	})
+
+	// Guard: 600 tokens. First attempt on "retrying" adds 500 tokens.
+	// After the retry trace entry is committed (attempt 1 = 500 tokens total),
+	// the budget check fires (500 < 600 still ok). On the second retry attempt
+	// another 500 is added (total 1000 > 600), budget must trip.
+	guard := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 600})
+	engine := NewEngine(g, reg,
+		WithPipelineEventHandler(handler),
+		WithBudgetGuard(guard),
+	)
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine.Run returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if result.Status != OutcomeBudgetExceeded {
+		t.Errorf("result.Status = %q, want %q", result.Status, OutcomeBudgetExceeded)
+	}
+
+	if len(result.BudgetLimitsHit) != 1 || result.BudgetLimitsHit[0] != "tokens" {
+		t.Errorf("BudgetLimitsHit = %v, want [\"tokens\"]", result.BudgetLimitsHit)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(budgetEvents) == 0 {
+		t.Error("expected at least one EventBudgetExceeded, got none")
+	}
+}

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -28,7 +28,21 @@ const (
 	EventDecisionCondition PipelineEventType = "decision_condition"
 	EventDecisionOutcome   PipelineEventType = "decision_outcome"
 	EventDecisionRestart   PipelineEventType = "decision_restart"
+
+	// Cost governance events — emitted after each completed node and when a budget is exceeded.
+	EventCostUpdated    PipelineEventType = "cost_updated"
+	EventBudgetExceeded PipelineEventType = "budget_exceeded"
 )
+
+// CostSnapshot is the payload for EventCostUpdated and EventBudgetExceeded events.
+// It is a point-in-time view of the run's aggregate token usage, cost, and
+// wall-clock elapsed time.
+type CostSnapshot struct {
+	TotalTokens    int
+	TotalCostUSD   float64
+	ProviderTotals map[string]ProviderUsage
+	WallElapsed    time.Duration
+}
 
 // DecisionDetail carries structured data about a pipeline decision point.
 // It is attached to PipelineEvent via the Decision field for audit trail events.
@@ -67,6 +81,7 @@ type PipelineEvent struct {
 	Message   string
 	Err       error
 	Decision  *DecisionDetail // non-nil for decision audit trail events
+	Cost      *CostSnapshot   // non-nil for EventCostUpdated and EventBudgetExceeded events
 }
 
 // PipelineEventHandler receives pipeline events for observability purposes.

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -37,6 +37,12 @@ type jsonlLogEntry struct {
 	ClearedNodes    []string          `json:"cleared_nodes,omitempty"`
 	TokenInput      int               `json:"token_input,omitempty"`
 	TokenOutput     int               `json:"token_output,omitempty"`
+
+	// Cost snapshot fields — non-zero for cost_updated and budget_exceeded events.
+	TotalTokens    int                      `json:"total_tokens,omitempty"`
+	TotalCostUSD   float64                  `json:"total_cost_usd,omitempty"`
+	ProviderTotals map[string]ProviderUsage `json:"provider_totals,omitempty"`
+	WallElapsedMs  int64                    `json:"wall_elapsed_ms,omitempty"`
 }
 
 // JSONLEventHandler appends every pipeline event as a JSON line to a file.
@@ -84,12 +90,12 @@ func (h *JSONLEventHandler) HandlePipelineEvent(evt PipelineEvent) {
 		return
 	}
 
-	entry := h.buildLogEntry(evt)
+	entry := buildLogEntry(evt)
 	h.writeEntry(entry)
 }
 
 // buildLogEntry converts a PipelineEvent to a jsonlLogEntry.
-func (h *JSONLEventHandler) buildLogEntry(evt PipelineEvent) jsonlLogEntry {
+func buildLogEntry(evt PipelineEvent) jsonlLogEntry {
 	entry := jsonlLogEntry{
 		Timestamp: evt.Timestamp.Format("2006-01-02T15:04:05.000Z07:00"),
 		Source:    "pipeline",
@@ -103,6 +109,12 @@ func (h *JSONLEventHandler) buildLogEntry(evt PipelineEvent) jsonlLogEntry {
 	}
 	if d := evt.Decision; d != nil {
 		applyDecisionFields(&entry, d)
+	}
+	if evt.Cost != nil {
+		entry.TotalTokens = evt.Cost.TotalTokens
+		entry.TotalCostUSD = evt.Cost.TotalCostUSD
+		entry.ProviderTotals = evt.Cost.ProviderTotals
+		entry.WallElapsedMs = evt.Cost.WallElapsed.Milliseconds()
 	}
 	return entry
 }

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -247,6 +247,43 @@ func TestJSONLEventHandlerAgentErrorCombining(t *testing.T) {
 	}
 }
 
+func TestBuildLogEntry_CostSnapshot(t *testing.T) {
+	evt := PipelineEvent{
+		Type:      EventCostUpdated,
+		Timestamp: time.Unix(100, 0),
+		RunID:     "run-1",
+		Cost: &CostSnapshot{
+			TotalTokens:  1500,
+			TotalCostUSD: 0.0375,
+			ProviderTotals: map[string]ProviderUsage{
+				"anthropic": {InputTokens: 1000, OutputTokens: 500, CostUSD: 0.0375, SessionCount: 2},
+			},
+			WallElapsed: 500 * time.Millisecond,
+		},
+	}
+	entry := buildLogEntry(evt)
+	if entry.TotalTokens != 1500 {
+		t.Errorf("TotalTokens = %d, want 1500", entry.TotalTokens)
+	}
+	if entry.TotalCostUSD < 0.03749 || entry.TotalCostUSD > 0.03751 {
+		t.Errorf("TotalCostUSD = %f, want 0.0375", entry.TotalCostUSD)
+	}
+	if entry.WallElapsedMs != 500 {
+		t.Errorf("WallElapsedMs = %d, want 500", entry.WallElapsedMs)
+	}
+	if entry.ProviderTotals == nil || entry.ProviderTotals["anthropic"].InputTokens != 1000 {
+		t.Errorf("ProviderTotals[anthropic] = %+v", entry.ProviderTotals["anthropic"])
+	}
+}
+
+func TestBuildLogEntry_NilCost(t *testing.T) {
+	evt := PipelineEvent{Type: EventPipelineStarted, Timestamp: time.Unix(100, 0), RunID: "run-1"}
+	entry := buildLogEntry(evt)
+	if entry.TotalTokens != 0 || entry.TotalCostUSD != 0 {
+		t.Errorf("nil cost should yield zero fields, got %+v", entry)
+	}
+}
+
 type testErr struct{ msg string }
 
 func (e *testErr) Error() string { return e.msg }

--- a/pipeline/handlers/transcript.go
+++ b/pipeline/handlers/transcript.go
@@ -103,5 +103,6 @@ func buildSessionStats(r agent.SessionResult) *pipeline.SessionStats {
 		ReasoningTokens:  derefInt(r.Usage.ReasoningTokens),
 		CacheReadTokens:  derefInt(r.Usage.CacheReadTokens),
 		CacheWriteTokens: derefInt(r.Usage.CacheWriteTokens),
+		Provider:         r.Provider,
 	}
 }

--- a/pipeline/handlers/transcript_test.go
+++ b/pipeline/handlers/transcript_test.go
@@ -78,6 +78,31 @@ func TestBuildSessionStatsIncludesTokenUsage(t *testing.T) {
 	}
 }
 
+func TestBuildSessionStatsPopulatesProvider(t *testing.T) {
+	r := agent.SessionResult{
+		Turns:    1,
+		Provider: "anthropic",
+		Usage:    llm.Usage{InputTokens: 100, OutputTokens: 50, TotalTokens: 150},
+	}
+
+	stats := buildSessionStats(r)
+	if stats.Provider != "anthropic" {
+		t.Errorf("expected Provider=%q, got %q", "anthropic", stats.Provider)
+	}
+}
+
+func TestBuildSessionStatsEmptyProvider(t *testing.T) {
+	r := agent.SessionResult{
+		Turns: 1,
+		// Provider not set — human gate / non-LLM node
+	}
+
+	stats := buildSessionStats(r)
+	if stats.Provider != "" {
+		t.Errorf("expected empty Provider, got %q", stats.Provider)
+	}
+}
+
 func TestBuildSessionStatsZeroUsage(t *testing.T) {
 	r := agent.SessionResult{
 		Turns:     1,

--- a/pipeline/trace.go
+++ b/pipeline/trace.go
@@ -27,6 +27,7 @@ type SessionStats struct {
 	ReasoningTokens  int            `json:"reasoning_tokens"`
 	CacheReadTokens  int            `json:"cache_read_tokens"`
 	CacheWriteTokens int            `json:"cache_write_tokens"`
+	Provider         string         `json:"provider,omitempty"`
 }
 
 // TraceEntry records the execution of a single pipeline node.
@@ -54,16 +55,29 @@ func (tr *Trace) AddEntry(entry TraceEntry) {
 	tr.Entries = append(tr.Entries, entry)
 }
 
+// ProviderUsage is the per-provider rollup embedded in UsageSummary.
+type ProviderUsage struct {
+	InputTokens      int     `json:"input_tokens"`
+	OutputTokens     int     `json:"output_tokens"`
+	TotalTokens      int     `json:"total_tokens"`
+	CostUSD          float64 `json:"cost_usd"`
+	ReasoningTokens  int     `json:"reasoning_tokens"`
+	CacheReadTokens  int     `json:"cache_read_tokens"`
+	CacheWriteTokens int     `json:"cache_write_tokens"`
+	SessionCount     int     `json:"session_count"`
+}
+
 // UsageSummary aggregates token usage and cost across all pipeline nodes.
 type UsageSummary struct {
-	TotalInputTokens      int     `json:"total_input_tokens"`
-	TotalOutputTokens     int     `json:"total_output_tokens"`
-	TotalTokens           int     `json:"total_tokens"`
-	TotalCostUSD          float64 `json:"total_cost_usd"`
-	TotalReasoningTokens  int     `json:"total_reasoning_tokens"`
-	TotalCacheReadTokens  int     `json:"total_cache_read_tokens"`
-	TotalCacheWriteTokens int     `json:"total_cache_write_tokens"`
-	SessionCount          int     `json:"session_count"`
+	TotalInputTokens      int                      `json:"total_input_tokens"`
+	TotalOutputTokens     int                      `json:"total_output_tokens"`
+	TotalTokens           int                      `json:"total_tokens"`
+	TotalCostUSD          float64                  `json:"total_cost_usd"`
+	TotalReasoningTokens  int                      `json:"total_reasoning_tokens"`
+	TotalCacheReadTokens  int                      `json:"total_cache_read_tokens"`
+	TotalCacheWriteTokens int                      `json:"total_cache_write_tokens"`
+	SessionCount          int                      `json:"session_count"`
+	ProviderTotals        map[string]ProviderUsage `json:"provider_totals,omitempty"`
 }
 
 // AggregateUsage sums token usage and cost from all trace entries with session stats.
@@ -71,7 +85,7 @@ func (tr *Trace) AggregateUsage() *UsageSummary {
 	if tr == nil {
 		return nil
 	}
-	s := &UsageSummary{}
+	s := &UsageSummary{ProviderTotals: make(map[string]ProviderUsage)}
 	for _, e := range tr.Entries {
 		if e.Stats == nil {
 			continue
@@ -84,9 +98,24 @@ func (tr *Trace) AggregateUsage() *UsageSummary {
 		s.TotalCacheReadTokens += e.Stats.CacheReadTokens
 		s.TotalCacheWriteTokens += e.Stats.CacheWriteTokens
 		s.SessionCount++
+		if p := e.Stats.Provider; p != "" {
+			pt := s.ProviderTotals[p]
+			pt.InputTokens += e.Stats.InputTokens
+			pt.OutputTokens += e.Stats.OutputTokens
+			pt.TotalTokens += e.Stats.TotalTokens
+			pt.CostUSD += e.Stats.CostUSD
+			pt.ReasoningTokens += e.Stats.ReasoningTokens
+			pt.CacheReadTokens += e.Stats.CacheReadTokens
+			pt.CacheWriteTokens += e.Stats.CacheWriteTokens
+			pt.SessionCount++
+			s.ProviderTotals[p] = pt
+		}
 	}
 	if s.SessionCount == 0 {
 		return nil
+	}
+	if len(s.ProviderTotals) == 0 {
+		s.ProviderTotals = nil
 	}
 	return s
 }

--- a/pipeline/trace_test.go
+++ b/pipeline/trace_test.go
@@ -707,6 +707,59 @@ func TestEngineResultUsageFromTraceStats(t *testing.T) {
 	}
 }
 
+func TestAggregateUsage_PerProviderTotals(t *testing.T) {
+	tr := &Trace{Entries: []TraceEntry{
+		{Stats: &SessionStats{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.01, Provider: "anthropic"}},
+		{Stats: &SessionStats{InputTokens: 200, OutputTokens: 75, TotalTokens: 275, CostUSD: 0.02, Provider: "openai"}},
+		{Stats: &SessionStats{InputTokens: 50, OutputTokens: 25, TotalTokens: 75, CostUSD: 0.005, Provider: "anthropic"}},
+	}}
+
+	s := tr.AggregateUsage()
+	if s == nil {
+		t.Fatal("AggregateUsage returned nil")
+	}
+	if s.TotalTokens != 500 {
+		t.Errorf("TotalTokens = %d, want 500", s.TotalTokens)
+	}
+	if len(s.ProviderTotals) != 2 {
+		t.Fatalf("ProviderTotals len = %d, want 2", len(s.ProviderTotals))
+	}
+
+	ant := s.ProviderTotals["anthropic"]
+	if ant.InputTokens != 150 || ant.OutputTokens != 75 || ant.TotalTokens != 225 {
+		t.Errorf("anthropic totals = %+v", ant)
+	}
+	if ant.CostUSD < 0.0149 || ant.CostUSD > 0.0151 {
+		t.Errorf("anthropic cost = %.4f, want 0.015", ant.CostUSD)
+	}
+	if ant.SessionCount != 2 {
+		t.Errorf("anthropic sessions = %d, want 2", ant.SessionCount)
+	}
+
+	oa := s.ProviderTotals["openai"]
+	if oa.InputTokens != 200 || oa.SessionCount != 1 {
+		t.Errorf("openai rollup = %+v", oa)
+	}
+}
+
+func TestAggregateUsage_SkipsEntriesWithoutProvider(t *testing.T) {
+	tr := &Trace{Entries: []TraceEntry{
+		{Stats: &SessionStats{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUSD: 0.01}}, // no provider
+		{Stats: &SessionStats{InputTokens: 200, OutputTokens: 75, TotalTokens: 275, CostUSD: 0.02, Provider: "openai"}},
+	}}
+
+	s := tr.AggregateUsage()
+	if s == nil || s.TotalTokens != 425 {
+		t.Fatalf("totals wrong: %+v", s)
+	}
+	if len(s.ProviderTotals) != 1 {
+		t.Errorf("should only have 1 provider, got %d", len(s.ProviderTotals))
+	}
+	if _, ok := s.ProviderTotals["openai"]; !ok {
+		t.Errorf("openai missing from ProviderTotals")
+	}
+}
+
 func TestTraceAggregateToolCalls(t *testing.T) {
 	t.Run("normal aggregation", func(t *testing.T) {
 		tr := &Trace{

--- a/tracker.go
+++ b/tracker.go
@@ -54,7 +54,7 @@ type Config struct {
 // CostReport summarizes spend for a pipeline run.
 // TotalUSD is the sum of ByProvider[*].USD.
 // LimitsHit names the budget dimensions that halted the run (empty when the
-// run completed normally). Populated by BudgetGuard in a later task.
+// run completed normally).
 type CostReport struct {
 	TotalUSD   float64
 	ByProvider map[string]llm.ProviderCost

--- a/tracker.go
+++ b/tracker.go
@@ -50,6 +50,16 @@ type Config struct {
 	AutoApprove   bool                          // auto-approve all human gates with default/first option
 }
 
+// CostReport summarizes spend for a pipeline run.
+// TotalUSD is the sum of ByProvider[*].USD.
+// LimitsHit names the budget dimensions that halted the run (empty when the
+// run completed normally). Populated by BudgetGuard in a later task.
+type CostReport struct {
+	TotalUSD   float64
+	ByProvider map[string]llm.ProviderCost
+	LimitsHit  []string
+}
+
 // Result contains the outcome of a pipeline execution.
 type Result struct {
 	RunID            string
@@ -60,6 +70,7 @@ type Result struct {
 	Trace            *pipeline.Trace      // full execution trace (nodes, timing, stats)
 	TokensByProvider map[string]llm.Usage // per-provider token totals
 	ToolCallsByName  map[string]int       // tool call counts by name
+	Cost             *CostReport          // per-provider cost rollup; nil when no usage recorded
 }
 
 // Engine wraps pipeline.Engine with auto-wired internals.
@@ -414,11 +425,38 @@ func (e *Engine) Run(ctx context.Context) (*Result, error) {
 	result := resultFromEngine(engineResult)
 	if e.tokenTracker != nil {
 		result.TokensByProvider = e.tokenTracker.AllProviderUsage()
+		resolver := e.defaultModelResolver()
+		byProvider := e.tokenTracker.CostByProvider(resolver)
+		if len(byProvider) > 0 {
+			total := 0.0
+			for _, pc := range byProvider {
+				total += pc.USD
+			}
+			result.Cost = &CostReport{
+				TotalUSD:   total,
+				ByProvider: byProvider,
+			}
+		}
 	}
 	if engineResult != nil && engineResult.Trace != nil {
 		result.ToolCallsByName = engineResult.Trace.AggregateToolCalls()
 	}
 	return result, nil
+}
+
+// defaultModelResolver returns an llm.ModelResolver that maps any provider to
+// the graph's default model. Per-provider model overrides are not yet supported
+// (the same model attr is used for cost estimation regardless of provider).
+// When the graph has no llm_model attr set, the resolver returns "", which
+// yields USD=0 via llm.EstimateCost.
+func (e *Engine) defaultModelResolver() llm.ModelResolver {
+	model := ""
+	if e.inner != nil {
+		if g := e.inner.Graph(); g != nil {
+			model = g.Attrs["llm_model"]
+		}
+	}
+	return func(provider string) string { return model }
 }
 
 // Close releases resources. Must be called if the engine was created

--- a/tracker.go
+++ b/tracker.go
@@ -48,6 +48,7 @@ type Config struct {
 	Backend       string                        // "native" (default), "claude-code", "acp"; selects agent backend
 	Autopilot     string                        // "" (interactive), "lax", "mid", "hard", "mentor"; LLM-driven gate decisions
 	AutoApprove   bool                          // auto-approve all human gates with default/first option
+	Budget        pipeline.BudgetLimits         // configures pipeline-level token, cost, and wall-time ceilings
 }
 
 // CostReport summarizes spend for a pipeline run.
@@ -278,6 +279,9 @@ func buildEngineOpts(cfg Config) []pipeline.EngineOption {
 	if len(cfg.Context) > 0 {
 		opts = append(opts, pipeline.WithInitialContext(cfg.Context))
 	}
+	if guard := pipeline.NewBudgetGuard(cfg.Budget); guard != nil {
+		opts = append(opts, pipeline.WithBudgetGuard(guard))
+	}
 	opts = append(opts, pipeline.WithStylesheetResolution(true))
 	return opts
 }
@@ -423,25 +427,43 @@ func (e *Engine) Run(ctx context.Context) (*Result, error) {
 		return nil, err
 	}
 	result := resultFromEngine(engineResult)
-	if e.tokenTracker != nil {
-		result.TokensByProvider = e.tokenTracker.AllProviderUsage()
-		resolver := e.defaultModelResolver()
-		byProvider := e.tokenTracker.CostByProvider(resolver)
-		if len(byProvider) > 0 {
-			total := 0.0
-			for _, pc := range byProvider {
-				total += pc.USD
-			}
-			result.Cost = &CostReport{
-				TotalUSD:   total,
-				ByProvider: byProvider,
-			}
-		}
-	}
+	e.populateResultTokensAndCost(result, engineResult)
+	e.populateBudgetHaltIfNeeded(result, engineResult)
 	if engineResult != nil && engineResult.Trace != nil {
 		result.ToolCallsByName = engineResult.Trace.AggregateToolCalls()
 	}
 	return result, nil
+}
+
+// populateResultTokensAndCost fills in per-provider token counts and cost report from the tracker.
+func (e *Engine) populateResultTokensAndCost(result *Result, engineResult *pipeline.EngineResult) {
+	if e.tokenTracker == nil {
+		return
+	}
+	result.TokensByProvider = e.tokenTracker.AllProviderUsage()
+	resolver := e.defaultModelResolver()
+	byProvider := e.tokenTracker.CostByProvider(resolver)
+	if len(byProvider) > 0 {
+		total := 0.0
+		for _, pc := range byProvider {
+			total += pc.USD
+		}
+		result.Cost = &CostReport{
+			TotalUSD:   total,
+			ByProvider: byProvider,
+		}
+	}
+}
+
+// populateBudgetHaltIfNeeded fills in LimitsHit when a budget guard halted the run.
+func (e *Engine) populateBudgetHaltIfNeeded(result *Result, engineResult *pipeline.EngineResult) {
+	if engineResult == nil || engineResult.Status != pipeline.OutcomeBudgetExceeded {
+		return
+	}
+	if result.Cost == nil {
+		result.Cost = &CostReport{}
+	}
+	result.Cost.LimitsHit = engineResult.BudgetLimitsHit
 }
 
 // defaultModelResolver returns an llm.ModelResolver that maps any provider to

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -372,6 +372,54 @@ func TestValidateSource_ReturnsWarnings(t *testing.T) {
 	}
 }
 
+func TestRun_PopulatesResultCost(t *testing.T) {
+	client := &stubCompleter{
+		response: &llm.Response{
+			Message:      llm.AssistantMessage("done"),
+			FinishReason: llm.FinishReason{Reason: "stop"},
+		},
+	}
+
+	// Build the engine directly so we can inject known usage into the
+	// tokenTracker before running. The test is in package tracker (not
+	// tracker_test) so unexported fields are accessible.
+	engine, err := NewEngine(simpleDOT, Config{
+		Format:    "dot",
+		LLMClient: client,
+		Model:     "claude-sonnet-4-6", // known model so EstimateCost returns > 0
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer engine.Close()
+
+	// Inject known usage directly — stubCompleter bypasses middleware so we
+	// add it manually, mirroring the claude-code backend pattern.
+	engine.tokenTracker.AddUsage("anthropic", llm.Usage{InputTokens: 1000, OutputTokens: 500})
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if result.Cost == nil {
+		t.Fatal("expected result.Cost to be non-nil")
+	}
+	if result.Cost.TotalUSD <= 0 {
+		t.Errorf("expected TotalUSD > 0, got %v", result.Cost.TotalUSD)
+	}
+	if len(result.Cost.ByProvider) == 0 {
+		t.Error("expected at least one entry in ByProvider")
+	}
+	entry, ok := result.Cost.ByProvider["anthropic"]
+	if !ok {
+		t.Fatalf("expected anthropic entry in ByProvider, got keys: %v", result.Cost.ByProvider)
+	}
+	if entry.Usage.InputTokens != 1000 {
+		t.Errorf("expected InputTokens=1000, got %d", entry.Usage.InputTokens)
+	}
+}
+
 func TestRun_WithRetryPolicy(t *testing.T) {
 	client := &stubCompleter{
 		response: &llm.Response{

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -440,3 +440,71 @@ func TestRun_WithRetryPolicy(t *testing.T) {
 		t.Errorf("expected success, got %q", result.Status)
 	}
 }
+
+func TestRun_BudgetHalt_FromConfig(t *testing.T) {
+	// Create a DIP pipeline with an agent node that will execute through the real handler.
+	// This ensures that the agent session is created and the completer response's usage
+	// is recorded as SessionStats in the trace.
+	dipSource := `workflow budget_test
+  start: a
+  exit: b
+
+  agent a
+    label: Agent
+    prompt: "respond with done"
+
+  agent b
+    label: Done
+
+  edges
+    a -> b
+`
+
+	// Create a stub completer that returns responses with token usage.
+	// Each agent call will return 500 total tokens (200 input + 300 output).
+	client := &stubCompleter{
+		response: &llm.Response{
+			Message:      llm.AssistantMessage("done"),
+			FinishReason: llm.FinishReason{Reason: "stop"},
+			Usage: llm.Usage{
+				InputTokens:  200,
+				OutputTokens: 300,
+				TotalTokens:  500,
+			},
+		},
+	}
+
+	// Build the engine with a budget limit of 400 tokens.
+	// The first agent call will return 500 tokens, which exceeds the 400-token limit.
+	engine, err := NewEngine(dipSource, Config{
+		Format:    "dip",
+		LLMClient: client,
+		Budget: pipeline.BudgetLimits{
+			MaxTotalTokens: 400,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	defer engine.Close()
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Verify that the run halted due to budget breach.
+	if result.Status != pipeline.OutcomeBudgetExceeded {
+		t.Errorf("expected status %q, got %q", pipeline.OutcomeBudgetExceeded, result.Status)
+	}
+
+	// Verify that LimitsHit identifies the tokens dimension.
+	if result.Cost == nil {
+		t.Fatal("expected result.Cost to be non-nil")
+	}
+	if len(result.Cost.LimitsHit) == 0 {
+		t.Error("expected LimitsHit to be non-empty")
+	} else if result.Cost.LimitsHit[0] != "tokens" {
+		t.Errorf("expected LimitsHit[0]='tokens', got %q", result.Cost.LimitsHit[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Expose per-provider token and dollar cost on `Result.Cost` in the library API, populated from the `llm.TokenTracker` middleware via `llm.EstimateCost` (closes #62).
- Enforce optional `MaxTotalTokens` / `MaxCostCents` / `MaxWallTime` ceilings via a new `pipeline.BudgetGuard`. Tripping any limit halts the run with `pipeline.OutcomeBudgetExceeded` and populates `EngineResult.BudgetLimitsHit` (closes #17).
- Stream per-node cost updates via new `EventCostUpdated` events (and `EventBudgetExceeded` on halt), each carrying a `CostSnapshot` payload with total tokens, dollar cost, per-provider totals, and wall elapsed.
- New `tracker.Config.Budget` library field + `--max-tokens`, `--max-cost`, `--max-wall-time` CLI flags.
- `tracker diagnose` and `activity.jsonl` now carry cost/halt data.

## Scope note
Reading budget limits directly from `.dip` workflow attrs is blocked on dippin-lang IR support. Tracked as a follow-up in #67.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./... -short` — all 15 packages pass
- [x] `dippin doctor` — A/100 on `ask_and_execute.dip`, `build_product.dip`, `build_product_with_superspec.dip`
- [x] Unit: `BudgetGuard` token / cost / wall-time / nil-guard / accumulated-float-rounding
- [x] Integration: `TestEngine_HaltsOnBudgetBreach` (5-node graph halts after node 3)
- [x] Integration: `TestRun_BudgetHalt_FromConfig` (library halt via `Config.Budget`)
- [x] Integration: `TestEngine_EmitsCostUpdatedAfterEachNode` (3-node graph emits ≥3 events, monotonic totals)
- [x] Integration: `TestRun_PopulatesResultCost` (per-provider cost in `Result.Cost.ByProvider`)
- [x] JSONL: `TestBuildLogEntry_CostSnapshot` / `TestBuildLogEntry_NilCost`
- [ ] Manual: `tracker run examples/ask_and_execute.dip --max-tokens 1` halts with budget banner
- [ ] Manual: `tracker diagnose` after a halted run surfaces the budget section

Closes #62
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Run results now include cost reports with per‑provider USD breakdowns and total spend; session/provider info is surfaced in traces.
  * Configurable budget enforcement (max tokens, max cost, max wall‑time) via config or CLI flags (--max-tokens, --max-cost, --max-wall-time).
  * Pipelines emit streaming cost snapshots and halt when budgets are exceeded; halted runs show a clear "HALTED: budget exceeded" banner and reason.

* **Documentation**
  * Added cost governance guide and implementation plan covering visibility, enforcement, diagnostics, and CLI usage.

* **Tests**
  * Added unit and integration tests for cost rollups, events, and budget-halt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->