### PR TITLE
docs(architecture): top-level overview + engine + handlers index

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,259 @@
+# Tracker Architecture
+
+Tracker is a pipeline orchestration engine for multi-agent LLM workflows.
+Pipelines are authored in [Dippin](https://github.com/2389-research/dippin-lang)
+(`.dip`) as a small DSL that compiles to an intermediate representation (IR)
+which tracker then executes as a directed graph of handler invocations. The
+engine supports human-in-the-loop gates, parallel fan-out, subgraph
+composition, checkpoint/resume, budget guards, a git-backed artifact trail,
+and a live TUI dashboard. It is built by 2389.ai.
+
+This document is the starting point for understanding the system. For
+subsystem detail, see [`docs/architecture/README.md`](docs/architecture/README.md).
+
+## System context
+
+The common-case path from a human typing `tracker build_product` to a
+finished run:
+
+```mermaid
+flowchart LR
+    author([Workflow author]) -->|writes .dip| dip[(.dip file)]
+    dip -->|parsed by| dippin[dippin-lang IR]
+    dippin -->|adapter| graphNode[pipeline.Graph]
+    cli[tracker CLI] -->|resolves + loads| graphNode
+    graphNode --> engine[pipeline.Engine]
+    registry[HandlerRegistry] --> engine
+    engine -->|dispatch| handlers[Handlers]
+    handlers -->|agent sessions| agentNode[agent.Session]
+    agentNode -->|requests| llm[LLM providers]
+    handlers -->|shell commands| shell[subprocess]
+    handlers -->|gates| gate[TUI / webhook / autopilot]
+    engine -->|events| tui[Bubbletea TUI]
+    engine -->|NDJSON / checkpoint / git| artifacts[(Run artifacts)]
+```
+
+Dippin-lang is an external dependency — tracker does not parse `.dip` text
+directly. It consumes the IR produced by dippin's parser and converts it to
+its own `Graph` via `pipeline/dippin_adapter.go`. The adapter is the single
+place where naming mismatches between the two ecosystems are reconciled (see
+`CLAUDE.md` §Architecture Gotchas for the full contract).
+
+## Layer diagram
+
+```mermaid
+flowchart TD
+    subgraph L1["CLI / TUI — cmd/tracker, tui/"]
+        cli["tracker CLI commands<br/>(run, validate, simulate, doctor, diagnose)"]
+        tui["Bubbletea dashboard<br/>(sidebar + activity log + modals)"]
+    end
+    subgraph L2["Library surface — tracker.go, tracker_*.go"]
+        lib["tracker.Run / NewEngine / Diagnose / Audit / Doctor / Simulate"]
+    end
+    subgraph L3["Pipeline engine — pipeline/"]
+        eng["Engine.Run loop: handler dispatch, edge selection,<br/>retry, restart, checkpoint, budget guard, steering"]
+    end
+    subgraph L4["Handlers — pipeline/handlers/"]
+        h["codergen, tool, wait.human, parallel, parallel.fan_in,<br/>subgraph, conditional, stack.manager_loop, start, exit"]
+    end
+    subgraph L5["Agent — agent/"]
+        ag["agent.Session turn loop + tool registry +<br/>compaction + episodic memory + planning"]
+    end
+    subgraph L6["LLM — llm/"]
+        llm["llm.Client + middleware + token tracker +<br/>cost estimator + provider adapters (anthropic/openai/google/openaicompat)"]
+    end
+    dippin[["dippin-lang IR<br/>(external)"]] -.-> eng
+    cli --> lib
+    lib --> eng
+    eng --> h
+    h --> ag
+    ag --> llm
+```
+
+Each layer only depends on layers below it. In particular, `pipeline/` never
+imports `agent/` at the engine level — handlers under `pipeline/handlers/` do
+the bridging, which is why the engine has no special-case code for LLM calls,
+tool invocations, or human gates.
+
+## End-to-end sequence
+
+Happy-path execution of an agent node followed by a tool node:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant CLI as tracker CLI
+    participant Lib as tracker library
+    participant Adapter as dippin_adapter
+    participant Engine as pipeline.Engine
+    participant Reg as HandlerRegistry
+    participant Handler as CodergenHandler
+    participant Sess as agent.Session
+    participant LLM as llm.Client
+    participant FS as artifact dir
+
+    User->>CLI: tracker build_product
+    CLI->>Lib: tracker.NewEngine(source, cfg)
+    Lib->>Adapter: FromDippinIR(workflow)
+    Adapter-->>Lib: *pipeline.Graph
+    Lib->>Engine: NewEngine(graph, registry, opts)
+    Lib->>Engine: Run(ctx)
+    Engine->>Engine: initRunState — checkpoint + ctx + trace
+    loop per node
+        Engine->>Reg: Execute(ctx, node, pctx)
+        Reg->>Handler: Execute(ctx, node, pctx)
+        Handler->>Sess: NewSession + Run(prompt)
+        Sess->>LLM: Complete(...)
+        LLM-->>Sess: stream of chunks + usage
+        Sess-->>Handler: SessionResult
+        Handler-->>Engine: Outcome (Status, ContextUpdates, Stats)
+        Engine->>Engine: applyOutcome, ScopeToNode,<br/>drainSteering
+        Engine->>FS: WriteStageArtifacts + saveCheckpoint
+        Engine->>Engine: emitCostUpdate + BudgetGuard.Check
+        Engine->>Engine: selectEdge by condition/label/suggested/weight
+    end
+    Engine-->>Lib: *EngineResult
+    Lib-->>CLI: *tracker.Result
+    CLI-->>User: summary (tokens, cost, status, runID)
+```
+
+Events are emitted at every step (`EventStageStarted`, `EventDecisionOutcome`,
+`EventDecisionEdge`, `EventCheckpointSaved`, `EventCostUpdated`, …) and fan
+out to the TUI, the NDJSON writer, and the event logger. See
+[`docs/architecture/engine.md`](docs/architecture/engine.md) for the full
+event list.
+
+## Key abstractions
+
+### Graph / Node / Edge
+
+The static shape of a pipeline. Defined in
+[`pipeline/graph.go`](pipeline/graph.go). A `Graph` has named nodes, a
+directed edge list, graph-level attrs (workflow-level config, `goal`,
+`max_restarts`, `default_retry_policy`, `params.*`), and a designated
+`StartNode` / `ExitNode`. Each `Node` carries a shape, a label, a resolved
+`Handler` name, and an `Attrs` map — the latter is the single untyped bag of
+per-node configuration that handlers parse through typed accessors like
+`node.AgentConfig(graphAttrs)` (see `pipeline/node_config.go`). An `Edge` has
+`From` / `To`, an optional `Label` for label-routed gates, an optional
+`Condition` expression, and `Attrs` (currently just `weight` for tiebreaking).
+
+Shapes map to handler names via `shapeHandlerMap`: `box → codergen`,
+`parallelogram → tool`, `hexagon → wait.human`, `diamond → conditional`,
+`component → parallel`, `tripleoctagon → parallel.fan_in`, `tab → subgraph`,
+`house → stack.manager_loop`, `Mdiamond → start`, `Msquare → exit`. See
+[`docs/architecture/handlers.md`](docs/architecture/handlers.md).
+
+### Engine and the Handler interface
+
+The `Handler` interface is intentionally narrow:
+
+```go
+type Handler interface {
+    Name() string
+    Execute(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error)
+}
+```
+
+The engine treats every handler the same — it has no knowledge of LLM calls,
+subprocess execution, parallel fan-out, or human gates. Handlers register
+themselves into a `HandlerRegistry` by name; the engine resolves
+`node.Handler` through the registry at dispatch time
+(`pipeline/handler.go`).
+
+The engine's job is to iterate: pick a node, call its handler, apply the
+resulting outcome to the context, decide where to go next. Everything else —
+concurrency, retries, branching — is either a handler concern or a
+post-outcome engine concern (edge selection, budget guard). See
+[`docs/architecture/engine.md`](docs/architecture/engine.md) for the run
+loop in detail.
+
+### Outcome
+
+Every handler returns an `Outcome` ([`pipeline/handler.go`](pipeline/handler.go)):
+
+```go
+type Outcome struct {
+    Status             string            // "success", "fail", "retry", or a custom status
+    ContextUpdates     map[string]string // merged into PipelineContext
+    PreferredLabel     string            // selects an outgoing edge by label
+    SuggestedNextNodes []string          // selects an outgoing edge by target ID
+    Stats              *SessionStats     // token + cost + timing (codergen only)
+}
+```
+
+`Status` drives retry and strict-failure edge logic. `ContextUpdates` get
+merged (and marked dirty so they enter the node-scoped namespace).
+`PreferredLabel` and `SuggestedNextNodes` are the two ways a handler can
+influence edge selection without using `when` conditions. The edge
+selector's priority order is condition > label > suggested IDs > weight >
+lexical ([`pipeline/engine_edges.go`](pipeline/engine_edges.go)).
+
+### PipelineContext
+
+The shared key-value store every handler reads from and writes to during a
+run. Defined in [`pipeline/context.go`](pipeline/context.go). Four conceptual
+namespaces:
+
+- **Bare keys** (`outcome`, `last_response`, `tool_stdout`, …) — last-writer-wins
+  globals, referenced as `${ctx.<key>}` in prompts and conditions.
+- **`graph.*`** — workflow-level attrs (including `graph.goal` and
+  declared workflow params).
+- **`params.*`** — declared workflow params overridable at invocation time
+  (`tracker run ... --param key=value`).
+- **`node.<id>.<key>`** — per-node scoped aliases. After each node finishes,
+  the engine calls `ScopeToNode(nodeID)` which copies keys the node
+  dirtied into this namespace, letting downstream nodes reference a
+  specific upstream node's output without relying on "latest writer".
+- **`internal.*`** — engine bookkeeping (artifact directory, retry state);
+  not visible to prompts.
+
+See [`docs/pipeline-context-flow.md`](docs/pipeline-context-flow.md) for the
+user-facing model. Per-node scoping is the key detail distinguishing
+sequential data flow from parallel (parallel branches do NOT populate
+`node.<branchID>.*` — they write a single `parallel.results` JSON blob).
+
+### Event bus
+
+Two event streams flow out of a run, handled identically by the TUI and by
+NDJSON observers:
+
+- `pipeline.PipelineEvent` — pipeline-level lifecycle (`pipeline_started`,
+  `stage_started`, `stage_completed`, `stage_failed`, `stage_retrying`,
+  `decision_edge`, `decision_condition`, `decision_outcome`,
+  `decision_restart`, `cost_updated`, `budget_exceeded`,
+  `checkpoint_saved`, `parallel_started`, `parallel_completed`,
+  `manager_cycle_tick`, `loop_restart`, `warning`,
+  `edge_tiebreaker`). Defined in [`pipeline/events.go`](pipeline/events.go).
+- `agent.Event` — session-level streaming events from agent handlers
+  (text deltas, tool calls, tool results, turn boundaries, usage). Defined
+  in [`agent/events.go`](agent/events.go).
+
+Both streams are multiplexed: the TUI consumes them for the dashboard, the
+NDJSON writer serializes them to `activity.jsonl`, and the token tracker
+sees agent usage deltas. The same event shape is produced regardless of
+which backend (native, claude-code, ACP) the agent node runs on.
+
+## Reading order
+
+Start with [`docs/architecture/README.md`](docs/architecture/README.md) for
+an index to all subsystem docs. From there:
+
+- For how the run loop works, read [`engine.md`](docs/architecture/engine.md).
+- For the set of handlers and dispatch, read
+  [`handlers.md`](docs/architecture/handlers.md), then the per-handler files
+  under `docs/architecture/handlers/`.
+- For data flow between nodes, read
+  [`docs/pipeline-context-flow.md`](docs/pipeline-context-flow.md).
+- For the `.dip` → `Graph` bridge, read
+  [`adapter.md`](docs/architecture/adapter.md).
+- For agent internals (turn loop, tools, compaction, memory, planning),
+  read [`agent.md`](docs/architecture/agent.md).
+- For the LLM client, middleware, and provider adapters, read
+  [`llm.md`](docs/architecture/llm.md).
+- For the dashboard, read [`tui.md`](docs/architecture/tui.md).
+- For native vs Claude-Code vs ACP backends, read
+  [`backends.md`](docs/architecture/backends.md).
+- For the workdir / checkpoint / activity.jsonl / git bundle layout, read
+  [`artifacts.md`](docs/architecture/artifacts.md).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -22,11 +22,11 @@ transitions.
 | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Fan-out (`parallel` / `component`) and join (`parallel.fan_in` / `tripleoctagon`): branch dispatch, `suggested_next_nodes`, branch overrides, `parallel.results` JSON. |
 | [`handlers/subgraph.md`](./handlers/subgraph.md) | Sub-pipeline composition (`subgraph` / `tab`): named graph reference resolution, `subgraph_params` passing, scoped events. |
 | [`handlers/conditional.md`](./handlers/conditional.md) | Routing-only diamond nodes (`conditional` / `diamond`): no-op handler that delegates to edge condition evaluation. |
-| [`handlers/manager-loop.md`](./handlers/manager-loop.md) | Async child-pipeline supervisor (`stack.manager_loop` / `house`). **Current canonical location: [`docs/manager-loop.md`](../manager-loop.md)**; will be moved here in a later PR. |
+| [`../manager-loop.md`](../manager-loop.md) | Async child-pipeline supervisor (`stack.manager_loop` / `house`). Canonical location today; a dedicated `handlers/manager-loop.md` deep-dive will land in a later PR. |
 | [`agent.md`](./agent.md) | Session turn loop, tool registry, context compaction, episodic memory, plan-before-execute, repository localization, steering. |
 | [`llm.md`](./llm.md) | `llm.Client`, middleware stack, `TokenTracker`, cost estimator via model catalog, and the four provider adapters (`anthropic`, `openai`, `google` / Gemini, `openaicompat`). |
 | [`adapter.md`](./adapter.md) | `pipeline/dippin_adapter.go` — the bridge from dippin-lang IR to tracker's `Graph` model. Documents every field mapping and naming convention. |
-| [`context-flow.md`](./context-flow.md) | **Current canonical location: [`docs/pipeline-context-flow.md`](../pipeline-context-flow.md)** — the user-facing model of context, fidelity, scoping, declared `reads:`/`writes:`, and safe-key restrictions. |
+| [`../pipeline-context-flow.md`](../pipeline-context-flow.md) | User-facing model of context, fidelity, scoping, declared `reads:`/`writes:`, and safe-key restrictions. Canonical location today; may move under `architecture/` in a later PR. |
 | [`tui.md`](./tui.md) | Bubbletea state machine, sidebar, activity log, modal content types (hybrid, review, interview), verbosity cycling, zen mode, search. |
 | [`backends.md`](./backends.md) | `AgentBackend` interface and the three implementations: native (`agent.Session`), claude-code (subprocess + NDJSON), ACP (Agent Client Protocol). Environment scoping and per-node override semantics. |
 | [`artifacts.md`](./artifacts.md) | Workdir layout, `checkpoint.json`, `activity.jsonl`, `status.json` per node, stage `prompt.md` / `response.md`, git-backed history, bundle export. |
@@ -58,9 +58,14 @@ they capture design deliberation, not the current system.
 
 ## Conventions
 
-- **Relative links** inside this tree: `./engine.md`, `./handlers/tool.md`,
-  `../manager-loop.md`. Source-file links are repo-relative from the file
-  being read, e.g. `pipeline/engine.go`.
+- **Doc-relative links everywhere.** Cross-doc links inside this tree:
+  `./engine.md`, `./handlers/tool.md`, `../manager-loop.md`. Source-file
+  links use the same convention — doc-relative from the current file:
+  `../../pipeline/engine.go` from a file in `docs/architecture/`,
+  `../../../pipeline/handlers/tool.go` from a file in
+  `docs/architecture/handlers/`. Pick the form that actually resolves when
+  the doc is rendered on GitHub; do not use bare repo-relative paths like
+  `pipeline/engine.go`.
 - **Mermaid** is used everywhere. Every subsystem doc should render on
   GitHub. If a diagram needs more than ~15 nodes, split it into multiple
   diagrams rather than one unreadable megadiagram.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,71 @@
+# Tracker Architecture Docs
+
+This directory collects per-subsystem design documentation for tracker.
+Start with [`ARCHITECTURE.md`](../../ARCHITECTURE.md) at the repo root for a
+high-level overview and reading order; this index is a flat map to the
+subsystem write-ups.
+
+All diagrams are mermaid and render on GitHub. Diagram styles vary by
+subject: sequence diagrams for time-ordered flows (run loops, steering,
+retry), flowcharts for layer or data-flow maps, state diagrams for outcome
+transitions.
+
+## Subsystems
+
+| Doc | Scope |
+|---|---|
+| [`engine.md`](./engine.md) | Pipeline execution engine: run loop, outcomes, edge selection, retry, restart, checkpoint resume, budget guard, steering channel, git artifact integration, emitted events. |
+| [`handlers.md`](./handlers.md) | `Handler` interface, `HandlerRegistry`, shape → handler mapping, and an index of every per-handler doc below. |
+| [`handlers/codergen.md`](./handlers/codergen.md) | LLM agent node (`codergen` / `box` shape): backend selection, prompt resolution, session wiring, transcript collection, response capture. |
+| [`handlers/tool.md`](./handlers/tool.md) | Shell command node (`tool` / `parallelogram`): safe-key allowlist, command expansion, timeouts, output capping, denylist/allowlist. |
+| [`handlers/human.md`](./handlers/human.md) | Human gate node (`wait.human` / `hexagon`): choice, freeform, yes/no, interview, hybrid review modes; autopilot and webhook interviewers. |
+| [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Fan-out (`parallel` / `component`) and join (`parallel.fan_in` / `tripleoctagon`): branch dispatch, `suggested_next_nodes`, branch overrides, `parallel.results` JSON. |
+| [`handlers/subgraph.md`](./handlers/subgraph.md) | Sub-pipeline composition (`subgraph` / `tab`): named graph reference resolution, `subgraph_params` passing, scoped events. |
+| [`handlers/conditional.md`](./handlers/conditional.md) | Routing-only diamond nodes (`conditional` / `diamond`): no-op handler that delegates to edge condition evaluation. |
+| [`handlers/manager-loop.md`](./handlers/manager-loop.md) | Async child-pipeline supervisor (`stack.manager_loop` / `house`). **Current canonical location: [`docs/manager-loop.md`](../manager-loop.md)**; will be moved here in a later PR. |
+| [`agent.md`](./agent.md) | Session turn loop, tool registry, context compaction, episodic memory, plan-before-execute, repository localization, steering. |
+| [`llm.md`](./llm.md) | `llm.Client`, middleware stack, `TokenTracker`, cost estimator via model catalog, and the four provider adapters (`anthropic`, `openai`, `google` / Gemini, `openaicompat`). |
+| [`adapter.md`](./adapter.md) | `pipeline/dippin_adapter.go` — the bridge from dippin-lang IR to tracker's `Graph` model. Documents every field mapping and naming convention. |
+| [`context-flow.md`](./context-flow.md) | **Current canonical location: [`docs/pipeline-context-flow.md`](../pipeline-context-flow.md)** — the user-facing model of context, fidelity, scoping, declared `reads:`/`writes:`, and safe-key restrictions. |
+| [`tui.md`](./tui.md) | Bubbletea state machine, sidebar, activity log, modal content types (hybrid, review, interview), verbosity cycling, zen mode, search. |
+| [`backends.md`](./backends.md) | `AgentBackend` interface and the three implementations: native (`agent.Session`), claude-code (subprocess + NDJSON), ACP (Agent Client Protocol). Environment scoping and per-node override semantics. |
+| [`artifacts.md`](./artifacts.md) | Workdir layout, `checkpoint.json`, `activity.jsonl`, `status.json` per node, stage `prompt.md` / `response.md`, git-backed history, bundle export. |
+
+## Where to start
+
+Three reading orders, depending on what you want to learn:
+
+- **"How does a run execute?"** — [`engine.md`](./engine.md), then
+  [`handlers.md`](./handlers.md), then whichever per-handler doc is
+  relevant to the node type you're looking at, then
+  [`artifacts.md`](./artifacts.md) to see what lands on disk.
+- **"How does data move between nodes?"** — start at
+  [`../pipeline-context-flow.md`](../pipeline-context-flow.md) (authoritative
+  user-facing doc), then [`engine.md#outcomes-and-routing`](./engine.md#outcomes-and-routing)
+  for routing decisions, then [`adapter.md`](./adapter.md) for how prompt /
+  condition variables are declared upstream in dippin-lang.
+- **"How does an agent actually call an LLM?"** — start at
+  [`handlers/codergen.md`](./handlers/codergen.md), then
+  [`agent.md`](./agent.md) for the session turn loop, then
+  [`llm.md`](./llm.md) for the provider adapters and middleware stack. If
+  the node uses an external backend, read [`backends.md`](./backends.md).
+
+## Pre-v0.10 design docs
+
+Archival design documents from tracker's pre-v0.10 era live under
+`docs/plans/`. Those are historical and not linked individually here —
+they capture design deliberation, not the current system.
+
+## Conventions
+
+- **Relative links** inside this tree: `./engine.md`, `./handlers/tool.md`,
+  `../manager-loop.md`. Source-file links are repo-relative from the file
+  being read, e.g. `pipeline/engine.go`.
+- **Mermaid** is used everywhere. Every subsystem doc should render on
+  GitHub. If a diagram needs more than ~15 nodes, split it into multiple
+  diagrams rather than one unreadable megadiagram.
+- **Don't duplicate** — the adapter doc owns naming mismatches, the
+  context-flow doc owns declared reads/writes, `CLAUDE.md` owns gotchas.
+  Subsystem docs cross-link rather than re-describe.
+- **Describe what IS**, not what's coming. Facts belong in these docs;
+  design deliberation belongs in `docs/plans/`.

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -177,10 +177,17 @@ rewriting the `.dip` file. See [`pipeline/stylesheet.go`](../../pipeline/stylesh
   `EdgeSelections`, `FallbackTaken`. Graph attrs (`graph.*`) are re-seeded
   from the live graph so `--param` overrides don't regress to stale
   checkpoint values.
-- **Saved on node outcome**: every successful node outcome and every retry
-  saves the checkpoint. Most failure paths also save a partial-context
-  checkpoint so a resume can see what was written before the error, with
-  two intentional exceptions:
+- **Saved on node outcome**: every successful non-terminal node outcome
+  and every retry saves the checkpoint. Most failure paths also save a
+  partial-context checkpoint so a resume can see what was written before
+  the error, with three intentional exceptions:
+  - `handleExitNode` (in `engine_run.go`) on the plain success path
+    records the trace entry, emits git/cost/budget events, and returns
+    without calling `saveCheckpoint` / `saveCheckpointWithTag` — the
+    exit node is the end of the run, so there is nothing to resume.
+    (The goal-gate retry and fallback branches inside `handleExitNode`
+    still call `saveCheckpointWithTag`, since those redirect to
+    another node.)
   - `checkStrictFailure` (in `engine.go`) returns its fail `loopResult`
     without calling `saveCheckpoint` — a strict-failure halt is terminal,
     so no resume would revisit this node.
@@ -261,10 +268,18 @@ uses strict mode.
 ### `SuggestedNextNodes` override
 
 The parallel handler uses this to direct post-dispatch control flow to the
-fan-in join node: after spawning branches, it returns with
-`SuggestedNextNodes: []string{joinID}`, and the engine routes there
-regardless of the graph's outgoing edges. This is how the engine supports
-parallel execution without knowing what parallel execution is.
+fan-in join node. After spawning branches, it records the join hint in its
+`Outcome.ContextUpdates` as `suggested_next_nodes: <joinID>` (see
+[`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go)
+writing `pipeline.ContextKeySuggestedNextNodes` into `ContextUpdates`). The
+engine's edge selector reads the value from the pipeline context via
+`pctx.Get(ContextKeySuggestedNextNodes)` in
+[`engine_edges.go`](../../pipeline/engine_edges.go), not from the
+`Outcome.SuggestedNextNodes` struct field, so the edge is chosen regardless
+of the graph's outgoing edges. This is how the engine supports parallel
+execution without knowing what parallel execution is. (`applyOutcome` does
+also mirror a non-empty `Outcome.SuggestedNextNodes` slice into the same
+context key — parallel just happens to route through `ContextUpdates`.)
 
 ### Strict failure edges
 

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -275,11 +275,15 @@ writing `pipeline.ContextKeySuggestedNextNodes` into `ContextUpdates`). The
 engine's edge selector reads the value from the pipeline context via
 `pctx.Get(ContextKeySuggestedNextNodes)` in
 [`engine_edges.go`](../../pipeline/engine_edges.go), not from the
-`Outcome.SuggestedNextNodes` struct field, so the edge is chosen regardless
-of the graph's outgoing edges. This is how the engine supports parallel
-execution without knowing what parallel execution is. (`applyOutcome` does
-also mirror a non-empty `Outcome.SuggestedNextNodes` slice into the same
-context key — parallel just happens to route through `ContextUpdates`.)
+`Outcome.SuggestedNextNodes` struct field, and uses it as a priority hint
+when selecting among the current node's existing outgoing edges — the
+selector matches each suggested ID against `edge.To` and picks the first
+match. This is a routing **hint**, not an override that can jump to
+arbitrary nodes outside the graph's edge set. It's how the engine supports
+parallel execution without knowing what parallel execution is, while still
+respecting the declared graph. (`applyOutcome` does also mirror a non-empty
+`Outcome.SuggestedNextNodes` slice into the same context key — parallel
+just happens to route through `ContextUpdates`.)
 
 ### Strict failure edges
 

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -48,10 +48,17 @@ func (e *Engine) Run(ctx context.Context) (*EngineResult, error)
 
 The options are set-once: `WithPipelineEventHandler`, `WithCheckpointPath`,
 `WithStylesheetResolution`, `WithArtifactDir`, `WithInitialContext`,
-`WithBudgetGuard`, `WithGitArtifacts`, `WithSteeringChan`. All are no-ops
-when their arguments are empty/nil, so zero-value engines are valid. The
-engine owns no LLM client, no exec environment, no interviewer — those are
-handler-scoped. Handlers are provided by the registry.
+`WithBudgetGuard`, `WithGitArtifacts`, `WithSteeringChan`. Most are
+effective no-ops when their arguments are empty/nil: an unset
+`checkpointPath` skips `saveCheckpoint`, a nil `BudgetGuard` short-circuits
+to `BudgetOK`, an empty `steeringCh` drains zero updates, and so on. One
+exception: `WithPipelineEventHandler(nil)` overwrites the default
+`PipelineNoopHandler` with a nil interface, which then panics on the first
+`Engine.emit` call. Callers that want to disable event handling should
+either omit the option entirely or pass `pipeline.PipelineNoopHandler`
+explicitly. The engine owns no LLM client, no exec environment, no
+interviewer — those are handler-scoped. Handlers are provided by the
+registry.
 
 `EngineResult` carries `RunID`, `Status` (one of `success`, `fail`,
 `budget_exceeded`), `CompletedNodes`, a full context `Snapshot`, the
@@ -116,17 +123,41 @@ hint from a previous node.
 
 ### Variable expansion
 
-Before dispatch, `prepareExecNode` applies two transforms to the node's attrs:
+Two unrelated expansion syntaxes live in the codebase, applied at different
+call sites:
 
-1. **Graph variable expansion** (`ExpandGraphVariables`) — rewrites
-   `${graph.*}` and `${params.*}` references everywhere.
-2. **Prompt variable expansion** (`ExpandPromptVariables`) — on the `prompt`
-   attr specifically, also expands `${ctx.*}` against the live pipeline
-   context.
+1. **Legacy `$key` syntax** — applied by `prepareExecNode` in
+   [`pipeline/engine_run.go`](../../pipeline/engine_run.go) before every
+   handler dispatch. Two transforms run over each node attr:
+   - `ExpandGraphVariables(text, vars)` rewrites `$key` tokens using the
+     `$key → value` map built by `GraphVarMap` from graph-scoped context
+     keys (`graph.*`). It does NOT touch `${...}` syntax.
+     Source: [`pipeline/transforms.go`](../../pipeline/transforms.go).
+   - `ExpandPromptVariables(prompt, ctx)` substitutes only the bare literal
+     `$goal` on the `prompt` attr. It does NOT expand `${ctx.*}`.
+2. **Namespaced `${ns.key}` syntax** — applied by `ExpandVariables` in
+   [`pipeline/expand.go`](../../pipeline/expand.go). Supports three
+   namespaces: `ctx.*` (pipeline context), `params.*` (subgraph
+   parameters), and `graph.*` (graph attributes). Called from:
+   - `engine_edges.go` when expanding edge `Condition` expressions before
+     evaluation.
+   - `handlers/prompt.go` when a codergen/human handler resolves its
+     `prompt` attr.
+   - `handlers/tool.go` when a tool handler resolves `tool_command` (with
+     `toolCommandMode=true`, which additionally blocks all non-allowlisted
+     `ctx.*` keys to prevent LLM output injection).
+   - `handlers/human.go` when resolving human-gate prompts.
+   - `expand.go` itself when a subgraph injects its `params` into a cloned
+     child graph via `InjectParamsIntoGraph`.
 
-Expansion is single-pass — resolved values are never rescanned, so a context
-value containing `${...}` syntax is left as-is. (See `CLAUDE.md` §Dippin-lang
-compatibility.)
+   The engine's `prepareExecNode` does NOT call `ExpandVariables`; that
+   happens at handler-level, inside the sites listed above. The split is
+   why `${ctx.*}` works in `prompt` / `tool_command` / `condition` but not
+   in arbitrary node attrs.
+
+Both expansion syntaxes are single-pass — resolved values are never
+rescanned, so a context value containing `$key` or `${...}` syntax is left
+as-is. (See `CLAUDE.md` §Dippin-lang compatibility.)
 
 ### Stylesheet resolution
 
@@ -147,8 +178,18 @@ rewriting the `.dip` file. See [`pipeline/stylesheet.go`](../../pipeline/stylesh
   from the live graph so `--param` overrides don't regress to stale
   checkpoint values.
 - **Saved on node outcome**: every successful node outcome and every retry
-  saves the checkpoint. Failures save a checkpoint with the partial context
-  so a resume can see what was written before the error.
+  saves the checkpoint. Most failure paths also save a partial-context
+  checkpoint so a resume can see what was written before the error, with
+  two intentional exceptions:
+  - `checkStrictFailure` (in `engine.go`) returns its fail `loopResult`
+    without calling `saveCheckpoint` — a strict-failure halt is terminal,
+    so no resume would revisit this node.
+  - `handleRetryExhausted` (in `engine_run.go`) with no
+    `fallback_retry_target` attr calls `failResult` directly, skipping
+    the checkpoint save. Retries exhausted with no fallback is also
+    terminal.
+  All non-terminal failure paths (retry with budget remaining, fallback
+  routing, loop-restart cap exceeded, handler error) do save a checkpoint.
 - **Edge selections are replayed**: if `cp.EdgeSelections[nodeID]` is set,
   resume uses the stored target instead of re-evaluating the condition —
   this prevents a condition like `when ctx.outcome = success` from being
@@ -204,8 +245,18 @@ so dippin-lang conditions like `ctx.outcome = success` match tracker's bare
 `outcome` key.
 
 Condition variables are expanded through `ExpandVariables` before
-evaluation. An unresolved `${ctx.x}` warns via `log` rather than silently
-returning an empty string (per CLAUDE.md §Never silently swallow errors).
+evaluation. In the default lenient mode used by the engine
+(`strict=false`), an unresolved `${ctx.x}` expands to an empty string
+**without logging** — see `expandVariablesPass` in
+[`pipeline/expand.go`](../../pipeline/expand.go). The only built-in
+warning path for unresolved variables lives inside
+[`pipeline/condition.go`](../../pipeline/condition.go) at
+`resolveAndWarnVar`: when a condition clause like `ctx.outcome = success`
+references a key the evaluator can't resolve, it logs `warning: unresolved
+condition variable %q ...` via the standard `log` package and treats the
+value as an empty string. `ExpandVariables` with `strict=true` returns an
+error instead of expanding to empty, but no engine call site currently
+uses strict mode.
 
 ### `SuggestedNextNodes` override
 
@@ -353,10 +404,13 @@ sequenceDiagram
 ```
 
 Three dimensions: tokens (`UsageSummary.TotalTokens`), cost (cents computed
-from `TotalCostUSD`), wall-time (since `trace.StartTime`). The first to
-breach wins; `BudgetBreach.Kind.String()` populates
-`EngineResult.BudgetLimitsHit`. Thresholds are inclusive — the exact limit
-is not a breach.
+from `TotalCostUSD`), wall-time (since `trace.StartTime`). `BudgetGuard.Check`
+evaluates them in a **fixed precedence order**: tokens → cost → wall-time.
+When multiple limits are exceeded in the same check, the reported
+`BudgetBreach.Kind` follows this ordering (a simultaneous token + wall-time
+breach reports as `tokens`). `BudgetBreach.Kind.String()` populates
+`EngineResult.BudgetLimitsHit`. Thresholds are **inclusive** — hitting the
+exact limit is not a breach; only strictly exceeding it is.
 
 Configuration flows through `tracker.Config.Budget` or CLI flags
 `--max-tokens`, `--max-cost` (cents), `--max-wall-time`. Reading from
@@ -409,9 +463,15 @@ repo at run start (`gitRepo.Init()` in
 [`pipeline/git_artifacts.go`](../../pipeline/git_artifacts.go)) and commits
 after every terminal node outcome:
 
-- `emitGitCommit(runState, nodeID, traceEntry)` runs `git add -A && git
-  commit -m "<handler>: <nodeID> (<status>)"` with a structured trailer
-  capturing the trace entry.
+- `emitGitCommit(runState, nodeID, traceEntry)` runs `git add . && git
+  commit --allow-empty -m "<msg>"` where `<msg>` has a one-line subject
+  and a structured body. Subject:
+  `node(<nodeID>): <handler> outcome=<status>`. Body (blank line after
+  the subject) is a `key: value` block that callers can grep/parse:
+  `duration: <d>`, `edge_to: <nextNode>` (when set), and
+  `tokens: <n> cost: $<usd>` (when the trace entry carries session
+  stats). Source: `gitArtifactRepo.CommitNode` in
+  [`pipeline/git_artifacts.go`](../../pipeline/git_artifacts.go).
 - `saveCheckpointWithTag` creates a lightweight tag
   `checkpoint/<runID>/<nodeID>` pointing at the most recent commit.
   `checkpoint.json` itself is `.gitignore`d.
@@ -438,10 +498,10 @@ The engine emits `PipelineEvent` values via the handler registered with
 |---|---|
 | `pipeline_started` | `Run` begins after `initRunState`. |
 | `pipeline_completed` | Run reaches exit node successfully. |
-| `pipeline_failed` | Cancellation, max-restart exhaustion, or handler error. |
+| `pipeline_failed` | Context cancellation (`cancelledResult`), max-restart ceiling exceeded (`handleLoopRestart`), or terminal failure built by `failResult` (retry exhausted with no fallback, exit-node goal-gate failure). Handler errors do **not** emit this event — they emit `stage_failed` instead. |
 | `stage_started` | Before each handler is dispatched. |
 | `stage_completed` | Handler returned `success`. |
-| `stage_failed` | Handler returned `fail` (or strict-failure halted the pipeline). |
+| `stage_failed` | Handler returned `fail`, strict-failure halted the pipeline, retries were exhausted, or the handler returned a Go error. |
 | `stage_retrying` | Retry budget remaining; about to loop back to `retry_target`. |
 | `checkpoint_saved` | `saveCheckpoint` succeeded. |
 | `checkpoint_failed` | `saveCheckpoint` wrote error output. |

--- a/docs/architecture/engine.md
+++ b/docs/architecture/engine.md
@@ -1,0 +1,476 @@
+# Engine
+
+The pipeline execution engine takes a `*pipeline.Graph` and a
+`*pipeline.HandlerRegistry`, executes each node in the order determined by
+handler outcomes and outgoing edges, emits lifecycle events, writes
+checkpoints, optionally enforces a cost/time budget, and ultimately returns
+an `*EngineResult`. Source: [`pipeline/engine.go`](../../pipeline/engine.go),
+[`pipeline/engine_run.go`](../../pipeline/engine_run.go),
+[`pipeline/engine_checkpoint.go`](../../pipeline/engine_checkpoint.go),
+[`pipeline/engine_edges.go`](../../pipeline/engine_edges.go).
+
+The engine is deliberately small. It has no knowledge of LLM calls,
+subprocesses, human gates, or concurrency. Everything handler-specific lives
+under [`pipeline/handlers/`](../../pipeline/handlers/). Everything
+engine-specific — edges, retries, restarts, checkpoints, budgets, steering —
+is in this file tree.
+
+## Contents
+
+1. [Overview](#overview)
+2. [Run loop](#run-loop)
+3. [Outcomes and routing](#outcomes-and-routing)
+4. [Retry, restart, escalate](#retry-restart-escalate)
+5. [Budget guard](#budget-guard)
+6. [Steering channel](#steering-channel)
+7. [Git artifact integration](#git-artifact-integration)
+8. [Emitted events](#emitted-events)
+
+## Overview
+
+```go
+type Engine struct {
+    graph             *Graph
+    registry          *HandlerRegistry
+    eventHandler      PipelineEventHandler
+    checkpointPath    string
+    resolveStylesheet bool
+    initialContext    map[string]string
+    artifactDir       string
+    budgetGuard       *BudgetGuard
+    gitArtifacts      bool
+    steeringCh        <-chan map[string]string
+}
+
+func NewEngine(graph *Graph, registry *HandlerRegistry, opts ...EngineOption) *Engine
+func (e *Engine) Run(ctx context.Context) (*EngineResult, error)
+```
+
+The options are set-once: `WithPipelineEventHandler`, `WithCheckpointPath`,
+`WithStylesheetResolution`, `WithArtifactDir`, `WithInitialContext`,
+`WithBudgetGuard`, `WithGitArtifacts`, `WithSteeringChan`. All are no-ops
+when their arguments are empty/nil, so zero-value engines are valid. The
+engine owns no LLM client, no exec environment, no interviewer — those are
+handler-scoped. Handlers are provided by the registry.
+
+`EngineResult` carries `RunID`, `Status` (one of `success`, `fail`,
+`budget_exceeded`), `CompletedNodes`, a full context `Snapshot`, the
+`*Trace`, aggregated `*UsageSummary`, and — when applicable — the list of
+budget dimensions that halted the run.
+
+## Run loop
+
+`Engine.Run(ctx)` is the main loop. It follows a simple pattern: look up the
+next node, dispatch to its handler, apply the outcome, scope the node's
+writes, drain any steering updates, pick an outgoing edge, repeat until the
+exit node is reached or an error halts the run.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant R as Run(ctx)
+    participant S as initRunState
+    participant Reg as HandlerRegistry
+    participant P as PipelineContext
+    participant Sel as edge selector
+    participant FS as checkpoint.json
+
+    R->>S: build runState<br/>(pctx, checkpoint, trace, gitRepo)
+    S-->>R: runState
+    R->>R: emit pipeline_started
+    loop per node
+        R->>R: ctx.Err() cancelled? → cancelledResult
+        R->>R: processNode(currentNodeID)
+        alt already completed (resume)
+            R->>Sel: selectEdge (or stored EdgeSelection)
+            Sel-->>R: next node
+        else fresh execution
+            R->>R: prepareExecNode — stylesheet + var expansion
+            R->>Reg: Execute(ctx, node, pctx)
+            Reg-->>R: Outcome
+            R->>P: Merge(ContextUpdates) + Set outcome/<br/>preferred_label/suggested_next_nodes
+            R->>P: ScopeToNode(nodeID)
+            R->>R: drainSteering(runState)
+            alt Outcome.Status == retry
+                R->>R: handleRetry (backoff + increment or exhaust)
+            else exit node
+                R->>R: handleExitNode (goal-gate retry?)
+            else normal
+                R->>Sel: selectEdge(edges, pctx)
+                Sel-->>R: next edge
+            end
+        end
+        R->>FS: saveCheckpoint(cp, pctx, runID)
+        R->>R: emitCostUpdate + BudgetGuard.Check
+    end
+    R->>R: emit pipeline_completed
+    R-->>R: return EngineResult Status success
+```
+
+`processNode` splits into `processResumeSkip` (already completed in a prior
+run, advance through stored edge selection or re-select) and
+`processActiveNode` (fresh dispatch). The engine clears three routing-hint
+keys on the context before every handler execution (`outcome`,
+`preferred_label`, `suggested_next_nodes`) so a node never inherits a stale
+hint from a previous node.
+
+### Variable expansion
+
+Before dispatch, `prepareExecNode` applies two transforms to the node's attrs:
+
+1. **Graph variable expansion** (`ExpandGraphVariables`) — rewrites
+   `${graph.*}` and `${params.*}` references everywhere.
+2. **Prompt variable expansion** (`ExpandPromptVariables`) — on the `prompt`
+   attr specifically, also expands `${ctx.*}` against the live pipeline
+   context.
+
+Expansion is single-pass — resolved values are never rescanned, so a context
+value containing `${...}` syntax is left as-is. (See `CLAUDE.md` §Dippin-lang
+compatibility.)
+
+### Stylesheet resolution
+
+If `WithStylesheetResolution(true)` is set and the graph has a
+`model_stylesheet` attr, `prepareExecNode` resolves per-role model
+overrides through the stylesheet before variable expansion. Used to
+override per-node `llm_model` / `llm_provider` based on role tags without
+rewriting the `.dip` file. See [`pipeline/stylesheet.go`](../../pipeline/stylesheet.go).
+
+### Checkpoint semantics
+
+- **Checkpoint file**: `checkpoint.json` inside the run artifact dir (or at
+  `Config.CheckpointDir` if explicitly set). Format in
+  [`pipeline/checkpoint.go`](../../pipeline/checkpoint.go).
+- **Loaded at startup**: `loadCheckpointAndMerge` restores `RunID`,
+  `CompletedNodes`, `RetryCounts`, `Context`, `RestartCount`,
+  `EdgeSelections`, `FallbackTaken`. Graph attrs (`graph.*`) are re-seeded
+  from the live graph so `--param` overrides don't regress to stale
+  checkpoint values.
+- **Saved on node outcome**: every successful node outcome and every retry
+  saves the checkpoint. Failures save a checkpoint with the partial context
+  so a resume can see what was written before the error.
+- **Edge selections are replayed**: if `cp.EdgeSelections[nodeID]` is set,
+  resume uses the stored target instead of re-evaluating the condition —
+  this prevents a condition like `when ctx.outcome = success` from being
+  re-evaluated against stale context after a resume.
+- **Fidelity-aware compaction**: on resume, completed-node context is
+  compacted to the node's declared fidelity level (preserving declared
+  `reads:` keys pinned at full fidelity). See `pipeline/fidelity.go` and
+  [`docs/pipeline-context-flow.md`](../pipeline-context-flow.md).
+
+## Outcomes and routing
+
+Every handler returns an `Outcome`:
+
+```go
+type Outcome struct {
+    Status             string            // "success", "fail", "retry", or custom
+    ContextUpdates     map[string]string
+    PreferredLabel     string
+    SuggestedNextNodes []string
+    Stats              *SessionStats
+}
+```
+
+After `applyOutcome`, the engine picks the next edge via `selectEdge` using
+priority order:
+
+```mermaid
+flowchart TD
+    start["outgoing edges from current node"]
+    start --> cond{any edge has<br/>matching condition?}
+    cond -->|yes| c_sel["select first matching edge<br/>priority = condition"]
+    cond -->|no| lbl{context.preferred_label<br/>matches any edge.Label?}
+    lbl -->|yes| l_sel["select by label<br/>priority = label"]
+    lbl -->|no| sug{context.suggested_next_nodes<br/>contains any edge.To?}
+    sug -->|yes| s_sel["select by suggested<br/>priority = suggested"]
+    sug -->|no| wgt["pick highest weight<br/>lexical tiebreak"]
+    c_sel --> emit["emit decision_edge event"]
+    l_sel --> emit
+    s_sel --> emit
+    wgt --> emit
+```
+
+Source: [`pipeline/engine_edges.go`](../../pipeline/engine_edges.go).
+
+### Condition expressions
+
+Edge conditions use a small language evaluated by
+[`pipeline/condition.go`](../../pipeline/condition.go): `=`, `==`, `!=`,
+`contains`, `startswith`, `endswith`, `in`, `not`, `&&`, `||` (no
+parentheses — `||` is lowest precedence, `&&` higher). The evaluator strips
+the `ctx.`, `context.`, and `internal.` prefixes from keys before lookup,
+so dippin-lang conditions like `ctx.outcome = success` match tracker's bare
+`outcome` key.
+
+Condition variables are expanded through `ExpandVariables` before
+evaluation. An unresolved `${ctx.x}` warns via `log` rather than silently
+returning an empty string (per CLAUDE.md §Never silently swallow errors).
+
+### `SuggestedNextNodes` override
+
+The parallel handler uses this to direct post-dispatch control flow to the
+fan-in join node: after spawning branches, it returns with
+`SuggestedNextNodes: []string{joinID}`, and the engine routes there
+regardless of the graph's outgoing edges. This is how the engine supports
+parallel execution without knowing what parallel execution is.
+
+### Strict failure edges
+
+When a node's outcome is `fail` and none of its outgoing edges carry a
+`Condition`, the pipeline stops with
+`fmt.Errorf("node %q failed with no conditional edges to handle failure")`.
+Implementation: `checkStrictFailure` in `engine.go`. This prevents tool
+nodes (Setup, Build, …) from silently continuing after a failure — pipelines
+that want to recover must use an explicit `when ctx.outcome = fail` edge.
+Nodes with **any** conditional edge are considered intentionally
+routed and are exempted from the check.
+
+## Retry, restart, escalate
+
+Three related but distinct recovery mechanisms:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Executing
+    Executing --> Completed: outcome=success
+    Executing --> Failed: outcome=fail,<br/>all edges unconditional
+    Executing --> RoutedFail: outcome=fail,<br/>has when ctx.outcome=fail edge
+    Executing --> RetryCheck: outcome=retry
+    RetryCheck --> Retrying: count under MaxRetries
+    RetryCheck --> RetryExhausted: count at MaxRetries
+    Retrying --> BackoffWait
+    BackoffWait --> Executing: ctx not cancelled
+    BackoffWait --> [*]: ctx cancelled
+    RetryExhausted --> FallbackTarget: fallback_retry_target set
+    RetryExhausted --> Failed: no fallback
+    FallbackTarget --> Executing
+    Completed --> SelectEdge
+    RoutedFail --> SelectEdge
+    SelectEdge --> LoopBack: target already completed
+    SelectEdge --> Executing: target not completed
+    LoopBack --> RestartCheck
+    RestartCheck --> Restarting: RestartCount under max_restarts
+    RestartCheck --> Failed: RestartCount at max_restarts
+    Restarting --> Executing: clear downstream + retries
+    Failed --> [*]
+```
+
+### Retry
+
+Per-node. Controlled by `RetryPolicy` resolved in
+[`pipeline/retry_policy.go`](../../pipeline/retry_policy.go):
+
+- Named policies: `none`, `standard` (default: 2 retries, 2s base,
+  exponential), `aggressive` (5 retries, 500ms), `patient` (3 retries, 10s),
+  `linear` (3 retries, 2s linear).
+- Resolution order: node attr `retry_policy` → graph attr
+  `default_retry_policy` → `standard`.
+- Overrides: node attr `max_retries` / graph attr `default_max_retry`
+  override `MaxRetries`; node attr `base_delay` overrides `BaseDelay`.
+- Backoff: `ExponentialBackoff` (2ⁿ × base + ±25% jitter) or
+  `LinearBackoff` ((n+1) × base + ±25% jitter). Both capped at 60s.
+
+When a handler returns `OutcomeRetry`:
+
+1. If `RetryCount(nodeID) < MaxRetries`: increment, wait backoff, emit
+   `EventStageRetrying`, clear downstream completion (so dependent nodes
+   re-run), save checkpoint, route to `retry_target` (default: the node
+   itself).
+2. Otherwise: route to `fallback_retry_target` if set; else fail the
+   pipeline.
+
+### Restart
+
+Pipeline-level. Triggered when the edge selector picks a target node that's
+already in `CompletedNodes` — this indicates a loop-back. `handleLoopRestart`
+in `engine_run.go` increments `cp.RestartCount`, emits `EventLoopRestart`
+and `EventDecisionRestart`, clears all downstream completion and retry
+counters from the loop target, saves the checkpoint, and resumes at the
+loop target.
+
+The budget is controlled by graph attr `max_restarts` (default 5). Hitting
+the ceiling fails the pipeline with `max restarts (N) exceeded`.
+
+**Caveat** (per CLAUDE.md §Architecture Gotchas): the restart counter is
+**global** across the run. A fix loop on milestone 1 consumes restart budget
+milestone 10 needs. The `build_product.dip` workflow uses a per-milestone
+on-disk counter (`fix_attempts`) to work around this.
+
+### Escalate
+
+Not a distinct outcome status. Escalation is a routing convention:
+
+- Failed nodes can route to an escalation node via `when ctx.outcome = fail`.
+- Goal-gate nodes (those with `goal_gate: "true"` attr) get a goal-gate
+  retry loop when the exit node is reached: if a goal gate was
+  unsatisfied, the engine routes back to its `retry_target` (or
+  `fallback_target` / `fallback_retry_target`) until retries are
+  exhausted. Implementation: `goalGateRetryTarget` in
+  `engine_checkpoint.go`.
+- The one-shot fallback/escalation path is guarded by `cp.FallbackTaken[gateID]`
+  to prevent infinite fallback loops.
+
+## Budget guard
+
+`pipeline.BudgetGuard` ([`pipeline/budget.go`](../../pipeline/budget.go))
+enforces three optional ceilings across the entire run:
+
+```go
+type BudgetLimits struct {
+    MaxTotalTokens int
+    MaxCostCents   int
+    MaxWallTime    time.Duration
+}
+```
+
+`NewBudgetGuard(limits)` returns `nil` when all limits are zero, so
+`BudgetGuard.Check(nil guard, ...)` is safely a no-op. The engine calls the
+guard after every `emitCostUpdate` (between nodes):
+
+```mermaid
+sequenceDiagram
+    participant N as node completes
+    participant Eng as Engine
+    participant T as trace.AggregateUsage
+    participant G as BudgetGuard
+    participant Evt as event handler
+
+    N->>Eng: advance
+    Eng->>Eng: s.trace.AddEntry + saveCheckpoint
+    Eng->>Evt: emit decision_edge
+    Eng->>T: summary = trace.AggregateUsage()
+    T-->>Eng: *UsageSummary (tokens + cost)
+    Eng->>Evt: emit cost_updated(snapshot)
+    Eng->>G: Check(summary, trace.StartTime)
+    alt BudgetOK
+        G-->>Eng: continue
+    else breach
+        G-->>Eng: BudgetBreach (Kind, Message)
+        Eng->>Evt: emit budget_exceeded
+        Eng-->>Eng: return EngineResult<br/>Status=budget_exceeded<br/>BudgetLimitsHit=kind
+    end
+```
+
+Three dimensions: tokens (`UsageSummary.TotalTokens`), cost (cents computed
+from `TotalCostUSD`), wall-time (since `trace.StartTime`). The first to
+breach wins; `BudgetBreach.Kind.String()` populates
+`EngineResult.BudgetLimitsHit`. Thresholds are inclusive — the exact limit
+is not a breach.
+
+Configuration flows through `tracker.Config.Budget` or CLI flags
+`--max-tokens`, `--max-cost` (cents), `--max-wall-time`. Reading from
+workflow attrs is blocked on dippin-lang IR support (issue #67).
+
+## Steering channel
+
+`WithSteeringChan(ch <-chan map[string]string)` provides an external input
+for context updates between nodes. Used by `stack.manager_loop` to inject
+context into a running child pipeline, but available to any supervisor.
+
+```mermaid
+sequenceDiagram
+    participant Sup as supervisor goroutine
+    participant Ch as steeringCh
+    participant Eng as Engine
+    participant P as PipelineContext
+
+    Note over Eng: node N completes
+    Eng->>P: applyOutcome + ScopeToNode(N)
+    Eng->>Ch: drainSteering (non-blocking)
+    loop until channel empty
+        Ch-->>Eng: map[string]string
+        Eng->>P: MergeWithoutDirty(update)
+    end
+    Note over Eng,P: merged values visible to edge condition<br/>evaluator + next node's prompt expansion
+    Eng->>Eng: selectEdge
+    Sup-->>Ch: send update (any time)
+```
+
+Two important properties:
+
+- **Non-blocking drain**. The engine reads until the channel is empty or
+  would block, so supervisors never slow the run even if they publish
+  bursts.
+- **`MergeWithoutDirty`**. Steering values land in the bare/global
+  namespace and are NOT copied into any node's `node.<id>.*` scope.
+  Otherwise external writes would be misattributed to whatever node
+  happened to be running next.
+
+Mirror: `agent/session_run.go` has a parallel `drainSteering` for mid-turn
+agent-session steering. The two systems share the channel-pattern but are
+independent — pipeline steering acts between nodes, agent steering acts
+between turns.
+
+## Git artifact integration
+
+`WithGitArtifacts(true)` initializes the artifact run directory as a git
+repo at run start (`gitRepo.Init()` in
+[`pipeline/git_artifacts.go`](../../pipeline/git_artifacts.go)) and commits
+after every terminal node outcome:
+
+- `emitGitCommit(runState, nodeID, traceEntry)` runs `git add -A && git
+  commit -m "<handler>: <nodeID> (<status>)"` with a structured trailer
+  capturing the trace entry.
+- `saveCheckpointWithTag` creates a lightweight tag
+  `checkpoint/<runID>/<nodeID>` pointing at the most recent commit.
+  `checkpoint.json` itself is `.gitignore`d.
+
+Best-effort: failures emit `EventWarning` and do not halt the pipeline.
+Requires `git` in `PATH`; silently no-ops when `ArtifactDir` is unset.
+
+After the run, callers can bundle the repo for portable hand-off:
+
+```go
+tracker.ExportBundle(runDir, outPath) // wraps git bundle create --all
+```
+
+Implementation in [`tracker_bundle.go`](../../tracker_bundle.go). Clone with
+`git clone <bundle>` on any machine — commits, tags, and the full history
+travel in one file.
+
+## Emitted events
+
+The engine emits `PipelineEvent` values via the handler registered with
+`WithPipelineEventHandler`. Full set:
+
+| Event | Fired when |
+|---|---|
+| `pipeline_started` | `Run` begins after `initRunState`. |
+| `pipeline_completed` | Run reaches exit node successfully. |
+| `pipeline_failed` | Cancellation, max-restart exhaustion, or handler error. |
+| `stage_started` | Before each handler is dispatched. |
+| `stage_completed` | Handler returned `success`. |
+| `stage_failed` | Handler returned `fail` (or strict-failure halted the pipeline). |
+| `stage_retrying` | Retry budget remaining; about to loop back to `retry_target`. |
+| `checkpoint_saved` | `saveCheckpoint` succeeded. |
+| `checkpoint_failed` | `saveCheckpoint` wrote error output. |
+| `parallel_started` | `ParallelHandler` begins branch dispatch. |
+| `parallel_completed` | All branches returned. |
+| `manager_cycle_tick` | Each poll cycle inside `stack.manager_loop`. |
+| `loop_restart` | Edge selector picked an already-completed target; restart budget check. |
+| `warning` | Git commit/tag failure, unknown outcome status, other non-fatal. |
+| `edge_tiebreaker` | Multiple unconditional edges with equal weight; lexical tiebreak used. |
+| `decision_edge` | Edge selection recorded (carries priority: condition, label, suggested, weight, lexical). |
+| `decision_condition` | Edge condition evaluator ran; records match result. |
+| `decision_outcome` | Handler outcome applied; records token stats and context snapshot. |
+| `decision_restart` | Loop-back restart happened; records cleared node list. |
+| `cost_updated` | After each node, with aggregate `CostSnapshot` (tokens + USD + wall time + per-provider). |
+| `budget_exceeded` | `BudgetGuard.Check` returned a breach. Halts the run. |
+
+All event types are defined in
+[`pipeline/events.go`](../../pipeline/events.go). Decision-class events
+carry a `DecisionDetail` payload with routing-relevant context; cost events
+carry a `CostSnapshot`. The TUI and `activity.jsonl` writer consume the same
+stream via `PipelineMultiHandler`.
+
+## Related docs
+
+- [`handlers.md`](./handlers.md) — every built-in handler and its
+  responsibilities at outcome time.
+- [`../pipeline-context-flow.md`](../pipeline-context-flow.md) — user-facing
+  model of the data flow the engine mediates.
+- [`artifacts.md`](./artifacts.md) — what the engine writes to disk during
+  and after a run.
+- [`backends.md`](./backends.md) — how codergen handlers route through
+  different execution backends while the engine stays unaware.

--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -86,8 +86,10 @@ Registration has conditional branches driven by `RegistryOption`:
 - **`WithExecEnvironment`** — registers the real tool handler. If neither
   `WithExecEnvironment` nor `WithToolExecFunc` is supplied, the `tool`
   handler is **not registered at all**, and tool nodes will error at
-  dispatch with "handler not found". `WithToolExecFunc` is the test-stub
-  path (used when `execEnv` is nil).
+  dispatch with `no handler registered for "tool" (node "<nodeID>")`
+  (from `HandlerRegistry.Execute` in
+  [`pipeline/handler.go`](../../pipeline/handler.go)).
+  `WithToolExecFunc` is the test-stub path (used when `execEnv` is nil).
 - **`WithInterviewer`** — required to register the human handler.
 - **`WithSubgraphs`** — enables the `subgraph` handler when the provided
   map is non-empty (`len(subgraphs) > 0`). An empty or nil map leaves
@@ -130,16 +132,24 @@ var shapeHandlerMap = map[string]string{
 
 | `.dip` keyword | IR NodeKind | Shape | Handler name |
 |---|---|---|---|
-| `start` | `start` | `Mdiamond` | `start` |
-| `exit` | `exit` | `Msquare` | `exit` |
-| `agent` | `agent` | `box` | `codergen` |
-| `human` | `human` | `hexagon` | `wait.human` |
-| `conditional` | `conditional` | `diamond` | `conditional` |
-| `parallel` | `parallel` | `component` | `parallel` |
-| `fan_in` | `fan_in` | `tripleoctagon` | `parallel.fan_in` |
-| `tool` | `tool` | `parallelogram` | `tool` |
-| `stack.manager_loop` | `stack_manager_loop` | `house` | `stack.manager_loop` |
-| `subgraph` | `subgraph` | `tab` | `subgraph` |
+| `start` | (no IR NodeKind — workflow-level `ir.Workflow.Start` field; shape forced by `ensureStartExitNodes` in the adapter) | `Mdiamond` | `start` |
+| `exit` | (no IR NodeKind — workflow-level `ir.Workflow.Exit` field; shape forced by `ensureStartExitNodes` in the adapter) | `Msquare` | `exit` |
+| `agent` | `NodeAgent` | `box` | `codergen` |
+| `human` | `NodeHuman` | `hexagon` | `wait.human` |
+| `conditional` | `NodeConditional` | `diamond` | `conditional` |
+| `parallel` | `NodeParallel` | `component` | `parallel` |
+| `fan_in` | `NodeFanIn` | `tripleoctagon` | `parallel.fan_in` |
+| `tool` | `NodeTool` | `parallelogram` | `tool` |
+| `stack.manager_loop` | (DOT-only today — no IR NodeKind; adapter support pending [#162](https://github.com/2389-research/tracker/issues/162)) | `house` | `stack.manager_loop` |
+| `subgraph` | `NodeSubgraph` | `tab` | `subgraph` |
+
+The adapter's `nodeKindToShapeMap` in [`pipeline/dippin_adapter.go`](../../pipeline/dippin_adapter.go)
+maps exactly `{NodeAgent, NodeHuman, NodeTool, NodeParallel, NodeFanIn, NodeSubgraph, NodeConditional}`.
+`start` / `exit` are workflow-level fields (not NodeKinds) whose shapes are
+forced by `ensureStartExitNodes`. `stack.manager_loop` is reachable today only
+via DOT graphs or an explicit `type: stack.manager_loop` override; IR-level
+support lands when dippin-lang v0.22.0 adds the corresponding NodeKind
+(tracked in [#162](https://github.com/2389-research/tracker/issues/162)).
 
 Two overrides handled by `applyDiamondOverrides` ([`graph.go`](../../pipeline/graph.go)):
 
@@ -161,11 +171,11 @@ behavior, and invariants. This table is the flat index.
 | `codergen` | [`pipeline/handlers/codergen.go`](../../pipeline/handlers/codergen.go) | [`handlers/codergen.md`](./handlers/codergen.md) | LLM agent sessions: resolves prompt, picks backend, runs a session, captures response into `last_response` / `response.<nodeID>`, optionally parses `STATUS:` tokens. |
 | `tool` | [`pipeline/handlers/tool.go`](../../pipeline/handlers/tool.go) | [`handlers/tool.md`](./handlers/tool.md) | Shell command execution with safe-key variable expansion, timeouts, output caps, denylist/allowlist enforcement, and sensitive-env stripping. |
 | `wait.human` | [`pipeline/handlers/human.go`](../../pipeline/handlers/human.go) | [`handlers/human.md`](./handlers/human.md) | Blocking human gate: choice, freeform, yes/no, interview, hybrid review modes. Routed through a pluggable interviewer (TUI, autopilot, webhook). |
-| `parallel` | [`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Concurrent fan-out over `parallel_targets`. Spawns one goroutine per branch with an isolated context snapshot; hints the engine toward the fan-in join via `SuggestedNextNodes`. |
+| `parallel` | [`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Concurrent fan-out over `parallel_targets`. Spawns one goroutine per branch with an isolated context snapshot; records the fan-in join hint in `Outcome.ContextUpdates` as `suggested_next_nodes` (the engine's edge selector reads it from the context, not the `Outcome.SuggestedNextNodes` struct field). |
 | `parallel.fan_in` | [`pipeline/handlers/fanin.go`](../../pipeline/handlers/fanin.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Join/aggregation node after a `parallel` dispatch. Reads `parallel.results` JSON; aggregates stats. |
 | `subgraph` | [`pipeline/subgraph.go`](../../pipeline/subgraph.go) | [`handlers/subgraph.md`](./handlers/subgraph.md) | Executes a named child graph inline. Merges `subgraph_params` with child `vars` defaults, runs a child `Engine` with scoped event handlers, propagates the result outcome. |
 | `conditional` | [`pipeline/handlers/conditional.go`](../../pipeline/handlers/conditional.go) | [`handlers/conditional.md`](./handlers/conditional.md) | Pure routing node: returns `OutcomeSuccess` with no writes and lets the engine's edge condition evaluator pick the next node based on existing context. |
-| `stack.manager_loop` | [`pipeline/handlers/manager_loop.go`](../../pipeline/handlers/manager_loop.go) | [`../manager-loop.md`](../manager-loop.md) | Async child-pipeline supervisor: launches a child in a goroutine, polls at intervals, evaluates `stop_condition`, injects `steer_context` through the engine's steering channel. Attractor spec 4.11. Canonical deep-dive lives at `docs/manager-loop.md` today; a dedicated `handlers/manager-loop.md` will land in a later PR. |
+| `stack.manager_loop` | [`pipeline/handlers/manager_loop.go`](../../pipeline/handlers/manager_loop.go) | [`../manager-loop.md`](../manager-loop.md) | Async child-pipeline supervisor: launches a child in a goroutine, polls at intervals, evaluates `manager.steer_condition`, and injects the `manager.steer_context` map through the engine's steering channel. Attractor spec 4.11. Canonical deep-dive lives at [`docs/manager-loop.md`](../manager-loop.md) today; a dedicated `docs/architecture/handlers/manager-loop.md` will land in a later PR (tracked in [#165](https://github.com/2389-research/tracker/issues/165)). |
 | `start` | [`pipeline/handlers/start.go`](../../pipeline/handlers/start.go) | — | Pass-through entry node. Always returns `OutcomeSuccess` with no writes. Dispatches to whatever edge is selected. |
 | `exit` | [`pipeline/handlers/exit.go`](../../pipeline/handlers/exit.go) | — | Pass-through terminal node. Returns `OutcomeSuccess`; the engine's `handleExitNode` takes over to run the goal-gate retry check and finalize the trace. |
 

--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -73,7 +73,7 @@ flowchart LR
     cg["codergen<br/>registerCodergenHandler"] --> reg
     tool["tool<br/>registerToolHandler"] --> reg
     hum["wait.human<br/>registerHumanHandler"] --> reg
-    sub["subgraph<br/>registerSubgraphHandler<br/>(only if subgraphs != nil)"] --> reg
+    sub["subgraph<br/>registerSubgraphHandler<br/>(only if len(subgraphs) > 0)"] --> reg
     mgr["stack.manager_loop<br/>registerManagerLoopHandler"] --> reg
 ```
 
@@ -83,13 +83,18 @@ Registration has conditional branches driven by `RegistryOption`:
   `backend: claude-code` or `backend: acp` can still be used as long as
   `WithDefaultBackend` or any node's `backend` attr picks an external
   backend.
-- **`WithExecEnvironment`** — required to register the tool handler (else
-  it becomes a stub for testing).
+- **`WithExecEnvironment`** — registers the real tool handler. If neither
+  `WithExecEnvironment` nor `WithToolExecFunc` is supplied, the `tool`
+  handler is **not registered at all**, and tool nodes will error at
+  dispatch with "handler not found". `WithToolExecFunc` is the test-stub
+  path (used when `execEnv` is nil).
 - **`WithInterviewer`** — required to register the human handler.
-- **`WithSubgraphs`** — enables the `subgraph` handler. The `stack.manager_loop`
-  handler is always registered, but falls back to a clear-error stub when
-  no subgraphs are available (so `tracker validate` and conformance tests
-  can still reach it).
+- **`WithSubgraphs`** — enables the `subgraph` handler when the provided
+  map is non-empty (`len(subgraphs) > 0`). An empty or nil map leaves
+  `subgraph` unregistered. The `stack.manager_loop` handler is always
+  registered, but falls back to a clear-error stub when no subgraphs are
+  available (so `tracker validate` and conformance tests can still reach
+  it).
 - **`WithCodergenFunc` / `WithToolExecFunc` / `WithHumanCallback`** — stub
   overrides for tests.
 - **`WithTokenTracker` / `WithAgentEventHandler` / `WithPipelineEventHandler`** —
@@ -160,7 +165,7 @@ behavior, and invariants. This table is the flat index.
 | `parallel.fan_in` | [`pipeline/handlers/fanin.go`](../../pipeline/handlers/fanin.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Join/aggregation node after a `parallel` dispatch. Reads `parallel.results` JSON; aggregates stats. |
 | `subgraph` | [`pipeline/subgraph.go`](../../pipeline/subgraph.go) | [`handlers/subgraph.md`](./handlers/subgraph.md) | Executes a named child graph inline. Merges `subgraph_params` with child `vars` defaults, runs a child `Engine` with scoped event handlers, propagates the result outcome. |
 | `conditional` | [`pipeline/handlers/conditional.go`](../../pipeline/handlers/conditional.go) | [`handlers/conditional.md`](./handlers/conditional.md) | Pure routing node: returns `OutcomeSuccess` with no writes and lets the engine's edge condition evaluator pick the next node based on existing context. |
-| `stack.manager_loop` | [`pipeline/handlers/manager_loop.go`](../../pipeline/handlers/manager_loop.go) | [`handlers/manager-loop.md`](./handlers/manager-loop.md) (currently [`docs/manager-loop.md`](../manager-loop.md)) | Async child-pipeline supervisor: launches a child in a goroutine, polls at intervals, evaluates `stop_condition`, injects `steer_context` through the engine's steering channel. Attractor spec 4.11. |
+| `stack.manager_loop` | [`pipeline/handlers/manager_loop.go`](../../pipeline/handlers/manager_loop.go) | [`../manager-loop.md`](../manager-loop.md) | Async child-pipeline supervisor: launches a child in a goroutine, polls at intervals, evaluates `stop_condition`, injects `steer_context` through the engine's steering channel. Attractor spec 4.11. Canonical deep-dive lives at `docs/manager-loop.md` today; a dedicated `handlers/manager-loop.md` will land in a later PR. |
 | `start` | [`pipeline/handlers/start.go`](../../pipeline/handlers/start.go) | — | Pass-through entry node. Always returns `OutcomeSuccess` with no writes. Dispatches to whatever edge is selected. |
 | `exit` | [`pipeline/handlers/exit.go`](../../pipeline/handlers/exit.go) | — | Pass-through terminal node. Returns `OutcomeSuccess`; the engine's `handleExitNode` takes over to run the goal-gate retry check and finalize the trace. |
 
@@ -196,4 +201,4 @@ documented in full at
 - [`backends.md`](./backends.md) — how `codergen` delegates to pluggable
   agent backends.
 - [`adapter.md`](./adapter.md) — how dippin-lang IR maps to the shapes
-  this doc tables.
+  this doc describes.

--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -148,8 +148,8 @@ maps exactly `{NodeAgent, NodeHuman, NodeTool, NodeParallel, NodeFanIn, NodeSubg
 `start` / `exit` are workflow-level fields (not NodeKinds) whose shapes are
 forced by `ensureStartExitNodes`. `stack.manager_loop` is reachable today only
 via DOT graphs or an explicit `type: stack.manager_loop` override; IR-level
-support lands when dippin-lang v0.22.0 adds the corresponding NodeKind
-(tracked in [#162](https://github.com/2389-research/tracker/issues/162)).
+support is pending and tracked in
+[#162](https://github.com/2389-research/tracker/issues/162).
 
 Two overrides handled by `applyDiamondOverrides` ([`graph.go`](../../pipeline/graph.go)):
 
@@ -171,7 +171,7 @@ behavior, and invariants. This table is the flat index.
 | `codergen` | [`pipeline/handlers/codergen.go`](../../pipeline/handlers/codergen.go) | [`handlers/codergen.md`](./handlers/codergen.md) | LLM agent sessions: resolves prompt, picks backend, runs a session, captures response into `last_response` / `response.<nodeID>`, optionally parses `STATUS:` tokens. |
 | `tool` | [`pipeline/handlers/tool.go`](../../pipeline/handlers/tool.go) | [`handlers/tool.md`](./handlers/tool.md) | Shell command execution with safe-key variable expansion, timeouts, output caps, denylist/allowlist enforcement, and sensitive-env stripping. |
 | `wait.human` | [`pipeline/handlers/human.go`](../../pipeline/handlers/human.go) | [`handlers/human.md`](./handlers/human.md) | Blocking human gate: choice, freeform, yes/no, interview, hybrid review modes. Routed through a pluggable interviewer (TUI, autopilot, webhook). |
-| `parallel` | [`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Concurrent fan-out over `parallel_targets`. Spawns one goroutine per branch with an isolated context snapshot; records the fan-in join hint in `Outcome.ContextUpdates` as `suggested_next_nodes` (the engine's edge selector reads it from the context, not the `Outcome.SuggestedNextNodes` struct field). |
+| `parallel` | [`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Concurrent fan-out over `parallel_targets`. Spawns one goroutine per branch with an isolated context snapshot; records the fan-in join hint in `Outcome.ContextUpdates` as `suggested_next_nodes` (the engine's edge selector reads it from the context). The two hinting paths converge: `applyOutcome` mirrors any non-empty `Outcome.SuggestedNextNodes` slice into the same context key, so parallel just skips the struct and writes the key directly. |
 | `parallel.fan_in` | [`pipeline/handlers/fanin.go`](../../pipeline/handlers/fanin.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Join/aggregation node after a `parallel` dispatch. Reads `parallel.results` JSON; aggregates stats. |
 | `subgraph` | [`pipeline/subgraph.go`](../../pipeline/subgraph.go) | [`handlers/subgraph.md`](./handlers/subgraph.md) | Executes a named child graph inline. Merges `subgraph_params` with child `vars` defaults, runs a child `Engine` with scoped event handlers, propagates the result outcome. |
 | `conditional` | [`pipeline/handlers/conditional.go`](../../pipeline/handlers/conditional.go) | [`handlers/conditional.md`](./handlers/conditional.md) | Pure routing node: returns `OutcomeSuccess` with no writes and lets the engine's edge condition evaluator pick the next node based on existing context. |

--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -1,0 +1,199 @@
+# Handlers
+
+Pipeline handlers are the unit of execution. Each node in a graph is
+dispatched to a handler by name; the handler does the work (call an LLM,
+run a shell command, wait on a human, fan out branches, …) and returns an
+`Outcome`. The engine consumes the outcome and moves on. Handlers are where
+all non-trivial behavior lives — the engine itself stays narrow (see
+[`engine.md`](./engine.md)).
+
+## Contents
+
+1. [Interface](#interface)
+2. [Registry](#registry)
+3. [Shape to handler mapping](#shape-to-handler-mapping)
+4. [Handler index](#handler-index)
+5. [Writes and reads contract](#writes-and-reads-contract)
+
+## Interface
+
+The contract is minimal. From [`pipeline/handler.go`](../../pipeline/handler.go):
+
+```go
+const (
+    OutcomeSuccess = "success"
+    OutcomeRetry   = "retry"
+    OutcomeFail    = "fail"
+)
+
+type Outcome struct {
+    Status             string            // one of the consts above, or a handler-specific value
+    ContextUpdates     map[string]string // merged into PipelineContext (dirty-tracked)
+    PreferredLabel     string            // picks an outgoing edge by Edge.Label
+    SuggestedNextNodes []string          // picks an outgoing edge by Edge.To
+    Stats              *SessionStats     // optional; populated by codergen
+}
+
+type Handler interface {
+    Name() string
+    Execute(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error)
+}
+```
+
+A handler's `Name()` is its registry key — the engine resolves
+`node.Handler` to an implementation via this name. `Execute` is pure with
+respect to the engine: it receives the resolved node (after stylesheet and
+variable expansion) and the shared `*PipelineContext`, and returns an
+outcome or an error. Errors halt the pipeline (after a checkpoint save);
+`OutcomeFail` is a routable status that participates in edge selection.
+
+The pseudo-status `OutcomeRetry` tells the engine to consult the retry
+policy for this node, increment the counter, wait the backoff, and
+re-dispatch — see [`engine.md#retry-restart-escalate`](./engine.md#retry-restart-escalate).
+
+## Registry
+
+`HandlerRegistry` ([`pipeline/handler.go`](../../pipeline/handler.go)) is a
+name→handler map with `Register`, `Has`, `Get`, and `Execute` operations.
+The engine holds a single registry and calls
+`registry.Execute(ctx, node, pctx)` at dispatch time.
+
+Registration happens once, up-front, in
+[`pipeline/handlers/registry.go`](../../pipeline/handlers/registry.go).
+`NewDefaultRegistry(graph, opts...)` builds a fully wired registry with:
+
+```mermaid
+flowchart LR
+    reg[("HandlerRegistry")]
+    start["start<br/>NewStartHandler"] --> reg
+    exit["exit<br/>NewExitHandler"] --> reg
+    cond["conditional<br/>NewConditionalHandler"] --> reg
+    fin["parallel.fan_in<br/>NewFanInHandler"] --> reg
+    par["parallel<br/>NewParallelHandler(graph, registry)"] --> reg
+    cg["codergen<br/>registerCodergenHandler"] --> reg
+    tool["tool<br/>registerToolHandler"] --> reg
+    hum["wait.human<br/>registerHumanHandler"] --> reg
+    sub["subgraph<br/>registerSubgraphHandler<br/>(only if subgraphs != nil)"] --> reg
+    mgr["stack.manager_loop<br/>registerManagerLoopHandler"] --> reg
+```
+
+Registration has conditional branches driven by `RegistryOption`:
+
+- **`WithLLMClient`** — enables the native codergen backend. Absent, per-node
+  `backend: claude-code` or `backend: acp` can still be used as long as
+  `WithDefaultBackend` or any node's `backend` attr picks an external
+  backend.
+- **`WithExecEnvironment`** — required to register the tool handler (else
+  it becomes a stub for testing).
+- **`WithInterviewer`** — required to register the human handler.
+- **`WithSubgraphs`** — enables the `subgraph` handler. The `stack.manager_loop`
+  handler is always registered, but falls back to a clear-error stub when
+  no subgraphs are available (so `tracker validate` and conformance tests
+  can still reach it).
+- **`WithCodergenFunc` / `WithToolExecFunc` / `WithHumanCallback`** — stub
+  overrides for tests.
+- **`WithTokenTracker` / `WithAgentEventHandler` / `WithPipelineEventHandler`** —
+  observability wiring.
+
+The `NewRegistryFactory` helper returns a `pipeline.RegistryFactory` used
+by the subgraph and manager-loop handlers to create child registries whose
+event handlers are namespaced under a parent node ID (e.g.
+`SubgraphNode/ChildAgent`). That way the TUI can keep nested-pipeline
+events attributable to their wrapper node.
+
+## Shape to handler mapping
+
+Dippin-lang IR `NodeKind` values compile (via the adapter) to DOT-style
+shapes on each `Node`. The shape is what the engine uses to derive the
+handler name. Mapping lives in
+[`pipeline/graph.go`](../../pipeline/graph.go):
+
+```go
+var shapeHandlerMap = map[string]string{
+    "Mdiamond":      "start",
+    "Msquare":       "exit",
+    "box":           "codergen",
+    "hexagon":       "wait.human",
+    "diamond":       "conditional",
+    "component":     "parallel",
+    "tripleoctagon": "parallel.fan_in",
+    "parallelogram": "tool",
+    "house":         "stack.manager_loop",
+    "tab":           "subgraph",
+}
+```
+
+| `.dip` keyword | IR NodeKind | Shape | Handler name |
+|---|---|---|---|
+| `start` | `start` | `Mdiamond` | `start` |
+| `exit` | `exit` | `Msquare` | `exit` |
+| `agent` | `agent` | `box` | `codergen` |
+| `human` | `human` | `hexagon` | `wait.human` |
+| `conditional` | `conditional` | `diamond` | `conditional` |
+| `parallel` | `parallel` | `component` | `parallel` |
+| `fan_in` | `fan_in` | `tripleoctagon` | `parallel.fan_in` |
+| `tool` | `tool` | `parallelogram` | `tool` |
+| `stack.manager_loop` | `stack_manager_loop` | `house` | `stack.manager_loop` |
+| `subgraph` | `subgraph` | `tab` | `subgraph` |
+
+Two overrides handled by `applyDiamondOverrides` ([`graph.go`](../../pipeline/graph.go)):
+
+- A `diamond` node with a `tool_command` attr is reclassified to the
+  `tool` handler (some graph generators emit diamond-shaped tool nodes).
+- A `diamond` node with a `prompt` attr (but no `tool_command`) is
+  reclassified to `codergen` and gets `auto_status: "true"` defaulted in.
+
+An explicit `type:` attribute on any node overrides shape-based resolution
+entirely — useful for edge cases or pipelines hand-authored in DOT.
+
+## Handler index
+
+Each per-handler doc goes deep on configuration attrs, outcomes, edge-case
+behavior, and invariants. This table is the flat index.
+
+| Handler | Source | Deep dive | Purpose |
+|---|---|---|---|
+| `codergen` | [`pipeline/handlers/codergen.go`](../../pipeline/handlers/codergen.go) | [`handlers/codergen.md`](./handlers/codergen.md) | LLM agent sessions: resolves prompt, picks backend, runs a session, captures response into `last_response` / `response.<nodeID>`, optionally parses `STATUS:` tokens. |
+| `tool` | [`pipeline/handlers/tool.go`](../../pipeline/handlers/tool.go) | [`handlers/tool.md`](./handlers/tool.md) | Shell command execution with safe-key variable expansion, timeouts, output caps, denylist/allowlist enforcement, and sensitive-env stripping. |
+| `wait.human` | [`pipeline/handlers/human.go`](../../pipeline/handlers/human.go) | [`handlers/human.md`](./handlers/human.md) | Blocking human gate: choice, freeform, yes/no, interview, hybrid review modes. Routed through a pluggable interviewer (TUI, autopilot, webhook). |
+| `parallel` | [`pipeline/handlers/parallel.go`](../../pipeline/handlers/parallel.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Concurrent fan-out over `parallel_targets`. Spawns one goroutine per branch with an isolated context snapshot; hints the engine toward the fan-in join via `SuggestedNextNodes`. |
+| `parallel.fan_in` | [`pipeline/handlers/fanin.go`](../../pipeline/handlers/fanin.go) | [`handlers/parallel-fan-in.md`](./handlers/parallel-fan-in.md) | Join/aggregation node after a `parallel` dispatch. Reads `parallel.results` JSON; aggregates stats. |
+| `subgraph` | [`pipeline/subgraph.go`](../../pipeline/subgraph.go) | [`handlers/subgraph.md`](./handlers/subgraph.md) | Executes a named child graph inline. Merges `subgraph_params` with child `vars` defaults, runs a child `Engine` with scoped event handlers, propagates the result outcome. |
+| `conditional` | [`pipeline/handlers/conditional.go`](../../pipeline/handlers/conditional.go) | [`handlers/conditional.md`](./handlers/conditional.md) | Pure routing node: returns `OutcomeSuccess` with no writes and lets the engine's edge condition evaluator pick the next node based on existing context. |
+| `stack.manager_loop` | [`pipeline/handlers/manager_loop.go`](../../pipeline/handlers/manager_loop.go) | [`handlers/manager-loop.md`](./handlers/manager-loop.md) (currently [`docs/manager-loop.md`](../manager-loop.md)) | Async child-pipeline supervisor: launches a child in a goroutine, polls at intervals, evaluates `stop_condition`, injects `steer_context` through the engine's steering channel. Attractor spec 4.11. |
+| `start` | [`pipeline/handlers/start.go`](../../pipeline/handlers/start.go) | — | Pass-through entry node. Always returns `OutcomeSuccess` with no writes. Dispatches to whatever edge is selected. |
+| `exit` | [`pipeline/handlers/exit.go`](../../pipeline/handlers/exit.go) | — | Pass-through terminal node. Returns `OutcomeSuccess`; the engine's `handleExitNode` takes over to run the goal-gate retry check and finalize the trace. |
+
+`start` and `exit` are internal and don't get deep-dive docs — they're
+pure pass-throughs whose behavior lives in the engine rather than in the
+handler (see [`engine.md#run-loop`](./engine.md#run-loop)).
+
+## Writes and reads contract
+
+Handlers — notably `codergen`, `tool`, and `wait.human` in interview mode —
+support declarative `writes:` and `reads:` attributes for structured I/O:
+
+- `writes:` — a list of keys the node promises to produce in
+  `Outcome.ContextUpdates`. After each handler returns,
+  [`pipeline/handlers/declared_writes.go`](../../pipeline/handlers/declared_writes.go)
+  extracts those keys from the handler's output, validates required fields,
+  and fails the node if anything declared is missing or malformed.
+- `reads:` — a list of keys the node consumes. These keys are pinned at
+  full fidelity when compaction runs on resume, so downstream nodes see
+  consistent data even when unrelated earlier keys get elided.
+
+The user-facing model (including examples, `response_format: json_object`
+integration, and the safe-key restrictions on tool `command:` fields) is
+documented in full at
+[`docs/pipeline-context-flow.md`](../pipeline-context-flow.md#returning-custom-data-from-a-node).
+
+## Related docs
+
+- [`engine.md`](./engine.md) — how the engine invokes handlers and consumes
+  outcomes.
+- [`../pipeline-context-flow.md`](../pipeline-context-flow.md) — how
+  handlers write and read the shared context.
+- [`backends.md`](./backends.md) — how `codergen` delegates to pluggable
+  agent backends.
+- [`adapter.md`](./adapter.md) — how dippin-lang IR maps to the shapes
+  this doc tables.


### PR DESCRIPTION
## Summary

Add the top-level architecture documentation tree. This PR covers four new files; three sibling PRs (landing in parallel) cover the rest of the tree.

- **`ARCHITECTURE.md`** (repo root, 259 lines, 3 diagrams) — system-context diagram, layer diagram, end-to-end sequence, key abstractions (Graph/Node/Edge, Handler/Engine, Outcome, PipelineContext, event bus), reading-order section.
- **`docs/architecture/README.md`** (71 lines) — table of subsystem docs, three targeted reading orders, conventions note. Index into the tree.
- **`docs/architecture/engine.md`** (476 lines, 5 diagrams) — deep dive on the engine: run loop (sequence), outcomes + edge priority (flowchart), retry/restart/escalate state machine, budget guard (sequence), steering channel (sequence), git artifacts, full PipelineEvent catalog.
- **`docs/architecture/handlers.md`** (199 lines, 1 diagram) — Handler interface, HandlerRegistry wiring, shape→handler table, per-handler index with source file + deep-dive link for each.

All internal links to the rest of the subsystem docs (`agent.md`, `llm.md`, `adapter.md`, `tui.md`, `backends.md`, `artifacts.md`, `context-flow.md`, per-handler files under `handlers/`) are intentional — those files are being written by sibling subagents. Links to the existing `docs/pipeline-context-flow.md` and `docs/manager-loop.md` point at their current locations until those files are moved later.

## Rendered preview

- [`ARCHITECTURE.md` on this branch](https://github.com/2389-research/tracker/blob/worktree-agent-ac50e994/ARCHITECTURE.md)
- [`docs/architecture/README.md` on this branch](https://github.com/2389-research/tracker/blob/worktree-agent-ac50e994/docs/architecture/README.md)
- [`docs/architecture/engine.md` on this branch](https://github.com/2389-research/tracker/blob/worktree-agent-ac50e994/docs/architecture/engine.md)
- [`docs/architecture/handlers.md` on this branch](https://github.com/2389-research/tracker/blob/worktree-agent-ac50e994/docs/architecture/handlers.md)

## Test plan

- [x] All 9 mermaid diagrams render without errors via `@mermaid-js/mermaid-cli` (validated locally with `--no-sandbox` puppeteer config).
- [x] All source-file links (`pipeline/engine.go`, `pipeline/handlers/*.go`, …) resolve to files that exist in the tree.
- [x] Cross-links to the existing `docs/pipeline-context-flow.md` and `docs/manager-loop.md` resolve.
- [x] `go build ./...` still passes (docs-only change).
- [ ] Reviewer check: facts match source. Specific spots to sanity-check: retry-policy defaults in `pipeline/retry_policy.go`, event list against `pipeline/events.go`, edge priority order against `pipeline/engine_edges.go::selectEdge`.
- [ ] Reviewer check: tone is prose-first, no marketing voice, describes what IS.

## Notes for downstream subagents

- Handler-index links in `handlers.md` use paths like `./handlers/tool.md` (sibling subdir) — match that convention when writing the per-handler docs.
- Subsystem-doc links in `README.md` use paths like `./agent.md` — match that convention at the top of each subsystem doc with a backlink to `./README.md`.
- `OutcomeEscalate` is NOT a real constant. Escalation is a routing convention (goal-gate fallback or `when ctx.outcome = fail`). I've documented it that way in `engine.md`.

## Observations

One small gap surfaced: the `docs/architecture/context-flow.md` path referenced in the spec doesn't exist yet — `docs/pipeline-context-flow.md` is the current canonical location. The index in `README.md` notes this explicitly and links to the current location; a later move-and-redirect PR can tidy up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive architecture overview describing end-to-end pipeline execution, layered responsibilities, and recommended reading order
  * New architecture index mapping subsystem design docs, diagram conventions, and doc-reading paths
  * Detailed engine spec covering run loop, checkpoints, routing/steering, retry/loop semantics, budgeting, artifacts, and emitted events
  * Expanded handler guidance on outcomes, dispatch behavior, registry mappings, I/O contracts, and illustrative Mermaid diagrams
<!-- end of auto-generated comment: release notes by coderabbit.ai -->