### PR TITLE
fix: reconcile validation between dippin-lang and tracker

### DIFF
--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -164,12 +164,13 @@ func loadEmbeddedPipeline(info WorkflowInfo) (*pipeline.Graph, error) {
 // printed to stderr but do not block execution.
 func loadDippinPipeline(source, filename string) (*pipeline.Graph, error) {
 	graph, diags, err := pipeline.LoadDippinWorkflow(source, filename)
-	if err != nil {
-		return nil, err
-	}
-	// Log validation errors and lint warnings to stderr.
+	// Log validation errors and lint warnings before returning so users
+	// see the specific diagnostics even on fatal failures.
 	for _, d := range diags {
 		fmt.Fprintln(os.Stderr, d.String())
+	}
+	if err != nil {
+		return nil, err
 	}
 	return graph, nil
 }

--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -191,5 +191,8 @@ func loadDippinPipeline(source, filename string) (*pipeline.Graph, error) {
 		return nil, fmt.Errorf("convert Dippin IR to graph: %w", err)
 	}
 
+	// Mark graph as already validated by dippin-lang so that tracker's
+	// own validator skips redundant structural checks (DIP001–DIP009).
+	graph.DippinValidated = true
 	return graph, nil
 }

--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/2389-research/dippin-lang/parser"
-	"github.com/2389-research/dippin-lang/validator"
 	"github.com/2389-research/tracker/pipeline"
 )
 
