### PR TITLE
fix(manager_loop): polish bundle — issues #171, #172, #174, #175, #176

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ lint:
 
 doctor:
 	@FAIL=0; \
-	for f in examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip; do \
+	for f in examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip examples/manager_loop_demo.dip; do \
 		GRADE=$$($(DIPPIN) doctor "$$f" 2>&1 | grep 'Grade' | sed 's/.*Grade: //' | sed 's/  .*//'); \
 		SCORE=$$($(DIPPIN) doctor "$$f" 2>&1 | grep 'Score' | sed 's/.*Score: //' | sed 's/\/100//'); \
 		printf "%-50s %s  %s/100\n" "$$(basename $$f)" "$$GRADE" "$$SCORE"; \

--- a/examples/manager_loop_demo.dip
+++ b/examples/manager_loop_demo.dip
@@ -12,7 +12,7 @@ workflow ManagerLoopDemo
     subgraph_ref: subgraphs/manager_loop_child.dip
     poll_interval: 30s
     max_cycles: 12
-    stop_condition: stack.child.status = success
+    stop_condition: stack.child.cycles = 10
     steer_condition: stack.child.cycles = 5
     steer_context:
       hint: halfway_through

--- a/examples/manager_loop_demo.dip
+++ b/examples/manager_loop_demo.dip
@@ -1,0 +1,31 @@
+workflow ManagerLoopDemo
+  goal: "Showcase the manager_loop supervisor: launch a child pipeline, poll for completion, steer mid-flight, and stop on a condition."
+  start: Supervise
+  exit: Done
+
+  defaults
+    model: claude-sonnet-4-6
+    provider: anthropic
+
+  manager_loop Supervise
+    label: "Supervise child pipeline"
+    subgraph_ref: subgraphs/manager_loop_child.dip
+    poll_interval: 30s
+    max_cycles: 12
+    stop_condition: stack.child.status = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+
+  agent Done
+    label: "Summarize the supervised run."
+    prompt:
+      The manager loop completed.
+      Final child status: ${ctx.stack.child.status}
+      Cycles elapsed: ${ctx.stack.child.cycles}
+
+      Summarize the outcome in one paragraph.
+
+  edges
+    Supervise -> Done

--- a/examples/subgraphs/manager_loop_child.dip
+++ b/examples/subgraphs/manager_loop_child.dip
@@ -1,0 +1,23 @@
+workflow ManagerLoopChild
+  goal: "Child pipeline supervised by manager_loop_demo.dip — performs one cycle of work per run."
+  start: DoWork
+  exit: Done
+
+  agent DoWork
+    label: "Perform one unit of supervised work."
+    auto_status: true
+    prompt:
+      You are a worker supervised by a manager_loop. Perform one cycle of
+      the assigned task. If the steering hint ${ctx.hint} is set, use it
+      to bias your approach.
+
+      End your response with STATUS: success when the work is complete,
+      or STATUS: fail if another cycle is required.
+
+  agent Done
+    label: "Finalize cycle result."
+    prompt:
+      Briefly summarize this cycle's outcome for the manager.
+
+  edges
+    DoWork -> Done

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -14,11 +14,13 @@ import (
 )
 
 var (
-	ErrNilWorkflow     = errors.New("nil workflow")
-	ErrMissingStart    = errors.New("workflow missing Start node")
-	ErrMissingExit     = errors.New("workflow missing Exit node")
-	ErrUnknownNodeKind = errors.New("unknown node kind")
-	ErrUnknownConfig   = errors.New("unknown config type")
+	ErrNilWorkflow            = errors.New("nil workflow")
+	ErrMissingStart           = errors.New("workflow missing Start node")
+	ErrMissingExit            = errors.New("workflow missing Exit node")
+	ErrUnknownNodeKind        = errors.New("unknown node kind")
+	ErrUnknownConfig          = errors.New("unknown config type")
+	ErrInvalidSteerContextKey = errors.New("steer_context key contains ':' which breaks block-form round-trip through the .dip formatter")
+	ErrMissingManagerLoopCfg  = errors.New("manager_loop node is missing required ir.ManagerLoopConfig")
 )
 
 // FromDippinIR converts a Dippin IR Workflow to a Tracker Graph.
@@ -141,6 +143,16 @@ func convertNode(irNode *ir.Node) (*Node, error) {
 		return nil, fmt.Errorf("%s: %w", irNode.Kind, ErrUnknownNodeKind)
 	}
 
