### PR TITLE
feat(cli): wire up --bypass-denylist / --tool-allowlist / --max-output-limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`--bypass-denylist`, `--tool-allowlist`, `--max-output-limit` CLI flags for tool command sandboxing.** The underlying denylist, allowlist, and per-stream output ceiling were already enforced by `pipeline/handlers/tool_safety.go` and `ToolHandlerConfig`, but only via node-attr and library APIs — the CLI paths were missing. `--bypass-denylist` (bool, default `false`) disables the built-in denylist and prints a loud stderr warning on startup; use only in sandboxed environments where dangerous patterns (eval, pipe-to-shell, curl|sh) are intentional. `--tool-allowlist <pattern>` is repeatable and accepts comma-separated glob patterns; every tool command statement must match at least one allowlist entry when the flag is set. Allowlist entries are additive with any `tool_commands_allow` graph attr and never override the denylist. `--max-output-limit <bytes>` sets the hard ceiling (default 10MB) applied to per-node `output_limit:` attrs. Node-attr and graph-attr paths remain unchanged; these flags are additive CLI surface.
+
 ## [0.22.0] - 2026-04-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -655,6 +655,9 @@ tracker version                  Show version information
 - `--gate-timeout-action` — what to do on gate timeout: `fail` (default) or `success`
 - `--webhook-auth` — `Authorization` header for outbound webhook requests
 - `--export-bundle` — write a portable git bundle of run artifacts to the given path after completion
+- `--bypass-denylist` — disable the built-in tool command denylist (prints a stderr warning; sandboxed use only)
+- `--tool-allowlist <pattern>` — glob pattern a tool command must match to execute (repeatable or comma-separated)
+- `--max-output-limit <bytes>` — hard ceiling per tool command output stream (default: 10MB)
 
 ## Development
 

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -269,6 +269,12 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 	}
 	activeRunParams = maps.Clone(cfg.params)
 	activeEffectiveRunParams = nil
+	// Store tool handler safety config for the registry (called from run/runTUI).
+	activeToolSafety = handlers.ToolHandlerConfig{
+		BypassDenylist: cfg.bypassDenylist,
+		Allowlist:      append([]string(nil), cfg.toolAllowlist...),
+		MaxOutputLimit: cfg.maxOutputLimit,
+	}
 	// Apply --gateway-url before buildLLMClient is called.
 	// Timing is correct: executeRun sets the env var here, then calls
 	// selectAndRunMode → run/runTUI → buildLLMClient → buildProviderConstructors,
@@ -316,7 +322,25 @@ func printRunPreamble(cfg runConfig) error {
 	} else if cfg.autoApprove {
 		fmt.Fprintln(os.Stderr, "Running in auto-approve mode — all human gates auto-approved")
 	}
+	printToolSafetyPreamble(cfg)
 	return nil
+}
+
+// printToolSafetyPreamble surfaces tool-command safety overrides to stderr so
+// operators can't accidentally forget they asked the denylist to be bypassed.
+// The denylist warning is deliberately loud — it's a security escape hatch.
+func printToolSafetyPreamble(cfg runConfig) {
+	if cfg.bypassDenylist {
+		fmt.Fprintln(os.Stderr, "WARNING: --bypass-denylist active — built-in tool_command denylist is DISABLED")
+		fmt.Fprintln(os.Stderr, "         Only run this in sandboxed or trusted environments.")
+	}
+	if len(cfg.toolAllowlist) > 0 {
+		fmt.Fprintf(os.Stderr, "Tool command allowlist active (%d pattern(s)): %s\n",
+			len(cfg.toolAllowlist), strings.Join(cfg.toolAllowlist, ", "))
+	}
+	if cfg.maxOutputLimit > 0 {
+		fmt.Fprintf(os.Stderr, "Tool command output ceiling: %d bytes per stream\n", cfg.maxOutputLimit)
+	}
 }
 
 // resolveRunCheckpoint returns the checkpoint path for a resume run, or "" for new runs.

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -135,6 +135,9 @@ func parseRunFlags(args []string, cfg runConfig) (runConfig, error) {
 	if err := validateWebhookFlags(cfg); err != nil {
 		return cfg, err
 	}
+	if err := validateToolSafetyFlags(cfg); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
 }
 
