### PR TITLE
security: fix 10 critical audit findings

### DIFF
--- a/agent/config.go
+++ b/agent/config.go
@@ -85,7 +85,7 @@ type Checkpoint struct {
 }
 
 const (
-	DefaultModel    = "claude-sonnet-4-5"
+	DefaultModel    = "claude-sonnet-4-6"
 	DefaultProvider = "anthropic"
 )
 

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -562,6 +562,13 @@ type pipelineOutcome struct {
 func runPipelineAsync(engine *pipeline.Engine, ctx context.Context, prog *tea.Program) chan pipelineOutcome {
 	outcomeCh := make(chan pipelineOutcome, 1)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				pipelineErr := fmt.Errorf("pipeline panicked: %v", r)
+				outcomeCh <- pipelineOutcome{err: pipelineErr}
+				prog.Send(tui.MsgPipelineDone{Err: pipelineErr})
+			}
+		}()
 		result, pipelineErr := engine.Run(ctx)
 		if pipelineErr == nil && result.Status != pipeline.OutcomeSuccess {
 			pipelineErr = fmt.Errorf("pipeline finished with status: %s", result.Status)

--- a/examples/subgraphs/manager_loop_child.dip
+++ b/examples/subgraphs/manager_loop_child.dip
@@ -8,7 +8,7 @@ workflow ManagerLoopChild
     auto_status: true
     prompt:
       You are a worker supervised by a manager_loop. Perform one cycle of
-      the assigned task. If the steering hint ${ctx.hint} is set, use it
+      the assigned task. If the steering hint ${ctx.steer.hint} is set, use it
       to bias your approach.
 
       End your response with STATUS: success when the work is complete,

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -658,13 +658,13 @@ func (e *Engine) handleOutcomeStatus(s *runState, currentNodeID string, status s
 
 	default:
 		e.emit(PipelineEvent{
-			Type:      EventWarning,
+			Type:      EventStageFailed,
 			Timestamp: time.Now(),
 			RunID:     s.runID,
 			NodeID:    currentNodeID,
-			Message:   fmt.Sprintf("unknown outcome status %q from node %q; treating as success", status, currentNodeID),
+			Message:   fmt.Sprintf("node %q returned unknown outcome status %q; treating as failure", currentNodeID, status),
 		})
-		s.cp.MarkCompleted(currentNodeID)
+		s.pctx.Set(ContextKeyOutcome, OutcomeFail)
 	}
 }
 

--- a/pipeline/engine_test.go
+++ b/pipeline/engine_test.go
@@ -1449,3 +1449,28 @@ func TestEngine_HaltsOnBudgetBreachDuringRetry(t *testing.T) {
 		t.Error("expected at least one EventBudgetExceeded, got none")
 	}
 }
+
+func TestEngine_UnknownOutcomeFailsNode(t *testing.T) {
+	g := NewGraph("unknown_outcome_test")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "bogus", Shape: "box", Label: "Bogus"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+
+	g.AddEdge(&Edge{From: "s", To: "bogus"})
+	g.AddEdge(&Edge{From: "bogus", To: "end"})
+
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{Status: "totally_bogus_status"}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(context.Background())
+
+	if err == nil && result.Status == OutcomeSuccess {
+		t.Fatal("expected unknown outcome to NOT be treated as success")
+	}
+}

--- a/pipeline/handlers/autopilot.go
+++ b/pipeline/handlers/autopilot.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/2389-research/tracker/llm"
@@ -77,10 +78,11 @@ type autopilotDecision struct {
 	Reasoning string `json:"reasoning"`
 }
 
-// Compile-time assertions: AutopilotInterviewer implements both LabeledFreeformInterviewer
-// and InterviewInterviewer.
+// Compile-time assertions: AutopilotInterviewer implements both LabeledFreeformInterviewer,
+// InterviewInterviewer, and ContextSetter.
 var _ LabeledFreeformInterviewer = (*AutopilotInterviewer)(nil)
 var _ InterviewInterviewer = (*AutopilotInterviewer)(nil)
+var _ ContextSetter = (*AutopilotInterviewer)(nil)
 
 // AutopilotInterviewer implements LabeledFreeformInterviewer using an LLM
 // to make gate decisions instead of a human.
