### PR TITLE
docs(architecture/handlers): per-handler deep-dive docs

### DIFF
--- a/docs/architecture/handlers/codergen.md
+++ b/docs/architecture/handlers/codergen.md
@@ -1,0 +1,397 @@
+# Codergen (Agent) Handler (`codergen`)
+
+## Purpose
+
+`CodergenHandler` is the bridge between pipeline nodes and LLM agent sessions.
+Every agent node (bare `agent X` or `codergen`-resolved handler in a `.dip`
+file) routes through this handler. It resolves the prompt, chooses an
+`AgentBackend` (native turn loop, Claude Code subprocess, or ACP), builds a
+run config from the node's typed `AgentNodeConfig`, invokes the backend, and
+translates the resulting `SessionResult` into a pipeline `Outcome`.
+
+The handler does **not** make LLM calls directly — that's the backend's job.
+It's a configuration and outcome-translation layer. This separation is what
+lets the same pipeline run with either a native API session (with
+tool-compaction, context management, verification retries) or a subscription
+Claude Code subprocess (which handles those concerns internally).
+
+Ground truth:
+[`pipeline/handlers/codergen.go`](../../../pipeline/handlers/codergen.go).
+
+## Node attributes
+
+Typed accessor: [`Node.AgentConfig(graphAttrs)`](../../../pipeline/node_config.go),
+which resolves graph-level defaults then overlays node-level overrides for
+the attrs that support that pattern.
+
+| Attribute | Graph default? | Behavior |
+|-----------|----------------|----------|
+| `prompt` | no | Required. Variable-expanded before execution (`${ctx.foo}`, `${graph.bar}`, `${params.baz}`). |
+| `backend` | no | `native` (alias `codergen`), `claude-code`, or `acp`. Per-node override wins over global `--backend` flag. |
+| `llm_model` | yes | Model ID. Graph `llm_model` applies unless node overrides. |
+| `llm_provider` | yes | Provider name (`anthropic`, `openai`, `gemini`, etc.). |
+| `system_prompt` | no | System message prepended to the session. |
+| `max_turns` | no | Turn limit. Zero/empty → `agent.DefaultConfig()` default. |
+| `working_dir` | no | Overrides handler's working dir for this session. |
+| `command_timeout` | no | Per-tool exec timeout (native backend only — external backends manage this internally). |
+| `reasoning_effort` | yes | `low`/`medium`/`high`/`minimal` for reasoning-capable models. |
+| `response_format` | no | `json_object` to force JSON via the provider API. |
+| `response_schema` | no | Optional JSON schema to enforce with response_format. |
+| `cache_tool_results` | yes (true only) | Reuse tool result outputs across turns. Node-level can explicitly disable. |
+| `context_compaction` | yes (auto only) | `auto` enables automatic mid-session compaction at a threshold. |
+| `context_compaction_threshold` | no | Fraction (0–1) of context window at which to compact. Default 0.6 with `auto`. |
+| `reflect_on_error` | no | Defaults to true. `false` disables reflection-on-error. |
+| `verify_after_edit` | yes | Run `verify_command` after each edit and retry on failure. |
+| `verify_command` | yes | Shell command whose exit status gates verification. |
+| `max_verify_retries` | yes | Cap on verification retry attempts. |
+| `plan_before_execute` (alias `plan`) | yes | Force a plan turn before the main execution turn. |
+| `auto_status` | no | Parse `STATUS: success/fail/retry` directives from response text and use them as the outcome. |
+| `mcp_servers` | no | JSON-encoded MCP server list (claude-code backend only). |
+| `allowed_tools` / `disallowed_tools` | no | Tool allowlist/denylist (claude-code). |
+| `permission_mode` | no | claude-code permission mode (default `bypassPermissions` for headless). |
+| `max_budget_usd` | no | Claude Code budget ceiling. |
+| `acp_agent` | no | ACP agent name (ACP backend). |
+| `writes` | no | Comma-separated declared JSON keys to extract from the response into context. |
+
+## Backend selection
+
+```mermaid
+flowchart TD
+    A[Execute] --> B{node.Attrs backend}
+    B -->|claude-code| CC[ensureClaudeCodeBackend]
+    B -->|acp| AP[ensureACPBackend]
+    B -->|native / codergen| NV[ensureNativeBackend]
+    B -->|unknown| ER[Error]
+    B -->|empty| G{defaultBackendName}
+    G -->|claude-code| CC
+    G -->|acp| AP
+    G -->|default| NV
+    NV --> NC{h.client nil?}
+    NC -->|yes| NER[Error: requires LLM client]
+    NC -->|no| NB[NativeBackend]
+```
+
+Priority: **per-node `backend` attr always wins over the global
+`--backend` flag**. This enables mixed-backend pipelines — a node with
+`backend: native` uses the native API even when the global flag is
+`claude-code`.
+
+Backends are lazy-initialized on first use:
+
+- Native: `sync.Once` — one-shot init from the injected `agent.Completer`
+  client.
+- Claude Code, ACP: mutex-guarded retry — failure leaves the backend slot
+  empty so a subsequent call can retry (useful when installing the CLI
+  mid-run).
+
+## Session config mapping
+
+[`buildConfig`](../../../pipeline/handlers/codergen.go) constructs an
+`agent.SessionConfig` from the typed `AgentNodeConfig`. Non-zero / non-empty
+fields override the corresponding defaults from `agent.DefaultConfig()`. The
+typed accessor already handles the graph-then-node merge, so the handler
+just copies fields across:
+
+```text
+AgentNodeConfig               agent.SessionConfig
+─────────────────             ─────────────────────
+Model            ──────────►  Model
+Provider         ──────────►  Provider
+SystemPrompt     ──────────►  SystemPrompt
+MaxTurns         ──────────►  MaxTurns (if > 0)
+CommandTimeout   ──────────►  CommandTimeout (if > 0, native only)
+ReasoningEffort  ──────────►  ReasoningEffort
+ResponseFormat   ──────────►  ResponseFormat
+ResponseSchema   ──────────►  ResponseSchema
+CacheToolResults ──────────►  CacheToolResults (when Set)
+ContextCompaction ─────────►  ContextCompaction + CompactionThreshold
+ReflectOnError   ──────────►  ReflectOnError (when explicitly false)
+VerifyAfterEdit/VerifyCommand/MaxVerifyRetries ─► VerifyAfterEdit/…
+PlanBeforeExecute ─────────►  PlanBeforeExecute (when Set)
+```
+
+Compaction has a specific rule in
+[`applyTypedCompaction`](../../../pipeline/handlers/codergen.go):
+
+- `context_compaction=auto` → enables `agent.CompactionAuto`, default
+  threshold 0.6 (overridable via `context_compaction_threshold`).
+- Any other non-empty value → `agent.CompactionNone`, but
+  `context_compaction_threshold` still wins if set.
+
+## AgentRunConfig and Extra
+
+[`buildRunConfig`](../../../pipeline/handlers/codergen.go) packages the
+session config into a backend-neutral
+[`pipeline.AgentRunConfig`](../../../pipeline/backend.go). Common fields
+(prompt, model, working dir, max turns) travel in `AgentRunConfig`;
+backend-specific config rides along in `Extra`:
+
+| Backend | Extra payload |
+|---------|---------------|
+| NativeBackend | `*agent.SessionConfig` (full) |
+| ClaudeCodeBackend | `*pipeline.ClaudeCodeConfig` (MCPs, tools, budget, permission mode) |
+| ACPBackend | `*pipeline.ACPConfig` (agent name) |
+
+`CommandTimeout` is only set on `AgentRunConfig.Timeout` for the native
+backend. External backends (claude-code, ACP) manage tool timeouts
+internally; applying a subprocess timeout to them would kill the agent
+prematurely.
+
+## Execute lifecycle
+
+```mermaid
+sequenceDiagram
+    participant E as Engine
+    participant C as CodergenHandler
+    participant B as AgentBackend
+    participant T as transcriptCollector
+    participant P as PipelineContext
+
+    E->>C: Execute ctx node pctx
+    C->>C: resolvePrompt expand vars and fidelity context
+    C->>C: selectBackend per-node attr vs global flag
+    C->>C: buildRunConfig SessionConfig to AgentRunConfig
+    C->>P: Get episode_summaries
+    C->>C: injectPriorEpisodes
+    C->>B: Run ctx runCfg emit
+    loop per agent event
+        B->>T: collector.HandleEvent
+        B->>C: scopedHandler.HandleEvent
+    end
+    B-->>C: SessionResult and err
+    alt err not nil
+        C->>C: handleRunError config/retry split
+        C-->>E: Outcome retry or fail with last_response as err
+    else empty response
+        C->>C: buildEmptyResponseOutcome fail or retry
+        C-->>E: Outcome with diagnostic msg
+    else normal
+        C->>C: buildSuccessOutcome
+        C->>C: parse auto_status if enabled
+        C->>C: applyDeclaredWrites if node.writes set
+        C-->>E: Outcome with last_response response.nodeID and stats
+    end
+```
+
+## Prompt resolution
+
+[`resolvePrompt`](../../../pipeline/handlers/codergen.go) delegates to
+`ResolvePrompt` in [prompt.go](../../../pipeline/handlers/prompt.go), which:
+
+1. Reads `node.Attrs["prompt"]`.
+2. Expands variables against the pipeline context (`${ctx.foo}`,
+   `${graph.bar}`, `${params.baz}`) with single-pass resolution.
+3. Applies the fidelity level to select which upstream context keys are
+   included as a "Context Summary" prepend.
+
+The handler also reads `pipeline.InternalKeyArtifactDir` so nested
+subgraph nodes use the parent's artifact directory for writes and the
+prompt expansion has access to the artifact root.
+
+## Event collection
+
+[`transcriptCollector`](../../../pipeline/handlers/transcript.go) receives
+every `agent.Event` from the backend and extracts:
+
+- Final response text (returned via `collector.text()`).
+- Full transcript (returned via `collector.transcript()`) — used as the
+  artifact written to disk.
+
+Events are simultaneously dispatched via `scopedHandler` (which prefixes
+node IDs for TUI display) so the TUI updates in real-time while the
+collector accumulates the transcript.
+
+## Outcomes produced
+
+Three paths through
+[`buildOutcome`](../../../pipeline/handlers/codergen.go):
+
+### handleRunError
+
+Triggered when `backend.Run` returns an error.
+
+- `llm.ConfigurationError` → hard error returned to the engine (quota,
+  auth, model misconfiguration). Pipeline halts.
+- Non-retryable provider error → hard error returned to the engine.
+- Otherwise → `OutcomeRetry` with `last_response` set to the error
+  message. Lets the engine's retry policy have a shot.
+
+### buildEmptyResponseOutcome
+
+Two subcases:
+
+1. **No turns, no tool calls** → session never started → `OutcomeFail` with
+   diagnostic `"agent session produced no output (0 tokens, 0 tool calls) —
+   check provider/model configuration"`.
+2. **Turns > 0 but zero output tokens and zero tool calls** → API swallowed
+   an error → `OutcomeRetry` with `"provider returned empty API response
+   (0 output tokens, 0 tool calls); retrying session"`.
+
+Case 2 doesn't apply when there were tool calls — the agent did real work,
+the lack of final-assistant text is a different issue.
+
+### buildSuccessOutcome
+
+The normal path. Sets `Status = OutcomeSuccess` by default. Two overrides:
+
+- **Turn-limit exhaustion** (`sessResult.MaxTurnsUsed`) → `OutcomeFail`
+  with a `turn_limit_msg` context write. Loop detection
+  (`sessResult.LoopDetected`) produces a slightly different message. On
+  nodes without conditional failure edges, this hits the strict-failure-edge
+  rule and the pipeline stops — which is correct: silently continuing
+  after an agent ran out of turns is almost always a bug.
+- **`auto_status=true`** → parses the response text for `STATUS:
+  success/fail/retry` directives via
+  [`parseAutoStatus`](../../../pipeline/handlers/codergen.go). The last
+  STATUS line wins. Lines inside ``` code fences are skipped so the agent
+  can discuss statuses in examples without triggering parsing.
+
+### ContextUpdates
+
+| Key | When | Value |
+|-----|------|-------|
+| `last_response` | always | Final assistant message text |
+| `response.<nodeID>` | always | Same as `last_response`, addressable by node ID |
+| `episode_summary` | always | Session's episode summary (tool attempts + outcomes) |
+| `episode_summaries` | when new summary is non-empty | JSON array of accumulated prior summaries |
+| `last_cost` | when `EstimatedCost > 0` | Dollar cost of the session, formatted to 4 decimals |
+| `last_turns` | when `Turns > 0` | Turn count as integer string |
+| `turn_limit_msg` | on turn exhaustion | Diagnostic message |
+| declared `writes` keys | when `writes` attr set | Top-level extraction of JSON fields from `last_response` |
+
+## Events emitted
+
+The codergen handler emits no pipeline events directly. Agent-level events
+from the backend are forwarded to the configured `agent.EventHandler` via
+`NodeScopedHandler`, which prefixes node IDs so the TUI and activity log
+can attribute events correctly. The engine emits `EventStageStarted` /
+`Completed` / `Failed` around `Execute`.
+
+## Structured output (response_format)
+
+From `CLAUDE.md`:
+
+> The `response_format: json_object` attribute on agent nodes forces JSON
+> output at the LLM API level. The path: `.dip` file → `AgentConfig.ResponseFormat`
+> → adapter → `node.Attrs["response_format"]` → `codergen.applyResponseFormat()`
+> → `SessionConfig.ResponseFormat` → `session.buildResponseFormat()` →
+> `llm.Request.ResponseFormat` → provider translator.
+
+Per-provider translation:
+
+- Anthropic: system instruction.
+- OpenAI: native `json_object` response format.
+- Gemini: `responseMimeType`.
+
+Use this on any agent that must produce structured JSON — interview
+question generators, autopilot decisions, structured planners.
+
+## Episode summaries and retries
+
+[`injectPriorEpisodes`](../../../pipeline/handlers/codergen.go) reads
+`episode_summaries` from context at handler start and seeds
+`SessionConfig.PriorEpisodeSummaries`. Backends that support it (native)
+prepend these summaries so retried or resumed sessions carry forward what
+earlier attempts tried.
+
+[`applyEpisodeContextUpdates`](../../../pipeline/handlers/codergen.go)
+appends the new session's `EpisodeSummary` to the accumulated list after
+each run.
+
+## Planning turn
+
+`plan_before_execute: true` (shorthand `plan: true`) tells the native
+backend to run a planning turn before the main execution turn. The plan
+turn produces a structured plan that the execution turn consumes as
+context. `applyTypedCompaction`-style `*Set` flags in
+`AgentNodeConfig.PlanBeforeExecuteSet` distinguish "unset" from "false"
+so consumers can treat absence differently from explicit disable.
+
+## External backend usage tracking
+
+Native backend usage is tracked by the LLM middleware automatically.
+Claude Code and ACP backends bypass the middleware, so the handler calls
+[`trackExternalBackendUsage`](../../../pipeline/handlers/codergen.go) to
+explicitly attribute their usage to the `claude-code` or `acp` provider
+slots in the shared `TokenTracker`. Native backend usage is skipped to
+avoid double-counting.
+
+## Edge cases and gotchas
+
+- **Provider errors are hard failures, not retries.** Quota and auth
+  errors from the LLM propagate out of `Execute` as errors, halting the
+  pipeline. CLAUDE.md explicitly calls this out: "Provider errors
+  (quota, auth, model not found) must hard-fail the pipeline, not retry."
+- **Empty response detection is load-bearing.** Silently succeeding on a
+  session with zero output tokens hides provider-side problems.
+- **Claude Code strips API keys from the subprocess env** unless
+  `TRACKER_PASS_API_KEYS=1` is set. This forces OAuth / subscription
+  auth for Max/Pro accounts. See `CLAUDE.md` § Claude Code backend.
+- **`auto_status` only runs inside fence-free regions** of the response.
+  The agent can safely write example STATUS lines inside triple-backtick
+  blocks.
+- **`buildLLMClient()` is lazy** — failure to construct a native LLM
+  client is non-fatal when `--backend claude-code` is set globally. The
+  native backend only needs to exist when a node explicitly selects it.
+
+## Example
+
+```dip
+vars:
+  llm_model: "claude-sonnet-4"
+  llm_provider: "anthropic"
+
+agent Planner
+  prompt: |
+    Given the goal: ${graph.goal}
+    Produce a plan. End with STATUS: success if coherent, retry if you need more info.
+  auto_status: true
+  max_turns: 10
+  response_format: "json_object"
+
+agent Executor
+  prompt: |
+    Execute this plan:
+    ${ctx.response.Planner}
+  plan_before_execute: true
+  verify_after_edit: true
+  verify_command: "go build ./..."
+  max_verify_retries: 3
+  backend: "claude-code"
+  permission_mode: "bypassPermissions"
+
+Planner -> Executor when: ctx.outcome = success
+Planner -> Replan when: ctx.outcome = retry
+```
+
+`Planner` runs with the native Anthropic API, must produce JSON, uses
+`auto_status` to self-diagnose. `Executor` runs through the Claude Code
+subprocess with a planning turn and a verify loop tied to `go build`.
+
+## See also
+
+- [`pipeline/handlers/codergen.go`](../../../pipeline/handlers/codergen.go)
+  — this handler
+- [`pipeline/backend.go`](../../../pipeline/backend.go) —
+  `AgentBackend` interface, `AgentRunConfig`, `ClaudeCodeConfig`,
+  `ACPConfig`
+- [`pipeline/handlers/backend_native.go`](../../../pipeline/handlers/backend_native.go)
+  — native backend (turn loop + tool registry)
+- [`pipeline/handlers/backend_claudecode.go`](../../../pipeline/handlers/backend_claudecode.go)
+  — subprocess backend
+- [`pipeline/handlers/backend_acp.go`](../../../pipeline/handlers/backend_acp.go)
+  — ACP backend
+- [`pipeline/handlers/prompt.go`](../../../pipeline/handlers/prompt.go) —
+  prompt resolution and fidelity prepend
+- [`pipeline/handlers/transcript.go`](../../../pipeline/handlers/transcript.go)
+  — `transcriptCollector` + `buildSessionStats`
+- [`pipeline/handlers/declared_writes.go`](../../../pipeline/handlers/declared_writes.go)
+  — `applyDeclaredWrites`
+- [`pipeline/node_config.go`](../../../pipeline/node_config.go) —
+  `AgentNodeConfig`
+- [`agent/session.go`](../../../agent/session.go) — native session runtime
+- [`llm/`](../../../llm/) — provider translators
+- [Pipeline Context Flow](../../pipeline-context-flow.md) — how
+  `last_response` / `response.<id>` / `episode_summary` are consumed
+- `CLAUDE.md` §§ `Structured output`, `Claude Code backend`,
+  `Strict failure edges`, `Tool node safety`

--- a/docs/architecture/handlers/conditional.md
+++ b/docs/architecture/handlers/conditional.md
@@ -1,0 +1,169 @@
+# Conditional (Edge Condition Evaluator)
+
+## Purpose
+
+A "conditional" node in tracker is a diamond-shaped router. The node itself does
+no real work — its handler is a no-op that returns `OutcomeSuccess` — but its
+outgoing edges carry `when` conditions that the engine evaluates to pick the
+next step. The actual routing logic lives in
+[`pipeline/condition.go`](../../../pipeline/condition.go), and every handler
+(not just conditional nodes) is routed through the same evaluator. Use a
+conditional node when you want an explicit branch point that doesn't execute an
+agent or a tool — just inspects context and picks a path.
+
+## Node attributes
+
+Conditional nodes have no specific attributes. The routing lives on outgoing
+edges via the `when` clause (see the dippin-lang spec). The handler
+implementation is a single-file [`ConditionalHandler`](../../../pipeline/handlers/conditional.go)
+that always returns success; everything below is about the evaluator that runs
+on every edge, not just on edges out of a conditional node.
+
+## Operators and syntax
+
+Supported forms, parsed in priority order: `||` (lowest) → `&&` → clause.
+
+| Operator | Form | Semantics |
+|----------|------|-----------|
+| `=` / `==` | `ctx.outcome = success` | String equality; surrounding quotes stripped on RHS |
+| `!=` | `ctx.outcome != fail` | String inequality; surrounding quotes stripped on RHS |
+| `contains` | `ctx.last_response contains error` | Substring match |
+| `startswith` | `ctx.tool_stdout startswith ERROR` | Prefix match |
+| `endswith` | `ctx.last_response endswith .json` | Suffix match |
+| `in` | `ctx.outcome in success,retry` | Membership against comma-separated set |
+| `not <op>` | `ctx.x not contains foo` | Negated form of `contains`, `startswith`, `endswith`, `in` |
+| `not <clause>` | `not ctx.outcome = success` | Clause-level negation |
+| `&&` | `ctx.a = 1 && ctx.b = 2` | Logical AND, short-circuited |
+| `\|\|` | `ctx.a = 1 \|\| ctx.b = 2` | Logical OR, short-circuited |
+
+Empty or whitespace-only conditions evaluate to `true` (equivalent to an
+unconditional edge).
+
+### Known limitations
+
+Documented at the top of
+[`pipeline/condition.go`](../../../pipeline/condition.go):
+
+- Operator splitting uses `strings.Split` on `||` and `&&` before clause
+  parsing — a quoted value that contains these literals is still split.
+- No parentheses for grouping. Precedence is fixed: `||` < `&&` < clause.
+- Quote stripping applies only to `=`, `==`, `!=` comparisons — the word
+  operators (`contains`, `startswith`, etc.) take their RHS verbatim.
+
+## Namespace handling
+
+The evaluator resolves variable references on the LHS of a clause with
+[`resolveVariable`](../../../pipeline/condition.go), which walks four lookup
+strategies:
+
+1. Bare key: `outcome`, `last_response` — looks up directly in the pipeline
+   context.
+2. `ctx.<key>`: strips the `ctx.` prefix, then falls through to the bare-key
+   lookup. This is the form emitted by dippin-lang IR.
+3. `context.<key>`: alias for `ctx.` — same behavior.
+4. `internal.<key>` (or `ctx.internal.<key>` / `context.internal.<key>`):
+   routed to the engine-only `internal` namespace, which stores bookkeeping
+   like `_artifact_dir`.
+
+Unresolved references log a warning and default to the empty string — not a
+silent success, but execution continues. See
+[`resolveAndWarnVar`](../../../pipeline/condition.go).
+
+## Outcomes produced
+
+The `ConditionalHandler` itself always returns
+`pipeline.Outcome{Status: OutcomeSuccess}`. No `ContextUpdates`,
+`PreferredLabel`, or `SuggestedNextNodes` are written. Routing is entirely the
+engine's job, so the handler exists only to satisfy the graph-traversal
+contract.
+
+## Events emitted
+
+Emitted by the engine (not by the handler) in
+[`pipeline/engine_edges.go`](../../../pipeline/engine_edges.go) while it walks
+outgoing edges:
+
+| Event | When |
+|-------|------|
+| `EventDecisionCondition` | One per conditional edge evaluated — records the expression, match result, and a context snapshot |
+| `EventDecisionEdge` | Emitted once when an edge is selected; records `EdgePriority` (condition / label / suggested / weight / lexical) |
+| `EventEdgeTiebreaker` | Emitted when two or more equal-weight unconditional edges force a lexical tiebreak |
+| `EventStageFailed` | Emitted by the engine on strict-failure-edge enforcement — node outcome was `fail` and no outgoing edge had a condition (see below) |
+
+## Strict failure edges
+
+[`checkStrictFailure`](../../../pipeline/engine.go) halts the pipeline when the
+current node's `outcome` is `fail` and every outgoing edge is unconditional.
+This is deliberate: an unconditional edge from a failed node almost always
+means the pipeline author forgot to handle failure. To route on failure,
+explicitly add `when ctx.outcome = fail` on one of the outgoing edges.
+
+From
+[`hasAnyConditionalEdge`](../../../pipeline/engine.go):
+
+> When a node has conditional edges, the pipeline author has intentionally
+> designed routing for different outcomes. When all edges are unconditional,
+> a failure outcome would blindly continue — which is almost always a bug.
+
+## Edge selection priority
+
+Evaluated top-down in [`selectEdge`](../../../pipeline/engine_edges.go):
+
+1. **Condition**: first edge whose `when` expression evaluates to true.
+2. **Preferred label**: matches `pctx[preferred_label]` against `edge.Label`
+   (human gate choice-mode).
+3. **Suggested next nodes**: matches `pctx[suggested_next_nodes]` against
+   `edge.To` (parallel handler's join hint).
+4. **Weight**: highest `weight` attr wins.
+5. **Lexical**: tie-break among equal-weight unconditional edges.
+
+## Example
+
+```dip
+agent Verify
+  prompt: "Check that the build succeeds."
+  auto_status: true
+
+conditional Gate
+
+Verify -> Gate
+Gate -> Retry when: ctx.outcome = retry
+Gate -> Escalate when: ctx.outcome = fail
+Gate -> Done when: ctx.outcome = success
+```
+
+The `Verify` agent emits a `STATUS:` directive that gets parsed into the
+`outcome` context key (via `auto_status: true`). `Gate` is a conditional node
+— its handler is a no-op, but the three outgoing edges are mutually exclusive
+and exhaustive across the three outcomes. No unconditional fallback is needed
+because the three conditions cover every value `auto_status` can produce.
+
+## Gotchas
+
+- **Dippin-lang emits `ctx.` prefix.** The evaluator strips it. Always use
+  `ctx.X` in `.dip` files; bare `X` works in tests but is inconsistent with
+  the IR.
+- **The adapter synthesizes implicit edges.** For parallel/fan-in nodes, the
+  adapter in
+  [`pipeline/dippin_adapter_edges.go`](../../../pipeline/dippin_adapter_edges.go)
+  generates unconditional edges from `ParallelConfig.Targets` /
+  `FanInConfig.Sources`. These implicit edges participate in the same
+  routing priority but are not visible in the source `.dip` file.
+- **No unconditional fallback to a loop target.** Pairing
+  `when ctx.outcome = fail -> FixX` with an unconditional `-> FixX` creates
+  an infinite loop when `outcome` is not `fail` (the fallback catches the
+  success case and routes right back). Send fallbacks to an escalation gate
+  or Done instead.
+
+## See also
+
+- [`pipeline/condition.go`](../../../pipeline/condition.go) — evaluator
+- [`pipeline/engine_edges.go`](../../../pipeline/engine_edges.go) — edge
+  selection priority
+- [`pipeline/handlers/conditional.go`](../../../pipeline/handlers/conditional.go)
+  — the no-op handler
+- [Parallel and Fan-In](./parallel-fan-in.md) — how `suggested_next_nodes`
+  works
+- [Human Gate](./human.md) — how `preferred_label` works
+- `CLAUDE.md` — `### Edge routing — no unconditional fallbacks to loop targets`
+  and `### Strict failure edges (v0.13.0)`

