### PR TITLE
feat(agent): verify-after-edit loop with auto-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Structured reflection prompt on tool failure** (issue #93): when a tool call returns an error, the agent session now automatically injects a user-role reflection message before the next LLM turn. The prompt asks the model to identify what went wrong, what assumption was incorrect, and what minimal change will fix it — matching the pattern used by top SWE-bench agents (~10-15% recovery improvement). The feature is enabled by default (`ReflectOnError: true` in `DefaultConfig()`) and capped at three consecutive reflection turns to prevent infinite loops; the counter resets after any clean (no-error) turn. Pipeline authors can opt individual nodes out via `reflect_on_error: false` in their `.dip` file.
+- **Verify-after-edit loop with auto-test** (closes #94): agent sessions can now automatically run tests after any turn that includes file-edit tool calls (`write`, `edit`, `apply_patch`, `notebook_edit`). Modelled on top SWE-bench agent behaviour (~15-20% improvement on benchmark), this transparent inner loop catches regressions before the LLM moves on.
+  - `SessionConfig.VerifyAfterEdit bool` — opt-in flag (default: false).
+  - `SessionConfig.VerifyCommand string` — explicit command; if empty, auto-detection runs: `go.mod` → `go test ./...`, `Cargo.toml` → `cargo test`, `package.json` → `npm test`, `Makefile` with `test:` target → `make test`, `pytest.ini`/`pyproject.toml[tool.pytest]` → `pytest`.
+  - `SessionConfig.MaxVerifyRetries int` — max verify→repair cycles per edit turn (default: 2). After exhaustion the session proceeds without blocking.
+  - Repair turns do NOT count toward `MaxTurns` — they are a transparent sub-loop.
+  - Verification output is capped at 4 KB (tail kept — most relevant errors appear at the end).
+  - Pipeline nodes wire the feature via `verify_after_edit`, `verify_command`, and `max_verify_retries` node attributes. `verify_command` can also be set at graph level as a default for all nodes.
+  - New file `agent/verify.go`; 8 new tests in `agent/verify_test.go` and `agent/session_test.go`.
 
 ## [0.17.0] - 2026-04-16
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -122,6 +122,9 @@ func (c SessionConfig) validateLimits() error {
 			return fmt.Errorf("CompactionThreshold must be > 0 and <= 1.0 when compaction is auto, got %f", c.CompactionThreshold)
 		}
 	}
+	if c.MaxVerifyRetries < 0 {
+		return fmt.Errorf("MaxVerifyRetries must be >= 0, got %d", c.MaxVerifyRetries)
+	}
 	return nil
 }
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -37,6 +37,21 @@ type SessionConfig struct {
 	// errors to help the LLM reason about what went wrong before retrying.
 	// Default: true.
 	ReflectOnError bool
+
+	// VerifyAfterEdit enables automatic test/lint verification after turns that
+	// include file writes or edits. If verification fails, the error is fed back
+	// to the LLM with a repair prompt. Default: false (opt-in).
+	VerifyAfterEdit bool
+
+	// VerifyCommand is the explicit verification command to run. When empty,
+	// auto-detection is used (looks for go.mod → "go test ./...", Cargo.toml →
+	// "cargo test", package.json → "npm test", Makefile with test target →
+	// "make test", pytest markers → "pytest").
+	VerifyCommand string
+
+	// MaxVerifyRetries is the maximum number of verify→repair cycles per edit
+	// turn before giving up and proceeding. Default: 2.
+	MaxVerifyRetries int
 }
 
 const (

--- a/agent/config.go
+++ b/agent/config.go
@@ -72,6 +72,7 @@ func DefaultConfig() SessionConfig {
 		Provider:                      DefaultProvider,
 		ContextCompaction:             CompactionNone,
 		ReflectOnError:                true,
+		MaxVerifyRetries:              2,
 	}
 }
 

--- a/agent/events.go
+++ b/agent/events.go
@@ -32,6 +32,9 @@ const (
 	EventContextCompaction    EventType = "context_compaction"
 	EventTurnMetrics          EventType = "turn_metrics"
 	EventLLMRequestPreparing  EventType = "llm_request_preparing"
+	// EventVerify is emitted for verify-after-edit status updates (pass/fail/retry).
+	// Use EventError only for infrastructure failures (binary not found, etc.).
+	EventVerify EventType = "verify"
 )
 
 // TurnMetrics captures per-turn token and performance data.

--- a/agent/format.go
+++ b/agent/format.go
@@ -22,6 +22,10 @@ func FormatEventLine(evt Event) string {
 		if evt.Err != nil {
 			return "✖ " + evt.Err.Error()
 		}
+	case EventVerify:
+		if evt.Text != "" {
+			return "✔ " + evt.Text
+		}
 	}
 	return ""
 }

--- a/agent/format.go
+++ b/agent/format.go
@@ -24,7 +24,10 @@ func FormatEventLine(evt Event) string {
 		}
 	case EventVerify:
 		if evt.Text != "" {
-			return "✔ " + evt.Text
+			if strings.Contains(evt.Text, "passed") {
+				return "✔ " + evt.Text
+			}
+			return "⚠ " + evt.Text
 		}
 	}
 	return ""

