### PR TITLE
fix(openai): always emit required fields on Responses API input items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **OpenAI Responses API: `function_call_output` and `function_call` items now always serialize required fields** (closes #114). Previously the shared `openaiInput` struct used `omitempty` on every field, so a tool returning an empty-string result produced `{"type":"function_call_output","call_id":"..."}` with no `output` field, and a no-argument tool call produced `function_call` with no `arguments`. OpenAI's endpoint tolerated this, but OpenRouter's strict Zod validator rejected the requests with `invalid_prompt` / `invalid_union` errors, symptomatic on GLM, Qwen, and Kimi via OpenRouter. Fixed by replacing the `omitempty`-tagged single struct with a `MarshalJSON` method that emits only fields valid per item type, with required fields always present. Reported by @Nopik.
+
 ## [0.18.0] - 2026-04-17
 
 ### Added

--- a/llm/openai/translate.go
+++ b/llm/openai/translate.go
@@ -44,19 +44,55 @@ type openaiTextFormat struct {
 }
 
 // openaiInput represents a single item in the flat input array.
+//
+// The OpenAI Responses API input array is a discriminated union keyed by
+// Type (empty Type = role-based message). MarshalJSON emits only the
+// fields valid for the item's discriminator, with each type's required
+// fields always present — never stripped by omitempty. This matters for
+// strict validators (OpenRouter's Zod schema, issue #114) that reject a
+// function_call_output with a missing `output` field when a tool returned
+// an empty string, or a function_call with missing `arguments`.
 type openaiInput struct {
-	// Common fields
-	Role string `json:"role,omitempty"`
-	// For user/assistant messages
-	Content string `json:"content,omitempty"`
-	// For function_call items (tool invocations from the model)
-	Type      string `json:"type,omitempty"`
-	ID        string `json:"id,omitempty"`
-	Name      string `json:"name,omitempty"`
-	Arguments string `json:"arguments,omitempty"`
-	// For function_call_output items (tool results)
-	CallID string `json:"call_id,omitempty"`
-	Output string `json:"output,omitempty"`
+	// Role-message fields (Type == "")
+	Role    string `json:"role"`
+	Content string `json:"content"`
+	// Discriminator
+	Type string `json:"type"`
+	// function_call fields
+	Name      string `json:"name"`
+	Arguments string `json:"arguments"`
+	// function_call / function_call_output shared
+	CallID string `json:"call_id"`
+	// function_call_output field
+	Output string `json:"output"`
+}
+
+// MarshalJSON serializes an openaiInput using only the fields required for
+// the item's type. Required fields are always emitted (no omitempty) so
+// strict validators cannot reject the request for missing fields when a
+// value happens to be an empty string.
+func (i openaiInput) MarshalJSON() ([]byte, error) {
+	switch i.Type {
+	case "function_call":
+		return json.Marshal(struct {
+			Type      string `json:"type"`
+			CallID    string `json:"call_id"`
+			Name      string `json:"name"`
+			Arguments string `json:"arguments"`
+		}{i.Type, i.CallID, i.Name, i.Arguments})
+	case "function_call_output":
+		return json.Marshal(struct {
+			Type   string `json:"type"`
+			CallID string `json:"call_id"`
+			Output string `json:"output"`
+		}{i.Type, i.CallID, i.Output})
+	default:
+		// Role-based message (user / assistant / system / developer).
+		return json.Marshal(struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		}{i.Role, i.Content})
+	}
 }
 
 type openaiTool struct {

--- a/llm/openai/translate.go
+++ b/llm/openai/translate.go
@@ -4,6 +4,7 @@ package openai
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/2389-research/tracker/llm"
@@ -70,7 +71,9 @@ type openaiInput struct {
 // MarshalJSON serializes an openaiInput using only the fields required for
 // the item's type. Required fields are always emitted (no omitempty) so
 // strict validators cannot reject the request for missing fields when a
-// value happens to be an empty string.
+// value happens to be an empty string. An unrecognized non-empty Type is
+// an error rather than a silent fallback — adding a new item shape should
+// be a compile-or-test failure, not a wire-format bug.
 func (i openaiInput) MarshalJSON() ([]byte, error) {
 	switch i.Type {
 	case "function_call":
@@ -79,19 +82,33 @@ func (i openaiInput) MarshalJSON() ([]byte, error) {
 			CallID    string `json:"call_id"`
 			Name      string `json:"name"`
 			Arguments string `json:"arguments"`
-		}{i.Type, i.CallID, i.Name, i.Arguments})
+		}{
+			Type:      i.Type,
+			CallID:    i.CallID,
+			Name:      i.Name,
+			Arguments: i.Arguments,
+		})
 	case "function_call_output":
 		return json.Marshal(struct {
 			Type   string `json:"type"`
 			CallID string `json:"call_id"`
 			Output string `json:"output"`
-		}{i.Type, i.CallID, i.Output})
-	default:
+		}{
+			Type:   i.Type,
+			CallID: i.CallID,
+			Output: i.Output,
+		})
+	case "":
 		// Role-based message (user / assistant / system / developer).
 		return json.Marshal(struct {
 			Role    string `json:"role"`
 			Content string `json:"content"`
-		}{i.Role, i.Content})
+		}{
+			Role:    i.Role,
+			Content: i.Content,
+		})
+	default:
+		return nil, fmt.Errorf("openai: unsupported input type %q", i.Type)
 	}
 }
 