--- a/docs/architecture/handlers/human.md
+++ b/docs/architecture/handlers/human.md
@@ -1,0 +1,339 @@
+# Human Gate Handler (`wait.human`)
+
+## Purpose
+
+A human gate pauses the pipeline for a decision. The handler presents a
+prompt to an `Interviewer` implementation, captures the response, and maps it
+onto either a `PreferredLabel` (used by the engine to pick a labeled outgoing
+edge) or a context write that downstream nodes read directly. The same
+handler serves five input modes — choice, freeform, yes/no, interview, and
+hybrid — routed via the `mode` attr. The `Interviewer` is swappable: a real
+TUI for interactive runs, `AutoApproveInterviewer` for tests,
+`AutopilotInterviewer` for LLM-backed headless runs, or `WebhookInterviewer`
+for external callback systems.
+
+Ground truth:
+[`pipeline/handlers/human.go`](../../../pipeline/handlers/human.go).
+
+## Node attributes
+
+| Attribute | Type | Default | Behavior |
+|-----------|------|---------|----------|
+| `mode` | string | `choice` | One of `choice`, `freeform`, `yes_no`, `interview`. Absent or unknown falls through to choice. |
+| `prompt` | string | node `Label` | Text shown to the user. Variable expansion applied (`${ctx.foo}`, `${graph.bar}`, `${params.baz}`). |
+| `default_choice` | string | falls back to `default` | Pre-selected option in choice mode. `default_choice` wins if both are present. |
+| `default` | string | — | Used by freeform-label mode (matches against edge labels); also secondary for `default_choice`. |
+| `timeout` | duration | 0 (no timeout) | Max wait for user input. On timeout, behavior depends on `timeout_action`. |
+| `timeout_action` | string | `default` | `fail` → `OutcomeFail` with `human_response=timed out`; `default` → pick `default_choice` with `OutcomeSuccess` (or fail if no default set). |
+| `questions_key` | string | `interview_questions` | Context key to read structured questions from (interview mode). Falls back to `last_response` if the primary key is empty. |
+| `answers_key` | string | `interview_answers` | Context key to write serialized answers under (interview mode). |
+| `writes` | string | — | Comma-separated JSON key list; interview answers are extracted and written as top-level context keys. |
+
+Typed accessor: [`Node.HumanConfig`](../../../pipeline/node_config.go).
+
+> **CLAUDE.md drift note**: the project memory claims `questions_key` defaults
+> to `last_response`, but `resolveInterviewKeys` in
+> [human.go](../../../pipeline/handlers/human.go) uses
+> `interview_questions` as the primary default and falls back to
+> `last_response` inside `resolveAgentOutput`. The code is load-bearing and
+> stays the source of truth; CLAUDE.md is inaccurate on this point. Flagged
+> for follow-up.
+
+## Mode dispatch
+
+```mermaid
+flowchart TD
+    A[HumanHandler.Execute] --> B[resolveHumanPrompt]
+    B --> C{cfg.Mode}
+    C -->|interview| I[executeInterview]
+    C -->|freeform| F[executeFreeform]
+    C -->|yes_no| Y[executeYesNo]
+    C -->|choice / empty| H[executeChoice]
+    I --> IR[runInterview or fallback]
+    F --> FR[interviewer.AskFreeform or AskFreeformWithLabels]
+    Y --> YR[interviewer.Ask choices=Yes,No]
+    H --> HR[interviewer.Ask choices=edge labels]
+```
+
+## Execute lifecycle
+
+```mermaid
+sequenceDiagram
+    participant E as Engine
+    participant H as HumanHandler
+    participant I as Interviewer
+    participant P as PipelineContext
+
+    E->>H: Execute(ctx, node, pctx)
+    H->>P: Get last_response (optional)
+    H->>H: resolveHumanPrompt (expand vars, append last_response)
+    H->>H: dispatchHumanMode (switch on cfg.Mode)
+    alt choice mode
+        H->>H: collect outgoing edge labels
+        H->>I: Ask with prompt choices default_choice
+        I-->>H: selected label
+        H-->>E: Outcome Success PreferredLabel=selected
+    else freeform mode
+        H->>I: AskFreeform or AskFreeformWithLabels
+        I-->>H: response text
+        H-->>E: Outcome Success human_response PreferredLabel matched
+    else yes_no mode
+        H->>I: Ask prompt with Yes/No choices
+        I-->>H: Yes or No
+        H-->>E: Outcome Success if Yes else Fail PreferredLabel
+    else interview mode
+        H->>P: Get questions_key with last_response fallback
+        H->>H: ParseStructuredQuestions then ParseQuestions fallback
+        alt zero questions
+            H->>I: AskFreeform fallback
+            I-->>H: response
+            H-->>E: Outcome Success human_response answers_key=response
+        else
+            H->>I: AskInterview questions prev
+            I-->>H: InterviewResult
+            H-->>E: Outcome Success or Fail on cancel answers_key=JSON summary
+        end
+    end
+```
+
+## Mode details
+
+### Choice (default)
+
+- `executeChoice` collects labels from outgoing edges (falling back to edge
+  `To` node ID when a label is empty).
+- Presents them via `Interviewer.Ask(prompt, choices, default_choice)`.
+- Returns `OutcomeSuccess` with `PreferredLabel=selected`. Routing picks
+  the edge whose `Label` matches.
+- Uses the bare `default_choice` attr (not the `HumanConfig.DefaultChoice`
+  accessor) to avoid the fallback to `default`, which has different
+  semantics in freeform mode.
+
+### Freeform
+
+- `executeFreeform` asks the `FreeformInterviewer` interface for open text.
+- If the interviewer also implements `LabeledFreeformInterviewer` AND the
+  node has labeled outgoing edges, it calls `AskFreeformWithLabels` — the
+  TUI shows a hybrid radio+textarea modal (see `CLAUDE.md` § Human gate UX).
+- Writes `human_response` and `response.<nodeID>` context keys.
+- Attempts to match the freeform text against an edge label via
+  `matchFreeformLabel` (case-insensitive, trimmed); sets `PreferredLabel`
+  when a match is found.
+
+### Yes/No
+
+- `executeYesNo` presents a fixed `["Yes", "No"]` choice via
+  `Interviewer.Ask`.
+- **Yes → `OutcomeSuccess`, No → `OutcomeFail`**. Pipelines route with
+  `when ctx.outcome = success` / `when ctx.outcome = fail` conditions.
+- This distinction from choice mode is load-bearing: choice mode always
+  returns success and routes on `PreferredLabel`.
+- `AutoApproveInterviewer` picks "Yes" (the first choice) by default —
+  forward-progress semantics for unattended runs.
+
+### Interview
+
+- `executeInterview` requires the interviewer to implement
+  `InterviewInterviewer`.
+- Reads structured questions from `questions_key` (default
+  `interview_questions`), falling back to `last_response`.
+- [`parseInterviewQuestions`](../../../pipeline/handlers/human.go) tries
+  `ParseStructuredQuestions` (JSON) first, then falls back to the
+  markdown-heuristic `ParseQuestions`. Upstream agents should use
+  `response_format: json_object` to force valid JSON.
+- If zero questions parse, the handler falls back to
+  `executeInterviewFallback` — freeform input with the node's `prompt`, and
+  the response is also persisted under `answers_key` for downstream nodes.
+- On success: writes `answers_key` (serialized JSON), `human_response` (a
+  markdown summary), and `response.<nodeID>`.
+- **Canceled interviews return `OutcomeFail`**, not `OutcomeSuccess`.
+  Pipeline edges can route on cancellation via `when ctx.outcome = fail`.
+- Previous answers (from a prior run of the same node during a retry) are
+  loaded from `answers_key` via `DeserializeInterviewResult` and passed to
+  `AskInterview` as pre-fill.
+
+### Hybrid (labeled freeform)
+
+Not a distinct `mode`, but the shape of `executeFreeform` when the
+interviewer implements `LabeledFreeformInterviewer` and the node has labeled
+edges. The TUI shows radio buttons for the labels plus an "other" textarea.
+`CLAUDE.md` § Human gate UX specifies the threshold rules for when the TUI
+picks `HybridContent` vs. `ReviewHybridContent` (prompt length, label
+count).
+
+## Interviewer implementations
+
+| Interviewer | Source | Use |
+|-------------|--------|-----|
+| `ConsoleInterviewer` | `human.go` | Stdin/stdout interactive prompts (non-TUI). |
+| `TUIInterviewer` | `tui/` | Default interactive mode. Implements `InterviewInterviewer` + `LabeledFreeformInterviewer`. |
+| `AutoApproveInterviewer` / `AutoApproveFreeformInterviewer` | `human.go` | Deterministic — picks `default_choice`, first option, or "Yes". Used by `--auto-approve`. |
+| `CallbackInterviewer` | `human.go` | Delegates `Ask` to a callback function. Used by test harnesses. |
+| `QueueInterviewer` | `human.go` | Returns pre-seeded answers in order. Used by test fixtures. |
+| `AutopilotInterviewer` | [autopilot.go](../../../pipeline/handlers/autopilot.go) | LLM-backed decisions with one of four personas. |
+| `ClaudeCodeAutopilotInterviewer` | [autopilot_claudecode.go](../../../pipeline/handlers/autopilot_claudecode.go) | Autopilot via the `claude` CLI subprocess. |
+| `WebhookInterviewer` | [webhook_interviewer.go](../../../pipeline/handlers/webhook_interviewer.go) | POSTs gates to an external URL and blocks on a signed callback. |
+
+## Autopilot mode
+
+From `CLAUDE.md` § Autopilot mode:
+
+- `--autopilot <persona>` swaps the default interviewer for
+  [`AutopilotInterviewer`](../../../pipeline/handlers/autopilot.go).
+- Four personas:
+  - `lax` — forward-progress bias; approve unless something is broken.
+  - `mid` (default) — balanced; treats decisions like a senior engineer.
+  - `hard` — high quality bar; scrutinize, push back on gaps.
+  - `mentor` — always approve + provide detailed feedback in reasoning.
+- Uses structured JSON output: `{"choice": "...", "reasoning": "..."}`.
+  `response_format: json_object` is set on the underlying LLM call.
+- **Provider errors hard-fail** per CLAUDE.md — only parse failures fall
+  back to the default choice.
+- `--backend claude-code` routes autopilot through
+  `ClaudeCodeAutopilotInterviewer`, which shells out to `claude` — no API
+  key needed.
+- Default model is the cheapest of the configured provider via
+  `Client.DefaultProvider()`; override with `WithAutopilotModel`.
+
+## Webhook mode
+
+`--webhook-url <URL>` swaps in
+[`WebhookInterviewer`](../../../pipeline/handlers/webhook_interviewer.go).
+The flow:
+
+1. Handler calls `Ask` / `AskFreeform` / `AskFreeformWithLabels`.
+2. Interviewer generates a per-gate ID and token, POSTs a
+   `WebhookGatePayload` (prompt, choices, callback URL, timeout) to the
+   configured webhook URL.
+3. Interviewer blocks on an internal reply channel with the configured
+   timeout (default 10m).
+4. External system responds by POSTing a `WebhookGateResponse` back to the
+   local callback server at `/gate/<gateID>` — with the per-gate token
+   echoed in `X-Tracker-Gate-Token`.
+5. Interviewer delivers the response to the waiting handler.
+
+Used for fully headless execution where a real human responds over email /
+Slack / push. See CLAUDE.md § Autopilot mode for the distinction between
+autopilot (LLM judge) and webhook (human over a transport).
+
+## Auto-approve mode
+
+`--auto-approve` uses `AutoApproveFreeformInterviewer`:
+
+- `Ask` → `default_choice` if set, else first choice.
+- `AskFreeform` → canned `"auto-approved"`.
+- `AskFreeformWithLabels` → `default_label` if set, else first label.
+- `AskInterview` → "yes" for yes/no questions, first option for options,
+  `"auto-approved"` for open-ended.
+
+This is deterministic — no LLM call. It's the fastest way to smoke-test a
+pipeline end-to-end.
+
+## Outcomes produced
+
+| Mode | Status | PreferredLabel | ContextUpdates |
+|------|--------|----------------|----------------|
+| choice | `OutcomeSuccess` | selected label | — |
+| freeform | `OutcomeSuccess` | matched label (if any) | `human_response`, `response.<nodeID>` |
+| yes_no | `OutcomeSuccess` (Yes) or `OutcomeFail` (No) | `"Yes"` or `"No"` | — |
+| interview | `OutcomeSuccess`, or `OutcomeFail` on cancel | — | `answers_key` (JSON), `human_response` (summary), `response.<nodeID>` |
+| interview (fallback) | `OutcomeSuccess` | matched label (if any) | `human_response`, `response.<nodeID>`, `answers_key` (same as response) |
+
+On timeout with `timeout_action=default` and a `default_choice` set, the
+handler returns `OutcomeSuccess` with `PreferredLabel=<default>` and
+writes `human_response=<default>`. Without a default: `OutcomeFail` with
+`human_response=timed out (no default)`.
+
+## Events emitted
+
+The handler emits no pipeline events directly — the engine emits
+`EventStageStarted` / `Completed` / `Failed` around the `Execute` call.
+However, the cancel path in interview mode is a specific concern:
+
+- All modal content types in the TUI must implement `Cancellable` so
+  Ctrl+C calls `Cancel()` to close reply channels.
+- **Never block a handler goroutine on a channel with no cancellation
+  path**. This is why the withTimeout/withTimeoutOutcome helpers exist:
+  they race the user's response against the configured timeout so the
+  handler can exit cleanly.
+
+## Edge cases and gotchas
+
+- **Choice mode requires outgoing edges.** `executeChoice` errors with
+  `human gate node %q has no outgoing edges to derive choices from` if the
+  node is a terminal sink.
+- **`default` vs `default_choice` have different fallback chains.** Choice
+  mode reads the raw `default_choice` attr only. Freeform mode reads the
+  raw `default` attr only. `HumanConfig.DefaultChoice` (the typed
+  accessor) unifies the two by preferring `default_choice` with fallback
+  to `default` — used by timeout handling.
+- **Timeout goroutine leaks are accepted.** `withTimeout` doesn't cancel
+  the inner `Interviewer.Ask` call on timeout — the goroutine runs until
+  the underlying I/O unblocks. Documented in
+  [withTimeout](../../../pipeline/handlers/human.go) as a deliberate
+  tradeoff to keep the `Interviewer` interface minimal.
+- **Freeform mode + no `FreeformInterviewer`** is an error. The handler
+  checks interface assertion and returns a hard error if the configured
+  interviewer doesn't support freeform input.
+- **Interview JSON parsing filters "other"-variant options.** The TUI always
+  provides its own "Other" escape hatch, so upstream agents should list
+  only the real options. `ParseStructuredQuestions` drops redundant "other"
+  entries via `filterOtherOption`.
+- **Canceled interview returns OutcomeFail.** Downstream edges should route
+  on `when ctx.outcome = fail` if you want to handle cancellation — a
+  retry of the node pre-fills previous answers.
+
+## Example
+
+```dip
+wait.human ApprovePlan
+  mode: "yes_no"
+  prompt: "Approve this plan?\n\n${ctx.last_response}"
+  timeout: "15m"
+  timeout_action: "default"
+  default_choice: "No"
+
+Planner -> ApprovePlan
+ApprovePlan -> Execute when: ctx.outcome = success
+ApprovePlan -> Escalate when: ctx.outcome = fail
+```
+
+Presents a Yes/No prompt with the planner's output embedded. On 15-minute
+timeout, takes the `No` default and routes to `Escalate`.
+
+```dip
+wait.human InterviewConstraints
+  mode: "interview"
+  prompt: "Answer the planner's questions:"
+  questions_key: "interview_questions"
+  answers_key: "constraint_answers"
+  writes: "timeout_seconds,retry_strategy"
+
+QuestionGen -> InterviewConstraints
+InterviewConstraints -> Build when: ctx.outcome = success
+InterviewConstraints -> Cancel when: ctx.outcome = fail
+```
+
+`QuestionGen` writes JSON questions to `interview_questions`. The gate
+parses them, runs a form UI, serializes answers to `constraint_answers`,
+and additionally extracts `timeout_seconds` and `retry_strategy` as
+top-level context keys via `writes`.
+
+## See also
+
+- [`pipeline/handlers/human.go`](../../../pipeline/handlers/human.go) —
+  handler core
+- [`pipeline/handlers/autopilot.go`](../../../pipeline/handlers/autopilot.go)
+  — LLM autopilot
+- [`pipeline/handlers/webhook_interviewer.go`](../../../pipeline/handlers/webhook_interviewer.go)
+  — external webhook
+- [`pipeline/handlers/interview_parse.go`](../../../pipeline/handlers/interview_parse.go)
+  — question parser
+- [`pipeline/handlers/interview_result.go`](../../../pipeline/handlers/interview_result.go)
+  — answer serialization
+- [`tui/`](../../../tui/) — interactive modals (HybridContent,
+  ReviewHybridContent, ReviewContent)
+- [Pipeline Context Flow](../../pipeline-context-flow.md) —
+  `human_response` / `preferred_label` semantics
+- `CLAUDE.md` §§ `Human gate UX`, `Yes/No mode`, `Interview mode`,
+  `Autopilot mode`