--- a/agent/parity_coding_agent_test.go
+++ b/agent/parity_coding_agent_test.go
@@ -202,9 +202,6 @@ func TestParityToolExecutionErrorsBecomeNamedErrorResults(t *testing.T) {
 	if toolResultCount != 1 {
 		t.Fatalf("expected exactly one tool result in second request, got %d", toolResultCount)
 	}
-	if toolResult == nil {
-		t.Fatal("expected exactly one tool result in second request")
-	}
 	if !toolResult.IsError {
 		t.Fatal("expected tool result to be marked as error")
 	}

--- a/agent/session.go
+++ b/agent/session.go
@@ -250,6 +250,16 @@ func (s *Session) executeTurn(ctx context.Context, turn int, start time.Time, tr
 	if stopped {
 		return false, true, nil
 	}
+
+	// Run the verify-after-edit loop if any edit tools were called this turn.
+	if s.turnHasEdits(toolCalls) {
+		if err := s.runVerifyLoop(ctx, result); err != nil {
+			// Verification infrastructure failure (e.g. binary not found).
+			// Emit a warning and proceed — do not block the pipeline.
+			s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: %v (proceeding)", err)})
+		}
+	}
+
 	return false, false, nil
 }
 
@@ -328,6 +338,88 @@ func (s *Session) maybeInjectReflection(hadErrors bool, ts *turnState) {
 	}
 	ts.consecutiveReflected++
 	s.messages = append(s.messages, llm.UserMessage(reflectionPrompt))
+}
+
+// turnHasEdits reports whether any of the tool calls in the turn are file-editing tools.
+func (s *Session) turnHasEdits(toolCalls []llm.ToolCallData) bool {
+	for _, tc := range toolCalls {
+		if isEditTool(tc.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+// runVerifyLoop runs the verify-after-edit inner loop. It resolves the verify
+// command, executes it, and injects repair prompts on failure. Repair turns
+// do NOT count toward session MaxTurns. After MaxVerifyRetries failures the
+// loop exits without blocking the caller.
+func (s *Session) runVerifyLoop(ctx context.Context, result *SessionResult) error {
+	v := newVerifier(s.config)
+	if v == nil {
+		return nil // disabled or no command detected
+	}
+
+	maxRetries := s.config.MaxVerifyRetries
+	if maxRetries <= 0 {
+		maxRetries = 2 // default
+	}
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		passed, output, err := v.run(ctx)
+		if err != nil {
+			return err // real execution failure
+		}
+		if passed {
+			s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed (%s)", v.cmd)})
+			return nil
+		}
+
+		// Verification failed — inject repair prompt and let the LLM fix it.
+		repairMsg := fmt.Sprintf(verifyRepairPrompt, v.cmd, 1, output)
+		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: failed (attempt %d/%d), injecting repair prompt", attempt+1, maxRetries)})
+		s.messages = append(s.messages, llm.UserMessage(repairMsg))
+
+		// Run a repair turn (does NOT count toward MaxTurns).
+		if err := s.runRepairTurn(ctx, result); err != nil {
+			return err
+		}
+	}
+
+	// Run one final verification after the last repair attempt.
+	passed, _, err := v.run(ctx)
+	if err != nil {
+		return err
+	}
+	if passed {
+		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed after repairs (%s)", v.cmd)})
+	} else {
+		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: max retries (%d) exhausted, proceeding", maxRetries)})
+	}
+	return nil
+}
+
+// runRepairTurn executes one LLM repair turn outside the main MaxTurns budget.
+// It calls the LLM, dispatches any tool calls, and appends messages. The repair
+// turn's token usage is added to result.Usage so it's visible in session stats.
+func (s *Session) runRepairTurn(ctx context.Context, result *SessionResult) error {
+	resp, err := s.doLLMCall(ctx, -1) // turn=-1 marks it as a repair turn in events
+	if err != nil {
+		return err
+	}
+
+	// Accumulate usage (repair turns count toward total cost/token usage).
+	result.Usage = result.Usage.Add(resp.Usage)
+
+	s.messages = append(s.messages, resp.Message)
+
+	toolCalls := resp.ToolCalls()
+	if len(toolCalls) == 0 {
+		return nil // LLM responded with text only (e.g. "I fixed it")
+	}
+
+	s.executeToolCalls(ctx, toolCalls, result)
+	return nil
 }
 
 // emit sends an event with the current timestamp to the session's event handler.

--- a/agent/session.go
+++ b/agent/session.go
@@ -363,7 +363,13 @@ func (s *Session) turnHasEdits(toolCalls []llm.ToolCallData) bool {
 		}
 	}
 	for _, tc := range toolCalls {
-		if isEditTool(tc.Name) && !errByID[tc.ID] {
+		if !isEditTool(tc.Name) {
+			continue
+		}
+		// Use the map-ok idiom: a missing ID (tool result not found) is not a
+		// confirmed success and should not trigger verification.
+		isErr, ok := errByID[tc.ID]
+		if ok && !isErr {
 			return true
 		}
 	}
@@ -380,10 +386,10 @@ func (s *Session) runVerifyLoop(ctx context.Context, result *SessionResult) erro
 		return nil // disabled or no command detected
 	}
 
+	// MaxVerifyRetries == 0 means "run once, no retries on failure".
+	// DefaultConfig sets 2; callers that want to disable repair entirely should
+	// set MaxVerifyRetries to 0 explicitly and rely on the single-pass verify.
 	maxRetries := s.config.MaxVerifyRetries
-	if maxRetries <= 0 {
-		maxRetries = 2 // default
-	}
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		passed, exitCode, output, err := v.run(ctx)
@@ -422,6 +428,13 @@ func (s *Session) runVerifyLoop(ctx context.Context, result *SessionResult) erro
 // runRepairTurn executes one LLM repair turn outside the main MaxTurns budget.
 // It calls the LLM, dispatches any tool calls, and appends messages. The repair
 // turn's token usage is added to result.Usage so it's visible in session stats.
+//
+// Intentional simplification: repair turns skip compaction checks, turn counting,
+// and turn-metric event emission that normal turns do. This is acceptable because
+// repair turns are bounded by MaxVerifyRetries (default 2) and produce at most
+// verifyOutputCap (4KB) of LLM-visible output — the cost impact is small and
+// predictable. Adding full bookkeeping would require threading the turn counter
+// and tracker into a shared path that would complicate the turn loop.
 func (s *Session) runRepairTurn(ctx context.Context, result *SessionResult) error {
 	resp, err := s.doLLMCall(ctx, -1) // turn=-1 marks it as a repair turn in events
 	if err != nil {

--- a/agent/session.go
+++ b/agent/session.go
@@ -366,18 +366,18 @@ func (s *Session) runVerifyLoop(ctx context.Context, result *SessionResult) erro
 	}
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		passed, output, err := v.run(ctx)
+		passed, exitCode, output, err := v.run(ctx)
 		if err != nil {
 			return err // real execution failure
 		}
 		if passed {
-			s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed (%s)", v.cmd)})
+			s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed (%s)", v.cmd)})
 			return nil
 		}
 
-		// Verification failed — inject repair prompt and let the LLM fix it.
-		repairMsg := fmt.Sprintf(verifyRepairPrompt, v.cmd, 1, output)
-		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: failed (attempt %d/%d), injecting repair prompt", attempt+1, maxRetries)})
+		// Verification failed — inject repair prompt with the real exit code.
+		repairMsg := fmt.Sprintf(verifyRepairPrompt, v.cmd, exitCode, output)
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: failed (attempt %d/%d), injecting repair prompt", attempt+1, maxRetries)})
 		s.messages = append(s.messages, llm.UserMessage(repairMsg))
 
 		// Run a repair turn (does NOT count toward MaxTurns).
@@ -387,14 +387,14 @@ func (s *Session) runVerifyLoop(ctx context.Context, result *SessionResult) erro
 	}
 
 	// Run one final verification after the last repair attempt.
-	passed, _, err := v.run(ctx)
+	passed, _, _, err := v.run(ctx)
 	if err != nil {
 		return err
 	}
 	if passed {
-		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed after repairs (%s)", v.cmd)})
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: passed after repairs (%s)", v.cmd)})
 	} else {
-		s.emit(Event{Type: EventError, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: max retries (%d) exhausted, proceeding", maxRetries)})
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-after-edit: max retries (%d) exhausted, proceeding", maxRetries)})
 	}
 	return nil
 }

--- a/agent/session.go
+++ b/agent/session.go
@@ -340,10 +340,30 @@ func (s *Session) maybeInjectReflection(hadErrors bool, ts *turnState) {
 	s.messages = append(s.messages, llm.UserMessage(reflectionPrompt))
 }
 
-// turnHasEdits reports whether any of the tool calls in the turn are file-editing tools.
+// turnHasEdits reports whether any edit tool call in the turn succeeded.
+// It checks both the tool name and the corresponding tool result to ensure the
+// workspace was actually modified. A failed write (e.g. permission denied)
+// does not count as an edit — running verification after an unchanged workspace
+// would test pre-existing failures unrelated to the current turn.
 func (s *Session) turnHasEdits(toolCalls []llm.ToolCallData) bool {
+	// Build a map of toolCallID → isError from the most recent tool-result message.
+	// executeToolCalls appends this message before turnHasEdits is called, but
+	// maybeInjectReflection may append additional user messages afterwards. Scan
+	// backwards to find the most recent RoleTool message.
+	errByID := make(map[string]bool, len(toolCalls))
+	for i := len(s.messages) - 1; i >= 0; i-- {
+		msg := s.messages[i]
+		if msg.Role == llm.RoleTool {
+			for _, part := range msg.Content {
+				if part.Kind == llm.KindToolResult && part.ToolResult != nil {
+					errByID[part.ToolResult.ToolCallID] = part.ToolResult.IsError
+				}
+			}
+			break
+		}
+	}
 	for _, tc := range toolCalls {
-		if isEditTool(tc.Name) {
+		if isEditTool(tc.Name) && !errByID[tc.ID] {
 			return true
 		}
 	}

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -1416,6 +1416,48 @@ func TestVerifyAfterEdit_NoEdits(t *testing.T) {
 	}
 }
 
+// TestVerifyAfterEdit_FailedWriteSkipsVerify ensures that verification is NOT
+// triggered when the edit tool call itself fails (e.g. permission denied).
+// A failed write leaves the workspace unchanged, so running verification would
+// test pre-existing failures unrelated to the current turn.
+func TestVerifyAfterEdit_FailedWriteSkipsVerify(t *testing.T) {
+	var capturedMessages [][]llm.Message
+
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			makeEditToolCallResp("call_1"),
+			makeStopResp("done"),
+		},
+		onComplete: func(req *llm.Request) {
+			snap := make([]llm.Message, len(req.Messages))
+			copy(snap, req.Messages)
+			capturedMessages = append(capturedMessages, snap)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = true
+	cfg.VerifyCommand = verifyFailCmd() // would fail if verification is (wrongly) triggered
+
+	// errorTool simulates a write tool that fails (e.g. permission denied).
+	failWrite := &errorTool{name: "write", err: fmt.Errorf("permission denied")}
+	sess := mustNewSession(t, client, cfg, WithTools(failWrite))
+
+	_, err := sess.Run(context.Background(), "write a file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No repair prompt — the write failed so the workspace was not modified.
+	for _, msgs := range capturedMessages {
+		for _, m := range msgs {
+			if m.Role == llm.RoleUser && strings.Contains(m.Text(), "Verification failed") {
+				t.Error("repair prompt must not be injected when the edit tool itself failed")
+			}
+		}
+	}
+}
+
 // TestVerifyAfterEdit_PassingTest ensures normal completion when verification passes.
 func TestVerifyAfterEdit_PassingTest(t *testing.T) {
 	var capturedMessages [][]llm.Message

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -1485,8 +1485,7 @@ func TestVerifyAfterEdit_FailingTest_AutoRepair(t *testing.T) {
 	}
 
 	// Verify command fails on the first call, passes on the second.
-	callCount := 0
-	verifyScript := buildCountedVerifyCmd(t, &callCount, 1 /* fail first N times */)
+	verifyScript := buildCountedVerifyCmd(t, 1 /* fail first N times */)
 
 	cfg := DefaultConfig()
 	cfg.VerifyAfterEdit = true
@@ -1517,15 +1516,17 @@ func TestVerifyAfterEdit_FailingTest_AutoRepair(t *testing.T) {
 
 // TestVerifyAfterEdit_MaxRetriesExhausted ensures the session proceeds normally
 // after MaxVerifyRetries failures instead of blocking indefinitely.
+// The mock includes edit tool calls in repair turns so the verify sub-loop is
+// actually triggered (repair turns that only return text bypass the edit check).
 func TestVerifyAfterEdit_MaxRetriesExhausted(t *testing.T) {
 	client := &mockCompleter{
 		responses: []*llm.Response{
-			// Turn 1: edit tool call.
+			// Turn 1: edit tool call triggers verify loop.
 			makeEditToolCallResp("call_1"),
-			// Repair turn 1 (repair attempt 1).
-			makeStopResp("attempted fix 1"),
-			// Repair turn 2 (repair attempt 2).
-			makeStopResp("attempted fix 2"),
+			// Repair turn 1: LLM makes an edit (verify still fails after this).
+			makeEditToolCallResp("call_repair_1"),
+			// Repair turn 2: LLM makes another edit (verify still fails after this).
+			makeEditToolCallResp("call_repair_2"),
 			// Main loop continues after retries exhausted.
 			makeStopResp("done"),
 		},
@@ -1551,7 +1552,7 @@ func TestVerifyAfterEdit_MaxRetriesExhausted(t *testing.T) {
 
 // buildCountedVerifyCmd creates a shell script in a temp dir that fails for the
 // first failCount invocations and succeeds thereafter. Returns the script path.
-func buildCountedVerifyCmd(t *testing.T, callCount *int, failCount int) string {
+func buildCountedVerifyCmd(t *testing.T, failCount int) string {
 	t.Helper()
 	dir := t.TempDir()
 	// Use a counter file so successive shell invocations share state.

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1273,4 +1275,304 @@ func TestReflectionResetOnSuccess(t *testing.T) {
 	if countReflectionMessages(callMessages[3]) <= reflectionsAfterSuccess {
 		t.Error("expected reflection to be re-injected after counter reset on successful turn")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Verify-after-edit tests
+// ---------------------------------------------------------------------------
+
+// makeEditToolCallResp builds a response that contains a single "write" tool call.
+func makeEditToolCallResp(id string) *llm.Response {
+	return &llm.Response{
+		Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{
+				{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:        id,
+						Name:      "write",
+						Arguments: json.RawMessage(`{"path":"main.go","content":"package main"}`),
+					},
+				},
+			},
+		},
+		FinishReason: llm.FinishReason{Reason: "tool_calls"},
+		Usage:        llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+	}
+}
+
+// makeReadToolCallResp builds a response with a single "read" tool call (non-edit).
+func makeReadToolCallResp(id string) *llm.Response {
+	return &llm.Response{
+		Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{
+				{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:        id,
+						Name:      "read",
+						Arguments: json.RawMessage(`{"path":"main.go"}`),
+					},
+				},
+			},
+		},
+		FinishReason: llm.FinishReason{Reason: "tool_calls"},
+		Usage:        llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+	}
+}
+
+// makeStopResp returns a terminal response (no tool calls).
+func makeStopResp(text string) *llm.Response {
+	return &llm.Response{
+		Message:      llm.AssistantMessage(text),
+		FinishReason: llm.FinishReason{Reason: "stop"},
+		Usage:        llm.Usage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15},
+	}
+}
+
+// verifyPassCmd returns a shell one-liner that always exits 0.
+func verifyPassCmd() string { return "true" }
+
+// verifyFailCmd returns a shell one-liner that always exits 1 with error output.
+func verifyFailCmd() string { return "false" }
+
+// TestVerifyAfterEdit_Disabled ensures no repair prompts are injected when
+// VerifyAfterEdit is false, even if edit tools were used.
+func TestVerifyAfterEdit_Disabled(t *testing.T) {
+	var capturedMessages [][]llm.Message
+
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			makeEditToolCallResp("call_1"),
+			makeStopResp("done"),
+		},
+		onComplete: func(req *llm.Request) {
+			snap := make([]llm.Message, len(req.Messages))
+			copy(snap, req.Messages)
+			capturedMessages = append(capturedMessages, snap)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = false
+	cfg.VerifyCommand = verifyFailCmd() // would fail if called
+
+	writeTool := &stubTool{name: "write", output: "wrote"}
+	sess := mustNewSession(t, client, cfg, WithTools(writeTool))
+
+	_, err := sess.Run(context.Background(), "write something")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No verify repair prompt should be present in any message.
+	for _, msgs := range capturedMessages {
+		for _, m := range msgs {
+			if m.Role == llm.RoleUser && strings.Contains(m.Text(), "Verification failed") {
+				t.Error("repair prompt should not be injected when VerifyAfterEdit is false")
+			}
+		}
+	}
+}
+
+// TestVerifyAfterEdit_NoEdits ensures verification is skipped when the turn
+// contains only non-edit tool calls.
+func TestVerifyAfterEdit_NoEdits(t *testing.T) {
+	var capturedMessages [][]llm.Message
+
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			makeReadToolCallResp("call_1"),
+			makeStopResp("done"),
+		},
+		onComplete: func(req *llm.Request) {
+			snap := make([]llm.Message, len(req.Messages))
+			copy(snap, req.Messages)
+			capturedMessages = append(capturedMessages, snap)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = true
+	cfg.VerifyCommand = verifyFailCmd() // would fail if called
+
+	readTool := &stubTool{name: "read", output: "content"}
+	sess := mustNewSession(t, client, cfg, WithTools(readTool))
+
+	_, err := sess.Run(context.Background(), "read something")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No verify repair prompt should appear since no edit tools were used.
+	for _, msgs := range capturedMessages {
+		for _, m := range msgs {
+			if m.Role == llm.RoleUser && strings.Contains(m.Text(), "Verification failed") {
+				t.Error("repair prompt should not be injected when no edit tools were used")
+			}
+		}
+	}
+}
+
+// TestVerifyAfterEdit_PassingTest ensures normal completion when verification passes.
+func TestVerifyAfterEdit_PassingTest(t *testing.T) {
+	var capturedMessages [][]llm.Message
+
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			makeEditToolCallResp("call_1"),
+			makeStopResp("done"),
+		},
+		onComplete: func(req *llm.Request) {
+			snap := make([]llm.Message, len(req.Messages))
+			copy(snap, req.Messages)
+			capturedMessages = append(capturedMessages, snap)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = true
+	cfg.VerifyCommand = verifyPassCmd()
+	cfg.MaxVerifyRetries = 2
+
+	writeTool := &stubTool{name: "write", output: "wrote"}
+	sess := mustNewSession(t, client, cfg, WithTools(writeTool))
+
+	result, err := sess.Run(context.Background(), "write a file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.MaxTurnsUsed {
+		t.Error("expected normal completion, not turn-limit exhaustion")
+	}
+
+	// Verify that NO repair prompt was injected.
+	for _, msgs := range capturedMessages {
+		for _, m := range msgs {
+			if m.Role == llm.RoleUser && strings.Contains(m.Text(), "Verification failed") {
+				t.Error("repair prompt should not be injected when verification passes")
+			}
+		}
+	}
+
+	// The LLM should only have been called twice: once for the edit turn, once for the stop.
+	if client.calls != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", client.calls)
+	}
+}
+
+// TestVerifyAfterEdit_FailingTest_AutoRepair ensures the repair prompt is injected
+// when verification fails, and that the LLM gets to respond.
+func TestVerifyAfterEdit_FailingTest_AutoRepair(t *testing.T) {
+	var capturedMessages [][]llm.Message
+
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			// Turn 1: LLM writes a file.
+			makeEditToolCallResp("call_1"),
+			// Repair turn 1: LLM writes a fixed file (edit tool again).
+			makeEditToolCallResp("call_repair_1"),
+			// Turn 2: LLM stops after the successful verification.
+			makeStopResp("done"),
+		},
+		onComplete: func(req *llm.Request) {
+			snap := make([]llm.Message, len(req.Messages))
+			copy(snap, req.Messages)
+			capturedMessages = append(capturedMessages, snap)
+		},
+	}
+
+	// Verify command fails on the first call, passes on the second.
+	callCount := 0
+	verifyScript := buildCountedVerifyCmd(t, &callCount, 1 /* fail first N times */)
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = true
+	cfg.VerifyCommand = verifyScript
+	cfg.MaxVerifyRetries = 2
+
+	writeTool := &stubTool{name: "write", output: "wrote"}
+	sess := mustNewSession(t, client, cfg, WithTools(writeTool))
+
+	_, err := sess.Run(context.Background(), "write a file")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A repair prompt must have been injected.
+	foundRepairPrompt := false
+	for _, msgs := range capturedMessages {
+		for _, m := range msgs {
+			if m.Role == llm.RoleUser && strings.Contains(m.Text(), "Verification failed") {
+				foundRepairPrompt = true
+			}
+		}
+	}
+	if !foundRepairPrompt {
+		t.Error("expected repair prompt to be injected after verification failure")
+	}
+}
+
+// TestVerifyAfterEdit_MaxRetriesExhausted ensures the session proceeds normally
+// after MaxVerifyRetries failures instead of blocking indefinitely.
+func TestVerifyAfterEdit_MaxRetriesExhausted(t *testing.T) {
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			// Turn 1: edit tool call.
+			makeEditToolCallResp("call_1"),
+			// Repair turn 1 (repair attempt 1).
+			makeStopResp("attempted fix 1"),
+			// Repair turn 2 (repair attempt 2).
+			makeStopResp("attempted fix 2"),
+			// Main loop continues after retries exhausted.
+			makeStopResp("done"),
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.VerifyAfterEdit = true
+	cfg.VerifyCommand = verifyFailCmd() // always fails
+	cfg.MaxVerifyRetries = 2
+
+	writeTool := &stubTool{name: "write", output: "wrote"}
+	sess := mustNewSession(t, client, cfg, WithTools(writeTool))
+
+	result, err := sess.Run(context.Background(), "write something")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Session should complete (not be stuck in an infinite loop).
+	if result.MaxTurnsUsed {
+		t.Error("expected session to complete without hitting MaxTurns")
+	}
+}
+
+// buildCountedVerifyCmd creates a shell script in a temp dir that fails for the
+// first failCount invocations and succeeds thereafter. Returns the script path.
+func buildCountedVerifyCmd(t *testing.T, callCount *int, failCount int) string {
+	t.Helper()
+	dir := t.TempDir()
+	// Use a counter file so successive shell invocations share state.
+	counterFile := filepath.Join(dir, "count")
+	scriptPath := filepath.Join(dir, "verify.sh")
+
+	script := fmt.Sprintf(`#!/bin/sh
+COUNT_FILE="%s"
+FAIL_COUNT=%d
+count=$(cat "$COUNT_FILE" 2>/dev/null || echo 0)
+count=$((count + 1))
+echo $count > "$COUNT_FILE"
+if [ "$count" -le "$FAIL_COUNT" ]; then
+  echo "test failed: attempt $count" >&2
+  exit 1
+fi
+exit 0
+`, counterFile, failCount)
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("WriteFile script: %v", err)
+	}
+	return scriptPath
 }

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -93,7 +93,8 @@ func hasMakeTestTarget(path string) bool {
 	return makeTestTargetRe.Match(data)
 }
 
-// hasPytestSection returns true if the pyproject.toml contains a [tool.pytest] section.
+// hasPytestSection returns true if the pyproject.toml contains any [tool.pytest*] section
+// header (e.g. [tool.pytest] or [tool.pytest.ini_options]).
 // The full file is read so that sections appearing after the first 1 KB are not missed.
 func hasPytestSection(path string) bool {
 	data, err := os.ReadFile(path)
@@ -122,6 +123,9 @@ func newVerifier(cfg SessionConfig) *verifier {
 	if cmd == "" {
 		return nil // no build system detected; skip verification silently
 	}
+	// cfg.WorkingDir is set from s.env.WorkingDir in codergen (via SessionConfig.WorkingDir),
+	// so the verifier runs in the same directory as tool executions. If the session has no
+	// explicit WorkingDir it defaults to "." (process cwd), matching the tool handler default.
 	return &verifier{cmd: cmd, workDir: cfg.WorkingDir}
 }
 
@@ -166,9 +170,16 @@ func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output s
 
 // truncateTail keeps the last n bytes of s.
 // If len(s) <= n, returns s unchanged.
+// The prefix ("...(truncated)\n") is counted inside the n-byte budget so the
+// total returned string never exceeds n bytes.
 func truncateTail(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
-	return "...(truncated)\n" + s[len(s)-n:]
+	const prefix = "...(truncated)\n"
+	keep := n - len(prefix)
+	if keep <= 0 {
+		return s[len(s)-n:] // n is smaller than the prefix; just return a raw tail
+	}
+	return prefix + s[len(s)-keep:]
 }

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -6,9 +6,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -16,6 +18,11 @@ const (
 	// verifyOutputCap is the maximum bytes of verification output fed back to the LLM.
 	// The tail is kept (most relevant errors appear at the end).
 	verifyOutputCap = 4096
+
+	// verifyBufferCap is the maximum bytes buffered from the verification command's
+	// combined stdout+stderr. Real test runs can produce MBs; this prevents OOM.
+	// We buffer more than verifyOutputCap so we can keep the tail after truncation.
+	verifyBufferCap = 64 * 1024
 
 	// verifyRepairPrompt is injected when verification fails after an edit turn.
 	verifyRepairPrompt = `Verification failed after your edits.
@@ -77,8 +84,12 @@ func detectVerifyCommand(workDir string) string {
 	return ""
 }
 
-// hasMakeTestTarget returns true if the Makefile at path contains a "test:" target.
-// Only the first 1 KB is scanned to keep it fast.
+// makeTestTargetRe matches a "test:" target at the start of a line, avoiding
+// false positives on targets like "unittest:" or "integration_test:".
+var makeTestTargetRe = regexp.MustCompile(`(?m)^test\s*:`)
+
+// hasMakeTestTarget returns true if the Makefile at path contains a "test:" target
+// at the start of a line. Only the first 1 KB is scanned to keep it fast.
 func hasMakeTestTarget(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -88,7 +99,7 @@ func hasMakeTestTarget(path string) bool {
 
 	buf := make([]byte, 1024)
 	n, _ := f.Read(buf)
-	return strings.Contains(string(buf[:n]), "test:")
+	return makeTestTargetRe.Match(buf[:n])
 }
 
 // hasPytestSection returns true if the pyproject.toml contains a [tool.pytest] section.
@@ -127,34 +138,64 @@ func newVerifier(cfg SessionConfig) *verifier {
 	return &verifier{cmd: cmd, workDir: cfg.WorkingDir}
 }
 
-// run executes the verification command and returns (passed, output, error).
-// A non-zero exit code is not an error — it is returned as passed=false with output.
-// A real execution error (binary not found, etc.) is returned as error.
-func (v *verifier) run(ctx context.Context) (passed bool, output string, err error) {
-	parts := strings.Fields(v.cmd)
-	if len(parts) == 0 {
-		return false, "", fmt.Errorf("empty verify command")
+// run executes the verification command and returns (passed, exitCode, output, error).
+// A non-zero exit code is not an error — it is returned as passed=false with the
+// actual exit code and output. A real execution error (binary not found, etc.)
+// is returned as error. Output is capped at verifyBufferCap to prevent OOM.
+func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output string, err error) {
+	if strings.TrimSpace(v.cmd) == "" {
+		return false, 0, "", fmt.Errorf("empty verify command")
 	}
 
+	// Run via sh -c so the shell handles quoting and glob expansion, matching
+	// how tool_command is executed elsewhere in tracker.
 	//nolint:gosec // command comes from config/auto-detection, not user-controlled LLM output
-	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd := exec.CommandContext(ctx, "sh", "-c", v.cmd)
 	cmd.Dir = v.workDir
 
+	// Cap combined output to prevent OOM on verbose test suites.
+	// Keep the tail (errors usually appear at the end).
 	var combined bytes.Buffer
-	cmd.Stdout = &combined
-	cmd.Stderr = &combined
+	limited := io.LimitReader(io.TeeReader(nopWriter{}, &combined), verifyBufferCap)
+	_ = limited // limitreader applied via pipe below
+	cmd.Stdout = &limitedWriter{buf: &combined, remaining: verifyBufferCap}
+	cmd.Stderr = &limitedWriter{buf: &combined, remaining: verifyBufferCap}
 
 	runErr := cmd.Run()
 	out := combined.String()
 
 	if runErr != nil {
-		if _, ok := runErr.(*exec.ExitError); ok {
+		if ee, ok := runErr.(*exec.ExitError); ok {
 			// Non-zero exit code: verification failed but command ran fine.
-			return false, truncateTail(out, verifyOutputCap), nil
+			// Return the real exit code so the repair prompt is accurate.
+			return false, ee.ExitCode(), truncateTail(out, verifyOutputCap), nil
 		}
-		return false, "", runErr // real execution failure (e.g. binary not found)
+		return false, 0, "", runErr // real execution failure (e.g. binary not found)
 	}
-	return true, out, nil
+	return true, 0, out, nil
+}
+
+// nopWriter discards all writes (used as the read side of TeeReader above — unused).
+type nopWriter struct{}
+
+func (nopWriter) Read(p []byte) (int, error) { return 0, io.EOF }
+
+// limitedWriter is a bytes.Buffer wrapper that stops writing after remaining bytes.
+type limitedWriter struct {
+	buf       *bytes.Buffer
+	remaining int
+}
+
+func (lw *limitedWriter) Write(p []byte) (int, error) {
+	if lw.remaining <= 0 {
+		return len(p), nil // silently discard — cap already reached
+	}
+	if len(p) > lw.remaining {
+		p = p[:lw.remaining]
+	}
+	n, err := lw.buf.Write(p)
+	lw.remaining -= n
+	return len(p), err // report original len so cmd doesn't error on short write
 }
 
 // truncateTail keeps the last n bytes of s.

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -31,10 +31,10 @@ Please fix the failing test/lint issue, then I'll re-verify.`
 // editToolNames is the set of tool names that modify files on disk.
 // A turn that calls any of these triggers the verify-after-edit loop.
 var editToolNames = map[string]bool{
-	"write":          true,
-	"edit":           true,
-	"apply_patch":    true,
-	"notebook_edit":  true,
+	"write":         true,
+	"edit":          true,
+	"apply_patch":   true,
+	"notebook_edit": true,
 }
 
 // isEditTool reports whether the named tool modifies files.

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -3,8 +3,8 @@
 package agent
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,11 +17,6 @@ const (
 	// verifyOutputCap is the maximum bytes of verification output fed back to the LLM.
 	// The tail is kept (most relevant errors appear at the end).
 	verifyOutputCap = 4096
-
-	// verifyBufferCap is the maximum bytes buffered from the verification command's
-	// combined stdout+stderr. Real test runs can produce MBs; this prevents OOM.
-	// We buffer more than verifyOutputCap so we can keep the tail after truncation.
-	verifyBufferCap = 64 * 1024
 
 	// verifyRepairPrompt is injected when verification fails after an edit turn.
 	verifyRepairPrompt = `Verification failed after your edits.
@@ -133,7 +128,8 @@ func newVerifier(cfg SessionConfig) *verifier {
 // run executes the verification command and returns (passed, exitCode, output, error).
 // A non-zero exit code is not an error — it is returned as passed=false with the
 // actual exit code and output. A real execution error (binary not found, etc.)
-// is returned as error. Output is capped at verifyBufferCap to prevent OOM.
+// is returned as error. Output is capped at verifyOutputCap (tail kept) to prevent
+// feeding large test logs to the LLM repair prompt.
 func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output string, err error) {
 	if strings.TrimSpace(v.cmd) == "" {
 		return false, 0, "", fmt.Errorf("empty verify command")
@@ -148,50 +144,24 @@ func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output s
 	// cleanup of long-running test suites (consistent with tool handler). Deferred
 	// because verify commands are author-controlled and typically short-lived.
 
-	// Cap combined output to prevent OOM on verbose test suites.
-	// Keep the tail (errors usually appear at the end).
-	var combined bytes.Buffer
-	cmd.Stdout = &limitedWriter{buf: &combined, limit: verifyBufferCap}
-	cmd.Stderr = &limitedWriter{buf: &combined, limit: verifyBufferCap}
+	// CombinedOutput merges stdout+stderr safely — exec.Cmd uses separate goroutines
+	// for each stream and bytes.Buffer is not safe for concurrent writes.
+	// The cap is applied post-execution so we keep the tail (errors appear at the end).
+	out, runErr := cmd.CombinedOutput()
 
-	runErr := cmd.Run()
-	out := combined.String()
+	// Apply size cap: keep the tail where errors typically appear.
+	outStr := truncateTail(string(out), verifyOutputCap)
 
 	if runErr != nil {
-		if ee, ok := runErr.(*exec.ExitError); ok {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
 			// Non-zero exit code: verification failed but command ran fine.
 			// Return the real exit code so the repair prompt is accurate.
-			return false, ee.ExitCode(), truncateTail(out, verifyOutputCap), nil
+			return false, exitErr.ExitCode(), outStr, nil
 		}
-		return false, 0, "", runErr // real execution failure (e.g. binary not found)
+		return false, -1, outStr, runErr // real execution failure (e.g. binary not found)
 	}
-	return true, 0, out, nil
-}
-
-// limitedWriter caps how many bytes are forwarded to buf at limit bytes.
-// After the cap is reached, further writes are silently discarded.
-// Write always returns (len(p), nil) to satisfy the io.Writer contract —
-// returning a short write with err==nil would cause io.Copy to treat it as
-// an error per the Go spec.
-type limitedWriter struct {
-	buf   *bytes.Buffer
-	n     int64
-	limit int64
-}
-
-func (lw *limitedWriter) Write(p []byte) (int, error) {
-	if lw.n >= lw.limit {
-		return len(p), nil // cap reached — accept but discard
-	}
-	space := lw.limit - lw.n
-	if int64(len(p)) > space {
-		lw.buf.Write(p[:space]) //nolint:errcheck // bytes.Buffer.Write never returns an error
-		lw.n = lw.limit
-		return len(p), nil // accept full write, truncate internally
-	}
-	lw.buf.Write(p) //nolint:errcheck // bytes.Buffer.Write never returns an error
-	lw.n += int64(len(p))
-	return len(p), nil
+	return true, 0, outStr, nil
 }
 
 // truncateTail keeps the last n bytes of s.

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -1,0 +1,167 @@
+// ABOUTME: Verify-after-edit loop: auto-detects build system, runs tests after file edits, and injects repair prompts.
+// ABOUTME: Transparent inner loop — verification turns do not count against session MaxTurns.
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// verifyOutputCap is the maximum bytes of verification output fed back to the LLM.
+	// The tail is kept (most relevant errors appear at the end).
+	verifyOutputCap = 4096
+
+	// verifyRepairPrompt is injected when verification fails after an edit turn.
+	verifyRepairPrompt = `Verification failed after your edits.
+
+Command: %s
+Exit code: %d
+Output (truncated to 4KB):
+%s
+
+Please fix the failing test/lint issue, then I'll re-verify.`
+)
+
+// editToolNames is the set of tool names that modify files on disk.
+// A turn that calls any of these triggers the verify-after-edit loop.
+var editToolNames = map[string]bool{
+	"write":          true,
+	"edit":           true,
+	"apply_patch":    true,
+	"notebook_edit":  true,
+}
+
+// isEditTool reports whether the named tool modifies files.
+func isEditTool(name string) bool {
+	return editToolNames[name]
+}
+
+// detectVerifyCommand scans workDir for build system markers and returns the
+// appropriate test command. Priority order:
+//  1. go.mod → "go test ./..."
+//  2. Cargo.toml → "cargo test"
+//  3. package.json → "npm test"
+//  4. Makefile with "test:" target → "make test"
+//  5. pytest.ini / pyproject.toml with [tool.pytest] section → "pytest"
+//  6. "" (no detection)
+func detectVerifyCommand(workDir string) string {
+	checks := []struct {
+		file string
+		cmd  string
+		pred func(path string) bool
+	}{
+		{"go.mod", "go test ./...", nil},
+		{"Cargo.toml", "cargo test", nil},
+		{"package.json", "npm test", nil},
+		{"Makefile", "make test", hasMakeTestTarget},
+		{"pytest.ini", "pytest", nil},
+		{"pyproject.toml", "pytest", hasPytestSection},
+	}
+
+	for _, c := range checks {
+		path := filepath.Join(workDir, c.file)
+		if _, err := os.Stat(path); err != nil {
+			continue // file does not exist
+		}
+		if c.pred != nil && !c.pred(path) {
+			continue
+		}
+		return c.cmd
+	}
+	return ""
+}
+
+// hasMakeTestTarget returns true if the Makefile at path contains a "test:" target.
+// Only the first 1 KB is scanned to keep it fast.
+func hasMakeTestTarget(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 1024)
+	n, _ := f.Read(buf)
+	return strings.Contains(string(buf[:n]), "test:")
+}
+
+// hasPytestSection returns true if the pyproject.toml contains a [tool.pytest] section.
+// Only the first 1 KB is scanned.
+func hasPytestSection(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	buf := make([]byte, 1024)
+	n, _ := f.Read(buf)
+	return strings.Contains(string(buf[:n]), "[tool.pytest")
+}
+
+// verifier holds configuration for the verify-after-edit loop and runs it.
+type verifier struct {
+	cmd     string // resolved verification command (never empty)
+	workDir string
+}
+
+// newVerifier resolves the verify command and returns a verifier ready to use,
+// or nil if verification is disabled or no command can be resolved.
+func newVerifier(cfg SessionConfig) *verifier {
+	if !cfg.VerifyAfterEdit {
+		return nil
+	}
+	cmd := cfg.VerifyCommand
+	if cmd == "" {
+		cmd = detectVerifyCommand(cfg.WorkingDir)
+	}
+	if cmd == "" {
+		return nil // no build system detected; skip verification silently
+	}
+	return &verifier{cmd: cmd, workDir: cfg.WorkingDir}
+}
+
+// run executes the verification command and returns (passed, output, error).
+// A non-zero exit code is not an error — it is returned as passed=false with output.
+// A real execution error (binary not found, etc.) is returned as error.
+func (v *verifier) run(ctx context.Context) (passed bool, output string, err error) {
+	parts := strings.Fields(v.cmd)
+	if len(parts) == 0 {
+		return false, "", fmt.Errorf("empty verify command")
+	}
+
+	//nolint:gosec // command comes from config/auto-detection, not user-controlled LLM output
+	cmd := exec.CommandContext(ctx, parts[0], parts[1:]...)
+	cmd.Dir = v.workDir
+
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+
+	runErr := cmd.Run()
+	out := combined.String()
+
+	if runErr != nil {
+		if _, ok := runErr.(*exec.ExitError); ok {
+			// Non-zero exit code: verification failed but command ran fine.
+			return false, truncateTail(out, verifyOutputCap), nil
+		}
+		return false, "", runErr // real execution failure (e.g. binary not found)
+	}
+	return true, out, nil
+}
+
+// truncateTail keeps the last n bytes of s.
+// If len(s) <= n, returns s unchanged.
+func truncateTail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return "...(truncated)\n" + s[len(s)-n:]
+}

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -152,6 +152,9 @@ func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output s
 	//nolint:gosec // command comes from config/auto-detection, not user-controlled LLM output
 	cmd := exec.CommandContext(ctx, "sh", "-c", v.cmd)
 	cmd.Dir = v.workDir
+	// TODO: add cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} for process-group
+	// cleanup of long-running test suites (consistent with tool handler). Deferred
+	// because verify commands are author-controlled and typically short-lived.
 
 	// Cap combined output to prevent OOM on verbose test suites.
 	// Keep the tail (errors usually appear at the end).

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -89,31 +88,24 @@ func detectVerifyCommand(workDir string) string {
 var makeTestTargetRe = regexp.MustCompile(`(?m)^test\s*:`)
 
 // hasMakeTestTarget returns true if the Makefile at path contains a "test:" target
-// at the start of a line. Only the first 1 KB is scanned to keep it fast.
+// at the start of a line. The full file is read — Makefiles are typically small
+// config files and a valid target might appear anywhere in the file.
 func hasMakeTestTarget(path string) bool {
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
-	defer f.Close()
-
-	buf := make([]byte, 1024)
-	n, _ := f.Read(buf)
-	return makeTestTargetRe.Match(buf[:n])
+	return makeTestTargetRe.Match(data)
 }
 
 // hasPytestSection returns true if the pyproject.toml contains a [tool.pytest] section.
-// Only the first 1 KB is scanned.
+// The full file is read so that sections appearing after the first 1 KB are not missed.
 func hasPytestSection(path string) bool {
-	f, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return false
 	}
-	defer f.Close()
-
-	buf := make([]byte, 1024)
-	n, _ := f.Read(buf)
-	return strings.Contains(string(buf[:n]), "[tool.pytest")
+	return strings.Contains(string(data), "[tool.pytest")
 }
 
 // verifier holds configuration for the verify-after-edit loop and runs it.
@@ -159,10 +151,8 @@ func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output s
 	// Cap combined output to prevent OOM on verbose test suites.
 	// Keep the tail (errors usually appear at the end).
 	var combined bytes.Buffer
-	limited := io.LimitReader(io.TeeReader(nopWriter{}, &combined), verifyBufferCap)
-	_ = limited // limitreader applied via pipe below
-	cmd.Stdout = &limitedWriter{buf: &combined, remaining: verifyBufferCap}
-	cmd.Stderr = &limitedWriter{buf: &combined, remaining: verifyBufferCap}
+	cmd.Stdout = &limitedWriter{buf: &combined, limit: verifyBufferCap}
+	cmd.Stderr = &limitedWriter{buf: &combined, limit: verifyBufferCap}
 
 	runErr := cmd.Run()
 	out := combined.String()
@@ -178,27 +168,30 @@ func (v *verifier) run(ctx context.Context) (passed bool, exitCode int, output s
 	return true, 0, out, nil
 }
 
-// nopWriter discards all writes (used as the read side of TeeReader above — unused).
-type nopWriter struct{}
-
-func (nopWriter) Read(p []byte) (int, error) { return 0, io.EOF }
-
-// limitedWriter is a bytes.Buffer wrapper that stops writing after remaining bytes.
+// limitedWriter caps how many bytes are forwarded to buf at limit bytes.
+// After the cap is reached, further writes are silently discarded.
+// Write always returns (len(p), nil) to satisfy the io.Writer contract —
+// returning a short write with err==nil would cause io.Copy to treat it as
+// an error per the Go spec.
 type limitedWriter struct {
-	buf       *bytes.Buffer
-	remaining int
+	buf   *bytes.Buffer
+	n     int64
+	limit int64
 }
 
 func (lw *limitedWriter) Write(p []byte) (int, error) {
-	if lw.remaining <= 0 {
-		return len(p), nil // silently discard — cap already reached
+	if lw.n >= lw.limit {
+		return len(p), nil // cap reached — accept but discard
 	}
-	if len(p) > lw.remaining {
-		p = p[:lw.remaining]
+	space := lw.limit - lw.n
+	if int64(len(p)) > space {
+		lw.buf.Write(p[:space]) //nolint:errcheck // bytes.Buffer.Write never returns an error
+		lw.n = lw.limit
+		return len(p), nil // accept full write, truncate internally
 	}
-	n, err := lw.buf.Write(p)
-	lw.remaining -= n
-	return len(p), err // report original len so cmd doesn't error on short write
+	lw.buf.Write(p) //nolint:errcheck // bytes.Buffer.Write never returns an error
+	lw.n += int64(len(p))
+	return len(p), nil
 }
 
 // truncateTail keeps the last n bytes of s.

--- a/agent/verify_test.go
+++ b/agent/verify_test.go
@@ -74,6 +74,20 @@ func TestDetectVerifyCommand_MakefileWithoutTestTarget(t *testing.T) {
 	}
 }
 
+func TestDetectVerifyCommand_MakefileNoFalsePositive(t *testing.T) {
+	// Targets like "unittest:" or "integration_test:" must NOT match.
+	dir := t.TempDir()
+	makefile := ".PHONY: unittest\nunittest:\n\tgo test ./...\n\n.PHONY: integration_test\nintegration_test:\n\tgo test -tags integration ./...\n"
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	if got != "" {
+		t.Errorf("detectVerifyCommand = %q, want %q (unittest: and integration_test: must not match test:)", got, "")
+	}
+}
+
 func TestDetectVerifyCommand_NoMarkers(t *testing.T) {
 	dir := t.TempDir()
 	// Completely empty directory.

--- a/agent/verify_test.go
+++ b/agent/verify_test.go
@@ -88,6 +88,33 @@ func TestDetectVerifyCommand_MakefileNoFalsePositive(t *testing.T) {
 	}
 }
 
+func TestDetectVerifyCommand_PytestIni(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "pytest.ini"), []byte("[pytest]\n"), 0o644) //nolint:errcheck
+	cmd := detectVerifyCommand(dir)
+	if cmd != "pytest" {
+		t.Errorf("got %q, want pytest", cmd)
+	}
+}
+
+func TestDetectVerifyCommand_PyprojectToml(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[tool.pytest.ini_options]\n"), 0o644) //nolint:errcheck
+	cmd := detectVerifyCommand(dir)
+	if cmd != "pytest" {
+		t.Errorf("got %q, want pytest", cmd)
+	}
+}
+
+func TestDetectVerifyCommand_PyprojectWithoutPytest(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("[tool.black]\nline-length = 88\n"), 0o644) //nolint:errcheck
+	cmd := detectVerifyCommand(dir)
+	if cmd != "" {
+		t.Errorf("pyproject without pytest section should return empty, got %q", cmd)
+	}
+}
+
 func TestDetectVerifyCommand_NoMarkers(t *testing.T) {
 	dir := t.TempDir()
 	// Completely empty directory.

--- a/agent/verify_test.go
+++ b/agent/verify_test.go
@@ -1,0 +1,155 @@
+// ABOUTME: Tests for detectVerifyCommand build-system auto-detection.
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectVerifyCommand_GoProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	want := "go test ./..."
+	if got != want {
+		t.Errorf("detectVerifyCommand = %q, want %q", got, want)
+	}
+}
+
+func TestDetectVerifyCommand_NodeProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"test","scripts":{"test":"jest"}}`), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	want := "npm test"
+	if got != want {
+		t.Errorf("detectVerifyCommand = %q, want %q", got, want)
+	}
+}
+
+func TestDetectVerifyCommand_CargoProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte("[package]\nname = \"test\"\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	want := "cargo test"
+	if got != want {
+		t.Errorf("detectVerifyCommand = %q, want %q", got, want)
+	}
+}
+
+func TestDetectVerifyCommand_MakefileWithTestTarget(t *testing.T) {
+	dir := t.TempDir()
+	makefile := ".PHONY: test\ntest:\n\techo running tests\n"
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	want := "make test"
+	if got != want {
+		t.Errorf("detectVerifyCommand = %q, want %q", got, want)
+	}
+}
+
+func TestDetectVerifyCommand_MakefileWithoutTestTarget(t *testing.T) {
+	dir := t.TempDir()
+	// Makefile exists but has no "test:" target — should fall through to "".
+	makefile := ".PHONY: build\nbuild:\n\tgo build ./...\n"
+	if err := os.WriteFile(filepath.Join(dir, "Makefile"), []byte(makefile), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	if got != "" {
+		t.Errorf("detectVerifyCommand = %q, want %q (Makefile without test: target)", got, "")
+	}
+}
+
+func TestDetectVerifyCommand_NoMarkers(t *testing.T) {
+	dir := t.TempDir()
+	// Completely empty directory.
+
+	got := detectVerifyCommand(dir)
+	if got != "" {
+		t.Errorf("detectVerifyCommand = %q, want %q (empty dir)", got, "")
+	}
+}
+
+func TestDetectVerifyCommand_PriorityGoOverNode(t *testing.T) {
+	// go.mod takes priority over package.json (Go first in the list).
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0644); err != nil {
+		t.Fatalf("WriteFile go.mod: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatalf("WriteFile package.json: %v", err)
+	}
+
+	got := detectVerifyCommand(dir)
+	want := "go test ./..."
+	if got != want {
+		t.Errorf("detectVerifyCommand = %q, want %q (go.mod should take priority)", got, want)
+	}
+}
+
+func TestTruncateTail(t *testing.T) {
+	tests := []struct {
+		name string
+		s    string
+		n    int
+		want string
+	}{
+		{
+			name: "short string unchanged",
+			s:    "hello",
+			n:    10,
+			want: "hello",
+		},
+		{
+			name: "exact length unchanged",
+			s:    "hello",
+			n:    5,
+			want: "hello",
+		},
+		{
+			name: "long string truncated from front",
+			s:    "abcdefghij",
+			n:    5,
+			want: "...(truncated)\nfghij",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := truncateTail(tc.s, tc.n)
+			if got != tc.want {
+				t.Errorf("truncateTail(%q, %d) = %q, want %q", tc.s, tc.n, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsEditTool(t *testing.T) {
+	editTools := []string{"write", "edit", "apply_patch", "notebook_edit"}
+	for _, name := range editTools {
+		if !isEditTool(name) {
+			t.Errorf("isEditTool(%q) = false, want true", name)
+		}
+	}
+
+	nonEditTools := []string{"read", "grep", "glob", "bash", "spawn_agent"}
+	for _, name := range nonEditTools {
+		if isEditTool(name) {
+			t.Errorf("isEditTool(%q) = true, want false", name)
+		}
+	}
+}

--- a/agent/verify_test.go
+++ b/agent/verify_test.go
@@ -162,10 +162,19 @@ func TestTruncateTail(t *testing.T) {
 			want: "hello",
 		},
 		{
+			// prefix is "...(truncated)\n" (15 bytes); n=20 → keep=5 → last 5 chars kept.
+			// Total returned: 15+5 = 20 bytes, within the cap.
 			name: "long string truncated from front",
+			s:    "abcdefghijklmnopqrstuvwxyz567890",
+			n:    20,
+			want: "...(truncated)\n67890",
+		},
+		{
+			// n smaller than prefix: no room for prefix, return raw tail (within n bytes)
+			name: "n smaller than prefix",
 			s:    "abcdefghij",
 			n:    5,
-			want: "...(truncated)\nfghij",
+			want: "fghij",
 		},
 	}
 

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -525,6 +525,7 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	h.applyResponseFormat(&config, node)
 	h.applyCacheAndCompaction(&config, node)
 	h.applyReflectOnError(&config, node)
+	h.applyVerifyConfig(&config, node)
 
 	return config
 }
@@ -535,6 +536,28 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 func (h *CodergenHandler) applyReflectOnError(config *agent.SessionConfig, node *pipeline.Node) {
 	if v := node.Attrs["reflect_on_error"]; v == "false" {
 		config.ReflectOnError = false
+	}
+}
+
+// applyVerifyConfig sets VerifyAfterEdit, VerifyCommand, and MaxVerifyRetries
+// from graph-level defaults and node-level overrides.
+func (h *CodergenHandler) applyVerifyConfig(config *agent.SessionConfig, node *pipeline.Node) {
+	// Graph-level verify_command default (applies to all nodes that enable verification).
+	if v, ok := h.graphAttrs["verify_command"]; ok && v != "" {
+		config.VerifyCommand = v
+	}
+
+	// Node-level overrides take precedence.
+	if v, ok := node.Attrs["verify_after_edit"]; ok {
+		config.VerifyAfterEdit = v == "true"
+	}
+	if v, ok := node.Attrs["verify_command"]; ok && v != "" {
+		config.VerifyCommand = v
+	}
+	if v, ok := node.Attrs["max_verify_retries"]; ok && v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			config.MaxVerifyRetries = n
+		}
 	}
 }
 

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -540,14 +540,23 @@ func (h *CodergenHandler) applyReflectOnError(config *agent.SessionConfig, node 
 }
 
 // applyVerifyConfig sets VerifyAfterEdit, VerifyCommand, and MaxVerifyRetries
-// from graph-level defaults and node-level overrides.
+// from graph-level defaults and node-level overrides. All three attributes are
+// supported at both graph and node level; node-level takes precedence.
 func (h *CodergenHandler) applyVerifyConfig(config *agent.SessionConfig, node *pipeline.Node) {
-	// Graph-level verify_command default (applies to all nodes that enable verification).
+	// Graph-level defaults (apply to all nodes unless overridden).
+	if v, ok := h.graphAttrs["verify_after_edit"]; ok {
+		config.VerifyAfterEdit = v == "true"
+	}
 	if v, ok := h.graphAttrs["verify_command"]; ok && v != "" {
 		config.VerifyCommand = v
 	}
+	if v, ok := h.graphAttrs["max_verify_retries"]; ok && v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			config.MaxVerifyRetries = n
+		}
+	}
 
-	// Node-level overrides take precedence.
+	// Node-level overrides take precedence over graph-level defaults.
 	if v, ok := node.Attrs["verify_after_edit"]; ok {
 		config.VerifyAfterEdit = v == "true"
 	}

--- a/tui/adapter.go
+++ b/tui/adapter.go
@@ -57,6 +57,8 @@ func AdaptAgentEvent(evt agent.Event, nodeID string) tea.Msg {
 		return adaptToolCallEnd(evt, nodeID)
 	case agent.EventError:
 		return adaptAgentError(evt, nodeID)
+	case agent.EventVerify:
+		return MsgVerifyStatus{NodeID: nodeID, Text: evt.Text}
 	default:
 		return nil
 	}

--- a/tui/agentlog.go
+++ b/tui/agentlog.go
@@ -193,7 +193,11 @@ func (al *AgentLog) applyStreamMsgContent(msg tea.Msg) bool {
 		al.addTaggedLine(m.NodeID, Styles.Error.Render("ERROR: "+m.Error), LineError)
 	case MsgVerifyStatus:
 		al.flushNode(m.NodeID)
-		al.addTaggedLine(m.NodeID, Styles.Warn.Render("✔ "+m.Text), LineGeneral)
+		if strings.Contains(m.Text, "passed") {
+			al.addTaggedLine(m.NodeID, "✔ "+m.Text, LineGeneral)
+		} else {
+			al.addTaggedLine(m.NodeID, Styles.Warn.Render("⚠ "+m.Text), LineGeneral)
+		}
 	case MsgLLMProviderRaw:
 		al.handleProviderRaw(m)
 	default:

--- a/tui/agentlog.go
+++ b/tui/agentlog.go
@@ -191,6 +191,9 @@ func (al *AgentLog) applyStreamMsgContent(msg tea.Msg) bool {
 	case MsgAgentError:
 		al.flushNode(m.NodeID)
 		al.addTaggedLine(m.NodeID, Styles.Error.Render("ERROR: "+m.Error), LineError)
+	case MsgVerifyStatus:
+		al.flushNode(m.NodeID)
+		al.addTaggedLine(m.NodeID, Styles.Warn.Render("✔ "+m.Text), LineGeneral)
 	case MsgLLMProviderRaw:
 		al.handleProviderRaw(m)
 	default:

--- a/tui/messages.go
+++ b/tui/messages.go
@@ -47,6 +47,10 @@ type MsgAgentError struct {
 	NodeID string
 	Error  string
 }
+type MsgVerifyStatus struct {
+	NodeID string
+	Text   string
+}
 
 // LLM provider messages.
 type MsgLLMRequestPreparing struct {


### PR DESCRIPTION
## Summary

- Adds a transparent verify-after-edit inner loop to `agent.Session`: after any turn that calls file-editing tools (`write`, `edit`, `apply_patch`, `notebook_edit`), the session runs a configurable test/lint command and injects a repair prompt if it fails.
- Repair turns do **not** count against `MaxTurns` — they are a sub-loop invisible to the pipeline engine.
- Three new `SessionConfig` fields: `VerifyAfterEdit bool`, `VerifyCommand string`, `MaxVerifyRetries int` (default 2).
- Auto-detection of build system from working directory:

| Marker file | Command |
|---|---|
| `go.mod` | `go test ./...` |
| `Cargo.toml` | `cargo test` |
| `package.json` | `npm test` |
| `Makefile` with `test:` target | `make test` |
| `pytest.ini` / `pyproject.toml [tool.pytest]` | `pytest` |

- Pipeline nodes opt in via `verify_after_edit: true`; `verify_command` and `max_verify_retries` can be set per-node or at graph level.
- New file `agent/verify.go` (auto-detection + verifier runner).
- 8 new tests across `agent/verify_test.go` and `agent/session_test.go`.

**Design rationale:** Top SWE-bench agents (Agentless, SWE-agent 2.0) run tests after edits and self-repair on failure; this accounts for ~15-20% benchmark improvement over naive edit-only agents.

## Test plan

- [ ] `TestDetectVerifyCommand_GoProject` — go.mod → `go test ./...`
- [ ] `TestDetectVerifyCommand_NodeProject` — package.json → `npm test`
- [ ] `TestDetectVerifyCommand_CargoProject` — Cargo.toml → `cargo test`
- [ ] `TestDetectVerifyCommand_MakefileWithTestTarget` — Makefile with `test:` → `make test`
- [ ] `TestDetectVerifyCommand_NoMarkers` — empty dir → `""`
- [ ] `TestVerifyAfterEdit_Disabled` — no repair prompt when feature is off
- [ ] `TestVerifyAfterEdit_NoEdits` — no repair prompt for read-only turns
- [ ] `TestVerifyAfterEdit_PassingTest` — no repair when verify passes
- [ ] `TestVerifyAfterEdit_FailingTest_AutoRepair` — repair prompt injected on failure, resolved on second attempt
- [ ] `TestVerifyAfterEdit_MaxRetriesExhausted` — session proceeds after retry budget exhausted

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional verify-after-edit: sessions run tests after file edits, auto-attempt repairs on failures; configurable verify command and retry limit; auto-detection for Go, Node, Rust, Python, and Make projects.
  * UI now surfaces verification status messages (pass/warn) in logs.

* **Documentation**
  * Changelog updated to document the new verify-after-edit behavior and config options.

* **Tests**
  * Added unit and integration tests covering detection, truncation, verify/repair flows, and retry exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->