### PR TITLE
chore(deps): bump dippin-lang v0.22.0 → v0.23.0, wire ToolCommandsAllow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **dippin-lang dependency bumped v0.22.0 → v0.23.0**. Upstream ships [DIP28 tool-safety defaults](https://github.com/2389-research/dippin-lang/releases/tag/v0.23.0): `ir.WorkflowDefaults` now exposes `ToolCommandsAllow` and `ToolDenylistAdd` fields so `.dip` authors can declare tool-safety constraints at the workflow level instead of reaching for DOT or the library API. `extractWorkflowDefaults` in `pipeline/dippin_adapter.go` wires `WorkflowDefaults.ToolCommandsAllow` → `graph.Attrs["tool_commands_allow"]` (the consumer side has been ready since #164). Closes the adapter-side follow-up noted in v0.23.0's own #164 entry. `ToolDenylistAdd` wiring is deferred until the matching `--tool-denylist-add` CLI flag lands (#168).
 - **Docs relocated under `docs/architecture/`** (closes #165). `docs/pipeline-context-flow.md` → `docs/architecture/context-flow.md` and `docs/manager-loop.md` → `docs/architecture/handlers/manager-loop.md`. Every inbound link in `README.md`, `ARCHITECTURE.md`, `CLAUDE.md`, `CHANGELOG.md`, and the `docs/architecture/` tree is updated; the `handlers.md` "tracked in #165 for a later PR" placeholder is removed and `architecture/README.md`'s "may move under `architecture/` in a later PR" note is retired.
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.22.0
+	github.com/2389-research/dippin-lang v0.23.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/2389-research/dippin-lang v0.21.0 h1:XNI6c72CXebcQZYNtuziq8gu547ZC6QWnidwBWUzvag=
-github.com/2389-research/dippin-lang v0.21.0/go.mod h1:y7R+8iLXXwUzqyXYL0VK/mfyLV/79M4L/iuGfVqOOi4=
-github.com/2389-research/dippin-lang v0.22.0 h1:wFVwQEgiT1pS1scz1v758xWdKqQ2A+iD42ard0DVrG8=
-github.com/2389-research/dippin-lang v0.22.0/go.mod h1:y7R+8iLXXwUzqyXYL0VK/mfyLV/79M4L/iuGfVqOOi4=
+github.com/2389-research/dippin-lang v0.23.0 h1:VQ6bM9SgTikCTfq1uEuRnUeMZC9cCNAsGVa2/e5bMo4=
+github.com/2389-research/dippin-lang v0.23.0/go.mod h1:y7R+8iLXXwUzqyXYL0VK/mfyLV/79M4L/iuGfVqOOi4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -675,25 +675,10 @@ func extractNodeIO(io ir.NodeIO, attrs map[string]string) {
 
 // extractWorkflowDefaults maps IR WorkflowDefaults to graph-level attributes.
 // These provide fallback values for nodes that don't specify per-node config.
-//
-// NOTE (tracker issue #164 / upstream dippin-lang gap): the tool-command
-// allowlist graph attribute (`tool_commands_allow`, consumed by
-// handlers.registerToolHandler) is intentionally not mapped here — the
-// dippin-lang v0.21.0 IR does not expose a ToolCommandsAllow field on
-// WorkflowDefaults, and the parser emits an "unknown defaults field"
-// diagnostic when a `.dip` author writes it. Authors who need a graph-level
-// allowlist today must use DOT (`graph [tool_commands_allow="git *,make *"]`)
-// or set Graph.Attrs["tool_commands_allow"] programmatically via the library
-// API. When dippin-lang adds the IR field, set it here with:
-//
-//	setIfNonEmpty(attrs, handlers.GraphAttrToolCommandsAllow, defaults.ToolCommandsAllow)
-//
-// Keeping the consumer side (registry.go) ready means that wiring this up
-// after upstream lands is a one-liner in the adapter, with no behavior change
-// needed in the handler.
 func extractWorkflowDefaults(defaults ir.WorkflowDefaults, attrs map[string]string) {
 	setIfNonEmpty(attrs, "llm_model", defaults.Model)
 	setIfNonEmpty(attrs, "llm_provider", defaults.Provider)
+	setIfNonEmpty(attrs, "tool_commands_allow", defaults.ToolCommandsAllow)
 	setIfNonEmpty(attrs, "default_retry_policy", defaults.RetryPolicy)
 	if defaults.MaxRetries > 0 {
 		attrs["default_max_retry"] = strconv.Itoa(defaults.MaxRetries)

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -492,15 +492,16 @@ func TestFromDippinIR_WorkflowDefaults(t *testing.T) {
 		Start: "start",
 		Exit:  "exit",
 		Defaults: ir.WorkflowDefaults{
-			Model:         "gpt-4",
-			Provider:      "openai",
-			RetryPolicy:   "standard",
-			MaxRetries:    3,
-			Fidelity:      "strict",
-			MaxRestarts:   10,
-			RestartTarget: "start",
-			CacheTools:    true,
-			Compaction:    "conservative",
+			Model:             "gpt-4",
+			Provider:          "openai",
+			RetryPolicy:       "standard",
+			MaxRetries:        3,
+			Fidelity:          "strict",
+			MaxRestarts:       10,
+			RestartTarget:     "start",
+			CacheTools:        true,
+			Compaction:        "conservative",
+			ToolCommandsAllow: "git *,make *",
 		},
 		Nodes: []*ir.Node{
 			{
@@ -538,6 +539,7 @@ func TestFromDippinIR_WorkflowDefaults(t *testing.T) {
 		{"restart_target", "start"},
 		{"cache_tool_results", "true"},
 		{"context_compaction", "conservative"},
+		{"tool_commands_allow", "git *,make *"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Bumps `github.com/2389-research/dippin-lang` from **v0.22.0 → v0.23.0** ([upstream release notes](https://github.com/2389-research/dippin-lang/releases/tag/v0.23.0)).
- Upstream ships **DIP28 tool-safety defaults**: `ir.WorkflowDefaults` now exposes `ToolCommandsAllow` and `ToolDenylistAdd` so `.dip` authors can declare tool-safety constraints at the workflow level.
- Wires `WorkflowDefaults.ToolCommandsAllow` → `graph.Attrs["tool_commands_allow"]` in `extractWorkflowDefaults`. The consumer side (`handlers.registerToolHandler`) has been ready since #164 — the adapter had a staged TODO comment explicitly flagging this as a one-liner once upstream landed the IR field. Closes that TODO.

## What's NOT in this PR

- `WorkflowDefaults.ToolDenylistAdd` wiring. That pairs naturally with the `--tool-denylist-add` CLI flag tracked in #168; landing them together keeps the two `.dip`/CLI halves of the same feature in one reviewable bundle.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -short` — all 17 packages pass
- [x] `make fmt-check`
- [x] `TestFromDippinIR_WorkflowDefaults` extended to assert `tool_commands_allow` flows through
- [x] `dippin doctor examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip` — all **Grade A 100/100**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated upstream dependency to latest version

* **New Features**
  * Workflow tool allowlist configuration now properly maps to pipeline attributes

* **Tests**
  * Added test coverage for workflow tool allowlist mapping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->