### PR TITLE
release: v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-04-20
+
 ### Added
 
 - **Library API hardening for v1.0** (#102, #103, #104, #106, #109):
@@ -19,7 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Diagnose` now streams `activity.jsonl` with `bufio.Scanner` instead of `os.ReadFile` → `strings.Split`, matching `LoadActivityLog` and avoiding a memory spike on large runs. Scanner errors (1 MB line-length overflow, I/O) and `ctx.Err()` now propagate out of `Diagnose` as a real error — partial reports are never returned as success, so automation with deadlines can distinguish complete from truncated analysis.
 - **Workflow params via `${params.*}` with CLI/library overrides** (closes #81): top-level Dippin `vars` now map to graph attrs under `params.<key>`, making them available in agent prompts, tool commands, and edge conditions through `${params.key}` interpolation. Added repeatable `--param key=value` on the CLI plus `tracker.Config.Params` for library callers; overrides hard-fail on unknown keys at startup and run summaries print effective overridden params. New lint rules DIP120 (undeclared `${params.*}` reference) and DIP121 (declared but unused var).
 - **Per-human-gate timeout / timeout_action in `.dip`** (closes #112): the dippin-lang v0.21.0 IR exposes `HumanConfig.Timeout` and `HumanConfig.TimeoutAction`; the adapter copies them into `node.Attrs["timeout"]` / `node.Attrs["timeout_action"]` where `pipeline/handlers/human.go` already consumed them. The `examples/human_gate_test_suite.dip` Makefile lint skip is removed.
-- **Workflow-level budget ceilings from `.dip`** (closes #67): dippin-lang v0.21.0 adds `WorkflowDefaults.MaxTotalTokens`, `WorkflowDefaults.MaxCostCents`, and `WorkflowDefaults.MaxWallTime`. The adapter now maps them to `graph.Attrs["max_total_tokens"]` / `["max_cost_cents"]` / `["max_wall_time"]`, and `tracker.resolveBudgetLimits` uses them as a fallback when `Config.Budget` and the matching `--max-*` CLI flags are zero. Explicit config values still win.
+- **Workflow-level budget ceilings from `.dip`** (closes #67): dippin-lang v0.21.0 adds `WorkflowDefaults.MaxTotalTokens`, `WorkflowDefaults.MaxCostCents`, and `WorkflowDefaults.MaxWallTime`. The adapter now maps them to `graph.Attrs["max_total_tokens"]` / `["max_cost_cents"]` / `["max_wall_time"]`, and `tracker.ResolveBudgetLimits` uses them as a fallback when `Config.Budget` and the matching `--max-*` CLI flags are zero. Explicit config values still win. Wired through both the library engine builder and the CLI's console/TUI engine builders.
+- **TUI pre-populates subgraph children in the sidebar** (closes #118): subgraph reference nodes previously appeared as opaque single rows until child `stage_started` events arrived. `buildNodeList` now accepts the `subgraphs` map and recursively flattens child graphs with prefixed IDs (`Parent/Child/...`), preserving user-set labels and parallel/fan-in flags. Lazy insertion remains as a fallback with a cycle guard for self-referential subgraph maps.
+- **Agent quality-of-life improvements from SWE-bench work**:
+  - **Turn-budget checkpoints**: optional guidance messages injected at configurable fractions of the turn budget (50%, 75%) to reduce thrashing on hard instances.
+  - **Two-phase verify-after-edit**: focused test first, broad regression test second, with a configurable repair retry budget. Models the pattern top SWE-bench agents use.
+  - **Tool polish**: `grep` gets context lines, noise-dir filtering, and truncated-match count; `read` gets `offset`/`limit` for paged access; `edit` shows nearby context on a miss.
+  - **Process safety**: tool subprocess groups are killed after the shell command completes, preventing orphan zombies on timeouts.
+  - **SWE-bench harness**: agent event logging + transcript capture; checkpoint and verify config threaded into `agent-runner`.
+  - **Config defaults promoted**: `DefaultConfig()` now uses `MaxTokens: 16384`, auto-continue on truncation, and `LoopDetectionThreshold: 4` — values measured effective in SWE-bench Lite (59.0% → 70.3% baseline shift).
+  - New CLI flag `--artifact-dir` overrides the node state directory.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,15 @@ tracker -r <run-id> build_product.dip
 
 # When something goes wrong
 tracker diagnose
+
+# Override workflow params at runtime (v0.19.0)
+tracker --param model=claude-opus-4 --param retries=3 build_product
+
+# Pin the run's artifact directory explicitly (v0.19.0)
+tracker --artifact-dir /tmp/tracker-runs build_product
 ```
+
+> **What's new in v0.19.0** (2026-04-20): breaking library API changes (ctx-first `Doctor`/`Diagnose`/`Audit`/`Simulate`, `NDJSONEvent` → `StreamEvent`, typed `CheckStatus` / `SuggestionKind`); workflow-level `${params.*}` with `--param` overrides; workflow-level budget ceilings (`max_total_tokens` / `max_cost_cents` / `max_wall_time`) in `defaults:`; per-human-gate `timeout` / `timeout_action`; TUI now pre-populates subgraph children in the sidebar; OpenRouter `invalid_prompt` fix for GLM/Qwen/Kimi; SWE-bench-driven agent defaults lifted benchmark from 59% → 70%. See [CHANGELOG.md](./CHANGELOG.md) for full migration notes.
 
 ## Pipeline Examples
 
@@ -157,7 +165,7 @@ Three namespaces for `${...}` syntax in prompts:
 
 Variables are expanded in a single pass — resolved values are never re-scanned, preventing recursive expansion.
 
-**Important**: Each agent node runs a fresh LLM session. Data flows between nodes via context keys, not conversation history. Per-node scoping (`${ctx.node.<nodeID>.<key>}`) is an unreleased feature currently on `main`; it lets you reference a specific earlier node's output without relying on the last-writer-wins `last_response` key. See **[Pipeline Context Flow](docs/pipeline-context-flow.md)** for the full model, fidelity levels, and parallel-branch patterns.
+**Important**: Each agent node runs a fresh LLM session. Data flows between nodes via context keys, not conversation history. Per-node scoping (`${ctx.node.<nodeID>.<key>}`) lets you reference a specific earlier node's output without relying on the last-writer-wins `last_response` key. See **[Pipeline Context Flow](docs/pipeline-context-flow.md)** for the full model, fidelity levels, and parallel-branch patterns.
 
 ### Edge Conditions
 


### PR DESCRIPTION
## Release v0.19.0

Minor bump from v0.18.0. Breaking library API changes are the driver — users need a semver boundary to pin against.

### Added
- **Library API hardening for v1.0** (#102, #103, #104, #106, #109) — ctx-first `Doctor`/`Diagnose`/`Audit`/`Simulate`, typed `CheckStatus`/`SuggestionKind`, `NDJSONWriter.Write` returns error, `StreamEvent` rename, `LogWriter` for suppressing library stderr, sanitized provider errors, per-instance panic recovery, streaming activity.jsonl parse.
- **Workflow params with CLI/library overrides** (#81) — `${params.*}` in prompts, tool commands, edge conditions; `--param k=v` on CLI; `Config.Params` in library; strict unknown-key validation; DIP120/DIP121 lint rules.
- **Per-human-gate `timeout` / `timeout_action` in .dip** (#112) — via dippin-lang v0.21.0.
- **Workflow-level budget ceilings in .dip** (#67) — `max_total_tokens`, `max_cost_cents`, `max_wall_time` on `defaults:`. CLI flags still win over workflow defaults.
- **TUI pre-populates subgraph children in the sidebar** (#118) — subgraph reference nodes expand into their child structure at init, not lazily on first `stage_started`.
- **SWE-bench–driven agent improvements** (#123) — turn-budget checkpoints, two-phase verify-after-edit, better grep/read/edit tools, process-group cleanup. Config defaults (`MaxTokens: 16384`, auto-continue, `LoopDetectionThreshold: 4`) lifted SWE-bench Lite 59.0% → 70.3%. New `--artifact-dir` CLI flag.

### Changed
- **dippin-lang v0.20.0 → v0.21.0** — picks up IR additions upstream.
- **BREAKING (library)** — see CHANGELOG for migration details.
- `tracker diagnose` suggestion ordering is deterministic.

### Fixed
- **OpenAI Responses API** `function_call_output` / `function_call` now serialize required fields even when they'd otherwise be empty. Fixes `invalid_prompt` on OpenRouter (GLM, Qwen, Kimi) reported by @Nopik (#114).

## Closed issues

- In this release: #67, #75, #81, #102, #103, #104, #105, #106, #109, #112, #114, #118

## Next steps after merge

1. Tag: `git tag v0.19.0 && git push origin v0.19.0`
2. GoReleaser will build + publish via CI
3. Draft GitHub release notes from this PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--artifact-dir` CLI flag and runtime parameter overrides via repeated `--param` flags
  * TUI sidebar now recursively shows subgraph entries for clearer workflow navigation
  * Improved budget-ceiling support across library and CLI builders
  * Agent quality-of-life: turn-budget checkpoints, two-phase verify-after-edit, safer tool subprocess handling, and enhanced logging/transcripts

* **Documentation**
  * Added v0.19.0 release notes and README examples for CLI usage and overrides
<!-- end of auto-generated comment: release notes by coderabbit.ai -->