### PR TITLE
docs: document pipeline context isolation and data flow between nodes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,9 @@ The CLI summary in `cmd/tracker/summary.go` uses `llm.TokenTracker` for
 per-provider breakdowns (middleware-level) and `EngineResult.Usage` for
 trace-level aggregation. These are independent data sources.
 
+### Pipeline context isolation (v0.17.0+)
+For the user-facing model of data flow between nodes, context scoping, and fidelity levels, see **[Pipeline Context Flow](docs/pipeline-context-flow.md)**.
+
 ### Cost governance (v0.17.0+)
 
 `UsageSummary.ProviderTotals` carries the per-provider rollup (tokens + cost),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,8 +176,8 @@ The CLI summary in `cmd/tracker/summary.go` uses `llm.TokenTracker` for
 per-provider breakdowns (middleware-level) and `EngineResult.Usage` for
 trace-level aggregation. These are independent data sources.
 
-### Pipeline context isolation (v0.17.0+)
-For the user-facing model of data flow between nodes, context scoping, and fidelity levels, see **[Pipeline Context Flow](docs/pipeline-context-flow.md)**.
+### Pipeline context isolation
+For the user-facing model of data flow between nodes, context scoping, and fidelity levels, see **[Pipeline Context Flow](docs/pipeline-context-flow.md)**. Per-node scoping (`node.<nodeID>.<key>`) is currently unreleased — it is on `main` and will ship in the next tagged release.
 
 ### Cost governance (v0.17.0+)
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Three namespaces for `${...}` syntax in prompts:
 
 Variables are expanded in a single pass — resolved values are never re-scanned, preventing recursive expansion.
 
-**Important**: Each node runs a fresh LLM session. Data flows between nodes via context keys, not conversation history. Use `${ctx.node.<nodeID>.<key>}` for specific upstream outputs (critical in parallel pipelines). See **[Pipeline Context Flow](docs/pipeline-context-flow.md)**.
+**Important**: Each agent node runs a fresh LLM session. Data flows between nodes via context keys, not conversation history. Per-node scoping (`${ctx.node.<nodeID>.<key>}`) is an unreleased feature currently on `main`; it lets you reference a specific earlier node's output without relying on the last-writer-wins `last_response` key. See **[Pipeline Context Flow](docs/pipeline-context-flow.md)** for the full model, fidelity levels, and parallel-branch patterns.
 
 ### Edge Conditions
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Three namespaces for `${...}` syntax in prompts:
 
 Variables are expanded in a single pass — resolved values are never re-scanned, preventing recursive expansion.
 