--- a/docs/architecture/handlers/parallel-fan-in.md
+++ b/docs/architecture/handlers/parallel-fan-in.md
@@ -1,0 +1,309 @@
+# Parallel and Fan-In Handlers (`parallel`, `parallel.fan_in`)
+
+## Purpose
+
+Parallel fan-out runs multiple branches concurrently and fan-in collects the
+results. The parallel handler is the dispatch point: it spins up one
+goroutine per branch target, hands each a fresh context snapshot, executes
+them in parallel (subject to an optional concurrency cap), and stores the
+collected `ParallelResult` array in context for the fan-in node to merge.
+
+Use parallel+fan-in when the branches are independent — for example,
+running the same review across three different models, or gathering
+diagnostics from several sources before a human gate. When branches need to
+pass data between themselves, use sequential nodes instead; each branch runs
+with an isolated context and their writes only merge at fan-in.
+
+Ground truth:
+[`pipeline/handlers/parallel.go`](../../../pipeline/handlers/parallel.go),
+[`pipeline/handlers/fanin.go`](../../../pipeline/handlers/fanin.go).
+
+## Architectural note
+
+From `CLAUDE.md`:
+
+> The engine doesn't know about parallel/fan-in. The engine treats every
+> node the same: execute handler, select edge, advance. The parallel
+> handler does concurrent dispatch internally and hints the engine where to
+> go next via `suggested_next_nodes`.
+
+This matters for understanding the edge-routing flow: outgoing graph edges
+from the parallel node are **ignored for branch dispatch** — dispatch
+targets come from the `parallel_targets` attr. But outgoing edges to the
+join node are still used by the engine's normal edge selector once the
+parallel handler suggests the join.
+
+## Node attributes — parallel
+
+| Attribute | Type | Default | Behavior |
+|-----------|------|---------|----------|
+| `parallel_targets` | string (comma-separated) | — | Branch target node IDs. Required unless outgoing graph edges carry the targets. |
+| `parallel_join` | string | empty | Node ID of the fan-in node branches should reconverge on. Written into `suggested_next_nodes` for engine routing. |
+| `max_concurrency` | int | 0 (unbounded) | Cap on concurrent branch goroutines. Used as a semaphore. |
+| `branch_timeout` | duration | 0 (none) | Per-branch wall-clock timeout applied via `context.WithTimeout`. |
+| `branch.N.target` | string | — | Declares override group N applies to the given target node ID. |
+| `branch.N.<attr>` | string | — | Attrs to override on branch N's target node (e.g. `branch.0.llm_model=gpt-4o`, `branch.1.fidelity=full`). |
+
+Typed accessor: [`Node.ParallelConfig`](../../../pipeline/node_config.go).
+
+## Node attributes — fan-in
+
+| Attribute | Type | Default | Behavior |
+|-----------|------|---------|----------|
+| `fan_in_sources` | string (comma-separated) | — | Upstream source node IDs — documented for dippin adapter; reads happen from the shared `parallel.results` key. |
+
+The fan-in handler reads `parallel.results` out of context directly; it
+doesn't inspect its own attrs at runtime.
+
+## Execute lifecycle
+
+```mermaid
+sequenceDiagram
+    participant E as Engine
+    participant P as ParallelHandler
+    participant B0 as Branch 0 goroutine
+    participant B1 as Branch 1 goroutine
+    participant F as FanInHandler
+
+    E->>P: Execute parallelNode
+    P->>P: resolveBranchEdges from parallel_targets or outgoing
+    P->>P: parseBranchOverrides
+    P->>P: emit EventParallelStarted
+    par branch 0
+        P->>B0: runBranch with snapshot timeout semaphore
+        B0->>B0: emit EventStageStarted
+        B0->>B0: registry.Execute on target
+        B0-->>P: ParallelResult via resultsCh
+        B0->>B0: emit EventStageCompleted
+    and branch 1
+        P->>B1: runBranch
+        B1->>B1: registry.Execute
+        B1-->>P: ParallelResult
+    end
+    P->>P: wg.Wait then aggregate
+    P->>P: pctx.Set parallel.results JSON
+    P-->>E: Outcome status SuggestedNextNodes=joinID
+    E->>F: Execute joinNode
+    F->>F: unmarshal parallel.results
+    F->>F: mergeSuccessfulBranches
+    F-->>E: Outcome status ContextUpdates=merged
+```
+
+## Branch dispatch
+
+[`collectBranchEdges`](../../../pipeline/handlers/parallel.go) picks one of
+two sources for branch targets:
+
+1. **`parallel_targets` attr** — when non-empty, split on commas, trim, and
+   build synthetic `Edge{From: parallelNode.ID, To: target}` entries.
+2. **Outgoing graph edges** — fallback when no `parallel_targets` attr is
+   set. The edge to `parallel_join` is filtered out so it doesn't run as a
+   branch.
+
+In practice, dippin-lang `.dip` files carry `parallel_targets` via
+`ParallelConfig.Targets`, which the adapter translates into the node attr.
+The fallback exists for hand-written graphs and older DOT files.
+
+## Branch context isolation
+
+Each branch goroutine calls
+[`pipeline.NewPipelineContextFrom(snapshot)`](../../../pipeline/context.go)
+to build a fresh context from a snapshot of the parent's context at dispatch
+time. This means:
+
+- Branches see all parent context at launch (including `graph.*` attrs,
+  previous node writes, `_artifact_dir`).
+- Branch writes do not bleed into each other. Two branches writing the same
+  key don't collide.
+- Branch writes only flow back to the parent at fan-in, via the merge
+  described below.
+
+The artifact directory internal key is explicitly re-seeded on the branch
+context so branches write into the same run artifact root as the parent.
+
+## Branch overrides
+
+[`parseBranchOverrides`](../../../pipeline/handlers/parallel.go) harvests
+`branch.N.*` attrs on the parallel node and groups them by the `branch.N.target`
+field. For each target node ID, the handler builds an override map applied
+via a shallow clone of the target node:
+
+```dip
+parallel Review
+  parallel_targets: "ReviewFast, ReviewDeep"
+  parallel_join: "Merge"
+  branch.0.target: "ReviewFast"
+  branch.0.llm_model: "gpt-4o-mini"
+  branch.1.target: "ReviewDeep"
+  branch.1.llm_model: "o1"
+```
+
+Override semantics: node attrs are overlaid onto a clone of the target
+node's `Attrs`; other fields (`Shape`, `Label`, `Handler`) are preserved.
+The original target node in the graph is untouched, so a second parallel
+node pointing at the same target isn't affected.
+
+## Concurrency and timeout
+
+- `max_concurrency` → a buffered `chan struct{}` used as a semaphore
+  ([`makeSemaphore`](../../../pipeline/handlers/parallel.go)). A value of 0
+  disables the semaphore (unbounded). Each goroutine acquires a slot before
+  starting real work and releases it on exit via `defer`.
+- `branch_timeout` → wraps each branch's execution context with
+  `context.WithTimeout`. On timeout, the branch returns with whatever
+  outcome the registry produced — typically a context-cancellation error
+  that the handler treats as `OutcomeFail`.
+
+The semaphore wait itself is cancellable: if the parent context cancels
+while a branch is blocked waiting for a slot, the branch records
+`context canceled while waiting for concurrency slot` and returns.
+`wg.Done()` is deferred before the semaphore wait, so this early-exit path
+still releases the WaitGroup — a prior bug where the defer sat after the
+select could deadlock `wg.Wait()` on cancellation.
+
+## Panic safety
+
+Every branch goroutine has a deferred
+[`recoverBranch`](../../../pipeline/handlers/parallel.go) that converts a
+panic into a `ParallelResult{Status: OutcomeFail, Error: "panic in branch..."}`
+plus an `EventStageFailed` event. The parent goroutine never crashes because
+of a misbehaving branch handler.
+
+## ParallelResult
+
+```go
+type ParallelResult struct {
+    NodeID         string
+    Status         string
+    ContextUpdates map[string]string
+    Error          string
+    Stats          *pipeline.SessionStats
+}
+```
+
+Each branch's result combines:
+
+- The target node's `Outcome.Status` and `Outcome.ContextUpdates`.
+- **Diff** of context writes applied to the branch context during
+  execution (`branchCtx.DiffFrom(snapshot)`) — catches writes that
+  happen inside sub-handlers but aren't in the outcome's explicit
+  `ContextUpdates`. Both are merged with outcome updates winning on
+  conflicts.
+- `Stats` — the target handler's session stats (if codergen), so the parent
+  node's trace entry can carry combined tokens/cost from all branches.
+
+## Aggregate outcome from parallel handler
+
+[`aggregateStatus`](../../../pipeline/handlers/parallel.go): `success` if at
+least one branch succeeded, else `fail`. This is deliberately permissive —
+fan-in reads the full results array and can route on richer criteria if
+needed.
+
+The outcome populates `suggested_next_nodes` with
+`parallel_join` so the engine's edge selector prefers the join node. Any
+outgoing edges from the parallel node that don't point to the join are
+ignored (they were used for branch dispatch, not for post-fan-out routing).
+
+## Fan-in merge
+
+[`FanInHandler.Execute`](../../../pipeline/handlers/fanin.go):
+
+1. Reads the JSON-encoded `parallel.results` from context.
+2. Iterates in order. For each **successful** branch, merges its
+   `ContextUpdates` into an accumulator map — later successful branches
+   overwrite earlier ones on key conflict.
+3. Returns `OutcomeSuccess` if any branch succeeded, `OutcomeFail`
+   otherwise.
+
+**Failed branches' context updates are discarded.** If you need data from a
+failed branch, have the branch itself write to a non-conflicting key
+(e.g. `<branchID>.error`) and it'll still be in `parallel.results` JSON
+for inspection — but it won't be merged into the fan-in outcome.
+
+## Events emitted
+
+Parallel handler:
+
+| Event | When |
+|-------|------|
+| `EventParallelStarted` | Before dispatch. `Message` lists branch IDs. |
+| `EventStageStarted` | One per branch, inside `runBranch`, for TUI visibility. |
+| `EventStageCompleted` / `EventStageFailed` | One per branch, emitted via `emitBranchComplete` based on the branch's status. |
+| `EventParallelCompleted` | After all branches return, `Message` gives the aggregate status. |
+| `EventStageFailed` (panic) | From `recoverBranch` when a goroutine panics. |
+
+Fan-in handler emits none directly — engine emits the normal stage
+lifecycle events.
+
+## Aggregate session stats
+
+[`aggregateBranchStats`](../../../pipeline/handlers/parallel.go) sums
+`SessionStats` across branches: turns, tool calls, input/output tokens,
+cost, compactions, cache hits/misses, longest turn (max), and the per-tool
+call map (additive). `FilesModified`/`FilesCreated` lists are concatenated.
+This single aggregated `Stats` is attached to the parallel node's outcome so
+the parent trace entry reflects the full cost of the fan-out.
+
+## Edge cases and gotchas
+
+- **Parallel targets do not share context during execution.** Two branches
+  writing to `last_response` are independent — neither sees the other. The
+  fan-in sees both via `parallel.results[].context_updates`.
+- **The adapter synthesizes implicit edges.** Dippin IR doesn't emit
+  explicit edges for parallel target fan-out; the adapter generates them so
+  the graph is structurally complete. See `CLAUDE.md` § Dippin-lang
+  compatibility.
+- **Branch overrides are keyed by target node ID, not by branch index.**
+  Two parallel nodes pointing at the same target with different overrides
+  will collide if they run concurrently — make the targets distinct node
+  IDs instead.
+- **`max_concurrency` can cause silent serialization.** Setting
+  `max_concurrency=1` runs branches sequentially inside goroutines;
+  correctness is preserved but you lose the parallelism benefit.
+  Log inspection should confirm actual parallel execution before trusting
+  throughput claims.
+
+## Example
+
+```dip
+parallel ReviewFanOut
+  parallel_targets: "ReviewArch, ReviewSec, ReviewPerf"
+  parallel_join: "Merge"
+  max_concurrency: "3"
+  branch_timeout: "5m"
+  branch.0.target: "ReviewArch"
+  branch.0.llm_model: "gpt-4o"
+  branch.1.target: "ReviewSec"
+  branch.1.llm_model: "claude-sonnet-4"
+  branch.2.target: "ReviewPerf"
+  branch.2.llm_model: "o1-mini"
+
+parallel.fan_in Merge
+  fan_in_sources: "ReviewArch, ReviewSec, ReviewPerf"
+
+Plan -> ReviewFanOut
+ReviewFanOut -> Merge
+Merge -> Done when: ctx.outcome = success
+Merge -> Escalate when: ctx.outcome = fail
+```
+
+Three reviewer branches run concurrently with different models. Each gets
+its own context snapshot at launch. `Merge` collects the results and merges
+the writes from any branch that succeeded. Each branch has a 5-minute
+ceiling.
+
+## See also
+
+- [`pipeline/handlers/parallel.go`](../../../pipeline/handlers/parallel.go)
+  — dispatch, goroutines, overrides
+- [`pipeline/handlers/fanin.go`](../../../pipeline/handlers/fanin.go) —
+  merge
+- [`pipeline/node_config.go`](../../../pipeline/node_config.go) —
+  `ParallelNodeConfig`
+- [`pipeline/dippin_adapter_edges.go`](../../../pipeline/dippin_adapter_edges.go)
+  — synthesized edges from `ParallelConfig.Targets`
+- [Conditional (edge evaluator)](./conditional.md) — how
+  `suggested_next_nodes` is matched during edge selection
+- [Pipeline Context Flow](../../pipeline-context-flow.md) — the
+  `parallel.results` key shape
+- `CLAUDE.md` § `Parallel execution`