@@ -142,6 +145,16 @@ func parseRunFlags(args []string, cfg runConfig) (runConfig, error) {
 func validateBudgetLimits(cfg runConfig) error {
 	if cfg.maxTokens < 0 || cfg.maxCostCents < 0 || cfg.maxWallTime < 0 {
 		return fmt.Errorf("budget limits must be non-negative")
+	}
+	return nil
+}
+
+// validateToolSafetyFlags rejects nonsensical values for the tool safety flags.
+// A negative --max-output-limit is a user error (probably a typo); reject loudly
+// rather than silently coercing to default, to avoid surprise.
+func validateToolSafetyFlags(cfg runConfig) error {
+	if cfg.maxOutputLimit < 0 {
+		return fmt.Errorf("--max-output-limit must be non-negative, got %d", cfg.maxOutputLimit)
 	}
 	return nil
 }
@@ -206,6 +219,9 @@ func newRunFlagSet(progName string, cfg *runConfig) *flag.FlagSet {
 	fs.StringVar(&cfg.webhookAuthHeader, "webhook-auth", "", "Authorization header value sent on outbound webhook requests (e.g. 'Bearer sk_live_...')")
 	fs.StringVar(&cfg.exportBundle, "export-bundle", "", "After the run completes, write a git bundle of run artifacts to this path")
 	fs.StringVar(&cfg.artifactDir, "artifact-dir", "", "Override node state directory (default: <workdir>/.tracker/runs)")
+	fs.BoolVar(&cfg.bypassDenylist, "bypass-denylist", false, "Disable the built-in tool_command denylist (SECURITY: use only in sandboxed environments)")
+	fs.Var(stringSliceFlag{target: &cfg.toolAllowlist}, "tool-allowlist", "Glob pattern(s) a tool_command must match to execute (repeatable or comma-separated)")
+	fs.IntVar(&cfg.maxOutputLimit, "max-output-limit", 0, "Hard ceiling in bytes on tool_command output per stream (0 = default 10MB)")
 	return fs
 }
 
@@ -240,6 +256,34 @@ func (p paramMapFlag) Set(value string) error {
 		*p.target = make(map[string]string)
 	}
 	(*p.target)[key] = val
+	return nil
+}
+
+// stringSliceFlag is a repeatable flag that appends each value to a target slice.
+// Each invocation may also provide a comma-separated list of values, which are
+// split and appended individually. Empty values (after TrimSpace) are ignored.
+type stringSliceFlag struct {
+	target *[]string
+}
+
+func (s stringSliceFlag) String() string {
+	if s.target == nil || *s.target == nil {
+		return ""
+	}
+	return strings.Join(*s.target, ",")
+}
+
+func (s stringSliceFlag) Set(value string) error {
+	if s.target == nil {
+		return fmt.Errorf("invalid stringSliceFlag target")
+	}
+	for _, part := range strings.Split(value, ",") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		*s.target = append(*s.target, trimmed)
+	}
 	return nil
 }
 
