### PR TITLE
feat: Cloudflare AI Gateway via TRACKER_GATEWAY_URL / --gateway-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Cloudflare AI Gateway support** (`TRACKER_GATEWAY_URL` env var, `--gateway-url` CLI flag): set one gateway root URL and tracker routes every provider through Cloudflare's AI Gateway — Anthropic, OpenAI, Gemini, OpenAI-compat — avoiding 429 rate limits and enabling gateway-side analytics, caching, and model routing. The new `ResolveProviderBaseURL(provider)` helper resolves the per-provider base URL with priority `<PROVIDER>_BASE_URL` > `TRACKER_GATEWAY_URL` + provider suffix > empty (SDK default), so per-provider env var overrides still work. Closes #64.
 - **Per-node context scoping** (`PipelineContext.ScopeToNode`): after each node's handler completes, the engine copies every key written during that node's execution into a `node.<nodeID>.<key>` namespace. Downstream nodes can read `node.MyAgent.last_response` to get a specific upstream node's output without being affected by later writes to the bare `last_response` key. Bare keys retain their last-writer-wins global semantics for full backward compatibility. New convenience method `GetScoped(nodeID, key)`. Closes #32.
 - `pipeline.ContextKeyNodePrefix` constant (`"node."`), the namespace prefix for per-node scoped keys.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,7 @@ parallel agents via a TUI dashboard. Built by 2389.ai.
 - `AgentConfig.Params` is a generic pass-through map — typed fields take precedence over Params keys
 - The adapter maps IR field names to tracker convention: `model` → `llm_model`, `provider` → `llm_provider`
 - Provider name is `gemini` not `google`
+- Provider base URL resolution goes through `tracker.ResolveProviderBaseURL(provider)`: `<PROVIDER>_BASE_URL` env var wins; if unset, `TRACKER_GATEWAY_URL` is used with the provider suffix appended (`/anthropic`, `/openai`, `/google-ai-studio`, `/compat`); otherwise empty (SDK default). The `--gateway-url` CLI flag sets `TRACKER_GATEWAY_URL` before the LLM client is built. Use this for Cloudflare AI Gateway routing.
 - Variable expansion is single-pass — never re-scan resolved values
 - `ensureStartExitNodes` only assigns passthrough start/exit handlers to bare codergen (Agent) nodes with no `prompt` attribute. All other resolved handlers (`tool`, `wait.human`, `parallel`, `parallel.fan_in`, `conditional`, `subgraph`, `stack.manager_loop`, etc.) are preserved. The detection is based on `n.Handler`, not on enumerating handler-specific attributes, so future handler types are automatically covered.
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Submit with **Ctrl+S**. Enter inserts newlines. Esc cancels (empty) or submits (
 
 ### Providers
 
-Tracker supports three LLM providers: `anthropic`, `openai`, `gemini`. Set up with:
+Tracker supports four LLM providers: `anthropic`, `openai`, `gemini`, and `openai-compat` (for any OpenAI-compatible API). Set up with:
 
 ```bash
 # Interactive setup wizard

--- a/README.md
+++ b/README.md
@@ -254,6 +254,47 @@ export GEMINI_API_KEY=...
 
 Non-retryable provider errors (quota exceeded, auth failure, model not found) immediately fail the pipeline with a clear message instead of silently retrying.
 
+### Cloudflare AI Gateway
+
+Tracker can route every provider through [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/) so you stop hitting rate limits (Anthropic, OpenAI, etc. cap per-account request rates; Cloudflare's gateway capacity is much higher), gain central analytics and caching, and enable model routing on the gateway side.
+
+Set one env var or flag instead of four:
+
+```bash
+# The root URL of your Cloudflare AI Gateway:
+#   https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_slug>
+export TRACKER_GATEWAY_URL="https://gateway.ai.cloudflare.com/v1/acc/gw"
+
+# API keys still go to the provider — Cloudflare just proxies.
+export ANTHROPIC_API_KEY=sk-ant-...
+export OPENAI_API_KEY=sk-...
+export GEMINI_API_KEY=...
+
+tracker build_product
+```
+
+Or as a CLI flag:
+
+```bash
+tracker --gateway-url https://gateway.ai.cloudflare.com/v1/acc/gw build_product
+```
+
+Tracker automatically appends the per-provider suffix:
+
+| Provider | Resolved URL |
+|---|---|
+| `anthropic` | `<gateway>/anthropic` |
+| `openai` | `<gateway>/openai` |
+| `gemini` | `<gateway>/google-ai-studio` |
+| `openai-compat` | `<gateway>/compat` |
+
+**Per-provider overrides still win.** If you set `ANTHROPIC_BASE_URL` directly, Anthropic traffic goes there, and the gateway only proxies the providers you haven't explicitly overridden. This means you can point Anthropic at a self-hosted proxy while keeping OpenAI on Cloudflare with one command.
+
+**Troubleshooting:**
+- `429` from Cloudflare: something bigger is wrong (account-level limits, bad gateway slug). 429s from direct provider calls are what the gateway is meant to prevent.
+- `401`: check your provider API key, not the gateway — Cloudflare passes auth through.
+- Empty responses: verify the gateway slug is correct and the provider is enabled in the Cloudflare dashboard.
+
 ## Architecture
 
 ```mermaid

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -253,10 +253,17 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 		MaxCostCents:   cfg.maxCostCents,
 		MaxWallTime:    cfg.maxWallTime,
 	}