@@ -165,34 +163,13 @@ func loadEmbeddedPipeline(info WorkflowInfo) (*pipeline.Graph, error) {
 // Graph representation. Validation errors are fatal; lint warnings are
 // printed to stderr but do not block execution.
 func loadDippinPipeline(source, filename string) (*pipeline.Graph, error) {
-	p := parser.NewParser(source, filename)
-	workflow, err := p.Parse()
+	graph, diags, err := pipeline.LoadDippinWorkflow(source, filename)
 	if err != nil {
-		return nil, fmt.Errorf("parse Dippin file: %w", err)
+		return nil, err
 	}
-
-	// Run Dippin structural validation (DIP001–DIP009).
-	valResult := validator.Validate(workflow)
-	if valResult.HasErrors() {
-		for _, d := range valResult.Diagnostics {
-			fmt.Fprintln(os.Stderr, d.String())
-		}
-		return nil, fmt.Errorf("%d validation error(s) in %s", len(valResult.Errors()), filename)
-	}
-
-	// Run Dippin lint checks (DIP101–DIP115). Warnings only — don't block.
-	lintResult := validator.Lint(workflow)
-	for _, d := range lintResult.Diagnostics {
+	// Log validation errors and lint warnings to stderr.
+	for _, d := range diags {
 		fmt.Fprintln(os.Stderr, d.String())
 	}
-
-	graph, err := pipeline.FromDippinIR(workflow)
-	if err != nil {
-		return nil, fmt.Errorf("convert Dippin IR to graph: %w", err)
-	}
-
-	// Mark graph as already validated by dippin-lang so that tracker's
-	// own validator skips redundant structural checks (DIP001–DIP009).
-	graph.DippinValidated = true
 	return graph, nil
 }

--- a/pipeline/dippin_load.go
+++ b/pipeline/dippin_load.go
@@ -24,7 +24,7 @@ func LoadDippinWorkflow(source, filename string) (*Graph, []validator.Diagnostic
 	// Run Dippin structural validation (DIP001–DIP009).
 	valResult := validator.Validate(workflow)
 	if valResult.HasErrors() {
-		return nil, nil, fmt.Errorf("%d validation error(s) in %s", len(valResult.Errors()), filename)
+		return nil, valResult.Diagnostics, fmt.Errorf("%d validation error(s) in %s", len(valResult.Errors()), filename)
 	}
 
 	// Run Dippin lint checks (DIP101–DIP115). Warnings only — don't block.

--- a/pipeline/dippin_load.go
+++ b/pipeline/dippin_load.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/2389-research/dippin-lang/parser"
+	"github.com/2389-research/dippin-lang/validator"
+)
+
+// LoadDippinWorkflow parses a dippin-lang source, runs the built-in validator
+// and linter, converts to a Graph, and marks the graph as dippin-validated.
+// This ensures all .dip entry points apply consistent validation semantics.
+//
+// filename is used for error messages (e.g., "inline.dip" or "/path/to/file.dip").
+// Returns the graph and any validation/lint diagnostics (warnings only).
+// Validation errors are returned as fatal errors.
+func LoadDippinWorkflow(source, filename string) (*Graph, []validator.Diagnostic, error) {
+	p := parser.NewParser(source, filename)
+	workflow, err := p.Parse()
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse Dippin file: %w", err)
+	}
+
+	// Run Dippin structural validation (DIP001–DIP009).
+	valResult := validator.Validate(workflow)
+	if valResult.HasErrors() {
+		return nil, nil, fmt.Errorf("%d validation error(s) in %s", len(valResult.Errors()), filename)
+	}
+
+	// Run Dippin lint checks (DIP101–DIP115). Warnings only — don't block.
+	lintResult := validator.Lint(workflow)
+
+	// Convert IR to tracker's Graph representation.
+	graph, err := FromDippinIR(workflow)
+	if err != nil {
+		return nil, nil, fmt.Errorf("convert Dippin IR to graph: %w", err)
+	}
+
+	// Mark graph as already validated by dippin-lang so that tracker's
+	// own validator skips redundant structural checks (DIP001–DIP009).
+	graph.DippinValidated = true
+
+	// Return all diagnostics (both validation and lint) so callers can log them.
+	var allDiags []validator.Diagnostic
+	allDiags = append(allDiags, valResult.Diagnostics...)
+	allDiags = append(allDiags, lintResult.Diagnostics...)
+
+	return graph, allDiags, nil
+}

--- a/pipeline/graph.go
+++ b/pipeline/graph.go
@@ -37,6 +37,13 @@ type Graph struct {
 	// rather than BFS order which puts "Done" in the middle.
 	NodeOrder []string
 
+	// DippinValidated is set to true when the graph was produced from a .dip
+	// source that has already passed dippin-lang's structural validator
+	// (DIP001–DIP009). Tracker's own validateGraph skips checks that overlap
+	// with those diagnostics, preventing false positives and divergence between
+	// `dippin doctor` and `tracker validate`.
+	DippinValidated bool
+
 	// Adjacency indexes for O(1) edge lookup. Built by AddEdge.
 	outgoing map[string][]*Edge
 	incoming map[string][]*Edge

--- a/pipeline/graph.go
+++ b/pipeline/graph.go
@@ -42,6 +42,13 @@ type Graph struct {
 	// (DIP001–DIP009). Tracker's own validateGraph skips checks that overlap
 	// with those diagnostics, preventing false positives and divergence between
 	// `dippin doctor` and `tracker validate`.
+	//
+	// CONTRACT: this flag reflects the graph's state at the moment dippin
+	// validation ran. If the graph is subsequently mutated (nodes or edges
+	// added/removed programmatically), callers MUST clear this flag or
+	// re-run dippin validation before calling Validate again — otherwise
+	// tracker's structural checks will be skipped for a shape that has
+	// changed since dippin last validated it.
 	DippinValidated bool
 
 	// Adjacency indexes for O(1) edge lookup. Built by AddEdge.

--- a/pipeline/validate.go
+++ b/pipeline/validate.go
@@ -1,5 +1,6 @@
 // ABOUTME: Validates pipeline graph structure for correctness before execution.
-// ABOUTME: Checks for single start/exit, no cycles, recognized shapes, and full reachability.
+// ABOUTME: Tracker-specific checks (shapes, duplicate edges, conditional routing) always run.
+// ABOUTME: Structural checks that dippin-lang already covers are skipped when DippinValidated=true.
 package pipeline
 
 import (
@@ -109,16 +110,36 @@ func validateGraph(g *Graph) *ValidationError {
 		return ve
 	}
 
-	// Structural checks (always run — defense in depth).
-	validateStartExit(g, ve)
-	validateEdgeEndpoints(g, ve)
-	validateExitOutgoingEdges(g, ve)
-	validateReachability(g, ve)
-	validateNoCycles(g, ve)
+	// Structural checks that overlap with dippin-lang's DIP001–DIP009.
+	// For graphs produced from .dip sources, dippin-lang's validator already ran
+	// these checks before conversion, so we skip them here to prevent
+	// false-positive divergence between `dippin doctor` and `tracker validate`.
+	// For DOT-format graphs (DippinValidated=false), we still run them because
+	// no upstream validator has covered them.
+	//
+	// Dippin checks covered:
+	//   DIP001 — start node missing (partial: we also check for >1 start)
+	//   DIP002 — exit node missing  (partial: we also check for >1 exit)
+	//   DIP003 — unknown node reference in edge
+	//   DIP004 — unreachable node(s) from start
+	//   DIP005 — unconditional cycle detected
+	//   DIP006 — exit node has outgoing edges
+	//   DIP009 — duplicate edge
+	if !g.DippinValidated {
+		validateStartExit(g, ve)
+		validateEdgeEndpoints(g, ve)
+		validateExitOutgoingEdges(g, ve)
+		validateReachability(g, ve)
+		validateNoCycles(g, ve)
+		validateNoDuplicateEdges(g, ve)
+	}
 
-	// Tracker-specific checks always run.
+	// Tracker-specific checks — always run regardless of source format.
+	// These cover concerns that dippin-lang does not validate:
+	//   validateShapes: DOT shape → handler resolution (tracker internal concept)
+	//   validateConditionalFailEdges: warns on diamond nodes missing a fail path
+	//   validateEdgeLabelConsistency: warns on mixed labeled/unlabeled edges
 	validateShapes(g, ve)
-	validateNoDuplicateEdges(g, ve)
 	validateConditionalFailEdges(g, ve)
 	validateEdgeLabelConsistency(g, ve)
 

--- a/pipeline/validate.go
+++ b/pipeline/validate.go
@@ -1,6 +1,6 @@
 // ABOUTME: Validates pipeline graph structure for correctness before execution.
-// ABOUTME: Tracker-specific checks (shapes, duplicate edges, conditional routing) always run.
-// ABOUTME: Structural checks that dippin-lang already covers are skipped when DippinValidated=true.
+// ABOUTME: Tracker-specific checks such as shapes and conditional routing always run.
+// ABOUTME: Structural checks that dippin-lang already covers, including duplicate-edge checks, are skipped when DippinValidated=true.
 package pipeline
 
 import (

--- a/pipeline/validate.go
+++ b/pipeline/validate.go
@@ -118,13 +118,17 @@ func validateGraph(g *Graph) *ValidationError {
 	// no upstream validator has covered them.
 	//
 	// Dippin checks covered:
-	//   DIP001 — start node missing (partial: we also check for >1 start)
-	//   DIP002 — exit node missing  (partial: we also check for >1 exit)
+	//   DIP001 — start node missing
+	//   DIP002 — exit node missing
 	//   DIP003 — unknown node reference in edge
 	//   DIP004 — unreachable node(s) from start
 	//   DIP005 — unconditional cycle detected
 	//   DIP006 — exit node has outgoing edges
 	//   DIP009 — duplicate edge
+	// Note: DIP001 and DIP002 are complete coverage for .dip workflows, which
+	// come through FromDippinIR with exactly one start/exit node. The >1 start/exit
+	// check in validateStartExit is primarily relevant for DOT graphs, which tracker
+	// directly parses and may contain multiple structural variants.
 	if !g.DippinValidated {
 		validateStartExit(g, ve)
 		validateEdgeEndpoints(g, ve)

--- a/pipeline/validate_test.go
+++ b/pipeline/validate_test.go
@@ -371,9 +371,11 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddNode(&Node{ID: "b", Shape: "Msquare"})
 		g.AddEdge(&Edge{From: "a", To: "b"})
 
-		// Should NOT error — dippin already validated this.
+		// Should return nil — dippin already validated structural checks and
+		// no tracker-specific checks fire on this graph (all shapes recognized,
+		// no diamond nodes to trigger fail-edge or label-consistency warnings).
 		if err := Validate(g); err != nil {
-			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
+			t.Errorf("DippinValidated graph should pass Validate with no errors, got: %v", err)
 		}
 	})
 
@@ -387,8 +389,9 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "s", To: "a"})
 		g.AddEdge(&Edge{From: "a", To: "e"})
 
+		// Should return nil — structural reachability check is skipped when dippin-validated.
 		if err := Validate(g); err != nil {
-			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
+			t.Errorf("DippinValidated graph should pass Validate with no errors, got: %v", err)
 		}
 	})
 
@@ -404,8 +407,9 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "b", To: "a"}) // unconditional cycle
 		g.AddEdge(&Edge{From: "b", To: "e"})
 