@@ -307,5 +351,8 @@ func printUsage(w io.Writer) {
 	fmt.Fprintf(w, "  --webhook-auth string     Authorization header for outbound webhook requests\n")
 	fmt.Fprintf(w, "  --export-bundle string    Write a portable git bundle of run artifacts to this path after completion\n")
 	fmt.Fprintf(w, "  --artifact-dir string     Override node state directory (default: <workdir>/.tracker/runs)\n")
+	fmt.Fprintf(w, "  --bypass-denylist         Disable the built-in tool_command denylist (SECURITY: sandboxed use only)\n")
+	fmt.Fprintf(w, "  --tool-allowlist pattern  Glob pattern a tool_command must match to execute (repeatable, comma-separated)\n")
+	fmt.Fprintf(w, "  --max-output-limit bytes  Hard ceiling per tool_command output stream (default: 10MB)\n")
 	fmt.Fprintf(w, "  --version                 Show version information\n")
 }

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -37,6 +37,9 @@ type runConfig struct {
 	webhookAuthHeader string        // Authorization header value for outbound webhook requests
 	exportBundle      string        // path for post-run git bundle export; "" = skip
 	artifactDir       string        // override node state directory; "" = <workdir>/.tracker/runs
+	bypassDenylist    bool          // disable the built-in tool_command denylist (SECURITY escape hatch)
+	toolAllowlist     []string      // additional allowlist patterns for tool_command (repeatable)
+	maxOutputLimit    int           // hard ceiling (bytes) on per-stream tool_command output; 0 = default 10MB
 }
 
 type commandMode string

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -70,6 +70,12 @@ var activeWebhookGate *webhookGateCfg
 // Set by executeRun before calling run/runTUI. Empty means default (<workdir>/.tracker/runs).
 var activeArtifactDir string
 
+// activeToolSafety holds the tool handler security config for the current run.
+// Set by executeRun from the --bypass-denylist, --tool-allowlist, and
+// --max-output-limit CLI flags. The zero value is the default-safe config
+// (denylist active, no allowlist, 10MB ceiling).
+var activeToolSafety handlers.ToolHandlerConfig
+
 // webhookGateCfg holds just the webhook gate settings needed by chooseInterviewer.
 type webhookGateCfg struct {
 	webhookURL        string
@@ -158,6 +164,7 @@ func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool
 		handlers.WithSubgraphs(subgraphs),
 		handlers.WithDefaultBackend(backend),
 		handlers.WithTokenTracker(tokenTracker),
+		handlers.WithToolHandlerConfig(activeToolSafety),
 	)
 
 	engine := pipeline.NewEngine(graph, registry, engineOpts...)
@@ -525,6 +532,7 @@ func buildTUIRegistry(graph *pipeline.Graph, llmClient *llm.Client, workdir stri
 		handlers.WithSubgraphs(subgraphs),
 		handlers.WithDefaultBackend(backend),
 		handlers.WithTokenTracker(tokenTracker),
+		handlers.WithToolHandlerConfig(activeToolSafety),
 	)
 }
 