-	// Apply the Cloudflare AI Gateway root URL before buildLLMClient runs.
-	// ResolveProviderBaseURL honors per-provider *_BASE_URL env vars first,
-	// so setting TRACKER_GATEWAY_URL only affects providers the user hasn't
-	// already overridden.
+	// Apply --gateway-url before buildLLMClient is called.
+	// Timing is correct: executeRun sets the env var here, then calls
+	// selectAndRunMode → run/runTUI → buildLLMClient → buildProviderConstructors,
+	// which reads TRACKER_GATEWAY_URL via resolveProviderBaseURLFromEnv. The env
+	// var is live for every provider constructor closure that runs later.
+	//
+	// NOTE: This is process-global state (os.Setenv). Library consumers should
+	// use Config.GatewayURL instead — the tracker.NewEngine path passes the URL
+	// through Config without touching os.Environ. The CLI uses os.Setenv because
+	// run/runTUI have fixed signatures that can't be extended without breaking tests.
+	// Per-provider *_BASE_URL env vars always win over TRACKER_GATEWAY_URL.
 	if cfg.gatewayURL != "" {
 		if err := os.Setenv("TRACKER_GATEWAY_URL", cfg.gatewayURL); err != nil {
 			return fmt.Errorf("set TRACKER_GATEWAY_URL: %w", err)

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -253,6 +253,15 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 		MaxCostCents:   cfg.maxCostCents,
 		MaxWallTime:    cfg.maxWallTime,
 	}
+	// Apply the Cloudflare AI Gateway root URL before buildLLMClient runs.
+	// ResolveProviderBaseURL honors per-provider *_BASE_URL env vars first,
+	// so setting TRACKER_GATEWAY_URL only affects providers the user hasn't
+	// already overridden.
+	if cfg.gatewayURL != "" {
+		if err := os.Setenv("TRACKER_GATEWAY_URL", cfg.gatewayURL); err != nil {
+			return fmt.Errorf("set TRACKER_GATEWAY_URL: %w", err)
+		}
+	}
 
 	if err := printRunPreamble(cfg); err != nil {
 		return err

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -146,6 +146,7 @@ func newRunFlagSet(progName string, cfg *runConfig) *flag.FlagSet {
 	fs.IntVar(&cfg.maxTokens, "max-tokens", 0, "Halt if total tokens across the run exceed this value (0 = no limit)")
 	fs.IntVar(&cfg.maxCostCents, "max-cost", 0, "Halt if total cost in cents exceeds this value (0 = no limit)")
 	fs.DurationVar(&cfg.maxWallTime, "max-wall-time", 0, "Halt if pipeline wall time exceeds this duration (0 = no limit)")
+	fs.StringVar(&cfg.gatewayURL, "gateway-url", "", "Cloudflare AI Gateway root URL (per-provider *_BASE_URL env vars override this)")
 	return fs
 }
 

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -205,5 +205,6 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  --max-tokens int          Halt if total tokens exceed this value (0 = no limit)\n")
 	fmt.Fprintf(w, "  --max-cost int            Halt if total cost in cents exceeds this value (0 = no limit)\n")
 	fmt.Fprintf(w, "  --max-wall-time duration  Halt if pipeline wall time exceeds this duration (0 = no limit)\n")
+	fmt.Fprintf(w, "  --gateway-url string      Cloudflare AI Gateway root URL (per-provider *_BASE_URL env vars override this)\n")
 	fmt.Fprintf(w, "  --version                 Show version information\n")
 }

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -27,6 +27,7 @@ type runConfig struct {
 	maxTokens    int           // halt if total tokens exceed this value (0 = no limit)
 	maxCostCents int           // halt if total cost in cents exceeds this value (0 = no limit)
 	maxWallTime  time.Duration // halt if wall time exceeds this duration (0 = no limit)
+	gatewayURL   string        // TRACKER_GATEWAY_URL override — synthesizes per-provider base URLs
 }
 
 type commandMode string

--- a/cmd/tracker/main_test.go
+++ b/cmd/tracker/main_test.go
@@ -834,6 +834,88 @@ func TestParseFlagsBackendInvalid(t *testing.T) {
 	}
 }
 