+**Important**: Each node runs a fresh LLM session. Data flows between nodes via context keys, not conversation history. Use `${ctx.node.<nodeID>.<key>}` for specific upstream outputs (critical in parallel pipelines). See **[Pipeline Context Flow](docs/pipeline-context-flow.md)**.
+
 ### Edge Conditions
 
 ```dip

--- a/docs/pipeline-context-flow.md
+++ b/docs/pipeline-context-flow.md
@@ -50,6 +50,24 @@ agent Synthesize
 
 Note that `ctx.` is the user-facing prefix; internally the engine stores bare keys (`last_response`) and scoped aliases (`node.Architect.last_response`). Conditions strip the prefix before lookup.
 
+### Safe-key restrictions for tool commands
+
+Agent prompts and conditions can interpolate any context key. **Tool commands have a restricted safe-key allowlist** to prevent LLM-origin values from leaking into shell commands and causing injection attacks.
+
+**Safe keys in tool commands:**
+- `outcome`, `preferred_label`, `human_response`, `interview_answers` (handler-written, user-controlled)
+- All `graph.*` keys (author-defined in the workflow)
+- All `params.*` keys (passed at pipeline invocation time)
+
+**Blocked keys in tool commands:**
+- `last_response` — LLM-generated, unsafe
+- `response.<nodeID>` — LLM-generated, unsafe
+- `tool_stdout`, `tool_stderr` — subprocess output, unsafe
+- `parallel.results` — LLM-generated, unsafe
+- Any other LLM-origin context keys
+
+If a tool command tries to interpolate a blocked key, the placeholder is replaced with an empty string. To safely use LLM output in a tool command, follow the **[Returning custom data from a node](#returning-custom-data-from-a-node)** pattern: have the agent write output to a file, then read the file in the tool command. See CLAUDE.md's **"Tool node safety"** section for detailed patterns and safety rationales.
+
 ## Per-node scoping details
 
 After a node finishes, the engine calls `PipelineContext.ScopeToNode(nodeID)`, which copies the keys marked dirty by `Set` or `Merge` since the previous scope into `node.<nodeID>.<key>` aliases. Bootstrap writes that happen before execution begins (via `NewPipelineContextFrom` and the `ClearDirty` call in `initRunState`) are excluded — only keys dirtied during the node's actual execution are scoped. Keys that already start with `node.` are skipped to avoid creating doubly-nested aliases. Earlier scoped aliases are preserved — only the bare keys get last-writer-wins semantics.

--- a/docs/pipeline-context-flow.md
+++ b/docs/pipeline-context-flow.md
@@ -1,101 +1,149 @@
 # Pipeline Context Flow
 
-Each node in a Tracker pipeline runs a fresh LLM session with a clean context window. There is no conversation history that automatically carries from one node to the next. Data flows between nodes via context keys in a shared key-value store.
+Tracker pipelines pass data between nodes through a shared key-value store called the **pipeline context**, not through LLM chat history. Agent nodes start a fresh LLM session each time they run — prior conversation turns are not replayed. Tool, human, parallel, and fan-in nodes produce outputs by writing specific keys into the context. Downstream nodes read those keys to see what happened upstream.
 
 ## Core Concept
 
-- **Fresh session per node**: Each node gets a new LLM conversation, not a continuation of the previous one.
-- **Data flows via context keys**: Values like `last_response`, `outcome`, and custom keys persist in the pipeline context.
-- **Per-node scoping** (v0.17.0+): After each node, outputs are stored in `node.<nodeID>.<key>` to prevent collisions in parallel pipelines.
-- **Fidelity levels**: Control how much prior context is injected into each node's prompt to manage token usage.
+- **Fresh LLM sessions**: each agent node runs a brand-new conversation with its own system prompt. No chat history leaks between agent nodes.
+- **Shared context store**: all nodes read from and write to a single `PipelineContext` (a string-keyed map) for the whole run.
+- **Per-node scoping** (upcoming — currently on `main`, unreleased): after each node completes, every key it wrote is also copied into `node.<nodeID>.<key>` so later nodes can reference a specific upstream node's output by name.
+- **Fidelity levels** control how much context an agent node sees in its prompt to prevent context-window bloat.
 
-## Why This Design
+## Why sessions are fresh
 
-As noted in the project meeting: "The DIP files have a weird context window situation where it doesn't necessarily have previous context in... which has turned out to be pretty positive because if you look at how people are doing Claude Code the best, it's like clear context before doing big work."
+Each node solves a single well-scoped problem. Carrying a full conversation history across nodes would push the LLM into a context window built for a different task, wasting tokens and confusing attention. By resetting the session every node, tracker matches how the best Claude Code workflows operate — clear the context before big work, pass only the inputs that matter.
 
-Each node gets only the context it needs, not accumulated noise from all prior steps.
+## Built-in context keys
 
-## Built-in Context Keys
+| Key | Written by | Purpose |
+|---|---|---|
+| `last_response` | agent (codergen) handler | The most recent agent node's final message content |
+| `response.<nodeID>` | agent and human handlers | Per-node response snapshot addressable by node ID |
+| `outcome` | every handler | `success` / `fail` / `retry` / `escalate` for the node that just ran |
+| `preferred_label` | human handler | Label the user selected on a labeled gate |
+| `human_response` | human handler | Freeform text the user typed at a gate |
+| `tool_stdout` / `tool_stderr` | tool handler | Subprocess output captured from `tool_command` |
+| `graph.goal` | engine (from `workflow.Goal`) | The workflow's stated objective, always available |
+| `parallel.results` | parallel handler | JSON array with one entry per branch: `{node_id, status, context_updates, stats}` |
 
-| Key | Set By | Purpose |
-|-----|--------|---------|
-| `last_response` | Agent/tool | Most recent node's output |
-| `response.<nodeID>` | Agents | Per-node response snapshot |
-| `outcome` | All handlers | success/fail/retry status |
-| `preferred_label` | Human gates | User's choice from options |
-| `human_response` | Human gates | Freeform user input |
-| `tool_stdout` / `tool_stderr` | Tools | Command output |
-| `graph.goal` | Engine | Pipeline's goal |
+Custom keys written by any handler are also available — for example a tool node can `echo "KEY=value" >> $TRACKER_CONTEXT`-style patterns if the workflow author designs for it.
 
-## Per-Node Scoping
+## Referencing context in prompts and commands
 
-In parallel pipelines, the last-writer-wins model causes collisions. Scoped keys prevent this:
+Inside an agent `prompt:`, a tool `command:`, or an edge `when:` condition, refer to a context key with `${ctx.<key>}`:
 
 ```dip