+		// Should return nil — cycle detection is skipped when dippin-validated.
 		if err := Validate(g); err != nil {
-			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
+			t.Errorf("DippinValidated graph should pass Validate with no errors, got: %v", err)
 		}
 	})
 
@@ -419,8 +423,9 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "s", To: "a"}) // duplicate
 		g.AddEdge(&Edge{From: "a", To: "e"})
 
+		// Should return nil — duplicate-edge check is skipped when dippin-validated.
 		if err := Validate(g); err != nil {
-			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
+			t.Errorf("DippinValidated graph should pass Validate with no errors, got: %v", err)
 		}
 	})
 

--- a/pipeline/validate_test.go
+++ b/pipeline/validate_test.go
@@ -373,9 +373,7 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 
 		// Should NOT error — dippin already validated this.
 		if err := Validate(g); err != nil {
-			if strings.Contains(err.Error(), "start") {
-				t.Errorf("DippinValidated graph should not re-check for missing start node, got: %v", err)
-			}
+			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
 		}
 	})
 
@@ -390,9 +388,7 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "a", To: "e"})
 
 		if err := Validate(g); err != nil {
-			if strings.Contains(err.Error(), "unreachable") {
-				t.Errorf("DippinValidated graph should not re-check reachability, got: %v", err)
-			}
+			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
 		}
 	})
 