+func TestParseFlagsGatewayURL(t *testing.T) {
+	const want = "https://gateway.ai.cloudflare.com/v1/acc/gw"
+	cfg, err := parseFlags([]string{"tracker", "--gateway-url", want, "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if cfg.gatewayURL != want {
+		t.Fatalf("gatewayURL = %q, want %q", cfg.gatewayURL, want)
+	}
+	if cfg.pipelineFile != "pipeline.dip" {
+		t.Fatalf("pipelineFile = %q, want %q", cfg.pipelineFile, "pipeline.dip")
+	}
+}
+
+func TestGatewayURLPropagatesViaEnv(t *testing.T) {
+	// executeRun sets TRACKER_GATEWAY_URL before buildLLMClient runs.
+	// Verify the env var is live in the same process after executeRun sets it.
+	unsetEnvForTest(t, "TRACKER_GATEWAY_URL")
+
+	const gateway = "https://gateway.ai.cloudflare.com/v1/acc/test"
+	var envValueAtRunTime string
+
+	_ = executeCommand(runConfig{
+		mode:         modeRun,
+		pipelineFile: "pipeline.dip",
+		workdir:      "/tmp",
+		noTUI:        true,
+		gatewayURL:   gateway,
+	}, commandDeps{
+		loadEnv: func(string) error { return nil },
+		run: func(pipelineFile, workdir, checkpoint, format, backend string, verbose bool, jsonOut bool) error {
+			// By the time run() is called, TRACKER_GATEWAY_URL must be set.
+			envValueAtRunTime = os.Getenv("TRACKER_GATEWAY_URL")
+			return nil
+		},
+		runTUI: func(pipelineFile, workdir, checkpoint, format, backend string, verbose bool) error {
+			t.Fatal("unexpected TUI path")
+			return nil
+		},
+	})
+
+	if envValueAtRunTime != gateway {
+		t.Fatalf("TRACKER_GATEWAY_URL inside run() = %q, want %q", envValueAtRunTime, gateway)
+	}
+}
+
+func TestResolveProviderBaseURLFromEnvGateway(t *testing.T) {
+	// resolveProviderBaseURLFromEnv must return the gateway-suffixed URL when
+	// TRACKER_GATEWAY_URL is set and no per-provider override exists.
+	unsetEnvForTest(t, "ANTHROPIC_BASE_URL")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com/v1/acc/slug")
+
+	got := resolveProviderBaseURLFromEnv("ANTHROPIC_BASE_URL", "/anthropic")
+	want := "https://gw.example.com/v1/acc/slug/anthropic"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveProviderBaseURLFromEnvPerProviderWins(t *testing.T) {
+	// Per-provider *_BASE_URL must win over TRACKER_GATEWAY_URL.
+	t.Setenv("ANTHROPIC_BASE_URL", "https://custom-proxy.example.com")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com/v1/acc/slug")
+
+	got := resolveProviderBaseURLFromEnv("ANTHROPIC_BASE_URL", "/anthropic")
+	want := "https://custom-proxy.example.com"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveProviderBaseURLFromEnvNoGateway(t *testing.T) {
+	// With neither env var set, must return empty string (use provider SDK default).
+	unsetEnvForTest(t, "ANTHROPIC_BASE_URL")
+	unsetEnvForTest(t, "TRACKER_GATEWAY_URL")
+
+	got := resolveProviderBaseURLFromEnv("ANTHROPIC_BASE_URL", "/anthropic")
+	if got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
 func TestExecuteCommandRunPassesBackend(t *testing.T) {
 	var gotBackend string
 	err := executeCommand(runConfig{

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -498,10 +498,31 @@ func buildProviderConstructors() map[string]func(string) (llm.ProviderAdapter, e
 	}
 }
 
+// resolveProviderBaseURLFromEnv resolves the base URL for a provider using the
+// same priority order as tracker.ResolveProviderBaseURL:
+//  1. Per-provider *_BASE_URL env var (always wins).
+//  2. TRACKER_GATEWAY_URL with provider suffix (set by --gateway-url before
+//     buildLLMClient runs, or by the user directly).
+//  3. Empty string → use provider SDK default.
+func resolveProviderBaseURLFromEnv(envKey, suffix string) string {
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	gateway := os.Getenv("TRACKER_GATEWAY_URL")
+	if gateway == "" {
+		return ""
+	}
+	// Strip trailing slash to prevent double-slash URLs.
+	for len(gateway) > 0 && gateway[len(gateway)-1] == '/' {
+		gateway = gateway[:len(gateway)-1]
+	}
+	return gateway + suffix
+}
+
 func buildAnthropicConstructor() func(string) (llm.ProviderAdapter, error) {
 	return func(key string) (llm.ProviderAdapter, error) {
 		var opts []anthropic.Option
-		if base := os.Getenv("ANTHROPIC_BASE_URL"); base != "" {
+		if base := resolveProviderBaseURLFromEnv("ANTHROPIC_BASE_URL", "/anthropic"); base != "" {
 			opts = append(opts, anthropic.WithBaseURL(base))
 		}
 		return anthropic.New(key, opts...), nil
@@ -511,7 +532,7 @@ func buildAnthropicConstructor() func(string) (llm.ProviderAdapter, error) {
 func buildOpenAIConstructor() func(string) (llm.ProviderAdapter, error) {
 	return func(key string) (llm.ProviderAdapter, error) {
 		var opts []openai.Option
-		if base := os.Getenv("OPENAI_BASE_URL"); base != "" {
+		if base := resolveProviderBaseURLFromEnv("OPENAI_BASE_URL", "/openai"); base != "" {
 			opts = append(opts, openai.WithBaseURL(base))
 		}
 		return openai.New(key, opts...), nil
@@ -521,7 +542,7 @@ func buildOpenAIConstructor() func(string) (llm.ProviderAdapter, error) {
 func buildGeminiConstructor() func(string) (llm.ProviderAdapter, error) {
 	return func(key string) (llm.ProviderAdapter, error) {
 		var opts []google.Option
-		if base := os.Getenv("GEMINI_BASE_URL"); base != "" {
+		if base := resolveProviderBaseURLFromEnv("GEMINI_BASE_URL", "/google-ai-studio"); base != "" {
 			opts = append(opts, google.WithBaseURL(base))
 		}
 		return google.New(key, opts...), nil
@@ -531,7 +552,7 @@ func buildGeminiConstructor() func(string) (llm.ProviderAdapter, error) {
 func buildOpenAICompatConstructor() func(string) (llm.ProviderAdapter, error) {
 	return func(key string) (llm.ProviderAdapter, error) {
 		var opts []openaicompat.Option
-		if base := os.Getenv("OPENAI_COMPAT_BASE_URL"); base != "" {
+		if base := resolveProviderBaseURLFromEnv("OPENAI_COMPAT_BASE_URL", "/compat"); base != "" {
 			opts = append(opts, openaicompat.WithBaseURL(base))
 		}
 		return openaicompat.New(key, opts...), nil

--- a/tracker.go
+++ b/tracker.go
@@ -47,6 +47,13 @@ type Config struct {
 	Autopilot     string                        // "" (interactive), "lax", "mid", "hard", "mentor"; LLM-driven gate decisions
 	AutoApprove   bool                          // auto-approve all human gates with default/first option
 	Budget        pipeline.BudgetLimits         // configures pipeline-level token, cost, and wall-time ceilings
+	// GatewayURL is the root URL of a Cloudflare AI Gateway (or any compatible
+	// proxy). When non-empty it is used as the base for all provider URLs, with
+	// the per-provider suffix appended (e.g. "<gateway>/anthropic"). A
+	// per-provider *_BASE_URL env var always takes precedence over GatewayURL so
+	// library callers can still override individual providers. The TRACKER_GATEWAY_URL
+	// env var is the fallback when GatewayURL is empty.
+	GatewayURL string
 }
 
 // CostReport summarizes spend for a pipeline run.
@@ -163,7 +170,7 @@ func resolveCompleter(cfg Config) (*llm.Client, agent.Completer, error) {
 	if cfg.LLMClient != nil {
 		return nil, cfg.LLMClient, nil
 	}
-	client, err := buildClient(cfg.Provider)
+	client, err := buildClient(cfg.Provider, cfg.GatewayURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create LLM client: %w", err)
 	}
@@ -338,8 +345,11 @@ func parseDIPSource(source string) (*pipeline.Graph, error) {
 // buildClient creates an LLM client from environment variables with
 // base URL support and retry middleware. If provider is non-empty, only
 // that provider is configured (returns error if unknown).
-func buildClient(provider string) (*llm.Client, error) {
-	constructors := allProviderConstructors()
+// gatewayURL is the Cloudflare AI Gateway root URL from Config.GatewayURL;
+// it is consulted after per-provider *_BASE_URL env vars and before
+// TRACKER_GATEWAY_URL (see resolveProviderBaseURLWithGateway).
+func buildClient(provider, gatewayURL string) (*llm.Client, error) {
+	constructors := allProviderConstructors(gatewayURL)
 
 	if provider != "" {
 		constructor, ok := constructors[provider]
@@ -366,13 +376,50 @@ func buildClient(provider string) (*llm.Client, error) {
 }
 
 // allProviderConstructors returns the full map of provider constructor functions.
-func allProviderConstructors() map[string]func(string) (llm.ProviderAdapter, error) {
+// gatewayURL is the explicit gateway root URL (from Config.GatewayURL); it is
+// passed to the adapter constructors so library consumers don't need to mutate
+// os.Environ.
+func allProviderConstructors(gatewayURL string) map[string]func(string) (llm.ProviderAdapter, error) {
 	return map[string]func(string) (llm.ProviderAdapter, error){
-		"anthropic":     newAnthropicAdapter,
-		"openai":        newOpenAIAdapter,
-		"gemini":        newGeminiAdapter,
-		"openai-compat": newOpenAICompatAdapter,
+		"anthropic":     func(k string) (llm.ProviderAdapter, error) { return newAnthropicAdapter(k, gatewayURL) },
+		"openai":        func(k string) (llm.ProviderAdapter, error) { return newOpenAIAdapter(k, gatewayURL) },
+		"gemini":        func(k string) (llm.ProviderAdapter, error) { return newGeminiAdapter(k, gatewayURL) },
+		"openai-compat": func(k string) (llm.ProviderAdapter, error) { return newOpenAICompatAdapter(k, gatewayURL) },
 	}
+}
+
+// resolveProviderBaseURLWithGateway resolves the base URL for a provider,
+// consulting sources in priority order:
+//
+//  1. Per-provider env var (*_BASE_URL) — always wins.
+//  2. gatewayURL argument (from Config.GatewayURL) with provider suffix appended.
+//  3. TRACKER_GATEWAY_URL env var with provider suffix appended.
+//  4. Empty string — use provider SDK default.
+func resolveProviderBaseURLWithGateway(provider, gatewayURL string) string {
+	var envKey, suffix string
+	switch provider {
+	case "anthropic":
+		envKey, suffix = "ANTHROPIC_BASE_URL", "/anthropic"
+	case "openai":
+		envKey, suffix = "OPENAI_BASE_URL", "/openai"
+	case "gemini":
+		envKey, suffix = "GEMINI_BASE_URL", "/google-ai-studio"
+	case "openai-compat":
+		envKey, suffix = "OPENAI_COMPAT_BASE_URL", "/compat"
+	default:
+		return ""
+	}
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	if gatewayURL != "" {
+		return strings.TrimRight(gatewayURL, "/") + suffix
+	}
+	gateway := strings.TrimRight(os.Getenv("TRACKER_GATEWAY_URL"), "/")
+	if gateway == "" {
+		return ""
+	}
+	return gateway + suffix
 }
 
 // ResolveProviderBaseURL returns the base URL a provider's HTTP client should
@@ -413,33 +460,33 @@ func ResolveProviderBaseURL(provider string) string {
 	return gateway + suffix
 }
 
-func newAnthropicAdapter(key string) (llm.ProviderAdapter, error) {
+func newAnthropicAdapter(key, gatewayURL string) (llm.ProviderAdapter, error) {
 	var opts []anthropic.Option
-	if base := ResolveProviderBaseURL("anthropic"); base != "" {
+	if base := resolveProviderBaseURLWithGateway("anthropic", gatewayURL); base != "" {
 		opts = append(opts, anthropic.WithBaseURL(base))
 	}
 	return anthropic.New(key, opts...), nil
 }
 
-func newOpenAIAdapter(key string) (llm.ProviderAdapter, error) {
+func newOpenAIAdapter(key, gatewayURL string) (llm.ProviderAdapter, error) {
 	var opts []openai.Option
-	if base := ResolveProviderBaseURL("openai"); base != "" {
+	if base := resolveProviderBaseURLWithGateway("openai", gatewayURL); base != "" {
 		opts = append(opts, openai.WithBaseURL(base))
 	}
 	return openai.New(key, opts...), nil
 }
 
-func newGeminiAdapter(key string) (llm.ProviderAdapter, error) {
+func newGeminiAdapter(key, gatewayURL string) (llm.ProviderAdapter, error) {
 	var opts []google.Option
-	if base := ResolveProviderBaseURL("gemini"); base != "" {
+	if base := resolveProviderBaseURLWithGateway("gemini", gatewayURL); base != "" {
 		opts = append(opts, google.WithBaseURL(base))
 	}
 	return google.New(key, opts...), nil
 }
 
-func newOpenAICompatAdapter(key string) (llm.ProviderAdapter, error) {
+func newOpenAICompatAdapter(key, gatewayURL string) (llm.ProviderAdapter, error) {
 	var opts []openaicompat.Option
-	if base := ResolveProviderBaseURL("openai-compat"); base != "" {
+	if base := resolveProviderBaseURLWithGateway("openai-compat", gatewayURL); base != "" {
 		opts = append(opts, openaicompat.WithBaseURL(base))
 	}
 	return openaicompat.New(key, opts...), nil

--- a/tracker.go
+++ b/tracker.go
@@ -375,9 +375,47 @@ func allProviderConstructors() map[string]func(string) (llm.ProviderAdapter, err
 	}
 }
 
+// ResolveProviderBaseURL returns the base URL a provider's HTTP client should
+// use. Resolution order:
+//
+//  1. The provider-specific env var (ANTHROPIC_BASE_URL, OPENAI_BASE_URL,
+//     GEMINI_BASE_URL, OPENAI_COMPAT_BASE_URL).
+//  2. TRACKER_GATEWAY_URL with the Cloudflare AI Gateway provider suffix
+//     appended (e.g. ".../anthropic", ".../openai", ".../google-ai-studio").
+//  3. Empty string, meaning the provider's SDK default.
+//
+// Per-provider env vars always win over TRACKER_GATEWAY_URL, so users can set
+// a single gateway URL for everything and still override individual providers.
+// Trailing slashes on the gateway root are stripped before the suffix is
+// appended to prevent double-slash URLs. Unknown provider names return the
+// empty string.
+func ResolveProviderBaseURL(provider string) string {
+	var envKey, suffix string
+	switch provider {
+	case "anthropic":
+		envKey, suffix = "ANTHROPIC_BASE_URL", "/anthropic"
+	case "openai":
+		envKey, suffix = "OPENAI_BASE_URL", "/openai"
+	case "gemini":
+		envKey, suffix = "GEMINI_BASE_URL", "/google-ai-studio"
+	case "openai-compat":
+		envKey, suffix = "OPENAI_COMPAT_BASE_URL", "/compat"
+	default:
+		return ""
+	}
+	if v := os.Getenv(envKey); v != "" {
+		return v
+	}
+	gateway := strings.TrimRight(os.Getenv("TRACKER_GATEWAY_URL"), "/")
+	if gateway == "" {
+		return ""
+	}
+	return gateway + suffix
+}
+
 func newAnthropicAdapter(key string) (llm.ProviderAdapter, error) {
 	var opts []anthropic.Option
-	if base := os.Getenv("ANTHROPIC_BASE_URL"); base != "" {
+	if base := ResolveProviderBaseURL("anthropic"); base != "" {
 		opts = append(opts, anthropic.WithBaseURL(base))
 	}
 	return anthropic.New(key, opts...), nil
@@ -385,7 +423,7 @@ func newAnthropicAdapter(key string) (llm.ProviderAdapter, error) {
 
 func newOpenAIAdapter(key string) (llm.ProviderAdapter, error) {
 	var opts []openai.Option
-	if base := os.Getenv("OPENAI_BASE_URL"); base != "" {
+	if base := ResolveProviderBaseURL("openai"); base != "" {
 		opts = append(opts, openai.WithBaseURL(base))
 	}
 	return openai.New(key, opts...), nil
@@ -393,7 +431,7 @@ func newOpenAIAdapter(key string) (llm.ProviderAdapter, error) {
 
 func newGeminiAdapter(key string) (llm.ProviderAdapter, error) {
 	var opts []google.Option
-	if base := os.Getenv("GEMINI_BASE_URL"); base != "" {
+	if base := ResolveProviderBaseURL("gemini"); base != "" {
 		opts = append(opts, google.WithBaseURL(base))
 	}
 	return google.New(key, opts...), nil
@@ -401,7 +439,7 @@ func newGeminiAdapter(key string) (llm.ProviderAdapter, error) {
 
 func newOpenAICompatAdapter(key string) (llm.ProviderAdapter, error) {
 	var opts []openaicompat.Option
-	if base := os.Getenv("OPENAI_COMPAT_BASE_URL"); base != "" {
+	if base := ResolveProviderBaseURL("openai-compat"); base != "" {
 		opts = append(opts, openaicompat.WithBaseURL(base))
 	}
 	return openaicompat.New(key, opts...), nil

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -508,3 +508,66 @@ func TestRun_BudgetHalt_FromConfig(t *testing.T) {
 		t.Errorf("expected LimitsHit[0]='tokens', got %q", result.Cost.LimitsHit[0])
 	}
 }
+
+func TestResolveProviderBaseURL_NoGatewayNoOverride(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("GEMINI_BASE_URL", "")
+	t.Setenv("OPENAI_COMPAT_BASE_URL", "")
+	t.Setenv("TRACKER_GATEWAY_URL", "")
+	for _, p := range []string{"anthropic", "openai", "gemini", "openai-compat"} {
+		if got := ResolveProviderBaseURL(p); got != "" {
+			t.Errorf("%s: got %q, want empty", p, got)
+		}
+	}
+}
+
+func TestResolveProviderBaseURL_GatewayOnly(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("GEMINI_BASE_URL", "")
+	t.Setenv("OPENAI_COMPAT_BASE_URL", "")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gateway.ai.cloudflare.com/v1/acc/gw")
+	cases := map[string]string{
+		"anthropic":     "https://gateway.ai.cloudflare.com/v1/acc/gw/anthropic",
+		"openai":        "https://gateway.ai.cloudflare.com/v1/acc/gw/openai",
+		"gemini":        "https://gateway.ai.cloudflare.com/v1/acc/gw/google-ai-studio",
+		"openai-compat": "https://gateway.ai.cloudflare.com/v1/acc/gw/compat",
+	}
+	for provider, want := range cases {
+		if got := ResolveProviderBaseURL(provider); got != want {
+			t.Errorf("%s: got %q, want %q", provider, got, want)
+		}
+	}
+}
+
+func TestResolveProviderBaseURL_ProviderOverridesGateway(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "https://my.proxy/anthropic")
+	t.Setenv("OPENAI_BASE_URL", "")
+	t.Setenv("GEMINI_BASE_URL", "")
+	t.Setenv("OPENAI_COMPAT_BASE_URL", "")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gateway.ai.cloudflare.com/v1/acc/gw")
+
+	if got := ResolveProviderBaseURL("anthropic"); got != "https://my.proxy/anthropic" {
+		t.Errorf("anthropic: got %q, want provider-specific override", got)
+	}
+	// Other providers still flow through the gateway.
+	if got := ResolveProviderBaseURL("openai"); got != "https://gateway.ai.cloudflare.com/v1/acc/gw/openai" {
+		t.Errorf("openai: got %q, want gateway URL", got)
+	}
+}
+
+func TestResolveProviderBaseURL_TrailingSlashStripped(t *testing.T) {
+	t.Setenv("ANTHROPIC_BASE_URL", "")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://example/v1/a/g/")
+	if got := ResolveProviderBaseURL("anthropic"); got != "https://example/v1/a/g/anthropic" {
+		t.Errorf("got %q, want trailing slash stripped", got)
+	}
+}
+
+func TestResolveProviderBaseURL_UnknownProvider(t *testing.T) {
+	t.Setenv("TRACKER_GATEWAY_URL", "https://example/v1/a/g")
+	if got := ResolveProviderBaseURL("mystery"); got != "" {
+		t.Errorf("unknown provider should return empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fresh re-do of #64 after the original PR #80 was contaminated by a shared-checkout bug during parallel agent execution.

- New \`tracker.ResolveProviderBaseURL(provider)\` helper resolves each provider's HTTP base URL in a documented priority order: per-provider \`<PROVIDER>_BASE_URL\` env var > \`TRACKER_GATEWAY_URL\` with provider suffix appended > SDK default.
- All four provider adapters (\`anthropic\`, \`openai\`, \`gemini\`, \`openai-compat\`) now call \`ResolveProviderBaseURL\` instead of reading env vars directly.
- New \`--gateway-url\` CLI flag sets \`TRACKER_GATEWAY_URL\` before the LLM client is built.
- README "Cloudflare AI Gateway" section with setup, URL table, and troubleshooting.
- CLAUDE.md rule added under dippin-lang compatibility.

## Provider suffix map

| Provider | Suffix |
|---|---|
| \`anthropic\` | \`/anthropic\` |
| \`openai\` | \`/openai\` |
| \`gemini\` | \`/google-ai-studio\` |
| \`openai-compat\` | \`/compat\` |

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./... -short\`
- [x] \`dippin doctor\` — A/100 on all three example workflows
- [x] \`TestResolveProviderBaseURL_NoGatewayNoOverride\` — resolver returns empty without config
- [x] \`TestResolveProviderBaseURL_GatewayOnly\` — gateway synthesizes all four providers
- [x] \`TestResolveProviderBaseURL_ProviderOverridesGateway\` — per-provider env var beats gateway
- [x] \`TestResolveProviderBaseURL_TrailingSlashStripped\` — \`https://example/v1/a/g/\` → \`.../anthropic\` (no double slash)
- [x] \`TestResolveProviderBaseURL_UnknownProvider\` — unknown provider returns empty

Closes #64