-fan_in Review <- BranchA, BranchB
-
-agent Review
-  prompt: |
-    BranchA result: ${ctx.node.BranchA.last_response}
-    BranchB result: ${ctx.node.BranchB.last_response}
-```
-
-Without scoped keys, `last_response` would only contain whichever branch finished last.
-
-## Fidelity Levels
-
-Control context window size by specifying how much prior context to inject:
-
-- `full` — all context (default)
-- `summary:high` — all keys + trimmed artifacts
-- `summary:medium` — only: outcome, last_response, human_response, tool_stdout, graph.goal
-- `summary:low` — only: goal + completed node list
-- `compact` — goal + outcome only
-- `truncate` — summary:medium keys capped at ~500 chars
-
-## Common Patterns
-
-### Sequential Pipe
-```dip
-agent Step1
-  prompt: Analyze...
-
 agent Step2
-  prompt: Based on ${ctx.last_response}, now...
-```
-
-### Reference Specific Node
-```dip
-agent Later
   prompt: |
-    From Step1: ${ctx.node.Step1.last_response}
-    From Step2: ${ctx.node.Step2.last_response}
+    The planner said: ${ctx.last_response}
+    Goal: ${ctx.graph.goal}
 ```
 
-### Parallel with Fan-in
+For per-node scoped reads (addressing a specific earlier node):
+
 ```dip
-parallel Work -> BranchA, BranchB
-
-fan_in Join <- BranchA, BranchB
-
 agent Synthesize
   prompt: |