@@ -88,6 +90,9 @@ type AutopilotInterviewer struct {
 	client  *llm.Client
 	persona Persona
 	model   string // override model; empty = use default
+
+	mu          sync.RWMutex
+	pipelineCtx context.Context // set by SetPipelineContext before each gate; nil = use Background
 }
 
 // AutopilotOption configures an AutopilotInterviewer.
@@ -110,6 +115,26 @@ func NewAutopilotInterviewer(client *llm.Client, persona Persona, opts ...Autopi
 		opt(ai)
 	}
 	return ai
+}
+
+// SetPipelineContext stores the pipeline execution context so that LLM calls
+// respect pipeline cancellation (ctrl-C, budget breach, etc.). Called by the
+// human handler via the ContextSetter interface before any gate method is invoked.
+func (a *AutopilotInterviewer) SetPipelineContext(ctx context.Context) {
+	a.mu.Lock()
+	a.pipelineCtx = ctx
+	a.mu.Unlock()
+}
+
+// parentContext returns the stored pipeline context, or context.Background() if none is set.
+func (a *AutopilotInterviewer) parentContext() context.Context {
+	a.mu.RLock()
+	ctx := a.pipelineCtx
+	a.mu.RUnlock()
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // Ask handles choice-mode gates by selecting from the given options.
@@ -175,7 +200,7 @@ func (a *AutopilotInterviewer) callLLM(prompt string, options []string, defaultO
 	// Provider errors (quota, auth, model not found) must hard-fail per CLAUDE.md.
 	// The infra retry middleware already handles transient errors (502, 503, 429).
 	// We only retry on parse failures (LLM returned non-JSON).
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(a.parentContext(), 30*time.Second)
 	resp, err := a.client.Complete(ctx, req)
 	cancel()
 	if err != nil {
@@ -185,7 +210,7 @@ func (a *AutopilotInterviewer) callLLM(prompt string, options []string, defaultO
 	decision, parseErr := parseDecision(resp.Message.Text())
 	if parseErr != nil {
 		// Retry once on parse failure — LLM may produce valid JSON on second try.
-		ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx2, cancel2 := context.WithTimeout(a.parentContext(), 30*time.Second)
 		resp2, err2 := a.client.Complete(ctx2, req)
 		cancel2()
 		if err2 != nil {
@@ -345,7 +370,7 @@ func buildInterviewPromptWithHistory(questions []Question, prev *InterviewResult
 
 // callInterviewLLM calls the LLM and retries once on parse failure.
 func (a *AutopilotInterviewer) callInterviewLLM(req *llm.Request, questions []Question) (*InterviewResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(a.parentContext(), 30*time.Second)
 	resp, err := a.client.Complete(ctx, req)
 	cancel()
 	if err != nil {
@@ -358,7 +383,7 @@ func (a *AutopilotInterviewer) callInterviewLLM(req *llm.Request, questions []Qu
 	}
 
 	// Retry once on parse failure.
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx2, cancel2 := context.WithTimeout(a.parentContext(), 30*time.Second)
 	resp2, err2 := a.client.Complete(ctx2, req)
 	cancel2()
 	if err2 != nil {

--- a/pipeline/handlers/autopilot_claudecode.go
+++ b/pipeline/handlers/autopilot_claudecode.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 	// parseDecision, matchChoice, personaPrompts, buildUserPrompt
 	// are reused from autopilot.go in this package.
@@ -21,6 +22,9 @@ import (
 type ClaudeCodeAutopilotInterviewer struct {
 	persona    Persona
 	claudePath string
+
+	mu          sync.RWMutex
+	pipelineCtx context.Context // set by SetPipelineContext before each gate; nil = use Background
 }
 
 // NewClaudeCodeAutopilotInterviewer creates an autopilot interviewer that
@@ -34,6 +38,26 @@ func NewClaudeCodeAutopilotInterviewer(persona Persona) (*ClaudeCodeAutopilotInt
 		persona:    persona,
 		claudePath: path,
 	}, nil
+}
+
+// SetPipelineContext stores the pipeline execution context so that subprocess
+// spawns respect pipeline cancellation (ctrl-C, budget breach, etc.). Called
+// by the human handler via the ContextSetter interface before any gate method.
+func (a *ClaudeCodeAutopilotInterviewer) SetPipelineContext(ctx context.Context) {
+	a.mu.Lock()
+	a.pipelineCtx = ctx
+	a.mu.Unlock()
+}
+
+// parentContext returns the stored pipeline context, or context.Background() if none is set.
+func (a *ClaudeCodeAutopilotInterviewer) parentContext() context.Context {
+	a.mu.RLock()
+	ctx := a.pipelineCtx
+	a.mu.RUnlock()
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
 }
 
 // Ask handles choice-mode gates by selecting from the given options.
@@ -81,7 +105,7 @@ func (a *ClaudeCodeAutopilotInterviewer) callClaude(prompt string, options []str
 	userPrompt := buildUserPrompt(prompt, options, defaultOption)
 	fullPrompt := systemPrompt + "\n\n" + userPrompt
 
-	responseText, err := runClaudeSubprocess(a.claudePath, fullPrompt)
+	responseText, err := runClaudeSubprocess(a.parentContext(), a.claudePath, fullPrompt)
 	if err != nil {
 		return nil, err
 	}
@@ -94,8 +118,8 @@ func (a *ClaudeCodeAutopilotInterviewer) callClaude(prompt string, options []str
 }
 
 // runClaudeSubprocess spawns the claude CLI and returns its trimmed stdout.
-func runClaudeSubprocess(claudePath, fullPrompt string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+func runClaudeSubprocess(parentCtx context.Context, claudePath, fullPrompt string) (string, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, claudePath,
@@ -147,8 +171,9 @@ func (a *ClaudeCodeAutopilotInterviewer) AskInterview(questions []Question, prev
 	systemPrompt := personaPrompts[a.persona]
 	fullPrompt := systemPrompt + "\n\n" + prompt
 
+	parentCtx := a.parentContext()
 	for attempt := 0; attempt < 2; attempt++ {
-		result, parseErr, fatalErr := a.runInterviewAttempt(fullPrompt, questions)
+		result, parseErr, fatalErr := a.runInterviewAttempt(parentCtx, fullPrompt, questions)
 		if fatalErr != nil {
 			return nil, fatalErr
 		}
@@ -166,8 +191,8 @@ func (a *ClaudeCodeAutopilotInterviewer) AskInterview(questions []Question, prev
 }
 
 // runInterviewAttempt executes one claude CLI call and returns parsed result, parse error, or fatal error.
-func (a *ClaudeCodeAutopilotInterviewer) runInterviewAttempt(fullPrompt string, questions []Question) (*InterviewResult, error, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+func (a *ClaudeCodeAutopilotInterviewer) runInterviewAttempt(parentCtx context.Context, fullPrompt string, questions []Question) (*InterviewResult, error, error) {
+	ctx, cancel := context.WithTimeout(parentCtx, 60*time.Second)
 
 	cmd := exec.CommandContext(ctx, a.claudePath,
 		"--print",
@@ -196,9 +221,11 @@ func (a *ClaudeCodeAutopilotInterviewer) runInterviewAttempt(fullPrompt string, 
 	return result, parseErr, nil
 }
 
-// Compile-time assertions: ClaudeCodeAutopilotInterviewer implements both interfaces.
+// Compile-time assertions: ClaudeCodeAutopilotInterviewer implements both interfaces
+// and ContextSetter.
 var _ LabeledFreeformInterviewer = (*ClaudeCodeAutopilotInterviewer)(nil)
 var _ InterviewInterviewer = (*ClaudeCodeAutopilotInterviewer)(nil)
+var _ ContextSetter = (*ClaudeCodeAutopilotInterviewer)(nil)
 
 // fallback returns the default option, or the first option, or empty string.
 func (a *ClaudeCodeAutopilotInterviewer) fallback(options []string, defaultOption string) string {

--- a/pipeline/handlers/backend_acp_client.go
+++ b/pipeline/handlers/backend_acp_client.go
@@ -397,12 +397,25 @@ func (h *acpClientHandler) WriteTextFile(_ context.Context, p acp.WriteTextFileR
 
 // CreateTerminal spawns a subprocess and tracks it for future output/wait/kill.
 func (h *acpClientHandler) CreateTerminal(_ context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
-	cmd := exec.Command(p.Command, p.Args...)
+	// Build the full command string for denylist checking.
+	fullCmd := strings.Join(append([]string{p.Command}, p.Args...), " ")
+	if denied, pattern := checkCommandDenylist(fullCmd, nil); denied {
+		return acp.CreateTerminalResponse{}, &acp.RequestError{
+			Code:    -32600,
+			Message: fmt.Sprintf("command matches denied pattern %q", pattern),
+		}
+	}
 
+	// Validate cwd stays within the working directory.
 	cwd := h.workingDir
 	if p.Cwd != nil && *p.Cwd != "" {
+		if err := validatePathInWorkDir(*p.Cwd, h.workingDir); err != nil {
+			return acp.CreateTerminalResponse{}, &acp.RequestError{Code: -32600, Message: err.Error()}
+		}
 		cwd = *p.Cwd
 	}
+
+	cmd := exec.Command(p.Command, p.Args...)
 	cmd.Dir = cwd
 
 	// Apply environment variables from the request. Use buildEnvForACP() to

--- a/pipeline/handlers/backend_acp_client.go
+++ b/pipeline/handlers/backend_acp_client.go
@@ -397,12 +397,23 @@ func (h *acpClientHandler) WriteTextFile(_ context.Context, p acp.WriteTextFileR
 
 // CreateTerminal spawns a subprocess and tracks it for future output/wait/kill.
 func (h *acpClientHandler) CreateTerminal(_ context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
-	// Build the full command string for denylist checking.
-	fullCmd := strings.Join(append([]string{p.Command}, p.Args...), " ")
-	if denied, pattern := checkCommandDenylist(fullCmd, nil); denied {
+	// Check the bare command name first to catch "eval" / "exec" / "source"
+	// with no args (the denylist patterns like "eval *" require a trailing
+	// argument and would miss the bare invocation without this check).
+	if denied, pattern := checkCommandDenylist(p.Command+" _", nil); denied {
 		return acp.CreateTerminalResponse{}, &acp.RequestError{
-			Code:    -32600,
+			Code:    -32602,
 			Message: fmt.Sprintf("command matches denied pattern %q", pattern),
+		}
+	}
+	// Also check the full command string with args for pipe-to-shell patterns.
+	if len(p.Args) > 0 {
+		fullCmd := strings.Join(append([]string{p.Command}, p.Args...), " ")
+		if denied, pattern := checkCommandDenylist(fullCmd, nil); denied {
+			return acp.CreateTerminalResponse{}, &acp.RequestError{
+				Code:    -32602,
+				Message: fmt.Sprintf("command matches denied pattern %q", pattern),
+			}
 		}
 	}
 
@@ -410,7 +421,7 @@ func (h *acpClientHandler) CreateTerminal(_ context.Context, p acp.CreateTermina
 	cwd := h.workingDir
 	if p.Cwd != nil && *p.Cwd != "" {
 		if err := validatePathInWorkDir(*p.Cwd, h.workingDir); err != nil {
-			return acp.CreateTerminalResponse{}, &acp.RequestError{Code: -32600, Message: err.Error()}
+			return acp.CreateTerminalResponse{}, &acp.RequestError{Code: -32602, Message: err.Error()}
 		}
 		cwd = *p.Cwd
 	}

--- a/pipeline/handlers/backend_acp_test.go
+++ b/pipeline/handlers/backend_acp_test.go
@@ -1473,8 +1473,8 @@ func TestCreateTerminal_DenylistedCommand(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *acp.RequestError, got %T: %v", err, err)
 	}
-	if reqErr.Code != -32600 {
-		t.Errorf("expected error code -32600, got %d", reqErr.Code)
+	if reqErr.Code != -32602 {
+		t.Errorf("expected error code -32602, got %d", reqErr.Code)
 	}
 }
 
@@ -1497,7 +1497,29 @@ func TestCreateTerminal_CwdOutsideWorkDir(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *acp.RequestError, got %T: %v", err, err)
 	}
-	if reqErr.Code != -32600 {
-		t.Errorf("expected error code -32600, got %d", reqErr.Code)
+	if reqErr.Code != -32602 {
+		t.Errorf("expected error code -32602, got %d", reqErr.Code)
+	}
+}
+
+func TestCreateTerminal_BareEvalBlocked(t *testing.T) {
+	h := &acpClientHandler{
+		workingDir: t.TempDir(),
+		toolNames:  make(map[string]string),
+	}
+	// "eval" with no args must be blocked by the bare-command denylist check.
+	_, err := h.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "eval",
+		Args:    nil,
+	})
+	if err == nil {
+		t.Fatal("expected error for bare denylisted command 'eval' with no args")
+	}
+	reqErr, ok := err.(*acp.RequestError)
+	if !ok {
+		t.Fatalf("expected *acp.RequestError, got %T: %v", err, err)
+	}
+	if reqErr.Code != -32602 {
+		t.Errorf("expected error code -32602, got %d", reqErr.Code)
 	}
 }

--- a/pipeline/handlers/backend_acp_test.go
+++ b/pipeline/handlers/backend_acp_test.go
@@ -1455,3 +1455,49 @@ func TestReadTextFile_RejectsPathOutsideWorkDir(t *testing.T) {
 		t.Errorf("error = %q, want 'outside working directory'", err)
 	}
 }
+
+func TestCreateTerminal_DenylistedCommand(t *testing.T) {
+	h := &acpClientHandler{
+		workingDir: t.TempDir(),
+		toolNames:  make(map[string]string),
+	}
+	// "eval" is in the built-in denylist as "eval *".
+	_, err := h.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "eval",
+		Args:    []string{"rm -rf /"},
+	})
+	if err == nil {
+		t.Fatal("expected error for denylisted command 'eval'")
+	}
+	reqErr, ok := err.(*acp.RequestError)
+	if !ok {
+		t.Fatalf("expected *acp.RequestError, got %T: %v", err, err)
+	}
+	if reqErr.Code != -32600 {
+		t.Errorf("expected error code -32600, got %d", reqErr.Code)
+	}
+}
+
+func TestCreateTerminal_CwdOutsideWorkDir(t *testing.T) {
+	workDir := t.TempDir()
+	outsideDir := t.TempDir()
+	h := &acpClientHandler{
+		workingDir: workDir,
+		toolNames:  make(map[string]string),
+	}
+	_, err := h.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "echo",
+		Args:    []string{"hello"},
+		Cwd:     &outsideDir,
+	})
+	if err == nil {
+		t.Fatal("expected error for cwd outside working directory")
+	}
+	reqErr, ok := err.(*acp.RequestError)
+	if !ok {
+		t.Fatalf("expected *acp.RequestError, got %T: %v", err, err)
+	}
+	if reqErr.Code != -32600 {
+		t.Errorf("expected error code -32600, got %d", reqErr.Code)
+	}
+}

--- a/pipeline/handlers/backend_claudecode.go
+++ b/pipeline/handlers/backend_claudecode.go
@@ -279,7 +279,7 @@ var providerKeyPrefixes = []string{
 // environment is passed through otherwise — Claude Code needs access to
 // its config directory, SSH agent, and other system state.
 func buildEnv() []string {
-	if os.Getenv("TRACKER_PASS_API_KEYS") != "" {
+	if os.Getenv("TRACKER_PASS_API_KEYS") == "1" {
 		return os.Environ()
 	}
 	return filterProviderKeys(os.Environ())

--- a/pipeline/handlers/backend_claudecode.go
+++ b/pipeline/handlers/backend_claudecode.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/pipeline"
@@ -79,6 +81,12 @@ func (b *ClaudeCodeBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig
 
 	cmd := exec.Command(b.claudePath, args...)
 	cmd.Env = buildEnv()
+	// Use process group for clean kill on cancellation.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	if cfg.WorkingDir != "" {
 		cmd.Dir = cfg.WorkingDir

--- a/pipeline/handlers/backend_claudecode_env_test.go
+++ b/pipeline/handlers/backend_claudecode_env_test.go
@@ -142,6 +142,18 @@ func TestBuildEnv_StripsOpenAICompatKey(t *testing.T) {
 	}
 }
 
+func TestBuildEnv_PassAPIKeysFalseDoesNotPassthrough(t *testing.T) {
+	t.Setenv("TRACKER_PASS_API_KEYS", "false")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	env := buildEnv()
+	for _, e := range env {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+			t.Error("TRACKER_PASS_API_KEYS=false should NOT pass through API keys")
+		}
+	}
+}
+
 func TestBuildEnvNoKeysNoop(t *testing.T) {
 	// Ensure no API keys are set.
 	os.Unsetenv("ANTHROPIC_API_KEY")

--- a/pipeline/handlers/backend_claudecode_test.go
+++ b/pipeline/handlers/backend_claudecode_test.go
@@ -1035,3 +1035,39 @@ func assertContainsFlag(t *testing.T, args []string, flag, value string) {
 	}
 	t.Errorf("expected args to contain %s %s, got %v", flag, value, args)
 }
+
+// TestClaudeCodeBackend_ContextCancelKillsSubprocess verifies that when the
+// context is cancelled, the claude subprocess process group is killed promptly
+// rather than being orphaned and running indefinitely.
+func TestClaudeCodeBackend_ContextCancelKillsSubprocess(t *testing.T) {
+	// Use "sleep" as a long-running stand-in for the claude binary.
+	// It will block for 300 seconds unless the process group is killed.
+	b := &ClaudeCodeBackend{claudePath: "sleep"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after 100ms to trigger the process group kill path.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	// Minimal config — sleep ignores all args but Run still needs a non-empty prompt
+	// to build the args slice without error.
+	cfg := pipeline.AgentRunConfig{
+		Prompt: "300",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		b.Run(ctx, cfg, func(agent.Event) {}) //nolint:errcheck
+	}()
+
+	select {
+	case <-done:
+		// Returned promptly after cancellation — process group kill worked.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5 seconds after context cancellation; subprocess may be orphaned")
+	}
+}

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -80,6 +80,14 @@ type Interviewer interface {
 	Ask(prompt string, choices []string, defaultChoice string) (string, error)
 }
 
+// ContextSetter is an optional interface for interviewers that can receive a
+// pipeline context for cancellation and timeout propagation. The human handler
+// calls SetPipelineContext via type assertion before invoking any interviewer
+// methods, so that LLM-backed interviewers can respect pipeline cancellation.
+type ContextSetter interface {
+	SetPipelineContext(ctx context.Context)
+}
+
 // FreeformInterviewer extends Interviewer with open-ended text input.
 // Used by human gate nodes with mode="freeform" to capture arbitrary user input
 // instead of presenting fixed choices.
@@ -520,6 +528,12 @@ func (h *HumanHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *p
 
 // dispatchHumanMode routes to the appropriate human input handler based on the node mode.
 func (h *HumanHandler) dispatchHumanMode(ctx context.Context, node *pipeline.Node, pctx *pipeline.PipelineContext, prompt string) (pipeline.Outcome, error) {
+	// Propagate pipeline context to LLM-backed interviewers so that pipeline
+	// cancellation (ctrl-C, budget breach) stops autopilot LLM calls promptly.
+	if cs, ok := h.interviewer.(ContextSetter); ok {
+		cs.SetPipelineContext(ctx)
+	}
+
 	// Parse the config once; reuse Mode and Timeout to avoid the double
 	// map-walk / ParseDuration that was happening when parseHumanTimeout
 	// called HumanConfig() a second time from the interview branch.

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -699,14 +699,6 @@ func (h *HumanHandler) executeInterview(ctx context.Context, node *pipeline.Node
 
 // resolveInterviewKeys returns the context keys for questions and answers,
 // using node attrs when set and falling back to pipeline constants.
-//
-// Note on the questions_key default: CLAUDE.md documents the default as
-// last_response, but the actual code (and the test suite) treats
-// interview_questions as the primary default and last_response as a
-// resolveAgentOutput fallback. The latter is load-bearing — tests and
-// production pipelines that write to interview_questions rely on it — so
-// the code stays the source of truth here. The CLAUDE.md line is inaccurate
-// and should be reconciled separately (not in this refactor PR).
 func resolveInterviewKeys(node *pipeline.Node) (questionsKey, answersKey string) {
 	cfg := node.HumanConfig()
 	questionsKey = cfg.QuestionsKey

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -22,7 +22,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod.
 // Keep in sync with the require line in go.mod.
-const PinnedDippinVersion = "v0.21.0"
+const PinnedDippinVersion = "v0.23.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {
@@ -170,7 +170,7 @@ func checkEnvWarnings() CheckResult {
 	}
 	var found []string
 	for envVar, desc := range dangerousVars {
-		if os.Getenv(envVar) != "" {
+		if os.Getenv(envVar) == "1" {
 			found = append(found, fmt.Sprintf("%s (%s)", envVar, desc))
 		}
 	}

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -3,6 +3,7 @@
 package tracker
 
 import (
+	"bufio"
 	"context"
 	"os"
 	"path/filepath"
@@ -245,4 +246,36 @@ func TestCheckArtifactDirs_NonENOENTStatError(t *testing.T) {
 			t.Errorf("detail %q hides the real permission error", d.Message)
 		}
 	}
+}
+
+// TestPinnedDippinVersionMatchesGoMod verifies that PinnedDippinVersion is kept
+// in sync with the actual dippin-lang version declared in go.mod.
+func TestPinnedDippinVersionMatchesGoMod(t *testing.T) {
+	f, err := os.Open("go.mod")
+	if err != nil {
+		t.Fatalf("open go.mod: %v", err)
+	}
+	defer f.Close()
+
+	const prefix = "\tgithub.com/2389-research/dippin-lang "
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, prefix) {
+			goModVersion := strings.TrimPrefix(line, prefix)
+			// Strip any indirect annotation (e.g. " // indirect")
+			if idx := strings.Index(goModVersion, " "); idx >= 0 {
+				goModVersion = goModVersion[:idx]
+			}
+			if goModVersion != PinnedDippinVersion {
+				t.Errorf("PinnedDippinVersion = %q, but go.mod has dippin-lang %q; update PinnedDippinVersion in tracker_doctor.go",
+					PinnedDippinVersion, goModVersion)
+			}
+			return
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan go.mod: %v", err)
+	}
+	t.Fatal("dippin-lang not found in go.mod")
 }

--- a/tui/notify.go
+++ b/tui/notify.go
@@ -29,7 +29,9 @@ func SendNotification(title, body string) {
 	go func() { _ = cmd.Run() }()
 }
 
-// escapeOsascript escapes double quotes and backslashes for osascript strings.
+// escapeOsascript escapes double quotes, backslashes, and newlines for
+// osascript strings. Newlines are replaced with a space; carriage returns
+// are stripped to prevent injection via multi-line input.
 func escapeOsascript(s string) string {
 	var out []byte
 	for i := 0; i < len(s); i++ {
@@ -38,6 +40,10 @@ func escapeOsascript(s string) string {
 			out = append(out, '\\', '"')
 		case '\\':
 			out = append(out, '\\', '\\')
+		case '\n':
+			out = append(out, ' ')
+		case '\r':
+			// skip
 		default:
 			out = append(out, s[i])
 		}

--- a/tui/notify_test.go
+++ b/tui/notify_test.go
@@ -4,6 +4,7 @@ package tui
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -12,6 +13,14 @@ func TestNotificationSuppressed(t *testing.T) {
 	defer os.Unsetenv("TRACKER_NO_NOTIFY")
 	// Should not panic or send anything.
 	SendNotification("Test", "Body")
+}
+
+func TestEscapeOsascript_Newlines(t *testing.T) {
+	input := "done\nevil command"
+	escaped := escapeOsascript(input)
+	if strings.Contains(escaped, "\n") {
+		t.Error("newlines should be escaped in osascript strings")
+	}
 }
 
 func TestEscapeOsascript(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes all 10 critical findings from the 13-expert panel audit of tracker v0.24.1.

### Security fixes
- **ACP CreateTerminal validation** — commands now checked against denylist, cwd constrained to workdir
- **ClaudeCode subprocess kill** — process group kill on pipeline cancellation (prevents orphaned API-consuming subprocesses)
- **TRACKER_PASS_API_KEYS** — requires `=1`, not just non-empty (prevents `=false`/`=0` from leaking keys)
- **osascript injection** — newlines escaped in notification strings

### Correctness fixes
- **Unknown outcome → fail** — engine no longer silently treats unknown handler outcomes as success
- **Pipeline goroutine panic recovery** — defer/recover in TUI pipeline goroutine
- **Autopilot context cancellation** — LLM calls now respect pipeline ctx (ctrl-C, budget breach)
- **PinnedDippinVersion** — updated to v0.23.0 to match go.mod
- **DefaultModel** — updated to claude-sonnet-4-6
- **Doctor env warning** — aligned with buildEnv() `== "1"` check

### Docs/examples
- **steer.* namespace** — example .dip file updated for PR #196 rename
- **Stale comment** — removed incorrect human.go comment about CLAUDE.md

## Test plan
- [x] All 17 packages pass `go test ./... -short`
- [x] `go build ./...` clean
- [x] New tests for: ACP denylist, ACP cwd, bare eval blocking, context cancel kill, PASS_API_KEYS=false, unknown outcome, osascript newlines, PinnedDippinVersion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Default AI model updated to claude-sonnet-4-6 for improved performance
  * Enhanced cancellation and timeout support for long-running pipeline operations

* **Bug Fixes**
  * Fixed pipeline execution to properly fail when encountering unknown outcome statuses
  * Improved subprocess cleanup and termination behavior
  * Enhanced input validation and escaping for system commands and notifications

* **Chores**
  * Updated language version dependency to v0.23.0
  * Refined environment variable validation for API key handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->