@@ -409,9 +405,7 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "b", To: "e"})
 
 		if err := Validate(g); err != nil {
-			if strings.Contains(err.Error(), "cycle") {
-				t.Errorf("DippinValidated graph should not re-check cycles, got: %v", err)
-			}
+			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
 		}
 	})
 
@@ -426,9 +420,7 @@ func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
 		g.AddEdge(&Edge{From: "a", To: "e"})
 
 		if err := Validate(g); err != nil {
-			if strings.Contains(err.Error(), "duplicate") {
-				t.Errorf("DippinValidated graph should not re-check duplicate edges, got: %v", err)
-			}
+			t.Errorf("DippinValidated graph should not fail validation, got: %v", err)
 		}
 	})
 

--- a/pipeline/validate_test.go
+++ b/pipeline/validate_test.go
@@ -1,5 +1,6 @@
 // ABOUTME: Tests for pipeline graph validation rules.
 // ABOUTME: Validates start/exit node requirements, cycle detection, shape recognition, and reachability.
+// ABOUTME: Also verifies that DippinValidated=true suppresses structural checks already covered by dippin-lang.
 package pipeline
 
 import (
@@ -356,4 +357,121 @@ func TestValidationErrorWithWarnings(t *testing.T) {
 	if !strings.Contains(msg, " | ") {
 		t.Errorf("expected ' | ' separator between errors and warnings, got: %s", msg)
 	}
+}
+
+// TestDippinValidatedSkipsStructuralChecks verifies that graphs with
+// DippinValidated=true bypass the structural checks that dippin-lang's
+// validator (DIP001–DIP009) already covers. This prevents false positives
+// and divergence between `dippin doctor` and `tracker validate`.
+func TestDippinValidatedSkipsStructuralChecks(t *testing.T) {
+	t.Run("missing start node is ignored when dippin-validated", func(t *testing.T) {
+		g := NewGraph("no-start-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "a", Shape: "box"})
+		g.AddNode(&Node{ID: "b", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "a", To: "b"})
+
+		// Should NOT error — dippin already validated this.
+		if err := Validate(g); err != nil {
+			if strings.Contains(err.Error(), "start") {
+				t.Errorf("DippinValidated graph should not re-check for missing start node, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("unreachable node is ignored when dippin-validated", func(t *testing.T) {
+		g := NewGraph("unreachable-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "s", Shape: "Mdiamond"})
+		g.AddNode(&Node{ID: "a", Shape: "box"})
+		g.AddNode(&Node{ID: "orphan", Shape: "box"})
+		g.AddNode(&Node{ID: "e", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "s", To: "a"})
+		g.AddEdge(&Edge{From: "a", To: "e"})
+
+		if err := Validate(g); err != nil {
+			if strings.Contains(err.Error(), "unreachable") {
+				t.Errorf("DippinValidated graph should not re-check reachability, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("unconditional cycle is ignored when dippin-validated", func(t *testing.T) {
+		g := NewGraph("cycle-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "s", Shape: "Mdiamond"})
+		g.AddNode(&Node{ID: "a", Shape: "box"})
+		g.AddNode(&Node{ID: "b", Shape: "box"})
+		g.AddNode(&Node{ID: "e", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "s", To: "a"})
+		g.AddEdge(&Edge{From: "a", To: "b"})
+		g.AddEdge(&Edge{From: "b", To: "a"}) // unconditional cycle
+		g.AddEdge(&Edge{From: "b", To: "e"})
+
+		if err := Validate(g); err != nil {
+			if strings.Contains(err.Error(), "cycle") {
+				t.Errorf("DippinValidated graph should not re-check cycles, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("duplicate edges ignored when dippin-validated", func(t *testing.T) {
+		g := NewGraph("dup-edges-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "s", Shape: "Mdiamond"})
+		g.AddNode(&Node{ID: "a", Shape: "box"})
+		g.AddNode(&Node{ID: "e", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "s", To: "a"})
+		g.AddEdge(&Edge{From: "s", To: "a"}) // duplicate
+		g.AddEdge(&Edge{From: "a", To: "e"})
+
+		if err := Validate(g); err != nil {
+			if strings.Contains(err.Error(), "duplicate") {
+				t.Errorf("DippinValidated graph should not re-check duplicate edges, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("tracker-specific shape check still runs when dippin-validated", func(t *testing.T) {
+		g := NewGraph("bad-shape-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "s", Shape: "Mdiamond"})
+		g.AddNode(&Node{ID: "x", Shape: "trapezium"}) // unrecognized shape
+		g.AddNode(&Node{ID: "e", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "s", To: "x"})
+		g.AddEdge(&Edge{From: "x", To: "e"})
+
+		err := Validate(g)
+		if err == nil {
+			t.Fatal("expected error for unrecognized shape even when dippin-validated")
+		}
+		if !strings.Contains(err.Error(), "trapezium") {
+			t.Errorf("error should mention 'trapezium', got: %v", err)
+		}
+	})
+
+	t.Run("tracker-specific fail-edge warning still fires when dippin-validated", func(t *testing.T) {
+		g := NewGraph("no-fail-edge-dip")
+		g.DippinValidated = true
+		g.AddNode(&Node{ID: "s", Shape: "Mdiamond"})
+		g.AddNode(&Node{ID: "check", Shape: "diamond"})
+		g.AddNode(&Node{ID: "e", Shape: "Msquare"})
+		g.AddEdge(&Edge{From: "s", To: "check"})
+		g.AddEdge(&Edge{From: "check", To: "e", Condition: "outcome=success", Label: "success"})
+
+		ve := ValidateAll(g)
+		if ve == nil {
+			t.Fatal("expected warning for conditional node missing fail edge even when dippin-validated")
+		}
+		found := false
+		for _, w := range ve.Warnings {
+			if strings.Contains(w, "check") && strings.Contains(w, "fail") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected warning about missing fail edge on 'check', got warnings: %v", ve.Warnings)
+		}
+	})
 }

--- a/tracker.go
+++ b/tracker.go
@@ -345,6 +345,9 @@ func parseDIPSource(source string) (*pipeline.Graph, error) {
 	if err != nil {
 		return nil, fmt.Errorf("convert pipeline IR: %w", err)
 	}
+	// Mark graph as already validated by dippin-lang so that tracker's
+	// own validator skips redundant structural checks (DIP001–DIP009).
+	graph.DippinValidated = true
 	return graph, nil
 }
 

--- a/tracker.go
+++ b/tracker.go
@@ -324,12 +324,13 @@ func parseDOTSource(source string) (*pipeline.Graph, error) {
 // parseDIPSource parses a Dippin-format pipeline source, runs validation and lint.
 func parseDIPSource(source string) (*pipeline.Graph, error) {
 	graph, diags, err := pipeline.LoadDippinWorkflow(source, "inline.dip")
-	if err != nil {
-		return nil, err
-	}
-	// Log validation errors and lint warnings.
+	// Log validation errors and lint warnings before returning so callers
+	// see the specific diagnostics even on fatal failures.
 	for _, d := range diags {
 		log.Println(d.String())
+	}
+	if err != nil {
+		return nil, err
 	}
 	return graph, nil
 }

--- a/tracker.go
+++ b/tracker.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/2389-research/dippin-lang/parser"
-	"github.com/2389-research/dippin-lang/validator"
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/agent/exec"
 	"github.com/2389-research/tracker/llm"
@@ -325,29 +323,14 @@ func parseDOTSource(source string) (*pipeline.Graph, error) {
 
 // parseDIPSource parses a Dippin-format pipeline source, runs validation and lint.
 func parseDIPSource(source string) (*pipeline.Graph, error) {
-	p := parser.NewParser(source, "inline.dip")
-	wf, err := p.Parse()
+	graph, diags, err := pipeline.LoadDippinWorkflow(source, "inline.dip")
 	if err != nil {
-		return nil, fmt.Errorf("parse pipeline: %w", err)
+		return nil, err
 	}
-	valResult := validator.Validate(wf)
-	if valResult.HasErrors() {
-		for _, d := range valResult.Diagnostics {
-			log.Println(d.String())
-		}
-		return nil, fmt.Errorf("%d validation error(s)", len(valResult.Errors()))
-	}
-	lintResult := validator.Lint(wf)
-	for _, d := range lintResult.Diagnostics {
+	// Log validation errors and lint warnings.
+	for _, d := range diags {
 		log.Println(d.String())
 	}
-	graph, err := pipeline.FromDippinIR(wf)
-	if err != nil {
-		return nil, fmt.Errorf("convert pipeline IR: %w", err)
-	}
-	// Mark graph as already validated by dippin-lang so that tracker's
-	// own validator skips redundant structural checks (DIP001–DIP009).
-	graph.DippinValidated = true
 	return graph, nil
 }
 


### PR DESCRIPTION
## Summary

- Add `Graph.DippinValidated bool` field that is set to `true` after the dippin-lang validator (DIP001–DIP009) runs successfully during `.dip` source parsing
- In `validateGraph`, skip the structural checks that overlap with dippin's diagnostics when `DippinValidated=true` — these are: start/exit existence, edge endpoint validity, reachability, unconditional cycles, and duplicate edges
- Tracker-specific checks that dippin does not cover still always run: `validateShapes` (DOT shape→handler resolution), `validateConditionalFailEdges`, and `validateEdgeLabelConsistency`
- DOT-format graphs (`DippinValidated=false`) continue to run all structural checks, since no upstream validator has covered them

## What was removed vs kept

**Removed from `.dip` code path** (dippin already covers these via DIP001–DIP009):
- `validateStartExit` — DIP001 (missing start) and DIP002 (missing exit)
- `validateEdgeEndpoints` — DIP003 (unknown node reference)
- `validateExitOutgoingEdges` — DIP006 (exit node has outgoing edges)
- `validateReachability` — DIP004 (unreachable nodes)
- `validateNoCycles` — DIP005 (unconditional cycles)
- `validateNoDuplicateEdges` — DIP009 (duplicate edges)

**Kept (tracker-specific, dippin does not check these)**:
- `validateShapes` — maps DOT shapes to handler names; dippin uses `role:` not DOT shapes
- `validateConditionalFailEdges` — warns on diamond nodes missing a fail path
- `validateEdgeLabelConsistency` — warns on mixed labeled/unlabeled edges from a single node

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` — all 15 packages pass
- [x] `dippin doctor examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip` — Grade A, 100/100
- [x] New `TestDippinValidatedSkipsStructuralChecks` table test covers all 6 sub-cases: missing start, unreachable node, unconditional cycle, duplicate edges (skipped for dippin-validated), and shape check + fail-edge warning (still fire for dippin-validated)
- [x] Existing structural tests (`TestValidateNoStartNode`, `TestValidateCycleDetection`, etc.) still pass because manually-constructed test graphs have `DippinValidated=false`
- [x] Pre-commit hooks passed: gofmt, go vet, build, tests, race detector, coverage, complexity, dippin lint

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported Dippin workflows are marked as pre-validated so redundant structural checks are skipped while tracker-specific validations still run.

* **Behavior Change**
  * Loading Dippin workflows now reports all validation/lint diagnostics (printed) and treats lint warnings as non-fatal; fatal parse/validation/conversion errors stop loading and are returned directly.

* **Tests**
  * Added tests confirming pre-validated graphs skip structural checks but still surface tracker-specific errors and warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->