-    A: ${ctx.node.BranchA.last_response}
-    B: ${ctx.node.BranchB.last_response}
-    Combine these...
+    Design from Architect: ${ctx.node.Architect.last_response}
+    Review from Critic:    ${ctx.node.Critic.last_response}
 ```
 
-## Common Mistakes
+Note that `ctx.` is the user-facing prefix; internally the engine stores bare keys (`last_response`) and scoped aliases (`node.Architect.last_response`). Conditions strip the prefix before lookup.
 
-❌ Expecting chat history: Each node is a fresh session.
-✅ Pass data explicitly: Use context keys and scoped keys.
+## Per-node scoping details
 
-❌ Using `last_response` in parallel: Gets the last branch to finish.
-✅ Use scoped keys: `${ctx.node.Branch1.output}`, `${ctx.node.Branch2.output}`.
+After a node finishes, the engine calls `PipelineContext.ScopeToNode(nodeID)` which copies every key the node wrote during its execution into a `node.<nodeID>.<key>` alias. Earlier scoped aliases are preserved — only the bare keys get last-writer-wins semantics.
 
-## See Also
+**Sequential pipelines:** `${ctx.node.<id>.last_response}` is the reliable way to reference a specific agent's output later in the run, instead of relying on `last_response` (which changes every node).
 
-- [CLAUDE.md](../CLAUDE.md): "Token usage flows through three layers"
-- `pipeline/context.go`: `PipelineContext`, `ScopeToNode`, `GetScoped`
-- `pipeline/fidelity.go`: Fidelity levels implementation
-- `examples/ask_and_execute.dip`: Real-world parallel example
+**Parallel branches:** parallel branch handlers run in their own isolated context snapshots and their updates are merged into the parent context under the *parallel node's* scope — not under each branch's scope. If you need per-branch outputs after a fan-in, the robust patterns today are:
+
+1. **Filesystem hand-off** (used by `examples/ask_and_execute.dip`): each branch writes files under `.ai/` and the fan-in node reads them.
+2. **Parse `parallel.results`**: the parallel handler writes a JSON array to `${ctx.parallel.results}` containing each branch's status and any `ContextUpdates` it produced.
+3. **Explicit per-branch keys**: a branch's agent prompt can instruct the model to write a specific key (e.g. `branch_a_summary`), and the fan-in node reads `${ctx.branch_a_summary}`.
+
+Reading `${ctx.node.<BranchID>.last_response}` after a parallel block will NOT automatically contain each branch's final output — use one of the patterns above instead.
+
+## Fidelity levels
+
+An agent node receives a compacted view of the pipeline context as part of its prompt construction. The amount of context injected is controlled by the `fidelity` attribute.
+
+### Levels (from `pipeline/fidelity.go`)
+
+- **`full`** — every key in the pipeline context is passed through. Expensive; use for nodes that genuinely need the whole picture.
+- **`summary:high`** — all keys plus a `summary.<nodeID>` entry per completed node, containing the first 2000 characters of each node's artifact `response.md`.
+- **`summary:medium`** — only these keys: `outcome`, `last_response`, `human_response`, `preferred_label`, `tool_stdout`, `tool_stderr`, `graph.goal`.
+- **`summary:low`** — `graph.goal` plus a single `completed_summary` key listing which nodes have finished.
+- **`compact`** — `graph.goal` and `outcome` only.
+- **`truncate`** — same keys as `summary:medium`, but each value is word-boundary-truncated to 500 characters.
+
+On resume from a checkpoint, the engine applies `DegradeFidelity()` to drop one level automatically so the replayed context doesn't blow out the window.
+
+### How to configure fidelity
+
+Set it as a node attribute (highest precedence):
+
+```dip
+agent Planner
+  fidelity: summary:high
+  prompt: ...
+```
+
+Or set a graph-level default that every node inherits unless it overrides:
+
+```dip
+workflow build_product
+  defaults:
+    fidelity: summary:medium
+```
+
+Lookup order: node `fidelity` attribute → graph `default_fidelity` attribute → hardcoded default (`full`).
+
+## Common patterns
+
+### Sequential pipe
+
+```dip
+agent Analyze
+  prompt: |
+    Analyze this spec: ${ctx.human_response}
+
+agent Build
+  prompt: |
+    Based on: ${ctx.last_response}
+    Build the described feature.
+```
+
+### Reference a specific earlier node
+
+```dip
+agent Review
+  prompt: |
+    Plan from Architect: ${ctx.node.Architect.last_response}
+    Code from Builder:   ${ctx.node.Builder.last_response}
+    Review both and report.
+```
+
+### Conditional routing on outcome
+
+```dip
+edges
+  Build -> Test        when ctx.outcome = success
+  Build -> FixFailure  when ctx.outcome = fail
+```
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Expecting the chat history from one agent node to carry into the next. | Reset your mental model: each agent node sees only its own prompt. Pass data explicitly via `${ctx.<key>}`. |
+| Reading `${ctx.last_response}` after a parallel fan-in and expecting the results of all branches. | Use `parallel.results`, filesystem hand-off, or explicit per-branch keys. |
+| Setting huge prompt content that blows past the context window. | Choose a lower fidelity, or use `truncate` / `summary:low` on downstream nodes. |
+| Relying on a custom key written by one node without declaring it in the workflow. | Pick a key name, write it in the upstream node's prompt/command, and read it downstream with `${ctx.<key>}`. |
+
+## See also
+
+- `CLAUDE.md` — "Token usage flows through three layers" explains how token accounting aggregates across nodes
+- `pipeline/context.go` — `PipelineContext`, `ScopeToNode`, `GetScoped`
+- `pipeline/fidelity.go` — fidelity level implementation and compaction
+- `examples/ask_and_execute.dip` — real-world parallel + fan-in pattern using filesystem hand-off

--- a/docs/pipeline-context-flow.md
+++ b/docs/pipeline-context-flow.md
@@ -1,0 +1,101 @@
+# Pipeline Context Flow
+
+Each node in a Tracker pipeline runs a fresh LLM session with a clean context window. There is no conversation history that automatically carries from one node to the next. Data flows between nodes via context keys in a shared key-value store.
+
+## Core Concept
+
+- **Fresh session per node**: Each node gets a new LLM conversation, not a continuation of the previous one.
+- **Data flows via context keys**: Values like `last_response`, `outcome`, and custom keys persist in the pipeline context.
+- **Per-node scoping** (v0.17.0+): After each node, outputs are stored in `node.<nodeID>.<key>` to prevent collisions in parallel pipelines.
+- **Fidelity levels**: Control how much prior context is injected into each node's prompt to manage token usage.
+
+## Why This Design
+
+As noted in the project meeting: "The DIP files have a weird context window situation where it doesn't necessarily have previous context in... which has turned out to be pretty positive because if you look at how people are doing Claude Code the best, it's like clear context before doing big work."
+
+Each node gets only the context it needs, not accumulated noise from all prior steps.
+
+## Built-in Context Keys
+
+| Key | Set By | Purpose |
+|-----|--------|---------|
+| `last_response` | Agent/tool | Most recent node's output |
+| `response.<nodeID>` | Agents | Per-node response snapshot |
+| `outcome` | All handlers | success/fail/retry status |
+| `preferred_label` | Human gates | User's choice from options |
+| `human_response` | Human gates | Freeform user input |
+| `tool_stdout` / `tool_stderr` | Tools | Command output |
+| `graph.goal` | Engine | Pipeline's goal |
+
+## Per-Node Scoping
+
+In parallel pipelines, the last-writer-wins model causes collisions. Scoped keys prevent this:
+
+```dip
+fan_in Review <- BranchA, BranchB
+
+agent Review
+  prompt: |
+    BranchA result: ${ctx.node.BranchA.last_response}
+    BranchB result: ${ctx.node.BranchB.last_response}
+```
+
+Without scoped keys, `last_response` would only contain whichever branch finished last.
+
+## Fidelity Levels
+
+Control context window size by specifying how much prior context to inject:
+
+- `full` — all context (default)
+- `summary:high` — all keys + trimmed artifacts
+- `summary:medium` — only: outcome, last_response, human_response, tool_stdout, graph.goal
+- `summary:low` — only: goal + completed node list
+- `compact` — goal + outcome only
+- `truncate` — summary:medium keys capped at ~500 chars
+
+## Common Patterns
+
+### Sequential Pipe
+```dip
+agent Step1
+  prompt: Analyze...
+
+agent Step2
+  prompt: Based on ${ctx.last_response}, now...
+```
+
+### Reference Specific Node
+```dip
+agent Later
+  prompt: |
+    From Step1: ${ctx.node.Step1.last_response}
+    From Step2: ${ctx.node.Step2.last_response}
+```
+
+### Parallel with Fan-in
+```dip
+parallel Work -> BranchA, BranchB
+
+fan_in Join <- BranchA, BranchB
+
+agent Synthesize
+  prompt: |
+    A: ${ctx.node.BranchA.last_response}
+    B: ${ctx.node.BranchB.last_response}
+    Combine these...
+```
+
+## Common Mistakes
+
+❌ Expecting chat history: Each node is a fresh session.
+✅ Pass data explicitly: Use context keys and scoped keys.
+
+❌ Using `last_response` in parallel: Gets the last branch to finish.
+✅ Use scoped keys: `${ctx.node.Branch1.output}`, `${ctx.node.Branch2.output}`.
+
+## See Also
+
+- [CLAUDE.md](../CLAUDE.md): "Token usage flows through three layers"
+- `pipeline/context.go`: `PipelineContext`, `ScopeToNode`, `GetScoped`
+- `pipeline/fidelity.go`: Fidelity levels implementation
+- `examples/ask_and_execute.dip`: Real-world parallel example

--- a/docs/pipeline-context-flow.md
+++ b/docs/pipeline-context-flow.md
@@ -52,11 +52,11 @@ Note that `ctx.` is the user-facing prefix; internally the engine stores bare ke
 
 ## Per-node scoping details
 
-After a node finishes, the engine calls `PipelineContext.ScopeToNode(nodeID)` which copies every key the node wrote during its execution into a `node.<nodeID>.<key>` alias. Earlier scoped aliases are preserved — only the bare keys get last-writer-wins semantics.
+After a node finishes, the engine calls `PipelineContext.ScopeToNode(nodeID)`, which copies the keys marked dirty by `Set` or `Merge` since the previous scope into `node.<nodeID>.<key>` aliases. Bootstrap writes that happen before execution begins (via `NewPipelineContextFrom` and the `ClearDirty` call in `initRunState`) are excluded — only keys dirtied during the node's actual execution are scoped. Keys that already start with `node.` are skipped to avoid creating doubly-nested aliases. Earlier scoped aliases are preserved — only the bare keys get last-writer-wins semantics.
 
 **Sequential pipelines:** `${ctx.node.<id>.last_response}` is the reliable way to reference a specific agent's output later in the run, instead of relying on `last_response` (which changes every node).
 
-**Parallel branches:** parallel branch handlers run in their own isolated context snapshots and their updates are merged into the parent context under the *parallel node's* scope — not under each branch's scope. If you need per-branch outputs after a fan-in, the robust patterns today are:
+**Parallel branches:** parallel branch handlers run in their own isolated context snapshots. After all branches complete, the parallel node writes a single `parallel.results` JSON array that surfaces each branch's status and context updates. The parent context does NOT gain per-branch scoped keys — there is no `${ctx.node.<BranchID>.*}` namespace populated by parallel execution. If you need per-branch outputs after a fan-in, the robust patterns today are:
 
 1. **Filesystem hand-off** (used by `examples/ask_and_execute.dip`): each branch writes files under `.ai/` and the fan-in node reads them.
 2. **Parse `parallel.results`**: the parallel handler writes a JSON array to `${ctx.parallel.results}` containing each branch's status and any `ContextUpdates` it produced.
@@ -148,7 +148,7 @@ An agent node receives a compacted view of the pipeline context as part of its p
 - **`summary:medium`** — only these keys: `outcome`, `last_response`, `human_response`, `preferred_label`, `tool_stdout`, `tool_stderr`, `graph.goal`.
 - **`summary:low`** — `graph.goal` plus a single `completed_summary` key listing which nodes have finished.
 - **`compact`** — `graph.goal` and `outcome` only.
-- **`truncate`** — same keys as `summary:medium`, but each value is word-boundary-truncated to 500 characters.
+- **`truncate`** — same keys as `summary:medium`, but each value is word-boundary-truncated to 500 characters and `"..."` is appended when truncation occurs.
 
 On resume from a checkpoint, the engine applies `DegradeFidelity()` to drop one level automatically so the replayed context doesn't blow out the window.
 

--- a/docs/pipeline-context-flow.md
+++ b/docs/pipeline-context-flow.md
@@ -26,7 +26,7 @@ Each node solves a single well-scoped problem. Carrying a full conversation hist
 | `graph.goal` | engine (from `workflow.Goal`) | The workflow's stated objective, always available |
 | `parallel.results` | parallel handler | JSON array with one entry per branch: `{node_id, status, context_updates, stats}` |
 
-Custom keys written by any handler are also available — for example a tool node can `echo "KEY=value" >> $TRACKER_CONTEXT`-style patterns if the workflow author designs for it.
+Handlers do NOT let user content set arbitrary context keys. The table above lists every key that each handler writes. Agent, tool, and human nodes each populate a fixed set — agents write `last_response` and `response.<nodeID>`, tools write `tool_stdout`/`tool_stderr`, humans write `human_response` and `preferred_label`. If you need to propagate a custom value from one node to the next, see **[Returning custom data from a node](#returning-custom-data-from-a-node)** below.
 
 ## Referencing context in prompts and commands
 
@@ -63,6 +63,79 @@ After a node finishes, the engine calls `PipelineContext.ScopeToNode(nodeID)` wh
 3. **Explicit per-branch keys**: a branch's agent prompt can instruct the model to write a specific key (e.g. `branch_a_summary`), and the fan-in node reads `${ctx.branch_a_summary}`.
 
 Reading `${ctx.node.<BranchID>.last_response}` after a parallel block will NOT automatically contain each branch's final output — use one of the patterns above instead.
+
+## Returning custom data from a node
+
+**Handlers write only a fixed set of built-in keys** (see the table above). There is no "write any key you want from the agent's response" feature — no `$TRACKER_CONTEXT` environment variable, no magic response prefix. If you need a custom value from one node to be available under a specific key for downstream nodes, pick one of these three supported patterns:
+
+### 1. Encode structured output in `last_response` and reference it downstream
+
+The easiest pattern when the next node is also an agent. The producer emits JSON or a key-value block inside its response; the consumer reads `${ctx.last_response}` (or `${ctx.node.<id>.last_response}` for a specific ancestor) and instructs the LLM to parse it.
+
+```dip
+agent Planner
+  prompt: |
+    Plan the work. Respond with JSON:
+    { "milestone": "m1-auth", "files": ["auth.go", "session.go"] }
+  response_format: json_object
+
+agent Builder
+  prompt: |
+    Plan from Planner: ${ctx.last_response}
+    Parse the JSON, extract "milestone", and build the listed files.
+```
+
+Force the structure at the API level with `response_format: json_object` so the producer is guaranteed to emit valid JSON (Anthropic, OpenAI, and Gemini all support this via their native JSON modes — see CLAUDE.md's "Structured output" section).
+
+### 2. Write to a file from one node, read from the file in the next
+
+The robust pattern when the handoff is large, binary, or needs to survive across tool and human nodes. The producer writes to a known path under the working directory or `.ai/` scratch dir; downstream nodes read from the same path.
+
+```dip
+agent GenerateSpec
+  prompt: |
+    Write the spec to .ai/spec.md. Your `write` tool is available.
+
+tool ExtractMilestone
+  command: |
+    set -eu
+    jq -r '.milestone' < .ai/spec.md > .ai/milestone.txt
+    cat .ai/milestone.txt      # goes to tool_stdout
+
+agent Builder
+  prompt: |
+    Implementing milestone: ${ctx.tool_stdout}
+    Full spec lives at .ai/spec.md — read it with your tools.
+```
+
+The filesystem is the source of truth; `tool_stdout` / `last_response` just carry a small reference. This scales to megabyte-sized intermediate artifacts without blowing up the context window.
+
+### 3. Use `auto_status` to route on a structured cue from an agent response
+
+When the "custom value" you actually need is just the node's outcome (success/fail/retry), set `auto_status: true` on the agent. The handler scans the response for a `STATUS: success|fail|retry` line and sets the outcome accordingly. This drives edge routing via `when ctx.outcome = ...` without needing a separate key.
+
+```dip
+agent Critic
+  auto_status: true
+  prompt: |
+    Review the diff. End your response with exactly one line:
+    STATUS: success   (if the change is ready to merge)
+    STATUS: retry     (if the author needs to fix something)
+    STATUS: fail      (if the whole approach is wrong)
+
+edges
+  Critic -> Merge      when ctx.outcome = success
+  Critic -> FixReview  when ctx.outcome = retry
+  Critic -> Abandon    when ctx.outcome = fail
+```
+
+### What about tool nodes writing custom keys?
+
+A `tool` handler only writes `tool_stdout` and `tool_stderr`. There is no `echo FOO=bar` pattern that sets `${ctx.FOO}`. Use pattern 2 (filesystem) for large values, or make the command emit JSON on stdout and have a downstream agent parse `${ctx.tool_stdout}`.
+
+### What about human gates?
+
+A `human` node (`mode: freeform`) writes exactly `human_response` (the free text) and `response.<nodeID>`. Labeled gates also write `preferred_label`. There is no way for the human to set additional keys — if you need structured data from a human, run an agent after the gate that parses `${ctx.human_response}` into the keys you want, or use `mode: interview` for multi-field form collection.
 
 ## Fidelity levels
 


### PR DESCRIPTION
## Summary

Adds a dedicated guide (`docs/pipeline-context-flow.md`) covering:

- **Fresh LLM sessions**: Each node runs a new session with a clean context window (no chat history bleed)
- **Context key data flow**: How data moves between nodes via shared key-value store
- **Per-node scoping** (v0.17.0): `node.<nodeID>.<key>` prevents collisions in parallel pipelines
- **Fidelity levels**: `full`, `summary:high`, `summary:medium`, `summary:low`, `compact`, `truncate` for controlling context window size
- **Common patterns**: Sequential pipe, referencing specific nodes, parallel with fan-in
- **Common mistakes**: Expecting chat history, misusing `last_response` in parallel, not using scoped keys
- **See also**: Links to context.go, fidelity.go, and examples

Also adds brief pointers in README.md (Variable Interpolation section) and CLAUDE.md (after Token usage section).

## Why This Matters

Users currently discover the context isolation behavior by surprise when one node's reasoning doesn't flow to the next. The meeting transcript shows this is intentional and beneficial ("clear context before doing big work"). This guide documents the design and provides actionable patterns for parallel pipelines and long sequences.

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added pipeline context isolation docs: fresh per-node LLM sessions and data flow via context keys instead of chat history.
  * Documented per-node context scoping, built-in context keys, allowlisting/blocked-key behavior, and fidelity levels with precedence and degradation rules.
  * Added examples for sequential and parallel patterns, common pitfalls, and guidance for referencing upstream values.
  * Noted per-node scoping is on main and will ship in the next tagged release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->