### PR TITLE
release: v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-21
+
+### Added
+
+- **`stack.manager_loop` handler — async child-pipeline supervision** (PR #126, Attractor spec 4.11). A supervisor node that launches a child pipeline in a goroutine, polls at a configurable interval, and optionally steers the running child by injecting context mid-execution. New attributes: `subgraph_ref`, `manager.poll_interval`, `manager.max_cycles`, `manager.stop_condition`, `manager.steer_condition`, `manager.steer_context`. Exposes `stack.child.status` / `stack.child.cycles` / `stack.child.exit_status` to parent context. Emits `EventStageStarted` on launch, `EventManagerCycleTick` per poll cycle, and `EventStageCompleted` / `EventStageFailed` on terminal outcomes (success, child fail, child crash, max_cycles exceeded, cancellation, stop/steer condition invalid). Bounded `childJoinGrace` (30 s) protects against non-context-aware child handlers hanging the manager. See `docs/manager-loop.md`.
+- **Engine steering channel** (PR #126): new `pipeline.WithSteeringChan(chan map[string]string)` engine option. Between node executions, the engine drains the channel and merges updates into the run's `PipelineContext`. Used by `manager_loop` to inject context into running children; available to any supervisor. Non-blocking drain; nil channel is a no-op.
+- **`PipelineContext.MergeWithoutDirty`** (PR #126): writes updates without marking keys as dirty, so externally-injected values never leak into any node's per-node scope. Used by the engine's steering drain so injected keys stay in the global/bare namespace.
+- **Accurate cost estimation via catalog + cache token pricing** (PRs #127, #128): `EstimateCost` now resolves prices through the model catalog (`GetModelInfo`) instead of a duplicated hardcoded map. Adds cache token pricing: cache reads at 10% of input rate, cache writes at 25%. `TokenTracker` now records the observed model per provider (`AddUsage` takes an optional model arg, normalized through the catalog to match `WrapComplete`) so per-provider cost estimates use the right rate sheet instead of a global fallback.
+- **Model catalog April 2026 refresh** (PR #128): adds `claude-opus-4-7`, `gpt-5.4-mini` / `gpt-5.4-nano`, `gpt-4.1` family, `o3`, `o4-mini`, GA Gemini 2.5 models, and `gemini-3.1-pro-preview` (replaces the shut-down `gemini-3-pro-preview`). Fixes `claude-opus-4-6` pricing (was incorrectly $15/$75; now $5/$25). Context windows for Sonnet/Opus 4.6 bumped to 1M. `claude-sonnet` / `claude-opus` aliases now point at the latest 4.7 entries. `claude-haiku-4-5`, `gpt-4o`, and `gpt-4o-mini` added (they were in the old pricing map but not the catalog).
+- **`docs/manager-loop.md`**: user-facing documentation for the manager-loop handler — lifecycle diagram, configuration reference, context outputs, event semantics, steering contract, and tuning guidance.
+- **`tracker-swebench` now captures the active provider base-URL override** in `run_meta.json` (`BaseURLOverride`). Derived from `${PROVIDER}_BASE_URL` with hyphens normalized to underscores, so `--provider openai-compat` maps to `OPENAI_COMPAT_BASE_URL` consistently with `ResolveProviderBaseURL`. Useful for reproducing SWE-bench runs that routed through a Cloudflare AI Gateway or custom endpoint.
+
+### Fixed
+
+- **ACP path validation rejects `..` path segments before symlink resolution** (PR #126, security hardening). Previously, a symlink pointing outside the work dir plus a `..` in the target path could escape the sandbox: symlink resolution occurred before the check, and `..` in the resolved path was not filtered. `validatePathInWorkDir` now splits on both `/` and `\` so Windows paths are also protected.
+- **Manager loop: poll timer vs. child-completion race** (PR #126 review): when `pollTimer.C` and `resultCh` are both ready, Go's `select` is nondeterministic. The timer path could trigger `max_cycles` failure even though the child had already finished. The timer case now does a non-blocking drain of `resultCh` first and dispatches to the child-result handler if the child is done.
+- **Manager loop: crash path always returns a non-nil error** (PR #126 review). If the child goroutine delivered neither a result nor an error, the handler synthesizes `"manager_loop: child exited with no result and no error"` so callers never see `(OutcomeFail, nil)`.
+- **Manager loop: config validation now hard-fails on malformed values** (PR #126 review). `manager.poll_interval` and `manager.max_cycles` with invalid or non-positive values now error at parse time instead of silently falling back to defaults (previously: `time.ParseDuration` error swallowed, zero/negative values ignored).
+- **Manager loop: `EvaluateCondition` errors surface for both `stop_condition` and `steer_condition`** (PR #126 review). A malformed expression now fails the loop with a clear error plus an `EventStageFailed` emission, instead of being treated as "never match" until `max_cycles`.
+- **Manager loop: emit `EventStageFailed` on context cancellation and condition-parse errors** (PR #126 review). Parity with other terminal failure paths (max_cycles, child fail, child crash) so the TUI surfaces every failure mode.
+- **Manager loop: `handleChildResult` returns `OutcomeFail` on child failure** (PR #126 review). Handler-level outcome values must be from the handler set (`success`/`fail`/`retry`); engine-level statuses like `OutcomeBudgetExceeded` would have fallen through the outcome switch and been silently treated as success. The real child status remains available via `pctx.Set("stack.child.exit_status", ...)`.
+
 ## [0.19.0] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tracker --artifact-dir /tmp/tracker-runs build_product
 ```
 
 > **What's new in v0.20.0** (2026-04-21): new `stack.manager_loop` supervisor handler for async child-pipeline supervision with stop conditions and steering (Attractor spec 4.11); engine-level steering channel (`WithSteeringChan`) for injecting context into running pipelines; accurate cost estimation via the model catalog with cache-token pricing; April 2026 model catalog refresh (Claude Opus 4.7, GPT-5.4 family, Gemini 2.5 GA, Gemini 3.1 pro preview, corrected Opus 4.6 pricing); ACP sandbox hardening against `..` path traversal. See [CHANGELOG.md](./CHANGELOG.md) and [`docs/manager-loop.md`](./docs/manager-loop.md).
-
+>
 > **Previously in v0.19.0** (2026-04-20): breaking library API changes (ctx-first `Doctor`/`Diagnose`/`Audit`/`Simulate`, `NDJSONEvent` → `StreamEvent`, typed `CheckStatus` / `SuggestionKind`); workflow-level `${params.*}` with `--param` overrides; workflow-level budget ceilings (`max_total_tokens` / `max_cost_cents` / `max_wall_time`) in `defaults:`; per-human-gate `timeout` / `timeout_action`; TUI now pre-populates subgraph children in the sidebar; OpenRouter `invalid_prompt` fix for GLM/Qwen/Kimi; SWE-bench-driven agent defaults lifted benchmark from 59% → 70%.
 
 ## Pipeline Examples

--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ tracker --param model=claude-opus-4 --param retries=3 build_product
 tracker --artifact-dir /tmp/tracker-runs build_product
 ```
 
-> **What's new in v0.19.0** (2026-04-20): breaking library API changes (ctx-first `Doctor`/`Diagnose`/`Audit`/`Simulate`, `NDJSONEvent` → `StreamEvent`, typed `CheckStatus` / `SuggestionKind`); workflow-level `${params.*}` with `--param` overrides; workflow-level budget ceilings (`max_total_tokens` / `max_cost_cents` / `max_wall_time`) in `defaults:`; per-human-gate `timeout` / `timeout_action`; TUI now pre-populates subgraph children in the sidebar; OpenRouter `invalid_prompt` fix for GLM/Qwen/Kimi; SWE-bench-driven agent defaults lifted benchmark from 59% → 70%. See [CHANGELOG.md](./CHANGELOG.md) for full migration notes.
+> **What's new in v0.20.0** (2026-04-21): new `stack.manager_loop` supervisor handler for async child-pipeline supervision with stop conditions and steering (Attractor spec 4.11); engine-level steering channel (`WithSteeringChan`) for injecting context into running pipelines; accurate cost estimation via the model catalog with cache-token pricing; April 2026 model catalog refresh (Claude Opus 4.7, GPT-5.4 family, Gemini 2.5 GA, Gemini 3.1 pro preview, corrected Opus 4.6 pricing); ACP sandbox hardening against `..` path traversal. See [CHANGELOG.md](./CHANGELOG.md) and [`docs/manager-loop.md`](./docs/manager-loop.md).
+
+> **Previously in v0.19.0** (2026-04-20): breaking library API changes (ctx-first `Doctor`/`Diagnose`/`Audit`/`Simulate`, `NDJSONEvent` → `StreamEvent`, typed `CheckStatus` / `SuggestionKind`); workflow-level `${params.*}` with `--param` overrides; workflow-level budget ceilings (`max_total_tokens` / `max_cost_cents` / `max_wall_time`) in `defaults:`; per-human-gate `timeout` / `timeout_action`; TUI now pre-populates subgraph children in the sidebar; OpenRouter `invalid_prompt` fix for GLM/Qwen/Kimi; SWE-bench-driven agent defaults lifted benchmark from 59% → 70%.
 
 ## Pipeline Examples
 


### PR DESCRIPTION
## Summary

Minor bump from v0.19.0. The headline additions are the `stack.manager_loop` handler and the engine-level steering channel that enables it.

- **`stack.manager_loop` handler** (Attractor spec 4.11, PR #126): async child-pipeline supervision with poll interval, max cycles, stop conditions, and mid-run steering context injection. Full docs at [`docs/manager-loop.md`](./docs/manager-loop.md).
- **Engine steering channel**: `pipeline.WithSteeringChan` option + `PipelineContext.MergeWithoutDirty` so external context injection stays out of per-node scope.
- **Accurate cost estimation**: `EstimateCost` now resolves through the catalog (no more duplicated hardcoded pricing map), cache-token pricing (reads 10% of input, writes 25%), and `TokenTracker.AddUsage` takes an optional model arg normalized through `normalizeModelID` to match `WrapComplete`.
- **Model catalog April 2026 refresh**: Claude Opus 4.7, GPT-5.4 family (5.4 / 5.4-mini / 5.4-nano), GPT-4.1 family, o3, o4-mini, Gemini 2.5 GA, Gemini 3.1 pro preview (replaces shut-down 3-pro-preview). Fixes Opus 4.6 pricing (was $15/$75, now correctly $5/$25). Sonnet/Opus 4.6 context bumped to 1M. `claude-sonnet` / `claude-opus` aliases now point at 4.7.
- **ACP sandbox hardening**: `validatePathInWorkDir` rejects `..` segments before symlink resolution; splits on both `/` and `\` for cross-platform safety.
- **Backend work from PR #126**: manager_loop tests, engine steering tests, roborev findings (goroutine join on early exit, closed-channel drain safety, cross-platform path traversal check), swebench `BaseURLOverride` metadata capture.

v0.19.0 was never tagged (PR #125 merged a release commit but no tag was pushed to origin). This release supersedes it — the CHANGELOG keeps the existing `[0.19.0]` section intact and adds `[0.20.0]` on top.

## Test plan

- [x] `go test ./... -short` — all 17 packages pass
- [x] `go build ./...` clean
- [x] `dippin doctor` on the three core example workflows — Grade A (95/100, same as v0.19.0)
- [x] Review passes from CodeRabbit + Copilot on PR #126 already applied

## Post-merge

- [ ] Tag `v0.20.0` and push so GoReleaser produces the GitHub release
- [ ] Update the project memory files if anything new is worth remembering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a supervisor handler with steering and stop conditions for long-running stacks.
  * Added an engine-level steering channel to inject runtime context.
  * Improved cost estimation via model catalog updates and cache-token pricing (April 2026 refresh).

* **Bug Fixes**
  * Hardened sandbox against path-traversal attacks.
  * Improved manager-loop robustness and failure handling.
  * Fixed child outcome routing to report failures correctly.

* **Documentation**
  * Updated release notes and changelog for v0.20.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->