--- a/cmd/tracker/tool_safety_flags_test.go
+++ b/cmd/tracker/tool_safety_flags_test.go
@@ -1,0 +1,268 @@
+// ABOUTME: Tests for the --bypass-denylist, --tool-allowlist, and --max-output-limit CLI flags.
+// ABOUTME: Covers flag parsing, defaults, repeatability, and propagation into the tool handler registry.
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/agent/exec"
+	"github.com/2389-research/tracker/pipeline"
+	"github.com/2389-research/tracker/pipeline/handlers"
+)
+
+// TestParseFlagsBypassDenylist verifies that --bypass-denylist sets cfg.bypassDenylist.
+func TestParseFlagsBypassDenylist(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "--bypass-denylist", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if !cfg.bypassDenylist {
+		t.Fatal("expected bypassDenylist to be true")
+	}
+	if cfg.pipelineFile != "pipeline.dip" {
+		t.Fatalf("pipelineFile = %q, want %q", cfg.pipelineFile, "pipeline.dip")
+	}
+}
+
+// TestParseFlagsBypassDenylistDefault verifies the default is false (denylist active).
+func TestParseFlagsBypassDenylistDefault(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if cfg.bypassDenylist {
+		t.Fatal("expected bypassDenylist default to be false")
+	}
+}
+
+// TestParseFlagsToolAllowlistSingle verifies one --tool-allowlist invocation populates the slice.
+func TestParseFlagsToolAllowlistSingle(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "--tool-allowlist", "make *", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if len(cfg.toolAllowlist) != 1 || cfg.toolAllowlist[0] != "make *" {
+		t.Fatalf("toolAllowlist = %#v, want [%q]", cfg.toolAllowlist, "make *")
+	}
+}
+
+// TestParseFlagsToolAllowlistRepeatable verifies multiple --tool-allowlist flags accumulate.
+func TestParseFlagsToolAllowlistRepeatable(t *testing.T) {
+	cfg, err := parseFlags([]string{
+		"tracker",
+		"--tool-allowlist", "make *",
+		"--tool-allowlist", "go test *",
+		"pipeline.dip",
+	})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if len(cfg.toolAllowlist) != 2 {
+		t.Fatalf("toolAllowlist len = %d, want 2: %#v", len(cfg.toolAllowlist), cfg.toolAllowlist)
+	}
+	if cfg.toolAllowlist[0] != "make *" || cfg.toolAllowlist[1] != "go test *" {
+		t.Fatalf("toolAllowlist = %#v", cfg.toolAllowlist)
+	}
+}
+
+// TestParseFlagsToolAllowlistCommaSeparated verifies comma-separated values within one flag.
+func TestParseFlagsToolAllowlistCommaSeparated(t *testing.T) {
+	cfg, err := parseFlags([]string{
+		"tracker",
+		"--tool-allowlist", "make *,go test *, echo *",
+		"pipeline.dip",
+	})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	want := []string{"make *", "go test *", "echo *"}
+	if len(cfg.toolAllowlist) != len(want) {
+		t.Fatalf("toolAllowlist = %#v, want %#v", cfg.toolAllowlist, want)
+	}
+	for i, p := range want {
+		if cfg.toolAllowlist[i] != p {
+			t.Fatalf("toolAllowlist[%d] = %q, want %q", i, cfg.toolAllowlist[i], p)
+		}
+	}
+}
+
+// TestParseFlagsToolAllowlistDefault verifies absent flag yields empty slice.
+func TestParseFlagsToolAllowlistDefault(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if len(cfg.toolAllowlist) != 0 {
+		t.Fatalf("toolAllowlist default = %#v, want empty", cfg.toolAllowlist)
+	}
+}
+
+// TestParseFlagsMaxOutputLimit verifies --max-output-limit populates the int.
+func TestParseFlagsMaxOutputLimit(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "--max-output-limit", "65536", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if cfg.maxOutputLimit != 65536 {
+		t.Fatalf("maxOutputLimit = %d, want 65536", cfg.maxOutputLimit)
+	}
+}
+
+// TestParseFlagsMaxOutputLimitDefault verifies the default is 0 (meaning use built-in 10MB).
+func TestParseFlagsMaxOutputLimitDefault(t *testing.T) {
+	cfg, err := parseFlags([]string{"tracker", "pipeline.dip"})
+	if err != nil {
+		t.Fatalf("parseFlags returned error: %v", err)
+	}
+	if cfg.maxOutputLimit != 0 {
+		t.Fatalf("maxOutputLimit default = %d, want 0 (library default)", cfg.maxOutputLimit)
+	}
+}
+
+// TestParseFlagsMaxOutputLimitNegativeRejected verifies that a negative value is rejected.
+func TestParseFlagsMaxOutputLimitNegativeRejected(t *testing.T) {
+	_, err := parseFlags([]string{"tracker", "--max-output-limit", "-1", "pipeline.dip"})
+	if err == nil {
+		t.Fatal("expected error for negative --max-output-limit")
+	}
+}
+
+// TestToolSafetyFlagsPropagateToActiveGlobal verifies executeRun copies the tool safety flag
+// values into the activeToolSafety global so the registry picks them up.
+func TestToolSafetyFlagsPropagateToActiveGlobal(t *testing.T) {
+	t.Cleanup(func() { activeToolSafety = handlers.ToolHandlerConfig{} })
+
+	var captured handlers.ToolHandlerConfig
+	_ = executeCommand(runConfig{
+		mode:           modeRun,
+		pipelineFile:   "pipeline.dip",
+		workdir:        "/tmp",
+		noTUI:          true,
+		bypassDenylist: true,
+		toolAllowlist:  []string{"make *", "go test *"},
+		maxOutputLimit: 131072,
+	}, commandDeps{
+		loadEnv: func(string) error { return nil },
+		run: func(pipelineFile, workdir, checkpoint, format, backend string, verbose bool, jsonOut bool) error {
+			captured = activeToolSafety
+			return nil
+		},
+		runTUI: func(pipelineFile, workdir, checkpoint, format, backend string, verbose bool) error {
+			t.Fatal("unexpected TUI path")
+			return nil
+		},
+	})
+
+	if !captured.BypassDenylist {
+		t.Error("activeToolSafety.BypassDenylist not propagated")
+	}
+	if len(captured.Allowlist) != 2 || captured.Allowlist[0] != "make *" || captured.Allowlist[1] != "go test *" {
+		t.Errorf("activeToolSafety.Allowlist = %#v, want [%q %q]", captured.Allowlist, "make *", "go test *")
+	}
+	if captured.MaxOutputLimit != 131072 {
+		t.Errorf("activeToolSafety.MaxOutputLimit = %d, want 131072", captured.MaxOutputLimit)
+	}
+}
+
+// TestToolHandlerConfigFlowsToRegistry drives the registry through the option wiring and
+// verifies that the resulting tool handler reflects the flag values in a real end-to-end
+// invocation: a denied command is blocked by default, permitted when bypass is active, and
+// rejected by an allowlist when the command isn't listed.
+func TestToolHandlerConfigFlowsToRegistry(t *testing.T) {
+	graph := &pipeline.Graph{
+		Nodes: map[string]*pipeline.Node{
+			"node1": {
+				ID:      "node1",
+				Shape:   "parallelogram",
+				Handler: "tool",
+				Attrs:   map[string]string{"tool_command": "eval $(date)"},
+			},
+		},
+	}
+	env := exec.NewLocalEnvironment(t.TempDir())
+	pctx := pipeline.NewPipelineContext()
+
+	// Default-safe: denylist is active, "eval" pattern is blocked.
+	reg := handlers.NewDefaultRegistry(graph,
+		handlers.WithExecEnvironment(env),
+	)
+	h := mustGetToolHandler(t, reg)
+	if _, err := h.Execute(t.Context(), graph.Nodes["node1"], pctx); err == nil {
+		t.Fatal("expected default tool handler to block eval pattern")
+	}
+
+	// With --bypass-denylist: eval pattern goes through (actual exec may still fail for
+	// other reasons in this synthetic test). What we assert is that the error, if any,
+	// is NOT the denylist error.
+	regBypass := handlers.NewDefaultRegistry(graph,
+		handlers.WithExecEnvironment(env),
+		handlers.WithToolHandlerConfig(handlers.ToolHandlerConfig{BypassDenylist: true}),
+	)
+	hBypass := mustGetToolHandler(t, regBypass)
+	if _, err := hBypass.Execute(t.Context(), graph.Nodes["node1"], pctx); err != nil {
+		if containsIgnoreCase(err.Error(), "denied pattern") {
+			t.Fatalf("bypass should skip denylist, but got denylist error: %v", err)
+		}
+	}
+
+	// With --tool-allowlist that does NOT match: blocked regardless of the command being
+	// outside the denylist. Using "echo hi" which is safe, but not in the allowlist.
+	graph.Nodes["node1"].Attrs["tool_command"] = "echo hi"
+	regAllow := handlers.NewDefaultRegistry(graph,
+		handlers.WithExecEnvironment(env),
+		handlers.WithToolHandlerConfig(handlers.ToolHandlerConfig{
+			Allowlist: []string{"make *"},
+		}),
+	)
+	hAllow := mustGetToolHandler(t, regAllow)
+	if _, err := hAllow.Execute(t.Context(), graph.Nodes["node1"], pctx); err == nil || !containsIgnoreCase(err.Error(), "allowlist") {
+		t.Fatalf("expected allowlist rejection, got err=%v", err)
+	}
+}
+
+// TestToolHandlerConfigMaxOutputLimitCap verifies that the hard ceiling overrides a larger
+// per-node output_limit attr. We drive it via NewToolHandlerWithConfig directly since
+// probing the internal cap requires inspecting clamped output rather than going through
+// the registry (which hides the handler fields).
+func TestToolHandlerConfigMaxOutputLimitCap(t *testing.T) {
+	env := exec.NewLocalEnvironment(t.TempDir())
+	h := handlers.NewToolHandlerWithConfig(env, handlers.ToolHandlerConfig{
+		MaxOutputLimit: 1024, // 1KB ceiling
+	})
+	node := &pipeline.Node{
+		ID:      "big",
+		Shape:   "parallelogram",
+		Handler: "tool",
+		Attrs: map[string]string{
+			// Ask for 10KB via the node attr — should be clamped to 1KB by the handler.
+			"tool_command": "yes x | head -c 10000",
+			"output_limit": "10KB",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(t.Context(), node, pctx)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	stdout := outcome.ContextUpdates[pipeline.ContextKeyToolStdout]
+	// With a 1KB ceiling, output + truncation marker should be well under the requested 10KB.
+	if len(stdout) > 1024+128 {
+		t.Errorf("stdout length = %d, expected <= ~1152 with 1KB ceiling", len(stdout))
+	}
+}
+
+// mustGetToolHandler fetches the "tool" handler from a registry or fails the test.
+func mustGetToolHandler(t *testing.T, reg *pipeline.HandlerRegistry) pipeline.Handler {
+	t.Helper()
+	h := reg.Get("tool")
+	if h == nil {
+		t.Fatal("registry missing tool handler")
+	}
+	return h
+}
+
+// containsIgnoreCase returns true when needle occurs in haystack, case-insensitive.
+func containsIgnoreCase(haystack, needle string) bool {
+	return strings.Contains(strings.ToLower(haystack), strings.ToLower(needle))
+}

--- a/pipeline/handlers/registry.go
+++ b/pipeline/handlers/registry.go
@@ -34,6 +34,8 @@ type registryConfig struct {
 	subgraphs      map[string]*pipeline.Graph
 	defaultBackend string
 	tokenTracker   *llm.TokenTracker
+	toolSafety     ToolHandlerConfig
+	toolSafetySet  bool
 }
 
 // WithCodergenFunc overrides the codergen handler with a stub function.
@@ -113,6 +115,18 @@ func WithTokenTracker(tracker *llm.TokenTracker) RegistryOption {
 func WithSubgraphs(graphs map[string]*pipeline.Graph) RegistryOption {
 	return func(c *registryConfig) {
 		c.subgraphs = graphs
+	}
+}
+
+// WithToolHandlerConfig supplies security configuration for the tool handler:
+// denylist bypass, allowlist patterns, and the hard output-limit ceiling. These
+// values thread from CLI flags into NewToolHandlerWithConfig. When this option
+// is not supplied, the tool handler is built with NewToolHandler (default safe
+// behavior: denylist active, no allowlist restriction, 10MB output ceiling).
+func WithToolHandlerConfig(cfg ToolHandlerConfig) RegistryOption {
+	return func(c *registryConfig) {
+		c.toolSafety = cfg
+		c.toolSafetySet = true
 	}
 }
 
@@ -228,9 +242,16 @@ func graphHasPerNodeBackend(graph *pipeline.Graph) bool {
 }
 
 // registerToolHandler registers the tool handler or a stub.
+// When WithToolHandlerConfig was supplied, the handler is built with the
+// CLI-provided safety config (denylist bypass, allowlist, output ceiling).
+// Otherwise the default-safe handler is used.
 func registerToolHandler(registry *pipeline.HandlerRegistry, cfg *registryConfig) {
 	if cfg.execEnv != nil {
-		registry.Register(NewToolHandler(cfg.execEnv))
+		if cfg.toolSafetySet {
+			registry.Register(NewToolHandlerWithConfig(cfg.execEnv, cfg.toolSafety))
+		} else {
+			registry.Register(NewToolHandler(cfg.execEnv))
+		}
 	} else if cfg.toolExecFunc != nil {
 		registry.Register(&funcHandler{name: "tool", fn: cfg.toolExecFunc})
 	}


### PR DESCRIPTION
## Why

CLAUDE.md and the README documented three tool-safety CLI flags as if they existed:

- `--bypass-denylist`
- `--tool-allowlist <pattern>`
- `--max-output-limit <bytes>`

They didn't. The underlying plumbing (`pipeline/handlers/tool_safety.go`, `ToolHandlerConfig`, `NewToolHandlerWithConfig`) has been in place since the tool-command sandboxing landed — but only the node-attr and library-API paths were wired. A README audit flagged these as ghost flags. This PR wires them up with no behavior change to the existing safety layers.

## What

Three flags on `newRunFlagSet` in `cmd/tracker/flags.go`:

| Flag | Type | Default | Purpose |
|---|---|---|---|
| `--bypass-denylist` | bool | `false` | Disables the built-in tool_command denylist. Prints a loud stderr warning on startup. |
| `--tool-allowlist <pattern>` | repeatable / comma-separated | empty | Glob pattern every tool command statement must match. Additive with `tool_commands_allow` graph attr; never overrides the denylist. |
| `--max-output-limit <bytes>` | int | `0` → 10MB | Hard ceiling on per-stream tool_command output. Per-node `output_limit:` attrs are clamped to this ceiling. Negative values rejected at parse. |

Threading follows the existing `active*` global pattern used for autopilot/webhook/budget/export-bundle:

```
CLI flags (parseFlags)
  → runConfig
    → activeToolSafety (set in executeRun)
      → handlers.WithToolHandlerConfig (registry option, new)
        → NewToolHandlerWithConfig (existing constructor)
```

Plus a new `stringSliceFlag` helper in `cmd/tracker/flags.go` for repeatable/comma-separated `[]string` CLI flags — same shape as the existing `paramMapFlag`.

## Safety note

`--bypass-denylist` is a security escape hatch. Typical legitimate use: CI pipelines that intentionally run patterns the denylist blocks (e.g., `curl | bash` for installer verification in a sandboxed VM, or `eval` for dynamic test-matrix setup). The startup warning is deliberately loud (two lines of stderr output) so nobody accidentally ships this flag in a production pipeline.

The denylist cannot be overridden from inside a `.dip` file or graph attr — only from the CLI. That boundary is preserved: `--tool-allowlist` is additive with `tool_commands_allow` (graph-attr-or-CLI), but `--bypass-denylist` has no in-file equivalent.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -short -count=1` — all 17 packages green
- [x] `make fmt-check` — exit 0
- [x] New tests in `cmd/tracker/tool_safety_flags_test.go`:
  - Flag parse (each flag sets the expected field)
  - Flag defaults (absent flag → documented default)
  - `--tool-allowlist` repeatable across invocations
  - `--tool-allowlist` comma-separated within one invocation
  - `--max-output-limit` negative value rejected
  - `executeRun` propagates values into `activeToolSafety` global
  - `WithToolHandlerConfig` registry option → `NewToolHandlerWithConfig` end-to-end (denylist enforced by default, bypass skips it, allowlist rejects unmatched commands, max-output-limit clamps node attr)

## Non-goals / follow-ups

- Dippin-lang support for `tool_commands_allow` graph attr remains blocked on the language side; CLI allowlist works today independently.
- No changes to the safety-check logic in `pipeline/handlers/tool_safety.go` — only registry wiring and CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--bypass-denylist` flag to disable the built-in tool command denylist with a warning.
  * Added `--tool-allowlist` flag to restrict tool commands to specified patterns (repeatable and comma-separated).
  * Added `--max-output-limit` flag to set a per-tool output cap with a 10MB default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->