--- a/llm/openai/translate_test.go
+++ b/llm/openai/translate_test.go
@@ -238,3 +238,85 @@ func TestTranslateRequestMultiTurnToolCall(t *testing.T) {
 		t.Errorf("input length = %d, want 4 (user, assistant_text, function_call, function_call_output)", len(input))
 	}
 }
+
+// TestTranslateRequest_EmptyToolResult_KeepsOutputField verifies that a
+// function_call_output item always serializes the `output` field, even when
+// the tool returned an empty string. OpenRouter's strict Zod validator for
+// the OpenAI Responses API rejects the request when `output` is missing
+// (issue #114). OpenAI itself is lenient and accepts it, so this bug only
+// surfaces on OpenRouter and OpenRouter-proxied models (GLM, Qwen, Kimi).
+func TestTranslateRequest_EmptyToolResult_KeepsOutputField(t *testing.T) {
+	req := &llm.Request{
+		Model: "openai/gpt-4.1",
+		Messages: []llm.Message{
+			llm.UserMessage("call the tool"),
+			llm.ToolResultMessage("call_empty", "", false),
+		},
+	}
+
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatalf("translateRequest: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	input := raw["input"].([]any)
+	fco := input[1].(map[string]any)
+	if fco["type"] != "function_call_output" {
+		t.Fatalf("expected function_call_output, got %v", fco["type"])
+	}
+	out, present := fco["output"]
+	if !present {
+		t.Fatal("output field must be present on function_call_output items " +
+			"(required by OpenAI Responses API; OpenRouter rejects if missing)")
+	}
+	if out != "" {
+		t.Errorf("output = %v, want empty string", out)
+	}
+}
+
+// TestTranslateRequest_EmptyArguments_KeepsArgumentsField verifies that a
+// function_call item always serializes the `arguments` field as a string.
+// A no-argument tool call produces an empty string, which the Responses API
+// spec requires to be present — strict validators reject `undefined`.
+func TestTranslateRequest_EmptyArguments_KeepsArgumentsField(t *testing.T) {
+	req := &llm.Request{
+		Model: "openai/gpt-4.1",
+		Messages: []llm.Message{
+			{
+				Role: llm.RoleAssistant,
+				Content: []llm.ContentPart{
+					{Kind: llm.KindToolCall, ToolCall: &llm.ToolCallData{
+						ID:   "call_noargs",
+						Name: "pwd",
+						// Arguments is nil → becomes empty string after string(...)
+					}},
+				},
+			},
+		},
+	}
+
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatalf("translateRequest: %v", err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	input := raw["input"].([]any)
+	fc := input[0].(map[string]any)
+	if fc["type"] != "function_call" {
+		t.Fatalf("expected function_call, got %v", fc["type"])
+	}
+	if _, present := fc["name"]; !present {
+		t.Error("name field must be present on function_call items")
+	}
+	if _, present := fc["arguments"]; !present {
+		t.Error("arguments field must be present on function_call items (empty string is OK, undefined is not)")
+	}
+}

--- a/llm/openai/translate_test.go
+++ b/llm/openai/translate_test.go
@@ -247,7 +247,7 @@ func TestTranslateRequestMultiTurnToolCall(t *testing.T) {
 // surfaces on OpenRouter and OpenRouter-proxied models (GLM, Qwen, Kimi).
 func TestTranslateRequest_EmptyToolResult_KeepsOutputField(t *testing.T) {
 	req := &llm.Request{
-		Model: "openai/gpt-4.1",
+		Model: "gpt-4.1",
 		Messages: []llm.Message{
 			llm.UserMessage("call the tool"),
 			llm.ToolResultMessage("call_empty", "", false),
@@ -263,8 +263,17 @@ func TestTranslateRequest_EmptyToolResult_KeepsOutputField(t *testing.T) {
 	if err := json.Unmarshal(body, &raw); err != nil {
 		t.Fatal(err)
 	}
-	input := raw["input"].([]any)
-	fco := input[1].(map[string]any)
+	input, ok := raw["input"].([]any)
+	if !ok {
+		t.Fatalf("input = %T, want []any", raw["input"])
+	}
+	if len(input) < 2 {
+		t.Fatalf("input length = %d, want at least 2", len(input))
+	}
+	fco, ok := input[1].(map[string]any)
+	if !ok {
+		t.Fatalf("input[1] = %T, want map[string]any", input[1])
+	}
 	if fco["type"] != "function_call_output" {
 		t.Fatalf("expected function_call_output, got %v", fco["type"])
 	}
@@ -273,8 +282,12 @@ func TestTranslateRequest_EmptyToolResult_KeepsOutputField(t *testing.T) {
 		t.Fatal("output field must be present on function_call_output items " +
 			"(required by OpenAI Responses API; OpenRouter rejects if missing)")
 	}
-	if out != "" {
-		t.Errorf("output = %v, want empty string", out)
+	outStr, ok := out.(string)
+	if !ok {
+		t.Fatalf("output = %T, want string (null/undefined breaks strict validators)", out)
+	}
+	if outStr != "" {
+		t.Errorf("output = %q, want empty string", outStr)
 	}
 }
 
@@ -284,7 +297,7 @@ func TestTranslateRequest_EmptyToolResult_KeepsOutputField(t *testing.T) {
 // spec requires to be present — strict validators reject `undefined`.
 func TestTranslateRequest_EmptyArguments_KeepsArgumentsField(t *testing.T) {
 	req := &llm.Request{
-		Model: "openai/gpt-4.1",
+		Model: "gpt-4.1",
 		Messages: []llm.Message{
 			{
 				Role: llm.RoleAssistant,
@@ -308,15 +321,46 @@ func TestTranslateRequest_EmptyArguments_KeepsArgumentsField(t *testing.T) {
 	if err := json.Unmarshal(body, &raw); err != nil {
 		t.Fatal(err)
 	}
-	input := raw["input"].([]any)
-	fc := input[0].(map[string]any)
+	input, ok := raw["input"].([]any)
+	if !ok {
+		t.Fatalf("input = %T, want []any", raw["input"])
+	}
+	if len(input) < 1 {
+		t.Fatalf("input length = %d, want at least 1", len(input))
+	}
+	fc, ok := input[0].(map[string]any)
+	if !ok {
+		t.Fatalf("input[0] = %T, want map[string]any", input[0])
+	}
 	if fc["type"] != "function_call" {
 		t.Fatalf("expected function_call, got %v", fc["type"])
 	}
-	if _, present := fc["name"]; !present {
-		t.Error("name field must be present on function_call items")
+	name, ok := fc["name"].(string)
+	if !ok {
+		t.Fatalf("name = %T, want string", fc["name"])
 	}
-	if _, present := fc["arguments"]; !present {
-		t.Error("arguments field must be present on function_call items (empty string is OK, undefined is not)")
+	if name != "pwd" {
+		t.Errorf("name = %q, want pwd", name)
+	}
+	args, present := fc["arguments"]
+	if !present {
+		t.Fatal("arguments field must be present on function_call items (empty string is OK, undefined is not)")
+	}
+	argsStr, ok := args.(string)
+	if !ok {
+		t.Fatalf("arguments = %T, want string", args)
+	}
+	if argsStr != "" {
+		t.Errorf("arguments = %q, want empty string", argsStr)
+	}
+}
+
+// TestOpenaiInput_MarshalJSON_UnknownTypeIsError verifies we fail fast on an
+// unrecognized discriminator rather than silently emitting a malformed item.
+func TestOpenaiInput_MarshalJSON_UnknownTypeIsError(t *testing.T) {
+	i := openaiInput{Type: "made_up_type"}
+	_, err := json.Marshal(i)
+	if err == nil {
+		t.Fatal("expected error when marshaling unknown Type, got nil")
 	}
 }


### PR DESCRIPTION
Closes #114.

## Diagnosis

The OpenAI Responses API input array is a **discriminated union** keyed by each item's `type` field:
- `function_call_output` requires `output: string | array`
- `function_call` requires `name: string` and `arguments: string`
- role-based messages require `role` and `content`

Tracker modeled this as a single Go struct with `omitempty` on every field. The serializer dropped required fields whenever the value happened to be an empty string — e.g. a tool that returned \`\"\"\` produced:

\`\`\`json
{\"type\": \"function_call_output\", \"call_id\": \"call_xyz\"}
\`\`\`

OpenAI's endpoint accepted the loose shape, so the bug was latent. **OpenRouter** validates with a strict Zod schema matching the published spec and rejected the requests with \`invalid_prompt\` / \`invalid_union\` errors. Symptoms matched the report: random-looking failures only on OpenRouter-proxied models (GLM, Qwen, Kimi), deterministic per-model on resume (the bad item replays from conversation history), different failure location when the model changes.

## Fix

Replace \`omitempty\`-on-every-field with a \`MarshalJSON\` method that emits only the fields valid per discriminator, with required fields always present (empty strings kept, undefined never produced). Keeps the single builder struct so translation code is unchanged; retains unmarshal tags for round-trip test reads.

## Test plan

- [x] Added \`TestTranslateRequest_EmptyToolResult_KeepsOutputField\` — fails on main, passes after fix
- [x] Added \`TestTranslateRequest_EmptyArguments_KeepsArgumentsField\` — fails on main, passes after fix
- [x] \`go test ./...\` (all 17 packages) — pass
- [x] \`go test -race ./llm/openai\` — pass
- [x] \`go vet ./...\` clean
- [x] \`dippin doctor\` on three core pipelines → A / 100
- [x] Existing \`TestTranslateRequestMultiTurnToolCall\` still asserts the \"function_call items use call_id, not id\" contract — still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently include required fields for tool call and result items (even when empty), avoiding external validation errors.
  * Marshaling now fails for unrecognized item types instead of producing partial/ambiguous payloads.

* **Tests**
  * Added tests verifying required fields are always present and unknown types produce an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->