--- a/docs/architecture/handlers/subgraph.md
+++ b/docs/architecture/handlers/subgraph.md
@@ -1,0 +1,201 @@
+# Subgraph Handler (`subgraph`)
+
+## Purpose
+
+The subgraph handler runs a referenced sub-pipeline inline as a single node in
+the parent graph. It enables composition — factoring a reusable workflow into
+its own `.dip` file and referencing it from multiple parent pipelines, or
+breaking a large pipeline into scoped sub-graphs with isolated contexts. The
+parent engine treats the subgraph node as one opaque step: its handler spins
+up a child engine, runs the referenced graph to completion, and maps the
+child's final status onto the parent's outcome.
+
+Use subgraphs for:
+
+- Reusable blocks (e.g. a common "set up git repo, run tests, commit" loop).
+- Scoping context: the child sees a snapshot of parent context at launch time
+  and its writes don't bleed back until the child completes.
+- Parameterized pipelines: pass `subgraph_params` as overrides to the child's
+  declared `vars`.
+
+## Node attributes
+
+| Attribute | Type | Default | Behavior |
+|-----------|------|---------|----------|
+| `subgraph_ref` | string (required) | — | Name or path of the child `.dip` file to launch. Resolution is CLI-side (see below). |
+| `subgraph_params` | string | empty | Comma-separated `key=value,key=value` pairs that override the child's declared vars. Parsed by `ParseSubgraphParams`. |
+
+Ground truth:
+[`pipeline/subgraph.go`](../../../pipeline/subgraph.go).
+
+## Ref resolution
+
+Resolution happens at pipeline load time, not at handler execution time.
+[`cmd/tracker/loading.go`](../../../cmd/tracker/loading.go) walks every node
+in the parent graph, collects `subgraph_ref` attrs, and resolves each one via
+[`resolveSubgraphPath`](../../../cmd/tracker/loading.go), trying candidates in
+order:
+
+1. `<parentDir>/<ref>`
+2. `<parentDir>/<ref>.dip`
+3. `<cwd>/<ref>`
+4. `<cwd>/<ref>.dip`
+
+Each resolved file is loaded into a `*pipeline.Graph` and registered under its
+original ref string. The resulting `map[string]*Graph` is handed to the
+`SubgraphHandler` via its constructor.
+
+### Recursion and the visited-set guard
+
+[`loadSubgraphsRecursive`](../../../cmd/tracker/loading.go) walks into every
+loaded subgraph and repeats the scan, so subgraphs can reference other
+subgraphs transitively. A `visited` map keyed by the resolved absolute path
+blocks cycles — if the same file would be loaded a second time while already
+in the visited set, loading fails with:
+
+> `circular subgraph reference detected: %q resolves to %q which is already
+> being loaded (cycle)`
+
+The visited entry is removed (`defer delete`) once the subgraph has been
+loaded, so two sibling nodes pointing at the same child reuse the cached
+`*Graph` rather than re-loading, but without tripping the cycle guard.
+
+## Execute lifecycle
+
+```mermaid
+sequenceDiagram
+    participant P as Parent Engine
+    participant SH as SubgraphHandler
+    participant RF as RegistryFactory
+    participant CE as Child Engine
+    participant CR as Child Registry
+
+    P->>SH: Execute ctx node pctx
+    SH->>SH: lookup child graph by subgraph_ref
+    SH->>SH: merge child vars and subgraph_params
+    SH->>SH: InjectParamsIntoGraph clones if params set
+    SH->>RF: factory childGraph parentNodeID
+    RF-->>SH: childRegistry with scoped events
+    SH->>CE: NewEngine childGraph childRegistry WithInitialContext snapshot
+    CE->>CR: run nodes
+    CR-->>CE: outcomes and ContextUpdates
+    CE-->>SH: EngineResult
+    SH-->>P: Outcome Status ContextUpdates=result.Context
+```
+
+## Param passing
+
+`subgraph_params` flows through two merge steps in
+[`SubgraphHandler.Execute`](../../../pipeline/subgraph.go):
+
+1. **Extract child defaults** from the child graph's `vars` declarations (via
+   `ExtractParamsFromGraphAttrs`).
+2. **Parse parent overrides** from the node's `subgraph_params` attr (via
+   `ParseSubgraphParams`).
+3. **Merge** — parent overrides win; child defaults supply fallbacks for
+   keys the parent didn't set.
+4. **Pre-expand** the merged params into the child graph via
+   `InjectParamsIntoGraph`. This clones the graph if any params are set so
+   the original cached graph is not mutated.
+5. **Write back** the effective params onto the clone's `Attrs` as
+   `graph.params.<key>` entries, so runtime handlers that read
+   `graph.Attrs` see the overridden values — not just the child's original
+   declarations.
+
+Without step 1, a pre-expansion of `${params.foo}` in the child would resolve
+to empty when the parent didn't pass `foo` — silently dropping the child's
+default.
+
+## Context overlay
+
+The child engine is started with
+`WithInitialContext(pctx.Snapshot())` — a full copy of the parent's context
+at launch time. This means the child sees:
+
+- Every `graph.*` attr from the parent.
+- Every node's writes so far (`last_response`, `tool_stdout`, `response.<id>`,
+  etc.).
+- Internal keys like `_artifact_dir`.
+
+The child gets its own `PipelineContext` instance, so writes inside the child
+do not bleed back to the parent during execution. When the child completes,
+its final context is returned as `result.Context` and the handler maps it
+into the parent via `Outcome.ContextUpdates` — the engine applies those
+updates to the parent context just like any other handler's writes.
+
+## Outcomes produced
+
+| Field | Value |
+|-------|-------|
+| `Status` | `OutcomeSuccess` if `result.Status == OutcomeSuccess`, else `OutcomeFail`. Non-success child statuses (including `OutcomeRetry`, `OutcomeBudgetExceeded`, etc.) all collapse to `OutcomeFail` at the parent level. |
+| `ContextUpdates` | The child's final context snapshot (`result.Context`). Every key the child wrote is visible to the parent. |
+| `SuggestedNextNodes` | Not set. |
+| `PreferredLabel` | Not set. |
+
+## Events emitted
+
+The subgraph handler does not emit events directly — the child engine emits
+its own lifecycle events, which are routed through a
+[`NodeScopedPipelineHandler`](../../../pipeline/events.go) that:
+
+- **Prefixes** every child event's `NodeID` with `parentNodeID + "/"`. So a
+  child node `Decompose` inside a parent subgraph node `Planner` shows up as
+  `Planner/Decompose` to the outer TUI/logger.
+- **Filters** child pipeline lifecycle events (`EventPipelineStarted`,
+  `EventPipelineCompleted`, `EventPipelineFailed`) — the parent engine
+  already tracks the subgraph node's own stage lifecycle, so the child's
+  pipeline events would double-report.
+
+Agent-level events are similarly scoped by `RegistryFactory`, which the
+caller supplies when constructing the handler. The factory creates a child
+registry where agent `Event` values carry namespaced node IDs.
+
+## Edge cases and gotchas
+
+- **Missing ref fails at load time, not at runtime.**
+  [`validateSubgraphRefs`](../../../cmd/tracker/loading.go) checks that every
+  `subgraph` node has a matching entry in the loaded `graphs` map before the
+  engine ever runs. At runtime, `SubgraphHandler.Execute` still double-checks
+  (`subgraph %q not found`) but that branch is a safety net, not the
+  expected error path.
+- **No per-subgraph budget.** Budget limits on the parent engine are enforced
+  at parent-node boundaries, not at child-node boundaries. A runaway child
+  can consume more cost than the parent budget allows — the breach is only
+  detected after the child returns.
+- **Subgraphs share the parent's artifact root.** The initial context
+  includes `_artifact_dir`, so every node in the child writes into the same
+  run directory. Child node artifacts get prefixed with the child node's
+  own ID, not the parent's — so two subgraph instances with overlapping node
+  IDs will collide unless the node IDs are made unique.
+- **No distinct outcome for "subgraph ran, final node was retry".** A retry
+  status at the child's exit node maps to `OutcomeFail` on the parent side.
+  If you need richer signaling, write a specific context key in the child's
+  final node and route on that.
+
+## Example
+
+```dip
+subgraph BuildAndTest
+  subgraph_ref: "build_and_test"
+  subgraph_params: "target_branch=${ctx.branch},verbose=true"
+
+Planner -> BuildAndTest
+BuildAndTest -> Review when: ctx.outcome = success
+BuildAndTest -> Escalate when: ctx.outcome = fail
+```
+
+Runs `build_and_test.dip` (resolved relative to this pipeline's directory) as
+a single node named `BuildAndTest`. The child inherits the full parent
+context plus the two overridden params.
+
+## See also
+
+- [`pipeline/subgraph.go`](../../../pipeline/subgraph.go) — handler
+- [`cmd/tracker/loading.go`](../../../cmd/tracker/loading.go) —
+  `loadSubgraphsRecursive`, `resolveSubgraphPath`, cycle guard
+- [`pipeline/params.go`](../../../pipeline/params.go) —
+  `ParseSubgraphParams`, `InjectParamsIntoGraph`
+- [`pipeline/events.go`](../../../pipeline/events.go) —
+  `NodeScopedPipelineHandler` event prefixing
+- [Manager Loop Handler](../../manager-loop.md) — related pattern that runs a
+  subgraph asynchronously with steering and polling

--- a/docs/architecture/handlers/tool.md
+++ b/docs/architecture/handlers/tool.md
@@ -1,0 +1,222 @@
+# Tool Handler (`tool`)
+
+## Purpose
+
+The tool handler runs a shell command in the run's working directory, captures
+stdout/stderr, and maps the exit code to a pipeline outcome. It's how a
+pipeline node executes something that's not an LLM agent — running tests,
+invoking a formatter, generating a file, reading a directory, etc. Because
+tool commands can embed LLM-generated content via variable expansion, the
+handler applies multiple safety layers before dispatch.
+
+Ground truth:
+[`pipeline/handlers/tool.go`](../../../pipeline/handlers/tool.go).
+
+## Node attributes
+
+| Attribute | Type | Default | Behavior |
+|-----------|------|---------|----------|
+| `tool_command` | string (required) | — | Shell command to execute. `${ctx.foo}`, `${graph.bar}`, `${params.baz}` variable refs are expanded before execution. |
+| `working_dir` | string | run dir | Prepends `cd "<dir>" && ` to the command. Rejected if it contains shell metacharacters or `..` path traversal. |
+| `timeout` | duration | 30s | Per-command wall-clock limit (e.g. `30s`, `5m`). Non-positive or unparseable values error at execution time. |
+| `output_limit` | bytes | 64KB | Per-stream (stdout or stderr) cap. Accepts raw bytes (`65536`), `KB`, or `MB` suffix. Capped at `max_output_limit` (default 10MB, configurable via `--max-output-limit`). |
+
+Typed accessor: [`Node.ToolConfig`](../../../pipeline/node_config.go).
+
+## Execute lifecycle
+
+```mermaid
+sequenceDiagram
+    participant E as Engine
+    participant T as ToolHandler
+    participant V as ExpandVariables
+    participant C as CheckToolCommand
+    participant X as Env (LocalEnvironment)
+
+    E->>T: Execute ctx node pctx
+    T->>V: expand tool_command with safe-key allowlist
+    V-->>T: expanded command or error fails closed
+    T->>C: denylist and allowlist check
+    C-->>T: ok or error aborts
+    T->>T: applyWorkingDir sanitize and prepend cd
+    T->>T: parseTimeout and parseOutputLimit
+    T->>X: ExecCommandWithLimit sh -c with env stripped
+    X-->>T: exit code stdout stderr
+    T-->>E: Outcome status tool_stdout tool_stderr
+```
+
+## Variable expansion and safe-key allowlist
+
+[`expandAndValidateCommand`](../../../pipeline/handlers/tool.go) calls
+`pipeline.ExpandVariables` with `toolCommandMode=true`. This mode enforces a
+**safe-key allowlist** for `ctx.*` references:
+
+- Allowed: `ctx.outcome`, `ctx.preferred_label`, `ctx.human_response`,
+  `ctx.interview_answers` — all structurally author-controlled via gate
+  edges or fixed handler outputs.
+- Always allowed: `graph.*` and `params.*` — both are declared in the
+  `.dip` file, so they're author-controlled by definition.
+- Blocked: any other `ctx.*` key, including LLM-origin keys like
+  `ctx.last_response`, `ctx.tool_stdout`, `ctx.response.*`.
+
+The safe pattern for consuming LLM output in a tool command is to have a
+prior tool node write the LLM response to a file on disk, then read from
+that file in the tool command:
+
+```dip
+tool SaveResponse
+  tool_command: 'printf "%s" "${ctx.last_response}" > .ai/output.json'  # blocked — fails closed
+
+tool SaveResponseSafe
+  tool_command: 'cat .ai/output.json | jq .field'  # LLM file already written by a previous agent
+```
+
+Expansion is **single-pass**: resolved values are not re-scanned. A value
+containing literal `${...}` syntax is left alone, not recursively expanded.
+
+If expansion fails or the expanded command is empty after trimming
+whitespace, the handler fails closed with an error — it does not run `sh -c
+""` or a command with literal `${...}` placeholders.
+
+## Denylist and allowlist
+
+[`CheckToolCommand`](../../../pipeline/handlers/tool_safety.go) runs after
+expansion, before working-dir prepend:
+
+- **Denylist** (built-in): patterns like `eval`, pipe-to-shell, `curl | sh`.
+  Matches abort the command unless `--bypass-denylist` was passed at startup.
+- **Allowlist** (optional): set via `--tool-allowlist` CLI flag or the
+  `tool_commands_allow` graph attr. When non-empty, commands must match at
+  least one allowlist pattern. The allowlist cannot override the denylist —
+  a denylisted command is still blocked even if it matches an allowlist
+  entry.
+
+The check runs on the expanded user command, not the final `cd <dir> && <cmd>`
+string, so allowlist patterns don't need to account for the injected `cd`
+prefix.
+
+## Working directory handling
+
+[`applyWorkingDir`](../../../pipeline/handlers/tool.go) rejects unsafe values
+before prepending `cd`:
+
+- Any shell metacharacter in the set `` `$;|&()<>\n\r `` → error.
+- `filepath.Clean`-normalized path that contains `..` → error.
+
+The final command becomes `cd "<cleaned>" && <command>`. The double-quote
+around `<cleaned>` protects path values with spaces.
+
+## Timeout
+
+[`parseTimeout`](../../../pipeline/handlers/tool.go):
+
+- Missing attr → 30-second default (overridable at handler construction).
+- Parseable positive duration → used as-is.
+- **Zero or negative** → hard error at execute time with a message naming
+  the node and the offending value. Previously these passed through to
+  `context.WithTimeout`, which produced confusing "command timed out"
+  failures immediately; this changed in v0.22.0 to surface misconfiguration
+  instead of silently breaking.
+- Unparseable string → error.
+
+## Output limits
+
+[`parseOutputLimit`](../../../pipeline/handlers/tool.go):
+
+- Missing attr → handler's configured `outputLimit` (default 64KB).
+- `parseByteSize` accepts raw digits, `KB` suffix, or `MB` suffix
+  (case-insensitive).
+- Capped at `maxOutputLimit` (default 10MB, configurable via
+  `--max-output-limit`).
+
+Limits apply per stream (stdout and stderr are capped independently). When a
+stream exceeds the limit, `exec.LocalEnvironment.ExecCommandWithLimit`
+truncates — the handler does not re-read after truncation.
+
+## Sensitive environment variable stripping
+
+[`buildToolEnv`](../../../pipeline/handlers/tool.go) filters `os.Environ()`
+against the patterns `*_API_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD`
+(case-insensitive `strings.Contains` match on the variable name). Matching
+variables are removed from the subprocess environment. The override env var
+`TRACKER_PASS_ENV=1` disables filtering entirely — set it explicitly when a
+tool command needs an API key.
+
+Stripping applies to `*exec.LocalEnvironment` only. Other
+`exec.ExecutionEnvironment` implementations call `ExecCommand` without the
+filtered env, because they have their own isolation model (sandbox, container).
+
+## Outcomes produced
+
+| Field | Value |
+|-------|-------|
+| `Status` | `OutcomeSuccess` on exit code 0, `OutcomeFail` on any non-zero exit. |
+| `ContextUpdates.tool_stdout` | Right-trimmed stdout (trailing whitespace / newlines stripped so edge conditions match reliably). |
+| `ContextUpdates.tool_stderr` | Right-trimmed stderr. |
+| `ContextUpdates.response.<nodeID>` | Not written by tool handler. |
+
+[`applyDeclaredWrites`](../../../pipeline/handlers/declared_writes.go) — if
+the node declares a `writes:` attr listing expected JSON fields, the handler
+parses stdout as JSON and writes each declared key into context. A parse
+failure or missing declared field flips status to `OutcomeFail`.
+
+## Events emitted
+
+The tool handler emits no pipeline events directly. The engine emits
+`EventStageStarted` before `Execute` and `EventStageCompleted`/`Failed`
+based on the returned outcome — the same lifecycle as every other handler.
+
+## Edge cases and gotchas
+
+- **LLM output injection is the #1 attack surface.** The safe-key allowlist
+  + denylist + env stripping are layered defenses; never pass
+  `--bypass-denylist` in CI.
+- **Output limits are per-stream, not combined.** A tool that writes 63KB
+  to stdout and 63KB to stderr fits well within limits; 65KB to either
+  alone gets truncated.
+- **Tool nodes participate in strict-failure-edge enforcement.** A tool
+  node that exits non-zero with only unconditional outgoing edges stops
+  the pipeline. Route on `when ctx.outcome = fail` explicitly to handle
+  failure.
+- **Exit code 124 is not special.** A 30s timeout kills the subprocess
+  with `SIGKILL` via context cancellation; the surfaced error is
+  `tool command failed ... context deadline exceeded`, and the outcome is
+  `OutcomeFail` (not a special timeout status).
+- **Comments and blank lines in LLM-generated pattern lists** must be
+  stripped before use (`grep -v '^#'`). See `CLAUDE.md` § `Tool node
+  safety` for the recommended patterns.
+
+## Example
+
+```dip
+tool RunTests
+  tool_command: "go test ./... -short"
+  working_dir: "src/${graph.subpath}"
+  timeout: "2m"
+  output_limit: "256KB"
+
+tool ExtractResults
+  tool_command: 'cat test-results.json | jq -r .summary'
+  timeout: "10s"
+```
+
+`RunTests` scopes into `src/<subpath>` (param-expanded at load time) and
+runs `go test` with a 2-minute timeout and a 256KB per-stream capture. On
+non-zero exit, `outcome=fail` and any edge without `when ctx.outcome =
+fail` triggers strict-failure-edge shutdown. `ExtractResults` safely reads
+a file produced by a prior node and emits its `.summary` field — no
+LLM content crosses the shell.
+
+## See also
+
+- [`pipeline/handlers/tool.go`](../../../pipeline/handlers/tool.go) — handler
+- [`pipeline/handlers/tool_safety.go`](../../../pipeline/handlers/tool_safety.go)
+  — denylist, allowlist
+- [`pipeline/expand.go`](../../../pipeline/expand.go) — variable expansion,
+  safe-key allowlist
+- [`pipeline/node_config.go`](../../../pipeline/node_config.go) —
+  `ToolNodeConfig`
+- [`agent/exec`](../../../agent/exec/) — `ExecCommandWithLimit`
+- [Pipeline Context Flow](../../pipeline-context-flow.md) — how
+  `tool_stdout` / `tool_stderr` are consumed by downstream nodes
+- `CLAUDE.md` § `Tool node safety — LLM output as shell input`


### PR DESCRIPTION
## Summary

Six per-handler architecture deep-dive docs under `docs/architecture/handlers/`, written as reference documentation for each pipeline handler type. Each doc follows a consistent shape (purpose, node attributes, execute lifecycle with mermaid diagram, outcomes, events, gotchas, example, see-also) and links inline to the Go source for ground truth.

Manager loop is already covered by `docs/manager-loop.md` and is not duplicated — subgraph.md links to it.

## File inventory

| File | Lines | Mermaid diagrams |
|------|-------|------------------|
| `docs/architecture/handlers/codergen.md` | 397 | 2 (flowchart + sequence) |
| `docs/architecture/handlers/tool.md` | 222 | 1 (sequence) |
| `docs/architecture/handlers/human.md` | 339 | 2 (flowchart + sequence) |
| `docs/architecture/handlers/parallel-fan-in.md` | 309 | 1 (sequence with `par` block) |
| `docs/architecture/handlers/subgraph.md` | 201 | 1 (sequence) |
| `docs/architecture/handlers/conditional.md` | 169 | 0 (evaluator is stateless) |
| **Total** | **1,637** | **7** |

## Source-level inconsistencies flagged

- `CLAUDE.md` § Interview mode states that `questions_key` defaults to `last_response`. The code (`resolveInterviewKeys` in `pipeline/handlers/human.go`) uses `interview_questions` as the primary default and falls back to `last_response` inside `resolveAgentOutput`. The code is load-bearing (production pipelines write to `interview_questions`); `human.md` documents the code's actual behavior and flags the CLAUDE.md discrepancy inline. This should be reconciled separately.

## Follow-up

- `docs/manager-loop.md` should be moved to `docs/architecture/handlers/manager-loop.md` in a later cleanup pass, per the assignment brief. Doing so in this PR would conflict with parallel subsystem doc work; left for a subsequent PR.

## Test plan

- [ ] Mermaid diagrams render on github.com (visual check on the PR's `Files changed` tab)
- [ ] All repo-relative source links (`../../../pipeline/...`) resolve from `docs/architecture/handlers/`
- [ ] Cross-links to `docs/manager-loop.md` and `docs/pipeline-context-flow.md` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation for six core pipeline handlers, covering their configuration options, execution lifecycles, behavior semantics, context updates, event emissions, and usage examples.
  * Documented support for routing conditions, session configuration, structured output, parallel execution, nested graphs, and tool execution with safety controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->