+	// Kind-specific required-config guard. A manager_loop node with a nil
+	// Config would otherwise flow through extractNodeAttrs as a no-op and
+	// produce a graph node without subgraph_ref, surfacing later at Execute
+	// time as a vague runtime error. Fail loudly at build time instead.
+	// Scoped to manager_loop for now — we may extend the same guard to other
+	// kinds as follow-ups if they exhibit the same silent-degrade pattern.
+	if irNode.Kind == ir.NodeManagerLoop && irNode.Config == nil {
+		return nil, fmt.Errorf("node %s: %w", irNode.ID, ErrMissingManagerLoopCfg)
+	}
+
 	gNode := &Node{
 		ID:    irNode.ID,
 		Shape: shape,
@@ -194,7 +206,7 @@ func extractValueNodeAttrs(config ir.NodeConfig, attrs map[string]string) (bool,
 	case ir.ConditionalConfig:
 		// Conditional nodes are pure routing — no config to extract.
 	case ir.ManagerLoopConfig:
-		extractManagerLoopAttrs(cfg, attrs)
+		return true, extractManagerLoopAttrs(cfg, attrs)
 	default:
 		return false, nil
 	}
@@ -453,7 +465,7 @@ func extractSubgraphAttrs(cfg ir.SubgraphConfig, attrs map[string]string) {
 // tracker defaults. If/when the handler grows those modes this extractor is
 // the right place to translate the zero-value IR sentinels into the
 // corresponding handler attrs.
-func extractManagerLoopAttrs(cfg ir.ManagerLoopConfig, attrs map[string]string) {
+func extractManagerLoopAttrs(cfg ir.ManagerLoopConfig, attrs map[string]string) error {
 	if cfg.SubgraphRef != "" {
 		attrs["subgraph_ref"] = cfg.SubgraphRef
 	}
@@ -469,9 +481,14 @@ func extractManagerLoopAttrs(cfg ir.ManagerLoopConfig, attrs map[string]string) 
 	if s := managerLoopConditionText(cfg.SteerCondition); s != "" {
 		attrs["steer_condition"] = s
 	}
-	if s := flattenSteerContext(cfg.SteerContext); s != "" {
+	s, err := flattenSteerContext(cfg.SteerContext)
+	if err != nil {
+		return err
+	}
+	if s != "" {
 		attrs["steer_context"] = s
 	}
+	return nil
 }
 
 // managerLoopConditionText extracts the best textual form of a condition:
@@ -520,17 +537,31 @@ func encodeSteerContextToken(s string) string {
 // characters (',', '=', '%') in keys and values are percent-encoded so the
 // round-trip through DOT → migrate stays lossless.
 //
-// Mirrors dippin-lang v0.22.0 export.flattenSteerContext exactly.
-func flattenSteerContext(m map[string]string) string {
+// Fails loudly when any key contains ':' — the dippin-lang v0.22.0 block-form
+// formatter writes steer_context entries as "key: value" lines, so a colon in
+// the key breaks the .dip→IR→.dip round-trip. The upstream parser silently
+// drops such keys with a diagnostic; we reject at graph-build time instead so
+// the author sees a clear, load-bearing error rather than a pipeline that
+// quietly lost a steering key. The three reserved delimiter chars (',', '=',
+// '%') are percent-encoded rather than rejected because the encoder can
+// round-trip them losslessly.
+//
+// Mirrors dippin-lang v0.22.0 export.flattenSteerContext for the happy path.
+func flattenSteerContext(m map[string]string) (string, error) {
 	if len(m) == 0 {
-		return ""
+		return "", nil
 	}
 	keys := slices.Sorted(maps.Keys(m))
+	for _, k := range keys {
+		if strings.Contains(k, ":") {
+			return "", fmt.Errorf("%w: %q", ErrInvalidSteerContextKey, k)
+		}
+	}
 	parts := make([]string, 0, len(keys))
 	for _, k := range keys {
 		parts = append(parts, encodeSteerContextToken(k)+"="+encodeSteerContextToken(m[k]))
 	}
-	return strings.Join(parts, ",")
+	return strings.Join(parts, ","), nil
 }
 
 // formatManagerLoopCondition re-serializes an ir.ConditionExpr back into its
@@ -689,10 +720,15 @@ func convertEdge(irEdge *ir.Edge) *Edge {
 		Attrs: make(map[string]string),
 	}
 
-	// Serialize condition if present
-	if irEdge.Condition != nil {
-		gEdge.Condition = irEdge.Condition.Raw
-		gEdge.Attrs["condition"] = irEdge.Condition.Raw
+	// Serialize condition if present. We prefer Raw (set by the parser) and
+	// fall back to formatting Parsed on the fly — the same Raw-then-Parsed
+	// preference as managerLoopConditionText so an ir.Edge with only
+	// .Parsed populated (e.g. constructed by tests or simulate without
+	// running the parser) still produces a conditional edge rather than a
+	// silent unconditional one.
+	if cond := managerLoopConditionText(irEdge.Condition); cond != "" {
+		gEdge.Condition = cond
+		gEdge.Attrs["condition"] = cond
 	}
 
 	// Preserve weight

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -25,9 +25,13 @@ var (
 	// ir.Condition formats to an expression containing parentheses. The pipeline
 	// edge evaluator (pipeline/condition.go) does not support parens — it tokenizes
 	// on plain strings.Split("||") and strings.Split("&&"), so `a || (b && c)`
-	// would become tokens `(b` and `c)` which are invalid variable names at
-	// runtime. Authors should populate Condition.Raw with a flat form (e.g.
-	// `a=1 || b=2 || c=3`) or simplify the Parsed tree so no parens are emitted.
+	// would become tokens like `(b` and `c)`. In EvaluateCondition, those are not
+	// hard runtime errors: they are treated as unknown variable names, a warning is
+	// logged, and they evaluate as empty strings, which can silently produce false
+	// or otherwise incorrect results. The adapter rejects these expressions up
+	// front to avoid that mis-evaluation. Authors should populate Condition.Raw
+	// with a flat form (e.g. `a=1 || b=2 || c=3`) or simplify the Parsed tree so
+	// no parens are emitted.
 	ErrParenthesizedParsedCondition = errors.New("formatted Parsed condition uses parentheses, which the pipeline edge evaluator does not support")
 )
 

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -21,6 +21,14 @@ var (
 	ErrUnknownConfig          = errors.New("unknown config type")
 	ErrInvalidSteerContextKey = errors.New("steer_context key contains ':' which breaks block-form round-trip through the .dip formatter")
 	ErrMissingManagerLoopCfg  = errors.New("manager_loop node is missing required ir.ManagerLoopConfig")
+	// ErrParenthesizedParsedCondition is returned by convertEdge when a Parsed-only
+	// ir.Condition formats to an expression containing parentheses. The pipeline
+	// edge evaluator (pipeline/condition.go) does not support parens — it tokenizes
+	// on plain strings.Split("||") and strings.Split("&&"), so `a || (b && c)`
+	// would become tokens `(b` and `c)` which are invalid variable names at
+	// runtime. Authors should populate Condition.Raw with a flat form (e.g.
+	// `a=1 || b=2 || c=3`) or simplify the Parsed tree so no parens are emitted.
+	ErrParenthesizedParsedCondition = errors.New("formatted Parsed condition uses parentheses, which the pipeline edge evaluator does not support")
 )
 
 // FromDippinIR converts a Dippin IR Workflow to a Tracker Graph.
@@ -55,7 +63,9 @@ func FromDippinIR(workflow *ir.Workflow) (*Graph, error) {
 	if err := addIRNodes(g, workflow.Nodes); err != nil {
 		return nil, err
 	}
-	addIREdges(g, workflow.Edges)
+	if err := addIREdges(g, workflow.Edges); err != nil {
+		return nil, err
+	}
 
 	// Synthesize implicit edges from parallel fan-out targets and fan-in sources.
 	synthesizeImplicitEdges(g, workflow)
@@ -105,13 +115,21 @@ func addIRNodes(g *Graph, irNodes []*ir.Node) error {
 }
 
 // addIREdges converts IR edges and adds them to the graph.
-func addIREdges(g *Graph, irEdges []*ir.Edge) {
+// Propagates convertEdge errors (e.g. ErrParenthesizedParsedCondition) so
+// adapter-time rejection surfaces to the caller rather than silently losing
+// or mis-evaluating the edge at runtime.
+func addIREdges(g *Graph, irEdges []*ir.Edge) error {
 	for _, irEdge := range irEdges {
 		if irEdge == nil {
 			continue
 		}
-		g.AddEdge(convertEdge(irEdge))
+		gEdge, err := convertEdge(irEdge)
+		if err != nil {
+			return err
+		}
+		g.AddEdge(gEdge)
 	}
+	return nil
 }
 
 // nodeKindToShapeMap maps IR NodeKind to DOT shape strings.
@@ -149,8 +167,11 @@ func convertNode(irNode *ir.Node) (*Node, error) {
 	// time as a vague runtime error. Fail loudly at build time instead.
 	// Scoped to manager_loop for now — we may extend the same guard to other
 	// kinds as follow-ups if they exhibit the same silent-degrade pattern.
+	//
+	// Return the sentinel bare — addIRNodes wraps all convertNode errors with
+	// `node <id>: ...`, so wrapping here too would produce `node mgr: node mgr: ...`.
 	if irNode.Kind == ir.NodeManagerLoop && irNode.Config == nil {
-		return nil, fmt.Errorf("node %s: %w", irNode.ID, ErrMissingManagerLoopCfg)
+		return nil, ErrMissingManagerLoopCfg
 	}
 
 	gNode := &Node{
@@ -712,7 +733,15 @@ func setIfNonEmpty(attrs map[string]string, key, value string) {
 
 // convertEdge transforms an IR Edge to a Graph Edge.
 // Serializes the parsed Condition back to a raw string for the tracker engine.
-func convertEdge(irEdge *ir.Edge) *Edge {
+//
+// Returns ErrParenthesizedParsedCondition when the condition only has .Parsed
+// populated and the formatted text contains parentheses. The pipeline edge
+// evaluator has no paren support — a mixed-precedence Parsed tree like
+// `a=1 || (b=2 && c=3)` would tokenize to garbage (`(b`, `c)`) at runtime.
+// Flat all-AND / all-OR Parsed trees are still accepted because they don't
+// require parens. Authors hitting this should populate Condition.Raw (the
+// parser does this natively) or simplify the Parsed tree.
+func convertEdge(irEdge *ir.Edge) (*Edge, error) {
 	gEdge := &Edge{
 		From:  irEdge.From,
 		To:    irEdge.To,
@@ -727,6 +756,16 @@ func convertEdge(irEdge *ir.Edge) *Edge {
 	// running the parser) still produces a conditional edge rather than a
 	// silent unconditional one.
 	if cond := managerLoopConditionText(irEdge.Condition); cond != "" {
+		// Parsed fallback without Raw may emit parens for mixed-precedence
+		// expressions. The edge evaluator can't parse those — reject at
+		// adapter time with a clear, actionable error rather than let a
+		// garbage token like `(b` fail at runtime. Raw-sourced conditions
+		// are trusted as-is (authors wrote them, and the evaluator is the
+		// same one the parser targets).
+		if irEdge.Condition != nil && irEdge.Condition.Raw == "" && strings.ContainsAny(cond, "()") {
+			return nil, fmt.Errorf("edge %s -> %s: %w: formatted as %q; populate Condition.Raw with a flat form (e.g. 'a=1 || b=2 || c=3') or simplify the Parsed tree",
+				irEdge.From, irEdge.To, ErrParenthesizedParsedCondition, cond)
+		}
 		gEdge.Condition = cond
 		gEdge.Attrs["condition"] = cond
 	}
@@ -741,7 +780,7 @@ func convertEdge(irEdge *ir.Edge) *Edge {
 		gEdge.Attrs["restart"] = "true"
 	}
 
-	return gEdge
+	return gEdge, nil
 }
 
 // serializeStylesheet converts IR stylesheet rules to the CSS-like format

--- a/pipeline/dippin_adapter_manager_loop_test.go
+++ b/pipeline/dippin_adapter_manager_loop_test.go
@@ -3,12 +3,15 @@
 package pipeline
 
 import (
+	"errors"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
 )
 
 // TestFromDippinIR_ManagerLoopFlatAttrs verifies that all six ManagerLoopConfig
@@ -302,7 +305,10 @@ func TestFlattenSteerContext_Deterministic(t *testing.T) {
 		"a": "first",
 		"m": "middle",
 	}
-	got := flattenSteerContext(m)
+	got, err := flattenSteerContext(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "a=first,m=middle,z=last"
 	if got != want {
 		t.Errorf("flattenSteerContext = %q, want %q", got, want)
@@ -312,34 +318,47 @@ func TestFlattenSteerContext_Deterministic(t *testing.T) {
 // TestFlattenSteerContext_EmptyMap documents the empty-map convention:
 // empty input → empty string so callers can suppress the attr entirely.
 func TestFlattenSteerContext_EmptyMap(t *testing.T) {
-	if got := flattenSteerContext(nil); got != "" {
+	got, err := flattenSteerContext(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
 		t.Errorf("flattenSteerContext(nil) = %q, want empty", got)
 	}
-	if got := flattenSteerContext(map[string]string{}); got != "" {
+	got, err = flattenSteerContext(map[string]string{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
 		t.Errorf("flattenSteerContext({}) = %q, want empty", got)
 	}
 }
 
 // TestFlattenSteerContext_EncodesReservedInKeysAndValues verifies both keys
-// and values get the three reserved chars escaped. Percent must go first so
-// it isn't double-encoded by the subsequent "," / "=" replacements.
+// and values get the three reserved chars escaped. The three delimiter chars
+// (',', '=', '%') are round-trippable via percent-encoding — only ':' is
+// rejected outright (see TestFlattenSteerContext_RejectsColonInKey).
+//
+// flattenSteerContext sorts the raw map keys before encoding, so the output
+// order reflects raw-key lexicographic order, not encoded-key order.
 func TestFlattenSteerContext_EncodesReservedInKeysAndValues(t *testing.T) {
 	// Key 'k,1' must encode to 'k%2C1'; value '50%off' to '50%25off';
 	// another key with '=' to '...%3D...'. flattenSteerContext sorts the
-	// raw map keys before encoding (slices.Sorted(maps.Keys(m))), so the
-	// output order reflects raw-key lexicographic order, not encoded-key
-	// order — this fixture's inputs happen to sort identically either way
-	// so the test exercises escaping, not ordering policy. If you add a
-	// case where raw and encoded order differ (e.g., '+' vs ','), update
-	// the expected output to match the raw-key sort.
+	// raw (unencoded) map keys before encoding them for emission — so
+	// this fixture's inputs sort as "k,1" < "k=2" < "percent" regardless
+	// of how the encoded form would sort. If you add a case where raw and
+	// encoded order differ (e.g., '+' vs ','), update the expected output
+	// to match the raw-key sort.
 	m := map[string]string{
 		"k,1":     "v1",
 		"k=2":     "v2",
 		"percent": "50%off",
 	}
-	got := flattenSteerContext(m)
-	// Raw keys sort as: "k,1" < "k=2" < "percent" (same order as encoded
-	// keys for this specific fixture).
+	got, err := flattenSteerContext(m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Raw keys sort as: "k,1" < "k=2" < "percent".
 	want := "k%2C1=v1,k%3D2=v2,percent=50%25off"
 	if got != want {
 		t.Errorf("flattenSteerContext = %q, want %q", got, want)
@@ -432,6 +451,263 @@ func TestFormatManagerLoopCondition_EvaluatorCompatibility(t *testing.T) {
 				t.Errorf("EvaluateCondition(%q) = %v, want %v", formatted, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestFromDippinIR_ManagerLoop_CondOrNotFormatting locks in the exact textual
+// form emitted by formatManagerLoopConditionExpr for ir.CondOr and ir.CondNot.
+// The sibling EvaluatorCompatibility test covers semantic round-trip, but this
+// one asserts the literal attr string on graph.Attrs so a typo in the `||` /
+// `not ` emitters (or a regression back to English `or` / `!`) fails a byte
+// comparison instead of slipping past a semantic-only check.
+func TestFromDippinIR_ManagerLoop_CondOrNotFormatting(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "MgrLoopOrNot",
+		Start: "start",
+		Exit:  "exit",
+		Nodes: []*ir.Node{
+			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{
+				ID:   "mgr",
+				Kind: ir.NodeManagerLoop,
+				Config: ir.ManagerLoopConfig{
+					SubgraphRef: "./child.dip",
+					// CondOr of two compare clauses.
+					StopCondition: &ir.Condition{
+						Parsed: ir.CondOr{
+							Left:  ir.CondCompare{Variable: "ctx.outcome", Op: "=", Value: "success"},
+							Right: ir.CondCompare{Variable: "ctx.status", Op: "=", Value: "done"},
+						},
+					},
+					// CondNot wrapping a compare clause.
+					SteerCondition: &ir.Condition{
+						Parsed: ir.CondNot{
+							Inner: ir.CondCompare{Variable: "ctx.outcome", Op: "=", Value: "success"},
+						},
+					},
+				},
+			},
+			{ID: "exit", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{
+			{From: "start", To: "mgr"},
+			{From: "mgr", To: "exit"},
+		},
+	}
+
+	g, err := FromDippinIR(workflow)
+	if err != nil {
+		t.Fatalf("FromDippinIR failed: %v", err)
+	}
+	node := g.Nodes["mgr"]
+
+	// Exact textual match — a typo in `||` (e.g. `|` or English `or`) fails here.
+	if got, want := node.Attrs["stop_condition"], "outcome = success || status = done"; got != want {
+		t.Errorf("stop_condition = %q, want %q", got, want)
+	}
+	// Exact textual match — a typo in `not ` (e.g. `!` or English `!=`) fails here.
+	if got, want := node.Attrs["steer_condition"], "not outcome = success"; got != want {
+		t.Errorf("steer_condition = %q, want %q", got, want)
+	}
+}
+
+// TestFromDippinIR_ManagerLoop_RawBeatsParsed pins managerLoopConditionText's
+// preference: when both Raw and Parsed are populated on the same Condition,
+// Raw wins. This mirrors dippin-lang v0.22.0 export.dotManagerLoopConditionText
+// and is load-bearing — Raw preserves author intent (including whitespace and
+// token choice) that the formatter would normalize away.
+func TestFromDippinIR_ManagerLoop_RawBeatsParsed(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "MgrLoopRawBeatsParsed",
+		Start: "start",
+		Exit:  "exit",
+		Nodes: []*ir.Node{
+			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{
+				ID:   "mgr",
+				Kind: ir.NodeManagerLoop,
+				Config: ir.ManagerLoopConfig{
+					SubgraphRef: "./child.dip",
+					StopCondition: &ir.Condition{
+						// Distinctive Raw text the formatter would NOT produce.
+						Raw:    "stack.child.cycles = 7",
+						Parsed: ir.CondCompare{Variable: "ctx.other", Op: "=", Value: "something"},
+					},
+					SteerCondition: &ir.Condition{
+						// Another distinctive Raw string.
+						Raw:    "stack.child.status = running",
+						Parsed: ir.CondCompare{Variable: "ctx.different", Op: "=", Value: "nope"},
+					},
+				},
+			},
+			{ID: "exit", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{
+			{From: "start", To: "mgr"},
+			{From: "mgr", To: "exit"},
+		},
+	}
+
+	g, err := FromDippinIR(workflow)
+	if err != nil {
+		t.Fatalf("FromDippinIR failed: %v", err)
+	}
+	node := g.Nodes["mgr"]
+
+	if got, want := node.Attrs["stop_condition"], "stack.child.cycles = 7"; got != want {
+		t.Errorf("stop_condition = %q, want %q (Raw must beat Parsed)", got, want)
+	}
+	if got, want := node.Attrs["steer_condition"], "stack.child.status = running"; got != want {
+		t.Errorf("steer_condition = %q, want %q (Raw must beat Parsed)", got, want)
+	}
+}
+
+// TestFromDippinIR_ManagerLoop_RejectsColonInSteerContextKey asserts that a
+// colon in a steer_context key is rejected at graph-build time (issue #171).
+// The dippin-lang v0.22.0 block-form formatter writes steer_context entries
+// as "key: value" lines, so a colon in the key breaks .dip→IR→.dip round-trip;
+// we fail loudly here instead of letting the bad key flow through silently.
+func TestFromDippinIR_ManagerLoop_RejectsColonInSteerContextKey(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "MgrLoopBadKey",
+		Start: "start",
+		Exit:  "exit",
+		Nodes: []*ir.Node{
+			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{
+				ID:   "mgr",
+				Kind: ir.NodeManagerLoop,
+				Config: ir.ManagerLoopConfig{
+					SubgraphRef:    "./child.dip",
+					SteerCondition: &ir.Condition{Raw: "stack.child.cycles = 1"},
+					SteerContext: map[string]string{
+						// Valid neighbor to prove rejection is per-key, not all-or-nothing.
+						"ok":      "value",
+						"bad:key": "value",
+					},
+				},
+			},
+			{ID: "exit", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{
+			{From: "start", To: "mgr"},
+			{From: "mgr", To: "exit"},
+		},
+	}
+
+	_, err := FromDippinIR(workflow)
+	if err == nil {
+		t.Fatal("expected error for steer_context key containing ':', got nil")
+	}
+	if !errors.Is(err, ErrInvalidSteerContextKey) {
+		t.Errorf("error = %v, want wrapping ErrInvalidSteerContextKey", err)
+	}
+	if !strings.Contains(err.Error(), "bad:key") {
+		t.Errorf("error = %v, want message to include the offending key %q", err, "bad:key")
+	}
+}
+
+// TestFromDippinIR_ManagerLoop_NilConfigRejected asserts that a manager_loop
+// node with a nil Config is rejected at graph-build time (issue #174). Without
+// this guard the adapter would silently produce a node with no subgraph_ref,
+// and the error would surface much later at Execute time with a vague
+// "missing subgraph_ref" message from the handler.
+func TestFromDippinIR_ManagerLoop_NilConfigRejected(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "MgrLoopNilConfig",
+		Start: "start",
+		Exit:  "exit",
+		Nodes: []*ir.Node{
+			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			// Manager-loop node with Config intentionally unset.
+			{ID: "mgr", Kind: ir.NodeManagerLoop, Config: nil},
+			{ID: "exit", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{
+			{From: "start", To: "mgr"},
+			{From: "mgr", To: "exit"},
+		},
+	}
+
+	_, err := FromDippinIR(workflow)
+	if err == nil {
+		t.Fatal("expected error for manager_loop node with nil Config, got nil")
+	}
+	if !errors.Is(err, ErrMissingManagerLoopCfg) {
+		t.Errorf("error = %v, want wrapping ErrMissingManagerLoopCfg", err)
+	}
+	if !strings.Contains(err.Error(), "mgr") {
+		t.Errorf("error = %v, want message to include the node ID", err)
+	}
+}
+
+// TestConvertEdge_ParsedFallback covers the symmetric Raw-then-Parsed
+// preference added to convertEdge (issue #176.6). An ir.Edge carrying only a
+// Parsed condition (no Raw) must still produce a conditional edge. Before the
+// fix, convertEdge read only Raw and silently produced an unconditional edge.
+func TestConvertEdge_ParsedFallback(t *testing.T) {
+	edge := &ir.Edge{
+		From: "a",
+		To:   "b",
+		Condition: &ir.Condition{
+			Parsed: ir.CondCompare{Variable: "ctx.outcome", Op: "=", Value: "success"},
+		},
+	}
+	got := convertEdge(edge)
+	if got.Condition == "" {
+		t.Fatal("convertEdge dropped Parsed-only condition — expected formatted condition text on the edge")
+	}
+	if want := "outcome = success"; got.Condition != want {
+		t.Errorf("edge.Condition = %q, want %q", got.Condition, want)
+	}
+	if got.Attrs["condition"] != got.Condition {
+		t.Errorf("edge.Attrs[condition] = %q, want %q (must mirror Condition)", got.Attrs["condition"], got.Condition)
+	}
+}
+
+// TestDippinAdapter_E2E_ManagerLoop loads a real .dip fixture through the
+// dippin-lang parser, verifying the 6 flat manager_loop attrs land correctly
+// on the produced graph node. This pins the end-to-end path — parser emits
+// ir.ManagerLoopConfig, adapter flattens to graph attrs — so a change on
+// either side fails here rather than in a downstream runtime.
+func TestDippinAdapter_E2E_ManagerLoop(t *testing.T) {
+	source, err := os.ReadFile("testdata/manager_loop.dip")
+	if err != nil {
+		t.Fatalf("failed to read testdata/manager_loop.dip: %v", err)
+	}
+	p := parser.NewParser(string(source), "testdata/manager_loop.dip")
+	workflow, err := p.Parse()
+	if err != nil {
+		t.Fatalf("parser.Parse() failed: %v", err)
+	}
+	graph, err := FromDippinIR(workflow)
+	if err != nil {
+		t.Fatalf("FromDippinIR() failed: %v", err)
+	}
+
+	node := graph.Nodes["Supervise"]
+	if node == nil {
+		t.Fatal("Supervise node missing from graph")
+	}
+	if node.Handler != "stack.manager_loop" {
+		t.Errorf("Supervise.Handler = %q, want %q", node.Handler, "stack.manager_loop")
+	}
+
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"subgraph_ref", "child.dip"},
+		{"poll_interval", "15s"},
+		{"max_cycles", "20"},
+		{"stop_condition", "stack.child.outcome = success"},
+		{"steer_condition", "stack.child.cycles = 5"},
+		{"steer_context", "hint=halfway_through,priority=high"},
+	}
+	for _, tc := range cases {
+		if got := node.Attrs[tc.key]; got != tc.want {
+			t.Errorf("Supervise.Attrs[%q] = %q, want %q", tc.key, got, tc.want)
+		}
 	}
 }
 

--- a/pipeline/dippin_adapter_manager_loop_test.go
+++ b/pipeline/dippin_adapter_manager_loop_test.go
@@ -697,8 +697,10 @@ func TestConvertEdge_ParsedFallback_FlatAndOr(t *testing.T) {
 // at adapter time with ErrParenthesizedParsedCondition. The pipeline edge
 // evaluator does not understand parentheses — letting a mixed-precedence
 // expression through would trade a silent "unconditional edge" bug (the
-// pre-#176.6 behavior) for a runtime "invalid variable name (b" bug, which
-// is still silent from the author's point of view.
+// pre-#176.6 behavior) for a different silent failure mode where a token
+// like "(b" is treated as an unknown variable, resolved to "" with a
+// warning, and the clause may then evaluate incorrectly from the author's
+// point of view.
 func TestConvertEdge_ParsedFallback_MixedPrecedenceRejected(t *testing.T) {
 	// a = 1 || (b = 2 && c = 3) — the inner AND has higher precedence than
 	// the outer OR, so formatManagerLoopBinaryOp wraps it in parens.
@@ -728,15 +730,19 @@ func TestConvertEdge_ParsedFallback_MixedPrecedenceRejected(t *testing.T) {
 }
 
 // TestConvertEdge_RawWinsOverParsed_WithParens ensures that a Condition whose
-// Raw is populated is trusted as-is even if the author's Raw happens to contain
-// parens. The paren rejection only targets the Parsed-only fallback path —
-// Raw is authored text, and the evaluator may ignore or reinterpret it.
+// Raw is populated is trusted as-is even when Raw itself contains parens. The
+// paren rejection only targets the Parsed-only fallback path — Raw is authored
+// text that the adapter passes through verbatim (the pipeline evaluator will
+// handle or ignore it on its own). Using a Raw value that actually contains
+// parentheses makes this test's guarantee match its name; a paren-free Raw
+// would prove nothing beyond "Raw wins over Parsed".
 func TestConvertEdge_RawWinsOverParsed_WithParens(t *testing.T) {
+	const rawWithParens = "(ctx.a = 1 || ctx.b = 2) && ctx.c = 3"
 	edge := &ir.Edge{
 		From: "src",
 		To:   "dst",
 		Condition: &ir.Condition{
-			Raw: "ctx.outcome = success",
+			Raw: rawWithParens,
 			Parsed: ir.CondOr{
 				Left: ir.CondCompare{Variable: "ctx.a", Op: "=", Value: "1"},
 				Right: ir.CondAnd{
@@ -750,8 +756,8 @@ func TestConvertEdge_RawWinsOverParsed_WithParens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("convertEdge returned unexpected error for Raw-populated edge: %v", err)
 	}
-	if got.Condition != "ctx.outcome = success" {
-		t.Errorf("edge.Condition = %q, want Raw value %q", got.Condition, "ctx.outcome = success")
+	if got.Condition != rawWithParens {
+		t.Errorf("edge.Condition = %q, want Raw value %q (verbatim passthrough)", got.Condition, rawWithParens)
 	}
 }
 

--- a/pipeline/dippin_adapter_manager_loop_test.go
+++ b/pipeline/dippin_adapter_manager_loop_test.go
@@ -720,7 +720,7 @@ func decodeFlatSteerContextForTest(s string) map[string]string {
 		return out
 	}
 	decoder := strings.NewReplacer("%25", "%", "%2C", ",", "%3D", "=")
-	for _, pair := range strings.Split(s, ",") {
+	for pair := range strings.SplitSeq(s, ",") {
 		kv := strings.SplitN(strings.TrimSpace(pair), "=", 2)
 		if len(kv) != 2 {
 			continue

--- a/pipeline/dippin_adapter_manager_loop_test.go
+++ b/pipeline/dippin_adapter_manager_loop_test.go
@@ -337,7 +337,7 @@ func TestFlattenSteerContext_EmptyMap(t *testing.T) {
 // TestFlattenSteerContext_EncodesReservedInKeysAndValues verifies both keys
 // and values get the three reserved chars escaped. The three delimiter chars
 // (',', '=', '%') are round-trippable via percent-encoding — only ':' is
-// rejected outright (see TestFlattenSteerContext_RejectsColonInKey).
+// rejected outright (see TestFromDippinIR_ManagerLoop_RejectsColonInSteerContextKey).
 //
 // flattenSteerContext sorts the raw map keys before encoding, so the output
 // order reflects raw-key lexicographic order, not encoded-key order.
@@ -653,7 +653,10 @@ func TestConvertEdge_ParsedFallback(t *testing.T) {
 			Parsed: ir.CondCompare{Variable: "ctx.outcome", Op: "=", Value: "success"},
 		},
 	}
-	got := convertEdge(edge)
+	got, err := convertEdge(edge)
+	if err != nil {
+		t.Fatalf("convertEdge returned error: %v", err)
+	}
 	if got.Condition == "" {
 		t.Fatal("convertEdge dropped Parsed-only condition — expected formatted condition text on the edge")
 	}
@@ -662,6 +665,93 @@ func TestConvertEdge_ParsedFallback(t *testing.T) {
 	}
 	if got.Attrs["condition"] != got.Condition {
 		t.Errorf("edge.Attrs[condition] = %q, want %q (must mirror Condition)", got.Attrs["condition"], got.Condition)
+	}
+}
+
+// TestConvertEdge_ParsedFallback_FlatAndOr verifies that a Parsed-only edge
+// with a flat all-AND (or all-OR) tree formats without parens and is accepted
+// as a conditional edge. This is the happy path the evaluator handles fine.
+func TestConvertEdge_ParsedFallback_FlatAndOr(t *testing.T) {
+	// a = 1 && b = 2 — no parens emitted at top level.
+	edge := &ir.Edge{
+		From: "src",
+		To:   "dst",
+		Condition: &ir.Condition{
+			Parsed: ir.CondAnd{
+				Left:  ir.CondCompare{Variable: "ctx.a", Op: "=", Value: "1"},
+				Right: ir.CondCompare{Variable: "ctx.b", Op: "=", Value: "2"},
+			},
+		},
+	}
+	got, err := convertEdge(edge)
+	if err != nil {
+		t.Fatalf("convertEdge returned unexpected error: %v", err)
+	}
+	if want := "a = 1 && b = 2"; got.Condition != want {
+		t.Errorf("edge.Condition = %q, want %q", got.Condition, want)
+	}
+}
+
+// TestConvertEdge_ParsedFallback_MixedPrecedenceRejected asserts that a
+// Parsed-only edge formatting to a paren-containing expression is rejected
+// at adapter time with ErrParenthesizedParsedCondition. The pipeline edge
+// evaluator does not understand parentheses — letting a mixed-precedence
+// expression through would trade a silent "unconditional edge" bug (the
+// pre-#176.6 behavior) for a runtime "invalid variable name (b" bug, which
+// is still silent from the author's point of view.
+func TestConvertEdge_ParsedFallback_MixedPrecedenceRejected(t *testing.T) {
+	// a = 1 || (b = 2 && c = 3) — the inner AND has higher precedence than
+	// the outer OR, so formatManagerLoopBinaryOp wraps it in parens.
+	edge := &ir.Edge{
+		From: "src",
+		To:   "dst",
+		Condition: &ir.Condition{
+			Parsed: ir.CondOr{
+				Left: ir.CondCompare{Variable: "ctx.a", Op: "=", Value: "1"},
+				Right: ir.CondAnd{
+					Left:  ir.CondCompare{Variable: "ctx.b", Op: "=", Value: "2"},
+					Right: ir.CondCompare{Variable: "ctx.c", Op: "=", Value: "3"},
+				},
+			},
+		},
+	}
+	_, err := convertEdge(edge)
+	if err == nil {
+		t.Fatal("expected error for paren-containing Parsed fallback, got nil")
+	}
+	if !errors.Is(err, ErrParenthesizedParsedCondition) {
+		t.Errorf("error = %v, want wrapping ErrParenthesizedParsedCondition", err)
+	}
+	if !strings.Contains(err.Error(), "src -> dst") {
+		t.Errorf("error = %v, want message to include the edge endpoints", err)
+	}
+}
+
+// TestConvertEdge_RawWinsOverParsed_WithParens ensures that a Condition whose
+// Raw is populated is trusted as-is even if the author's Raw happens to contain
+// parens. The paren rejection only targets the Parsed-only fallback path —
+// Raw is authored text, and the evaluator may ignore or reinterpret it.
+func TestConvertEdge_RawWinsOverParsed_WithParens(t *testing.T) {
+	edge := &ir.Edge{
+		From: "src",
+		To:   "dst",
+		Condition: &ir.Condition{
+			Raw: "ctx.outcome = success",
+			Parsed: ir.CondOr{
+				Left: ir.CondCompare{Variable: "ctx.a", Op: "=", Value: "1"},
+				Right: ir.CondAnd{
+					Left:  ir.CondCompare{Variable: "ctx.b", Op: "=", Value: "2"},
+					Right: ir.CondCompare{Variable: "ctx.c", Op: "=", Value: "3"},
+				},
+			},
+		},
+	}
+	got, err := convertEdge(edge)
+	if err != nil {
+		t.Fatalf("convertEdge returned unexpected error for Raw-populated edge: %v", err)
+	}
+	if got.Condition != "ctx.outcome = success" {
+		t.Errorf("edge.Condition = %q, want Raw value %q", got.Condition, "ctx.outcome = success")
 	}
 }
 
@@ -700,7 +790,7 @@ func TestDippinAdapter_E2E_ManagerLoop(t *testing.T) {
 		{"subgraph_ref", "child.dip"},
 		{"poll_interval", "15s"},
 		{"max_cycles", "20"},
-		{"stop_condition", "stack.child.outcome = success"},
+		{"stop_condition", "stack.child.status = success"},
 		{"steer_condition", "stack.child.cycles = 5"},
 		{"steer_context", "hint=halfway_through,priority=high"},
 	}

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -1507,7 +1507,10 @@ func TestExtractToolAttrs_ZeroValueFieldsOmitted(t *testing.T) {
 
 func TestConvertEdge_WeightAndRestart(t *testing.T) {
 	irEdge := &ir.Edge{From: "a", To: "b", Weight: 5, Restart: true}
-	gEdge := convertEdge(irEdge)
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge returned error: %v", err)
+	}
 	if gEdge.Attrs["weight"] != "5" {
 		t.Errorf("weight = %q, want %q", gEdge.Attrs["weight"], "5")
 	}
@@ -1518,7 +1521,10 @@ func TestConvertEdge_WeightAndRestart(t *testing.T) {
 
 func TestConvertEdge_ZeroWeightOmitted(t *testing.T) {
 	irEdge := &ir.Edge{From: "a", To: "b"}
-	gEdge := convertEdge(irEdge)
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge returned error: %v", err)
+	}
 	if _, ok := gEdge.Attrs["weight"]; ok {
 		t.Error("zero weight should not be in attrs")
 	}

--- a/pipeline/handlers/manager_loop.go
+++ b/pipeline/handlers/manager_loop.go
@@ -80,7 +80,7 @@ type managerLoopConfig struct {
 // present the unprefixed form wins — it is the authoritative contract going
 // forward, so a migrated pipeline with leftover `manager.*` attrs still gets
 // the new values.
-func parseManagerLoopConfig(attrs map[string]string) (managerLoopConfig, error) {
+func parseManagerLoopConfig(nodeID string, attrs map[string]string) (managerLoopConfig, error) {
 	cfg := managerLoopConfig{
 		pollInterval: 45 * time.Second,
 		maxCycles:    1000,
@@ -115,8 +115,8 @@ func parseManagerLoopConfig(attrs map[string]string) (managerLoopConfig, error) 
 
 	cfg.stopCondition = managerAttr(attrs, "stop_condition")
 	cfg.steerExpr = managerAttr(attrs, "steer_condition")
-	warnUnknownStackChildKeys("stop_condition", cfg.stopCondition)
-	warnUnknownStackChildKeys("steer_condition", cfg.steerExpr)
+	warnUnknownStackChildKeys(nodeID, "stop_condition", cfg.stopCondition)
+	warnUnknownStackChildKeys(nodeID, "steer_condition", cfg.steerExpr)
 	rawSteerContext := managerAttr(attrs, "steer_context")
 	cfg.steerKeys = parseSteerContext(rawSteerContext)
 
@@ -164,17 +164,13 @@ var stackChildObservables = map[string]struct{}{
 	"stack.child.exit_status": {},
 }
 
-// extractStackChildKeys identifies `stack.child.<word>` occurrences in a
-// condition expression. It is intentionally forgiving for the tail so we catch
-// typos like `stack.child.cylce` or `stack.child.stats`. Deliberately does NOT
-// match deeper keys (e.g. `stack.child.foo.bar`) — those are outside the
-// narrow scope of this warning.
-
 // warnUnknownStackChildKeys scans expr for `stack.child.<word>` references and
-// logs one diagnostic per unknown subkey. Safe for empty/unset expressions
-// (early return on empty input). Called from parseManagerLoopConfig so the
-// warning fires once at graph-build / handler-parse time, not on every cycle.
-func warnUnknownStackChildKeys(attrName, expr string) {
+// logs one diagnostic per unknown subkey, tagged with the owning node's ID so
+// authors can locate the offending attr in a larger graph. Safe for
+// empty/unset expressions (early return on empty input). Called from
+// parseManagerLoopConfig so the warning fires once at graph-build /
+// handler-parse time, not on every cycle.
+func warnUnknownStackChildKeys(nodeID, attrName, expr string) {
 	if expr == "" {
 		return
 	}
@@ -187,8 +183,8 @@ func warnUnknownStackChildKeys(attrName, expr string) {
 			continue
 		}
 		seen[key] = struct{}{}
-		log.Printf("[manager_loop] warning: %s references %q which is not a known observable; known keys: stack.child.status, stack.child.cycles, stack.child.exit_status",
-			attrName, key)
+		log.Printf("[manager_loop] warning: node %q %s references %q which is not a known observable; known keys: stack.child.status, stack.child.cycles, stack.child.exit_status",
+			nodeID, attrName, key)
 	}
 }
 
@@ -255,8 +251,13 @@ func managerAttr(attrs map[string]string, key string) string {
 	unprefixedVal, unprefixedSet := attrs[key]
 	legacyVal, legacySet := attrs[prefixed]
 	if unprefixedSet && legacySet {
-		log.Printf("[manager_loop] warning: both %q=%q and %q=%q are set; unprefixed wins — delete %q to silence this warning",
-			key, unprefixedVal, prefixed, legacyVal, prefixed)
+		// Log keys only, never values: manager_loop attrs are author-controlled
+		// today, but a future use could carry sensitive material (URLs with
+		// tokens, paths, etc.) and leaking those into logs would be a
+		// regression. Keys are enough to point the author at the offending
+		// attr; the author can inspect the values themselves.
+		log.Printf("[manager_loop] warning: both %q and %q are set; unprefixed wins — delete %q to silence this warning",
+			key, prefixed, prefixed)
 	}
 	if unprefixedSet {
 		return unprefixedVal
@@ -321,7 +322,7 @@ type engineResultMsg struct {
 // Execute runs the manager loop: launches a child pipeline in a goroutine,
 // polls at intervals, and returns when the child completes or limits are hit.
 func (h *ManagerLoopHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *pipeline.PipelineContext) (pipeline.Outcome, error) {
-	cfg, err := parseManagerLoopConfig(node.Attrs)
+	cfg, err := parseManagerLoopConfig(node.ID, node.Attrs)
 	if err != nil {
 		return pipeline.Outcome{Status: pipeline.OutcomeFail}, err
 	}

--- a/pipeline/handlers/manager_loop.go
+++ b/pipeline/handlers/manager_loop.go
@@ -298,7 +298,7 @@ func parseSteerContext(s string) map[string]string {
 		return nil
 	}
 	result := make(map[string]string)
-	for _, pair := range strings.Split(s, ",") {
+	for pair := range strings.SplitSeq(s, ",") {
 		parts := strings.SplitN(strings.TrimSpace(pair), "=", 2)
 		if len(parts) == 2 {
 			k := decodeSteerContextToken(strings.TrimSpace(parts[0]))

--- a/pipeline/handlers/manager_loop.go
+++ b/pipeline/handlers/manager_loop.go
@@ -5,6 +5,7 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 	"time"
@@ -114,6 +115,8 @@ func parseManagerLoopConfig(attrs map[string]string) (managerLoopConfig, error) 
 
 	cfg.stopCondition = managerAttr(attrs, "stop_condition")
 	cfg.steerExpr = managerAttr(attrs, "steer_condition")
+	warnUnknownStackChildKeys("stop_condition", cfg.stopCondition)
+	warnUnknownStackChildKeys("steer_condition", cfg.steerExpr)
 	rawSteerContext := managerAttr(attrs, "steer_context")
 	cfg.steerKeys = parseSteerContext(rawSteerContext)
 
@@ -145,6 +148,93 @@ func parseManagerLoopConfig(attrs map[string]string) (managerLoopConfig, error) 
 	return cfg, nil
 }
 
+// stackChildObservables enumerates the canonical `stack.child.*` context keys
+// written by ManagerLoopHandler.Execute each cycle. Conditions that reference
+// a `stack.child.*` key not in this set are almost certainly a typo —
+// warnUnknownStackChildKeys fires a one-line diagnostic in that case.
+//
+// Intentionally narrow: we only warn on keys under the `stack.child.*`
+// namespace that tracker itself owns. Bare keys (e.g., `outcome`, `status`)
+// are left alone because they are commonly set by the parent pipeline and
+// referenced by conditions — flagging them would false-positive on the happy
+// path. Issue #176.2.
+var stackChildObservables = map[string]struct{}{
+	"stack.child.status":      {},
+	"stack.child.cycles":      {},
+	"stack.child.exit_status": {},
+}
+
+// stackChildKeyPattern matches `stack.child.<word>` occurrences in a condition
+// expression. It is intentionally forgiving (`\w+` for the tail) so we catch
+// typos like `stack.child.cylce` or `stack.child.stats`. Deliberately does NOT
+// match deeper keys (e.g. `stack.child.foo.bar`) — those would need a more
+// involved extractor and are outside the narrow scope of this warning.
+
+// warnUnknownStackChildKeys scans expr for `stack.child.<word>` references and
+// logs one diagnostic per unknown subkey. Safe for empty/unset expressions
+// (early return on empty input). Called from parseManagerLoopConfig so the
+// warning fires once at graph-build / handler-parse time, not on every cycle.
+func warnUnknownStackChildKeys(attrName, expr string) {
+	if expr == "" {
+		return
+	}
+	seen := map[string]struct{}{}
+	for _, key := range extractStackChildKeys(expr) {
+		if _, known := stackChildObservables[key]; known {
+			continue
+		}
+		if _, alreadyWarned := seen[key]; alreadyWarned {
+			continue
+		}
+		seen[key] = struct{}{}
+		log.Printf("[manager_loop] warning: %s references %q which is not a known observable; known keys: stack.child.status, stack.child.cycles, stack.child.exit_status",
+			attrName, key)
+	}
+}
+
+// extractStackChildKeys returns every `stack.child.<word>` token in expr, in
+// source order with duplicates preserved. Pulled out of warnUnknownStackChildKeys
+// so the scanner stays cheap and the caller's conditional policy stays small.
+func extractStackChildKeys(expr string) []string {
+	const marker = "stack.child."
+	var keys []string
+	rest := expr
+	for {
+		idx := strings.Index(rest, marker)
+		if idx < 0 {
+			return keys
+		}
+		tail := rest[idx+len(marker):]
+		end := identifierEnd(tail)
+		if end > 0 {
+			keys = append(keys, marker+tail[:end])
+		}
+		rest = tail[end:]
+	}
+}
+
+// identifierEnd returns the index of the first non-identifier byte in s, i.e.
+// the length of the leading identifier token. Returns 0 when s starts with a
+// non-identifier byte. `strings.IndexFunc` with a single "is NOT identifier"
+// predicate keeps the function under the project complexity budget.
+func identifierEnd(s string) int {
+	i := strings.IndexFunc(s, func(r rune) bool { return !isIdentifierRune(r) })
+	if i < 0 {
+		return len(s)
+	}
+	return i
+}
+
+// isIdentifierRune reports whether r is an ASCII identifier rune
+// (letter, digit, or underscore). Condition identifiers in dippin-lang are
+// ASCII-only, so we do not need Unicode letter support here.
+func isIdentifierRune(r rune) bool {
+	return r == '_' ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9')
+}
+
 // managerAttr looks up a manager_loop attribute, preferring the unprefixed
 // dippin-lang v0.22.0 contract key and falling back to the legacy
 // "manager."+key form so hand-authored DOT files keep working.
@@ -154,11 +244,24 @@ func parseManagerLoopConfig(attrs map[string]string) (managerLoopConfig, error) 
 // Using the zero-value fallthrough (`if v := attrs[key]; v != ""`) would
 // silently defer to the legacy attr even when the author explicitly cleared
 // the new one, violating the "unprefixed wins" contract (issue #173).
+//
+// When both forms are present on the same node a one-line diagnostic is
+// emitted (issue #176.1) so an author who migrated from the legacy form but
+// forgot to delete the old attr learns of the shadowing rather than silently
+// running with the unprefixed value. Log-only — the value returned is still
+// the unprefixed one, keeping the contract intact.
 func managerAttr(attrs map[string]string, key string) string {
-	if v, ok := attrs[key]; ok {
-		return v
+	prefixed := "manager." + key
+	unprefixedVal, unprefixedSet := attrs[key]
+	legacyVal, legacySet := attrs[prefixed]
+	if unprefixedSet && legacySet {
+		log.Printf("[manager_loop] warning: both %q=%q and %q=%q are set; unprefixed wins — delete %q to silence this warning",
+			key, unprefixedVal, prefixed, legacyVal, prefixed)
 	}
-	return attrs["manager."+key]
+	if unprefixedSet {
+		return unprefixedVal
+	}
+	return legacyVal
 }
 
 // steerContextDecoder reverses the encoder in pipeline/dippin_adapter.go

--- a/pipeline/handlers/manager_loop.go
+++ b/pipeline/handlers/manager_loop.go
@@ -164,11 +164,11 @@ var stackChildObservables = map[string]struct{}{
 	"stack.child.exit_status": {},
 }
 
-// stackChildKeyPattern matches `stack.child.<word>` occurrences in a condition
-// expression. It is intentionally forgiving (`\w+` for the tail) so we catch
+// extractStackChildKeys identifies `stack.child.<word>` occurrences in a
+// condition expression. It is intentionally forgiving for the tail so we catch
 // typos like `stack.child.cylce` or `stack.child.stats`. Deliberately does NOT
-// match deeper keys (e.g. `stack.child.foo.bar`) — those would need a more
-// involved extractor and are outside the narrow scope of this warning.
+// match deeper keys (e.g. `stack.child.foo.bar`) — those are outside the
+// narrow scope of this warning.
 
 // warnUnknownStackChildKeys scans expr for `stack.child.<word>` references and
 // logs one diagnostic per unknown subkey. Safe for empty/unset expressions

--- a/pipeline/handlers/manager_loop_test.go
+++ b/pipeline/handlers/manager_loop_test.go
@@ -350,26 +350,65 @@ func TestManagerLoopHandler_EventsEmitted(t *testing.T) {
 		t.Fatal("expected at least one event")
 	}
 
-	// Verify we got a stage_started event for the child launch.
-	var hasStarted, hasCompleted, hasCycleTick bool
+	// Upgrade to ordered slice assertion (issue #176.5): the prior boolean
+	// flags accepted any interleaving, so a regression firing
+	// EventStageCompleted before EventStageStarted or duplicating
+	// EventStageStarted would slip past. Collect the relevant event types in
+	// order and assert exact position / count invariants:
+	//
+	//   1. The first relevant event is EventStageStarted (child launch).
+	//   2. Exactly one EventStageStarted (no duplicate-launch regression).
+	//   3. Exactly one EventStageCompleted (terminal completion event).
+	//   4. EventStageCompleted is the LAST relevant event (no tick/started
+	//      events after completion).
+	//   5. At least one EventManagerCycleTick between started and completed.
+	//
+	// Filter to the MANAGER node's own events (NodeID = "mgr"). The child
+	// engine also emits StageStarted/StageCompleted per inner node and those
+	// are scoped through NodeScopedPipelineHandler but still land on the same
+	// collector — they'd drown out the manager's own lifecycle.
+	var seq []pipeline.PipelineEventType
 	for _, evt := range events {
+		if evt.NodeID != node.ID {
+			continue
+		}
 		switch evt.Type {
-		case pipeline.EventStageStarted:
-			hasStarted = true
-		case pipeline.EventStageCompleted:
-			hasCompleted = true
-		case pipeline.EventManagerCycleTick:
-			hasCycleTick = true
+		case pipeline.EventStageStarted,
+			pipeline.EventManagerCycleTick,
+			pipeline.EventStageCompleted:
+			seq = append(seq, evt.Type)
 		}
 	}
-	if !hasStarted {
-		t.Error("expected EventStageStarted event")
+	if len(seq) < 2 {
+		t.Fatalf("expected at least started+completed events, got %v", seq)
 	}
-	if !hasCompleted {
-		t.Error("expected EventStageCompleted event")
+	if seq[0] != pipeline.EventStageStarted {
+		t.Errorf("expected first relevant event to be EventStageStarted, got %q (full seq: %v)", seq[0], seq)
 	}
-	if !hasCycleTick {
-		t.Error("expected at least one EventManagerCycleTick event")
+	if seq[len(seq)-1] != pipeline.EventStageCompleted {
+		t.Errorf("expected last relevant event to be EventStageCompleted, got %q (full seq: %v)", seq[len(seq)-1], seq)
+	}
+	// Count occurrences — starting or completing more than once would
+	// indicate a handler-level duplication bug.
+	var startedCount, completedCount, tickCount int
+	for _, typ := range seq {
+		switch typ {
+		case pipeline.EventStageStarted:
+			startedCount++
+		case pipeline.EventStageCompleted:
+			completedCount++
+		case pipeline.EventManagerCycleTick:
+			tickCount++
+		}
+	}
+	if startedCount != 1 {
+		t.Errorf("EventStageStarted count = %d, want 1 (full seq: %v)", startedCount, seq)
+	}
+	if completedCount != 1 {
+		t.Errorf("EventStageCompleted count = %d, want 1 (full seq: %v)", completedCount, seq)
+	}
+	if tickCount < 1 {
+		t.Errorf("EventManagerCycleTick count = %d, want >= 1 (full seq: %v)", tickCount, seq)
 	}
 }
 

--- a/pipeline/handlers/manager_loop_test.go
+++ b/pipeline/handlers/manager_loop_test.go
@@ -414,7 +414,7 @@ func TestManagerLoopHandler_EventsEmitted(t *testing.T) {
 
 func TestManagerLoopHandler_DefaultConfig(t *testing.T) {
 	// Verify default parsing when no attrs are specified (except subgraph_ref).
-	cfg, err := parseManagerLoopConfig(map[string]string{
+	cfg, err := parseManagerLoopConfig("Supervise", map[string]string{
 		"subgraph_ref": "test",
 	})
 	if err != nil {
@@ -432,7 +432,7 @@ func TestManagerLoopHandler_DefaultConfig(t *testing.T) {
 }
 
 func TestManagerLoopHandler_CustomConfig(t *testing.T) {
-	cfg, err := parseManagerLoopConfig(map[string]string{
+	cfg, err := parseManagerLoopConfig("Supervise", map[string]string{
 		"subgraph_ref":            "my_child",
 		"manager.poll_interval":   "10s",
 		"manager.max_cycles":      "50",
@@ -730,7 +730,7 @@ func TestParseSteerContext_LiteralPercentEncodedSequenceIsPreserved(t *testing.T
 // the authoritative names; the legacy "manager.*" forms remain for manually
 // authored DOT files.
 func TestParseManagerLoopConfig_UnprefixedAttrs(t *testing.T) {
-	cfg, err := parseManagerLoopConfig(map[string]string{
+	cfg, err := parseManagerLoopConfig("Supervise", map[string]string{
 		"subgraph_ref":    "child",
 		"poll_interval":   "15s",
 		"max_cycles":      "20",
@@ -772,7 +772,7 @@ func TestParseManagerLoopConfig_UnprefixedAttrs(t *testing.T) {
 // swallow errors" rule.
 func TestParseManagerLoopConfig_PartialSteeringRejected(t *testing.T) {
 	t.Run("steer_condition without steer_context", func(t *testing.T) {
-		_, err := parseManagerLoopConfig(map[string]string{
+		_, err := parseManagerLoopConfig("Supervise", map[string]string{
 			"subgraph_ref":    "child",
 			"steer_condition": "stack.child.cycles = 3",
 		})
@@ -785,7 +785,7 @@ func TestParseManagerLoopConfig_PartialSteeringRejected(t *testing.T) {
 	})
 
 	t.Run("steer_context without steer_condition", func(t *testing.T) {
-		_, err := parseManagerLoopConfig(map[string]string{
+		_, err := parseManagerLoopConfig("Supervise", map[string]string{
 			"subgraph_ref":  "child",
 			"steer_context": "hint=go_faster",
 		})
@@ -801,7 +801,7 @@ func TestParseManagerLoopConfig_PartialSteeringRejected(t *testing.T) {
 		// A non-empty value with no `=` pairs parses to nil — the prior
 		// error message conflated this with "unset". The message must now
 		// cite the raw value and call out invalidity.
-		_, err := parseManagerLoopConfig(map[string]string{
+		_, err := parseManagerLoopConfig("Supervise", map[string]string{
 			"subgraph_ref":    "child",
 			"steer_condition": "stack.child.cycles = 3",
 			"steer_context":   "bad",
@@ -824,7 +824,7 @@ func TestParseManagerLoopConfig_PartialSteeringRejected(t *testing.T) {
 		// from the validator's perspective) and the malformed input was
 		// silently discarded. The invalid-steer-context check runs
 		// independently of steer_condition, so this must now error.
-		_, err := parseManagerLoopConfig(map[string]string{
+		_, err := parseManagerLoopConfig("Supervise", map[string]string{
 			"subgraph_ref":  "child",
 			"steer_context": "bad",
 		})
@@ -845,7 +845,7 @@ func TestParseManagerLoopConfig_PartialSteeringRejected(t *testing.T) {
 // forms, the unprefixed value is used. This matters for migrated pipelines
 // that may carry leftover "manager.*" attrs — the new contract takes priority.
 func TestParseManagerLoopConfig_UnprefixedWinsOverPrefixed(t *testing.T) {
-	cfg, err := parseManagerLoopConfig(map[string]string{
+	cfg, err := parseManagerLoopConfig("Supervise", map[string]string{
 		"subgraph_ref":          "child",
 		"poll_interval":         "5s",
 		"manager.poll_interval": "99s",

--- a/pipeline/testdata/manager_loop.dip
+++ b/pipeline/testdata/manager_loop.dip
@@ -1,0 +1,21 @@
+workflow ManagerLoopFixture
+  goal: "E2E fixture for the manager_loop adapter path — exercises all 6 flat attrs."
+  start: Supervise
+  exit: Done
+
+  manager_loop Supervise
+    label: "Quality Gate Supervisor"
+    subgraph_ref: child.dip
+    poll_interval: 15s
+    max_cycles: 20
+    stop_condition: stack.child.outcome = success
+    steer_condition: stack.child.cycles = 5
+    steer_context:
+      hint: halfway_through
+      priority: high
+
+  agent Done
+    label: Done
+
+  edges
+    Supervise -> Done

--- a/pipeline/testdata/manager_loop.dip
+++ b/pipeline/testdata/manager_loop.dip
@@ -8,7 +8,7 @@ workflow ManagerLoopFixture
     subgraph_ref: child.dip
     poll_interval: 15s
     max_cycles: 20
-    stop_condition: stack.child.outcome = success
+    stop_condition: stack.child.status = success
     steer_condition: stack.child.cycles = 5
     steer_context:
       hint: halfway_through


### PR DESCRIPTION
## Summary

Bundles five follow-up fixes filed after the PR #170 review-squad pass on the manager_loop feature shipped in v0.23.0. One commit, tight scope, everything verified end-to-end.

## Closed Issues

### Closes #171 — Reject ':' in steer_context keys
- `flattenSteerContext` in `pipeline/dippin_adapter.go` now fails loudly at graph-build time when any key contains `:`. Rationale: dippin-lang v0.22.0's block-form formatter writes entries as `key: value` lines, so a colon in the key breaks `.dip`→IR→`.dip` round-trip. Upstream parser silently drops such keys with a diagnostic; tracker refuses to build the graph.
- Error: `ErrInvalidSteerContextKey` wrapping the offending key.
- Test: `TestFromDippinIR_ManagerLoop_RejectsColonInSteerContextKey`.

### Closes #172 — Test coverage gaps
Three new adapter tests:
- `TestFromDippinIR_ManagerLoop_CondOrNotFormatting` — asserts the exact textual output (`"outcome = success || status = done"`, `"not outcome = success"`) so a typo in the `||` or `not ` emitter fails a byte comparison instead of passing a semantic-only check.
- `TestFromDippinIR_ManagerLoop_RawBeatsParsed` — pins `managerLoopConditionText`'s preference: Raw wins over Parsed when both populated.
- `TestDippinAdapter_E2E_ManagerLoop` — loads `pipeline/testdata/manager_loop.dip` through the real `dippin-lang/parser` and asserts all 6 flat attrs (`subgraph_ref`, `poll_interval`, `max_cycles`, `stop_condition`, `steer_condition`, `steer_context`) land on the graph node.

### Closes #174 — Defensive nil-check for ManagerLoopConfig
- `convertNode` in `pipeline/dippin_adapter.go` now rejects a `NodeManagerLoop` with `Config == nil` at graph-build time. Before: silent pass-through, vague failure at Execute time. After: clear `ErrMissingManagerLoopCfg` naming the node.
- Scoped to `manager_loop` only per the issue — other kinds may get the same guard as follow-ups.
- Test: `TestFromDippinIR_ManagerLoop_NilConfigRejected`.

### Closes #175 — manager_loop example for CI doctor gate
- `examples/manager_loop_demo.dip` — small supervisor pipeline using `subgraph_ref`, `poll_interval`, `max_cycles`, `stop_condition`, `steer_condition`, `steer_context`. 25 lines.
- `examples/subgraphs/manager_loop_child.dip` — minimal child pipeline (DoWork → Done). 18 lines.
- Both grade A via `dippin doctor`.
- Added `manager_loop_demo.dip` to the `Makefile` doctor target so CI fails if a future change regresses adapter-path round-trip of the new attrs.

### Closes #176 — Bundled polish (6 items)
1. **Both-form warning in `managerAttr`.** When both `foo` and `manager.foo` are set on the same node, log a one-line diagnostic (`log.Printf`, matching the `[claude-code]`/`[webhook]` idiom in sibling handlers). Contract unchanged: unprefixed still wins.
2. **Unresolvable-key warning in `parseManagerLoopConfig`.** `warnUnknownStackChildKeys` scans `stop_condition` / `steer_condition` for `stack.child.<word>` references and warns on any subkey not in the canonical observables set (`stack.child.status`, `.cycles`, `.exit_status`). Narrow on purpose — bare keys like `outcome` or `status` are left alone because they are commonly set by parent pipelines.
3. **Misleading `steerContextDecoder` comment** — verification: the current comment (written in commit `dc566b9` during PR #170 round-4) does NOT claim "longest-first/greedy". It correctly says `strings.NewReplacer` "does not overlap matches" and "pattern order is not a correctness requirement" here. **No code change required.**
4. **Inaccurate sort-order test comment** — verification: the current comment in `TestFlattenSteerContext_EncodesReservedInKeysAndValues` already says "raw-key lexicographic order, not encoded-key order" (also fixed in `dc566b9`). **No code change required** beyond minor wording tidy to reflect the new colon-rejection semantics.
5. **`TestManagerLoopHandler_EventsEmitted` upgrade.** Boolean flags replaced with an ordered-slice assertion filtered to the manager's own `NodeID`. Checks: exactly one `EventStageStarted`, exactly one `EventStageCompleted`, ≥1 `EventManagerCycleTick` between them, started is first, completed is last. A regression firing completed before started or duplicating started now fails the test.
6. **Symmetric Parsed fallback in `convertEdge`.** `convertEdge` now reuses `managerLoopConditionText` (Raw-then-Parsed) rather than reading `.Raw` only. A Parsed-only `ir.Edge` (e.g. constructed by tests or simulate without running the parser) now produces a conditional edge instead of a silent unconditional one. Test: `TestConvertEdge_ParsedFallback`.

## Verification

- `go build ./...` — clean
- `go test ./... -short` — all 17 packages pass (3 consecutive runs green; pre-existing `TestManagerLoopHandler_CtxCancellation` timing flake confirmed to exist on `main` unchanged by this PR)
- `go test -race ./pipeline/... ./tui/...` — clean
- `gofmt -l .` — no output
- `go vet ./...` — clean
- `dippin doctor` on `ask_and_execute.dip`, `build_product.dip`, `build_product_with_superspec.dip`, `manager_loop_demo.dip` — all grade A
- `make doctor` — all grade A
- `make lint` — all `.dip` files pass lint

## Test plan

- [x] Adapter unit tests cover colon-in-key rejection, nil-config rejection, CondOr/CondNot formatting, Raw-beats-Parsed, E2E parse+adapt
- [x] Handler unit tests cover managerAttr both-form warning path (implicit via existing `TestParseManagerLoopConfig_UnprefixedWinsOverPrefixed` which prints the warning), event sequencing, Parsed-fallback for convertEdge
- [x] `make doctor` passes with new example
- [x] Race detector clean on `./pipeline/...` and `./tui/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added example and E2E workflows demonstrating manager-loop supervision with polling, cycle limits, conditional stops, and steering hints.

* **Bug Fixes**
  * More explicit validation and clearer errors for missing or invalid manager-loop and steer-context configurations.

* **Improvements**
  * Runtime warnings for legacy/duplicate attributes and for unsupported child-subkey references; safer condition handling to prevent unintended edges.

* **Tests**
  * Strengthened unit and E2E tests with stricter event-order assertions and broader adapter coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->