### PR TITLE
release: v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-04-21
+
 ### Added
 
-- **`tracker.SimulateGraph(ctx, graph)`** — graph-in variant of `Simulate` that accepts a pre-parsed `*pipeline.Graph` and returns a `SimulateReport`. Lets callers that already parsed the pipeline (CLI flows that also run `ValidateSource`, tooling that builds a graph programmatically) avoid a second parse. `Simulate(ctx, source)` is now a thin wrapper over `parsePipelineSource` + `SimulateGraph`; signature and behavior unchanged.
-- **Repository localization pre-processing** (agent): optional pre-processing phase that scans the working directory for files relevant to the task prompt and injects a structured context block before the first LLM turn. Pure text analysis + filesystem scan — zero LLM calls. Opt-in via `SessionConfig.Localize` (default `false`). Extracts file paths, camelCase/snake_case identifiers, quoted phrases, and error-line excerpts from the prompt; capped at 10 files / ~2KB injected context with 5-line snippets. Reduces wasted turns on `glob`/`grep` for repository-level tasks.
-- **Agent episodic memory across retries/resumes**: native codergen sessions now record a structured per-tool episode log (`tool`, args, success/fail, summary), publish `episode_summary` and rolling `episode_summaries` context keys at session end, and inject prior summaries into subsequent retry/resume attempts so the model can avoid repeating failed approaches.
-- **Plan-before-execute phase** (agent): optional single planning LLM call before the main execution loop. Opt-in via `SessionConfig.PlanBeforeExecute` (default `false`) or codergen node attrs (`plan_before_execute: "true"` or `plan: "true"`). The generated plan is retained in conversation context for subsequent execution turns.
+- **Declarative `writes:` / `reads:` unified structured output** (closes #85). Agent, human, and tool nodes can now declare the keys they produce and consume. Declared writes are extracted from handler output into the pipeline context and validated — missing required fields fail the node. `reads:` pins fidelity for the keys a node consumes so downstream nodes see consistent data. New helpers: `pipeline/context_writes.go`, `pipeline/handlers/declared_writes.go`. Replaces node-type-specific workarounds previously needed to thread typed outputs through.
+- **`tracker.SimulateGraph(ctx, graph)`** (closes #108) — graph-in variant of `Simulate` that accepts a pre-parsed `*pipeline.Graph` and returns a `SimulateReport`. Lets callers that already parsed the pipeline (CLI flows that also run `ValidateSource`, tooling that builds a graph programmatically) avoid a second parse. `Simulate(ctx, source)` is now a thin wrapper over `parsePipelineSource` + `SimulateGraph`; signature and behavior unchanged.
+- **Repository localization pre-processing** (agent, closes #95): optional pre-processing phase that scans the working directory for files relevant to the task prompt and injects a structured context block before the first LLM turn. Pure text analysis + filesystem scan — zero LLM calls. Opt-in via `SessionConfig.Localize` (default `false`). Extracts file paths, camelCase/snake_case identifiers, quoted phrases, and error-line excerpts from the prompt; capped at 10 files / ~2KB injected context with 5-line snippets. Reduces wasted turns on `glob`/`grep` for repository-level tasks.
+- **Agent episodic memory across retries/resumes** (closes #96): native codergen sessions now record a structured per-tool episode log (`tool`, args, success/fail, summary), publish `episode_summary` and rolling `episode_summaries` context keys at session end, and inject prior summaries into subsequent retry/resume attempts so the model can avoid repeating failed approaches.
+- **Plan-before-execute phase** (agent, closes #97): optional single planning LLM call before the main execution loop. Opt-in via `SessionConfig.PlanBeforeExecute` (default `false`) or codergen node attrs (`plan_before_execute: "true"` or `plan: "true"`). The generated plan is retained in conversation context for subsequent execution turns.
+- **Library API godoc, stability policy, and runnable examples** (closes #110). Package-level `doc.go` now documents pre-1.0 API stability expectations; README gains a stability callout; `tracker_examples_test.go` ships runnable `ExampleDiagnose` / `ExampleAudit` / `ExampleDoctor` examples that double as godoc content.
+- **Test coverage close-out for `Diagnose` / `Audit` / `Doctor`** (closes #107). Covers `DiagnoseMostRecent`, `MostRecentRunID`, `ResolveRunDir` no-match path, corrupted `status.json` warning, `Audit` error paths (missing / malformed / empty run dir), `Doctor` warnings sentinel, and `checkArtifactDirs` non-ENOENT stat errors.
+
+### Changed
+
+- **`tracker simulate` output is now deterministic** (closes #111). Graph-level attributes in the simulate header are now sorted alphabetically; orphan/unreachable nodes in the node table are appended in sorted order. Previously both depended on Go's random map iteration order, producing different diffs on each run.
+- **`MostRecentRunID` no longer writes to `os.Stderr`** from library paths (#107 follow-up). Parse warnings now route through `DiagnoseConfig.LogWriter` so library callers aren't surprised by stray stderr.
 
 ### Fixed
 
 - **`tracker simulate` now parses the pipeline source exactly once** (closes #108). Previously `runSimulateCmd` parsed twice — once for the validation-warnings section, again inside `tracker.Simulate`. That risked a TOCTOU mismatch between the two views, duplicated dippin-lang parser side effects (lint warnings printed twice), and burned extra CPU on large `.dip` files. The CLI now reads the source once, calls `tracker.ValidateSource` for `{Graph, Errors, Warnings}`, and hands the same graph to `tracker.SimulateGraph`. CLI stdout is byte-identical to before; only the duplicated parser-logging lines are gone.
-- Cost accounting and reporting are now consistent across runtime and CLI summaries:
-  -  CLI run summaries now read token/cost totals from `EngineResult.Usage` (trace aggregate) instead of `TokenTracker.TotalUsage().EstimatedCost`, so cost is shown correctly.
+- **Cost accounting and reporting are now consistent across runtime and CLI summaries** (closes #128):
+  - CLI run summaries now read token/cost totals from `EngineResult.Usage` (trace aggregate) instead of `TokenTracker.TotalUsage().EstimatedCost`, so cost is shown correctly.
   - Repair turns now apply the same `EstimateCost` compensation path used by normal turns when providers omit `EstimatedCost`.
   - OpenAI SSE `response.completed` now preserves `ReasoningTokens` in finish usage events.
   - Gemini adapter now falls back to the requested model when `modelVersion` is absent in API responses.


### PR DESCRIPTION
## Summary

Minor bump from v0.20.0. Rolls up 9 merged PRs' worth of work sitting in the CHANGELOG's `[Unreleased]` section.

### Added

- **Declarative `writes:` / `reads:` unified structured output** (#131, closes #85) — nodes declare the keys they produce/consume; enforced at runtime.
- **`tracker.SimulateGraph(ctx, graph)`** (#135, closes #108) — graph-in variant of `Simulate`.
- **Repository localization pre-processing** (#130, closes #95) — scan-and-inject phase before first agent turn.
- **Agent episodic memory across retries** (#136, closes #96) — structured per-tool episode log, summaries injected into subsequent attempts.
- **Plan-before-execute phase** (#137, closes #97) — optional single planning turn.
- **Library API godoc, stability policy, runnable examples** (#133, closes #110).
- **Test coverage close-out for Diagnose/Audit/Doctor** (#138, closes #107).

### Changed

- **`tracker simulate` output is deterministic** (#132, closes #111).
- **`MostRecentRunID` no longer writes to `os.Stderr`** from library paths.

### Fixed

- **Single-parse refactor in `tracker simulate`** (#135, closes #108).
- **Cost accounting consistency** (#129, closes #128).

## Release hygiene note

Also as part of this release cycle, v0.19.0 and v0.20.0 have been **back-tagged** at their original release-PR merge commits — those releases were CHANGELOG-documented but never actually tagged. GoReleaser has now published binaries for both. See:

- https://github.com/2389-research/tracker/releases/tag/v0.19.0
- https://github.com/2389-research/tracker/releases/tag/v0.20.0

Going forward, every release PR merge will be followed immediately by `git tag` + `git push origin <tag>` to trigger GoReleaser.

## Test plan

- [x] `go test ./... -short` — all 17 packages pass
- [x] `go build ./...` clean
- [ ] After merge: tag `v0.21.0` at the resulting merge commit and push to origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Declarative writes/reads unified structured output feature
  * Tracker simulation capabilities
  * Enhanced diagnostics and testing coverage

* **Bug Fixes**
  * Fixed determinism in tracker simulation output ordering
  * Improved cost reporting accuracy and warning handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->