### PR TITLE
Add dispatch_sprints + TerminalTool + 4-strategy SR matcher (architect-side machinery for local codegen)

### DIFF
--- a/agent/session.go
+++ b/agent/session.go
@@ -259,9 +259,9 @@ func (s *Session) executeTurn(ctx context.Context, turn int, start time.Time, tr
 		return done, stop, err
 	}
 
-	stopped := s.handleToolCalls(ctx, toolCalls, resp, turn, turnStart, tracker, prevCacheHits, prevCacheMisses, result, ts)
-	if stopped {
-		return false, true, nil
+	stop, naturally := s.handleToolCalls(ctx, toolCalls, resp, turn, turnStart, tracker, prevCacheHits, prevCacheMisses, result, ts)
+	if stop {
+		return naturally, true, nil
 	}
 
 	// Run the verify-after-edit loop if any edit tools were called this turn.
@@ -309,8 +309,11 @@ func (s *Session) handleNoTools(resp *llm.Response, turn int, turnStart time.Tim
 }
 
 // handleToolCalls processes a turn where the LLM returned tool calls.
-// Returns true if the loop should stop (loop detected).
-func (s *Session) handleToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, resp *llm.Response, turn int, turnStart time.Time, tracker *ContextWindowTracker, prevCacheHits, prevCacheMisses int, result *SessionResult, ts *turnState) bool {
+// Returns:
+//   - stop: the outer loop should break.
+//   - naturally: the stop was a clean end (terminal-tool success), as opposed
+//     to a loop-detection abort. Only meaningful when stop=true.
+func (s *Session) handleToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, resp *llm.Response, turn int, turnStart time.Time, tracker *ContextWindowTracker, prevCacheHits, prevCacheMisses int, result *SessionResult, ts *turnState) (stop, naturally bool) {
 	signature := s.computeToolSignature(toolCalls)
 	if signature == ts.lastToolSignature {
 		ts.consecutiveLoopCount++
@@ -325,14 +328,14 @@ func (s *Session) handleToolCalls(ctx context.Context, toolCalls []llm.ToolCallD
 		result.LoopDetected = true
 		s.emitTurnMetrics(turn, turnStart, resp, tracker, prevCacheHits, prevCacheMisses, result)
 		s.emit(Event{Type: EventTurnEnd, SessionID: s.id, Turn: turn})
-		return true
+		return true, false
 	}
 
-	hadErrors := s.executeToolCalls(ctx, toolCalls, result)
+	hadErrors, terminate := s.executeToolCalls(ctx, toolCalls, result)
 	s.maybeInjectReflection(hadErrors, ts)
 	s.emitTurnMetrics(turn, turnStart, resp, tracker, prevCacheHits, prevCacheMisses, result)
 	s.emit(Event{Type: EventTurnEnd, SessionID: s.id, Turn: turn})
-	return false
+	return terminate, terminate
 }
 
 // maybeInjectReflection appends the structured reflection prompt when tool errors
@@ -467,7 +470,7 @@ func (s *Session) runRepairTurn(ctx context.Context, result *SessionResult) erro
 		return nil // LLM responded with text only (e.g. "I fixed it")
 	}
 
-	s.executeToolCalls(ctx, toolCalls, result)
+	_, _ = s.executeToolCalls(ctx, toolCalls, result)
 	return nil
 }
 

--- a/agent/session.go
+++ b/agent/session.go
@@ -14,10 +14,10 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
-// Completer is the interface needed from the LLM client.
-type Completer interface {
-	Complete(ctx context.Context, req *llm.Request) (*llm.Response, error)
-}
+// Completer is the interface needed from the LLM client. It's an alias of
+// tools.Completer so both packages refer to the same type — preventing
+// silent divergence if either side grows new methods.
+type Completer = tools.Completer
 
 // SessionOption configures a Session.
 type SessionOption func(*Session)

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -261,18 +261,30 @@ func (s *Session) computeToolSignature(toolCalls []llm.ToolCallData) string {
 	return strings.Join(toolSigs, ",")
 }
 
-// executeToolCalls runs each tool call sequentially and appends results to messages.
-// It returns true if any tool call resulted in an error.
-func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult) bool {
+// executeToolCalls runs each tool call sequentially and appends results to
+// messages. Returns:
+//   - hadErrors: any tool call in the batch errored (used to drive reflection).
+//   - terminate: a tool implementing TerminalTool succeeded; the caller should
+//     break out of the agent loop.
+//
+// On terminal-tool success the loop short-circuits: later tool calls in the
+// same batch are skipped. Running them would feed results to a session that
+// the model never gets a chance to react to.
+func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult) (hadErrors, terminate bool) {
 	var toolResults []llm.ContentPart
-	anyError := false
 	for _, call := range toolCalls {
 		toolResult, toolDuration := s.executeSingleTool(ctx, call)
 		result.ToolCalls[call.Name]++
 		if toolResult.IsError {
-			anyError = true
+			hadErrors = true
 		}
 		s.episodeLog.Record(call.Name, string(call.Arguments), toolResult.Content, toolResult.IsError)
+
+		if !toolResult.IsError {
+			if tool := s.registry.Get(call.Name); tool != nil && tools.IsToolTerminal(tool) {
+				terminate = true
+			}
+		}
 
 		s.emit(Event{
 			Type:         EventToolCallEnd,
@@ -287,13 +299,17 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 			Kind:       llm.KindToolResult,
 			ToolResult: &toolResult,
 		})
+
+		if terminate {
+			break
+		}
 	}
 
 	s.messages = append(s.messages, llm.Message{
 		Role:    llm.RoleTool,
 		Content: toolResults,
 	})
-	return anyError
+	return hadErrors, terminate
 }
 
 // executeSingleTool runs a single tool call, handling caching.

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -267,9 +267,12 @@ func (s *Session) computeToolSignature(toolCalls []llm.ToolCallData) string {
 //   - terminate: a tool implementing TerminalTool succeeded; the caller should
 //     break out of the agent loop.
 //
-// On terminal-tool success the loop short-circuits: later tool calls in the
-// same batch are skipped. Running them would feed results to a session that
-// the model never gets a chance to react to.
+// On terminal-tool success the loop also breaks immediately, skipping any
+// remaining tool calls in the same LLM response. This is intentional: once
+// a terminal tool has done its job, subsequent calls in the same turn are
+// either redundant or could perform unwanted side-effects after the "final
+// step" (e.g., a model emitting `[dispatch_sprints, write_summary_doc]`
+// shouldn't run write_summary_doc once dispatch_sprints succeeded).
 func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult) (hadErrors, terminate bool) {
 	var toolResults []llm.ContentPart
 	for _, call := range toolCalls {
@@ -280,9 +283,14 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 		}
 		s.episodeLog.Record(call.Name, string(call.Arguments), toolResult.Content, toolResult.IsError)
 
+		// Terminal-tool check: a successful invocation of a tool that
+		// flags itself terminal ends the agent session. Errors keep the
+		// loop alive so the model can react to the failure.
+		thisIsTerminal := false
 		if !toolResult.IsError {
 			if tool := s.registry.Get(call.Name); tool != nil && tools.IsToolTerminal(tool) {
 				terminate = true
+				thisIsTerminal = true
 			}
 		}
 
@@ -300,7 +308,7 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 			ToolResult: &toolResult,
 		})
 
-		if terminate {
+		if thisIsTerminal {
 			break
 		}
 	}

--- a/agent/tools/completer.go
+++ b/agent/tools/completer.go
@@ -1,0 +1,51 @@
+// ABOUTME: Canonical Completer interface used by tools that need direct LLM
+// ABOUTME: access (generate_code, write_enriched_sprint). Re-exported by the
+// ABOUTME: agent package as a type alias so the two are identical, not parallel.
+package tools
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// Completer is the minimal LLM-call surface a tool needs to invoke the
+// model directly (e.g. for an audit pass or per-file generation). The
+// agent package re-exports this as a type alias so the two interfaces
+// are literally the same type, preventing silent divergence.
+type Completer interface {
+	Complete(ctx context.Context, req *llm.Request) (*llm.Response, error)
+}
+
+// resolveUnderRoot resolves rel against root and verifies the cleaned path
+// stays within root. An absolute rel is accepted as long as it points
+// inside root — the goal is "no path escape," not "no absolute path"
+// (which would break tests that use t.TempDir()).
+//
+// Used by tools that read or write files based on LLM-supplied paths
+// (write_enriched_sprint, generate_code) to prevent directory traversal
+// and accidental writes/reads outside the working tree.
+func resolveUnderRoot(root, rel string) (string, error) {
+	if root == "" {
+		return "", fmt.Errorf("root directory is empty")
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve root: %w", err)
+	}
+
+	var candidate string
+	if filepath.IsAbs(rel) {
+		candidate = filepath.Clean(rel)
+	} else {
+		candidate = filepath.Clean(filepath.Join(rootAbs, rel))
+	}
+
+	if candidate != rootAbs && !strings.HasPrefix(candidate, rootAbs+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes working directory: %s", rel)
+	}
+	return candidate, nil
+}

--- a/agent/tools/completer.go
+++ b/agent/tools/completer.go
@@ -6,6 +6,7 @@ package tools
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,9 +22,14 @@ type Completer interface {
 }
 
 // resolveUnderRoot resolves rel against root and verifies the cleaned path
-// stays within root. An absolute rel is accepted as long as it points
-// inside root — the goal is "no path escape," not "no absolute path"
-// (which would break tests that use t.TempDir()).
+// stays within root, including after symlink evaluation. An absolute rel is
+// accepted as long as it points inside root — the goal is "no path escape,"
+// not "no absolute path" (which would break tests using t.TempDir()).
+//
+// Symlinks are evaluated for both root and the candidate so a symlink inside
+// root pointing outside the workspace can't be used to escape. If the
+// candidate doesn't yet exist (common for write paths), its parent directory
+// is symlink-resolved instead and the cleaned filename is reattached.
 //
 // Used by tools that read or write files based on LLM-supplied paths
 // (write_enriched_sprint, generate_code) to prevent directory traversal
@@ -36,6 +42,10 @@ func resolveUnderRoot(root, rel string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve root: %w", err)
 	}
+	rootEval, err := evalSymlinksLeniently(rootAbs)
+	if err != nil {
+		return "", fmt.Errorf("resolve root symlinks: %w", err)
+	}
 
 	var candidate string
 	if filepath.IsAbs(rel) {
@@ -44,8 +54,41 @@ func resolveUnderRoot(root, rel string) (string, error) {
 		candidate = filepath.Clean(filepath.Join(rootAbs, rel))
 	}
 
-	if candidate != rootAbs && !strings.HasPrefix(candidate, rootAbs+string(filepath.Separator)) {
+	candidateEval, err := evalSymlinksLeniently(candidate)
+	if err != nil {
+		return "", fmt.Errorf("resolve path symlinks: %w", err)
+	}
+
+	if candidateEval != rootEval && !strings.HasPrefix(candidateEval, rootEval+string(filepath.Separator)) {
 		return "", fmt.Errorf("path escapes working directory: %s", rel)
 	}
-	return candidate, nil
+	return candidateEval, nil
+}
+
+// evalSymlinksLeniently is filepath.EvalSymlinks plus a fallback for paths
+// that don't yet exist: resolve the longest existing prefix and re-attach the
+// missing tail. This is required for write paths (the file isn't there yet)
+// while still catching symlink-based escapes for any directory that does
+// exist along the way.
+func evalSymlinksLeniently(p string) (string, error) {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved, nil
+	}
+
+	// Walk up until we find an existing directory, then re-append the rest.
+	parent := p
+	tail := ""
+	for parent != "" && parent != filepath.Dir(parent) {
+		if _, err := os.Stat(parent); err == nil {
+			resolved, err := filepath.EvalSymlinks(parent)
+			if err != nil {
+				return "", err
+			}
+			return filepath.Clean(filepath.Join(resolved, tail)), nil
+		}
+		tail = filepath.Join(filepath.Base(parent), tail)
+		parent = filepath.Dir(parent)
+	}
+	// Path has no existing ancestor — return the cleaned absolute form.
+	return filepath.Clean(p), nil
 }

--- a/agent/tools/completer_test.go
+++ b/agent/tools/completer_test.go
@@ -1,0 +1,80 @@
+// ABOUTME: Tests for resolveUnderRoot — the path-confinement helper used by
+// ABOUTME: tools that read or write LLM-supplied paths (write_enriched_sprint, generate_code).
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveUnderRoot_RejectsTraversal(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := resolveUnderRoot(dir, "../escape.txt"); err == nil {
+		t.Errorf("expected escape via .. to be rejected")
+	}
+	if _, err := resolveUnderRoot(dir, "subdir/../../escape.txt"); err == nil {
+		t.Errorf("expected escape via subdir/../.. to be rejected")
+	}
+}
+
+func TestResolveUnderRoot_RejectsAbsoluteOutside(t *testing.T) {
+	dir := t.TempDir()
+	other := t.TempDir() // distinct directory
+	if _, err := resolveUnderRoot(dir, filepath.Join(other, "x.txt")); err == nil {
+		t.Errorf("expected absolute path outside root to be rejected")
+	}
+}
+
+func TestResolveUnderRoot_AcceptsAbsoluteInside(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveUnderRoot(dir, filepath.Join(dir, "sub", "x.txt"))
+	if err != nil {
+		t.Fatalf("expected absolute path inside root to be accepted, got: %v", err)
+	}
+	if !strings.HasPrefix(got, dir) {
+		t.Errorf("resolved path %q should start with root %q", got, dir)
+	}
+}
+
+// TestResolveUnderRoot_RejectsSymlinkEscape is the regression test for
+// CodeRabbit's pr-feedback-5 finding: a symlink inside root pointing
+// outside should not be usable to escape. The pure string-prefix check
+// passed because the symlink path itself looked fine; symlink evaluation
+// catches the escape.
+func TestResolveUnderRoot_RejectsSymlinkEscape(t *testing.T) {
+	if _, err := os.Stat("/tmp"); err != nil {
+		t.Skip("symlink test requires a writable tmp")
+	}
+	root := t.TempDir()
+	outside := t.TempDir()
+
+	// Create a symlink inside root that points to outside.
+	link := filepath.Join(root, "escape")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Skipf("symlink unsupported on this filesystem: %v", err)
+	}
+
+	// A path "escape/secret.txt" string-resolves to root/escape/secret.txt
+	// (under root), but symlink-resolves to outside/secret.txt (outside).
+	// The fixed helper must reject it.
+	if _, err := resolveUnderRoot(root, "escape/secret.txt"); err == nil {
+		t.Errorf("expected symlink-escape path to be rejected; symlink-aware containment check is missing or broken")
+	}
+}
+
+// TestResolveUnderRoot_AcceptsNonexistentInRoot covers the write-path
+// case: the file we're going to write doesn't exist yet, but the parent
+// directory does. The helper should resolve the parent's symlinks and
+// accept the path when the parent is under root.
+func TestResolveUnderRoot_AcceptsNonexistentInRoot(t *testing.T) {
+	root := t.TempDir()
+	got, err := resolveUnderRoot(root, "newfile.txt")
+	if err != nil {
+		t.Fatalf("expected nonexistent path under root to be accepted, got: %v", err)
+	}
+	if !strings.HasPrefix(got, root) {
+		t.Errorf("resolved path %q should start with root %q", got, root)
+	}
+}

--- a/agent/tools/dispatch_sprints.go
+++ b/agent/tools/dispatch_sprints.go
@@ -163,7 +163,10 @@ func (t *DispatchSprintsTool) Execute(ctx context.Context, input json.RawMessage
 	if args.OutputDir == "" {
 		args.OutputDir = ".ai/sprints"
 	}
-	outputDir := t.inner.resolveOutputDir(args.OutputDir)
+	outputDir, err := t.inner.resolveOutputDir(args.OutputDir)
+	if err != nil {
+		return "", fmt.Errorf("dispatch_sprints: %w", err)
+	}
 
 	contract, err := t.inner.LoadContract(args.ContractFile)
 	if err != nil {
@@ -176,13 +179,13 @@ func (t *DispatchSprintsTool) Execute(ctx context.Context, input json.RawMessage
 	}
 
 	var (
-		perSprint   []string
-		failures    []string
-		passes      int
-		patched     int
-		fallbacks   int
-		totalIn     int
-		totalOut    int
+		perSprint []string
+		failures  []string
+		passes    int
+		patched   int
+		fallbacks int
+		totalIn   int
+		totalOut  int
 	)
 
 	for _, e := range entries {

--- a/agent/tools/dispatch_sprints.go
+++ b/agent/tools/dispatch_sprints.go
@@ -92,7 +92,11 @@ func readDispatchPlan(path string) ([]dispatchEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", path, err)
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			fmt.Fprintf(os.Stderr, "dispatch_sprints: close %s: %v\n", path, cerr)
+		}
+	}()
 
 	var entries []dispatchEntry
 	sc := bufio.NewScanner(f)

--- a/agent/tools/dispatch_sprints.go
+++ b/agent/tools/dispatch_sprints.go
@@ -133,6 +133,13 @@ func readDispatchPlan(path string) ([]dispatchEntry, error) {
 }
 
 func (t *DispatchSprintsTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	// Defensive guard: a misregistered tool (nil receiver or nil inner) would
+	// otherwise panic at the first method call. Surface as a tool error so
+	// the agent loop sees the failure cleanly.
+	if t == nil || t.inner == nil {
+		return "", errors.New("dispatch_sprints: misconfigured tool (inner WriteEnrichedSprintTool is nil)")
+	}
+
 	var args struct {
 		DescriptionsFile string `json:"descriptions_file"`
 		ContractFile     string `json:"contract_file"`

--- a/agent/tools/dispatch_sprints.go
+++ b/agent/tools/dispatch_sprints.go
@@ -269,12 +269,12 @@ func (t *DispatchSprintsTool) runOneWithRetry(ctx context.Context, contract stri
 
 // isRetryableError returns true when the error chain contains a provider
 // error that the llm package marks retryable (rate limits, 5xx, timeouts,
-// transient network errors).
+// transient network errors). Uses errors.As so joined-error chains are
+// handled correctly.
 func isRetryableError(err error) bool {
-	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
-		if pe, ok := cur.(llm.ProviderErrorInterface); ok {
-			return pe.Retryable()
-		}
+	var pe llm.ProviderErrorInterface
+	if errors.As(err, &pe) {
+		return pe.Retryable()
 	}
 	return false
 }

--- a/agent/tools/dispatch_sprints.go
+++ b/agent/tools/dispatch_sprints.go
@@ -1,0 +1,269 @@
+// ABOUTME: Tool that dispatches enriched-sprint generation across a JSONL plan.
+// ABOUTME: Reads {path, description} per line and invokes WriteEnrichedSprintTool.RunOne for each, returning an aggregate summary.
+package tools
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// DispatchSprintsTool reads a JSONL plan and runs the per-sprint author+audit
+// pipeline once per line. The loop is mechanical — there is no LLM agency
+// between sprints. The contract file is loaded once and shared across all
+// sprints.
+type DispatchSprintsTool struct {
+	inner   *WriteEnrichedSprintTool
+	workDir string
+
+	// retryBackoff returns the wait duration after a retryable failure on the
+	// given attempt number (1-indexed). Defaults to attempt²·second if nil
+	// (1s, 4s, 9s, ...). Tests override with a small constant.
+	retryBackoff func(attempt int) time.Duration
+}
+
+// NewDispatchSprintsTool wraps a WriteEnrichedSprintTool with a deterministic
+// JSONL-driven loop.
+func NewDispatchSprintsTool(inner *WriteEnrichedSprintTool, workDir string) *DispatchSprintsTool {
+	return &DispatchSprintsTool{inner: inner, workDir: workDir}
+}
+
+func (t *DispatchSprintsTool) Name() string { return "dispatch_sprints" }
+
+// IsTerminal flags this tool as the terminal step in the architect agent's
+// session. When dispatch_sprints succeeds, the agent runtime ends the session
+// immediately — there is no meaningful follow-up for the model. JSONL/contract
+// validation errors still bubble back as tool errors so the agent can retry.
+func (t *DispatchSprintsTool) IsTerminal() bool { return true }
+
+func (t *DispatchSprintsTool) Description() string {
+	return "Dispatch enriched-sprint generation for every line of a JSONL plan. " +
+		"Reads `.ai/sprint_descriptions.jsonl` (one JSON object per line: " +
+		"`{path: \"SPRINT-NNN.md\", description: str}`), reads `.ai/contract.md` once, " +
+		"and runs the author+audit pipeline once per sprint. Returns an aggregate summary. " +
+		"Call this AFTER writing the contract and the descriptions JSONL — once, with no per-sprint args."
+}
+
+func (t *DispatchSprintsTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"descriptions_file": {
+				"type": "string",
+				"description": "Path to the JSONL plan. Defaults to .ai/sprint_descriptions.jsonl"
+			},
+			"contract_file": {
+				"type": "string",
+				"description": "Path to the project contract. Defaults to .ai/contract.md"
+			},
+			"output_dir": {
+				"type": "string",
+				"description": "Directory to write sprint files. Defaults to .ai/sprints"
+			},
+			"strict": {
+				"type": "boolean",
+				"description": "If true, abort on the first per-sprint failure. Default false (continue and report)."
+			}
+		}
+	}`)
+}
+
+type dispatchEntry struct {
+	Path        string `json:"path"`
+	Description string `json:"description"`
+}
+
+var sprintPathRE = regexp.MustCompile(`^SPRINT-\d{3}\.md$`)
+
+// readDispatchPlan parses a JSONL file into validated entries. Returns an error
+// on the first malformed or invalid line so problems surface before any
+// expensive LLM calls fire.
+func readDispatchPlan(path string) ([]dispatchEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var entries []dispatchEntry
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 64*1024), 8*1024*1024) // allow long descriptions
+	lineno := 0
+	for sc.Scan() {
+		lineno++
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e dispatchEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			return nil, fmt.Errorf("line %d: parse: %w", lineno, err)
+		}
+		if e.Path == "" {
+			return nil, fmt.Errorf("line %d: missing path", lineno)
+		}
+		if !sprintPathRE.MatchString(e.Path) {
+			return nil, fmt.Errorf("line %d: invalid path %q (want SPRINT-NNN.md)", lineno, e.Path)
+		}
+		if strings.TrimSpace(e.Description) == "" {
+			return nil, fmt.Errorf("line %d: empty description", lineno)
+		}
+		entries = append(entries, e)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan %s: %w", path, err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("no entries in %s", path)
+	}
+	return entries, nil
+}
+
+func (t *DispatchSprintsTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var args struct {
+		DescriptionsFile string `json:"descriptions_file"`
+		ContractFile     string `json:"contract_file"`
+		OutputDir        string `json:"output_dir"`
+		Strict           bool   `json:"strict"`
+	}
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &args); err != nil {
+			return "", fmt.Errorf("dispatch_sprints: parse args: %w", err)
+		}
+	}
+
+	if args.DescriptionsFile == "" {
+		args.DescriptionsFile = ".ai/sprint_descriptions.jsonl"
+	}
+	descPath := args.DescriptionsFile
+	if !filepath.IsAbs(descPath) && t.workDir != "" {
+		descPath = filepath.Join(t.workDir, descPath)
+	}
+
+	if args.OutputDir == "" {
+		args.OutputDir = ".ai/sprints"
+	}
+	outputDir := t.inner.resolveOutputDir(args.OutputDir)
+
+	contract, err := t.inner.LoadContract(args.ContractFile)
+	if err != nil {
+		return "", fmt.Errorf("dispatch_sprints: %w", err)
+	}
+
+	entries, err := readDispatchPlan(descPath)
+	if err != nil {
+		return "", fmt.Errorf("dispatch_sprints: %w", err)
+	}
+
+	var (
+		perSprint   []string
+		failures    []string
+		passes      int
+		patched     int
+		fallbacks   int
+		totalIn     int
+		totalOut    int
+	)
+
+	for _, e := range entries {
+		r, runErr := t.runOneWithRetry(ctx, contract, e, outputDir)
+		if runErr != nil {
+			msg := fmt.Sprintf("%s: FAIL: %v", e.Path, runErr)
+			failures = append(failures, msg)
+			perSprint = append(perSprint, msg)
+			fmt.Fprintln(os.Stderr, "dispatch_sprints: "+msg)
+			if args.Strict {
+				return strings.Join(perSprint, "\n"), fmt.Errorf("dispatch_sprints: strict halt on %s: %w", e.Path, runErr)
+			}
+			continue
+		}
+		switch {
+		case r.Verdict == "PASS":
+			passes++
+		case r.Verdict == "PATCHED" || r.Verdict == "PATCHED-PARTIAL":
+			patched++
+		case strings.HasPrefix(r.Verdict, "PASS-FALLBACK"):
+			fallbacks++
+		}
+		totalIn += r.AuthorIn + r.AuditIn
+		totalOut += r.AuthorOut + r.AuditOut
+		perSprint = append(perSprint, fmt.Sprintf(
+			"%s: %d bytes, audit=%s, patches=%d, tokens=%d/%d",
+			r.Path, r.Bytes, r.Verdict, r.PatchesApplied,
+			r.AuthorIn+r.AuditIn, r.AuthorOut+r.AuditOut,
+		))
+		fmt.Fprintf(os.Stderr, "dispatch_sprints: %s\n", perSprint[len(perSprint)-1])
+	}
+
+	status := "ok"
+	if len(failures) > 0 {
+		status = "partial"
+	}
+	header := fmt.Sprintf(
+		"dispatch_sprints %s: dispatched=%d (PASS=%d, PATCHED=%d, fallbacks=%d, failures=%d). Tokens: %d in / %d out.",
+		status, len(entries), passes, patched, fallbacks, len(failures), totalIn, totalOut,
+	)
+	return header + "\n" + strings.Join(perSprint, "\n"), nil
+}
+
+// dispatchMaxRetries is the upper bound on per-sprint retry attempts when the
+// underlying author/audit LLM call hits a transient provider error.
+const dispatchMaxRetries = 3
+
+// runOneWithRetry wraps WriteEnrichedSprintTool.RunOne with bounded
+// exponential-backoff retry for transient provider errors. Hard failures
+// (auth, invalid request, content filter, etc.) do NOT retry.
+func (t *DispatchSprintsTool) runOneWithRetry(ctx context.Context, contract string, e dispatchEntry, outputDir string) (*SprintRunResult, error) {
+	var lastErr error
+	for attempt := 1; attempt <= dispatchMaxRetries; attempt++ {
+		r, err := t.inner.RunOne(ctx, contract, e.Path, e.Description, outputDir)
+		if err == nil {
+			if attempt > 1 {
+				fmt.Fprintf(os.Stderr, "dispatch_sprints: %s succeeded on attempt %d\n", e.Path, attempt)
+			}
+			return r, nil
+		}
+		lastErr = err
+		if !isRetryableError(err) {
+			return nil, err
+		}
+		if attempt == dispatchMaxRetries {
+			break
+		}
+		var backoff time.Duration
+		if t.retryBackoff != nil {
+			backoff = t.retryBackoff(attempt)
+		} else {
+			backoff = time.Duration(attempt*attempt) * time.Second
+		}
+		fmt.Fprintf(os.Stderr, "dispatch_sprints: %s attempt %d hit transient error (%v); retrying in %s\n",
+			e.Path, attempt, err, backoff)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, fmt.Errorf("after %d attempts: %w", dispatchMaxRetries, lastErr)
+}
+
+// isRetryableError returns true when the error chain contains a provider
+// error that the llm package marks retryable (rate limits, 5xx, timeouts,
+// transient network errors).
+func isRetryableError(err error) bool {
+	for cur := err; cur != nil; cur = errors.Unwrap(cur) {
+		if pe, ok := cur.(llm.ProviderErrorInterface); ok {
+			return pe.Retryable()
+		}
+	}
+	return false
+}

--- a/agent/tools/dispatch_sprints_test.go
+++ b/agent/tools/dispatch_sprints_test.go
@@ -1,0 +1,461 @@
+// ABOUTME: Unit tests for dispatch_sprints — JSONL parsing, validation, and aggregation.
+// ABOUTME: Uses an inline mock Completer to drive the per-sprint author+audit loop without real LLM calls.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// mockCompleter cycles through a list of canned responses on each Complete call.
+type mockCompleter struct {
+	responses []*llm.Response
+	calls     int32
+	failOn    int // 0-indexed call number to fail on; -1 means never
+}
+
+func (m *mockCompleter) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	idx := atomic.AddInt32(&m.calls, 1) - 1
+	if m.failOn >= 0 && int(idx) == m.failOn {
+		return nil, errors.New("mock: induced failure")
+	}
+	if int(idx) >= len(m.responses) {
+		return m.responses[len(m.responses)-1], nil
+	}
+	return m.responses[idx], nil
+}
+
+func authorResponse(body string) *llm.Response {
+	return &llm.Response{
+		ID:      "a",
+		Message: llm.AssistantMessage(body),
+		Usage:   llm.Usage{InputTokens: 100, OutputTokens: 50},
+	}
+}
+
+func auditPassResponse() *llm.Response {
+	return &llm.Response{
+		ID:      "b",
+		Message: llm.AssistantMessage("AUDIT-VERDICT: PASS"),
+		Usage:   llm.Usage{InputTokens: 80, OutputTokens: 5},
+	}
+}
+
+func writeJSONL(t *testing.T, dir string, lines []dispatchEntry) string {
+	t.Helper()
+	path := filepath.Join(dir, "plan.jsonl")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create plan: %v", err)
+	}
+	defer f.Close()
+	for _, e := range lines {
+		b, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		fmt.Fprintln(f, string(b))
+	}
+	return path
+}
+
+func writeContract(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "contract.md")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write contract: %v", err)
+	}
+	return path
+}
+
+func TestDispatchSprintsHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "# Contract\n\nstack: python\n")
+
+	entries := []dispatchEntry{
+		{Path: "SPRINT-001.md", Description: "Sprint 1 — foundation. " + strings.Repeat("x", 250)},
+		{Path: "SPRINT-002.md", Description: "Sprint 2 — additive notes. " + strings.Repeat("y", 250)},
+		{Path: "SPRINT-003.md", Description: "Sprint 3 — additive tags. " + strings.Repeat("z", 250)},
+	}
+	planPath := writeJSONL(t, dir, entries)
+
+	// 6 LLM calls expected: 3 sprints × (author + audit).
+	mock := &mockCompleter{
+		failOn: -1,
+		responses: []*llm.Response{
+			authorResponse("# Sprint 001 — Foundation (enriched spec)\n\n## Scope\n..."),
+			auditPassResponse(),
+			authorResponse("# Sprint 002 — Notes (enriched spec)\n\n## Scope\n..."),
+			auditPassResponse(),
+			authorResponse("# Sprint 003 — Tags (enriched spec)\n\n## Scope\n..."),
+			auditPassResponse(),
+		},
+	}
+
+	writer := NewWriteEnrichedSprintTool(mock,
+		WithSprintWriterModel("mock-sonnet"),
+		WithSprintWriterWorkDir(dir),
+	)
+	dispatch := NewDispatchSprintsTool(writer, dir)
+
+	args := map[string]any{
+		"descriptions_file": planPath,
+		"contract_file":     contractPath,
+		"output_dir":        filepath.Join(dir, "sprints"),
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	out, err := dispatch.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("dispatch failed: %v", err)
+	}
+	if !strings.Contains(out, "dispatched=3") || !strings.Contains(out, "PASS=3") {
+		t.Errorf("summary missing expected counts: %s", out)
+	}
+	if mock.calls != 6 {
+		t.Errorf("expected 6 LLM calls (3 sprints × 2 passes), got %d", mock.calls)
+	}
+	for _, e := range entries {
+		if _, err := os.Stat(filepath.Join(dir, "sprints", e.Path)); err != nil {
+			t.Errorf("expected sprint file %s: %v", e.Path, err)
+		}
+	}
+}
+
+func TestDispatchSprintsRejectsInvalidJSONL(t *testing.T) {
+	dir := t.TempDir()
+	writeContract(t, dir, "contract")
+
+	cases := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{"malformed json", "{not json}\n", "parse"},
+		{"missing path", `{"description":"x"}` + "\n", "missing path"},
+		{"invalid path", `{"path":"sprint1.md","description":"hello world hello world hello world"}` + "\n", "invalid path"},
+		{"empty description", `{"path":"SPRINT-001.md","description":""}` + "\n", "empty description"},
+		{"empty file", "", "no entries"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := filepath.Join(dir, tc.name+".jsonl")
+			if err := os.WriteFile(plan, []byte(tc.content), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			mock := &mockCompleter{failOn: -1}
+			writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+			dispatch := NewDispatchSprintsTool(writer, dir)
+
+			args := map[string]any{
+				"descriptions_file": plan,
+				"contract_file":     filepath.Join(dir, "contract.md"),
+			}
+			argsJSON, _ := json.Marshal(args)
+
+			_, err := dispatch.Execute(context.Background(), argsJSON)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErr)
+			}
+			if mock.calls != 0 {
+				t.Errorf("expected 0 LLM calls when validation fails up-front, got %d", mock.calls)
+			}
+		})
+	}
+}
+
+func TestDispatchSprintsContinuesOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "contract body")
+
+	entries := []dispatchEntry{
+		{Path: "SPRINT-001.md", Description: "s1 " + strings.Repeat("a", 250)},
+		{Path: "SPRINT-002.md", Description: "s2 " + strings.Repeat("b", 250)},
+		{Path: "SPRINT-003.md", Description: "s3 " + strings.Repeat("c", 250)},
+	}
+	planPath := writeJSONL(t, dir, entries)
+
+	// Fail on call index 2 → that's the AUTHOR pass for sprint 002.
+	// Sprint 001 succeeds (calls 0,1), sprint 002 fails (call 2),
+	// sprint 003 should still proceed (calls 3 author, 4 audit).
+	mock := &mockCompleter{
+		failOn: 2,
+		responses: []*llm.Response{
+			authorResponse("# Sprint 001\n## Scope\nx"),
+			auditPassResponse(),
+			nil, // unused, the failOn intercepts
+			authorResponse("# Sprint 003\n## Scope\nx"),
+			auditPassResponse(),
+		},
+	}
+
+	writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+	dispatch := NewDispatchSprintsTool(writer, dir)
+
+	args := map[string]any{
+		"descriptions_file": planPath,
+		"contract_file":     contractPath,
+		"output_dir":        filepath.Join(dir, "sprints"),
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	out, err := dispatch.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("non-strict mode should not error on per-sprint failure, got: %v", err)
+	}
+	if !strings.Contains(out, "failures=1") {
+		t.Errorf("expected failures=1 in summary: %s", out)
+	}
+	if !strings.Contains(out, "SPRINT-002.md: FAIL") {
+		t.Errorf("expected sprint 002 marked FAIL: %s", out)
+	}
+	// Sprint 001 and 003 should be on disk; sprint 002 should NOT.
+	for _, p := range []string{"SPRINT-001.md", "SPRINT-003.md"} {
+		if _, err := os.Stat(filepath.Join(dir, "sprints", p)); err != nil {
+			t.Errorf("expected %s written: %v", p, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dir, "sprints", "SPRINT-002.md")); err == nil {
+		t.Errorf("did not expect SPRINT-002.md to be written after failure")
+	}
+}
+
+func TestDispatchSprintsStrictHaltsOnFailure(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "contract body")
+
+	entries := []dispatchEntry{
+		{Path: "SPRINT-001.md", Description: "s1 " + strings.Repeat("a", 250)},
+		{Path: "SPRINT-002.md", Description: "s2 " + strings.Repeat("b", 250)},
+		{Path: "SPRINT-003.md", Description: "s3 " + strings.Repeat("c", 250)},
+	}
+	planPath := writeJSONL(t, dir, entries)
+
+	// Fail on first call → first author pass for sprint 001.
+	mock := &mockCompleter{failOn: 0}
+
+	writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+	dispatch := NewDispatchSprintsTool(writer, dir)
+
+	args := map[string]any{
+		"descriptions_file": planPath,
+		"contract_file":     contractPath,
+		"output_dir":        filepath.Join(dir, "sprints"),
+		"strict":            true,
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	_, err := dispatch.Execute(context.Background(), argsJSON)
+	if err == nil {
+		t.Fatal("strict mode should error on per-sprint failure")
+	}
+	if !strings.Contains(err.Error(), "strict halt") {
+		t.Errorf("expected strict-halt error, got: %v", err)
+	}
+	// Subsequent sprints should NOT have been attempted (only 1 call total).
+	if mock.calls != 1 {
+		t.Errorf("expected 1 LLM call before strict halt, got %d", mock.calls)
+	}
+}
+
+// retryBehavior describes one call's response: either an error (returned to
+// the caller) or a Response (returned as success). Used by retryMockCompleter
+// to script per-call outcomes.
+type retryBehavior struct {
+	err  error
+	resp *llm.Response
+}
+
+// retryMockCompleter returns a different (response, error) per call based on
+// its scripted behaviors. After the script is exhausted, returns fallback
+// for every subsequent call. Used to simulate transient-then-success flows
+// for runOneWithRetry tests.
+type retryMockCompleter struct {
+	behaviors []retryBehavior
+	fallback  *llm.Response
+	calls     int32
+}
+
+func (m *retryMockCompleter) Complete(ctx context.Context, req *llm.Request) (*llm.Response, error) {
+	idx := int(atomic.AddInt32(&m.calls, 1) - 1)
+	if idx < len(m.behaviors) {
+		b := m.behaviors[idx]
+		if b.err != nil {
+			return nil, b.err
+		}
+		return b.resp, nil
+	}
+	return m.fallback, nil
+}
+
+// TestRunOneWithRetry_TransientThenSucceeds verifies that two consecutive
+// retryable provider errors (RateLimitError, ServerError) are retried, and
+// the third attempt's success is returned to the caller. The dispatch tool
+// uses a no-op backoff in tests to keep the wall time fast.
+func TestRunOneWithRetry_TransientThenSucceeds(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "contract body")
+	entries := []dispatchEntry{
+		{Path: "SPRINT-001.md", Description: "s1 " + strings.Repeat("a", 250)},
+	}
+	planPath := writeJSONL(t, dir, entries)
+
+	// Calls 0-1: retryable errors → runOneWithRetry should retry.
+	// Call 2: real author response → RunOne's author succeeds.
+	// Call 3: real audit response → RunOne returns successfully.
+	mock := &retryMockCompleter{
+		behaviors: []retryBehavior{
+			{err: &llm.RateLimitError{ProviderError: llm.ProviderError{StatusCode: 429}}},
+			{err: &llm.ServerError{ProviderError: llm.ProviderError{StatusCode: 503}}},
+			{resp: authorResponse("# Sprint 001 — Foundation\n\n## Scope\nBody.")},
+			{resp: auditPassResponse()},
+		},
+	}
+
+	writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+	dispatch := NewDispatchSprintsTool(writer, dir)
+	dispatch.retryBackoff = func(int) time.Duration { return 1 * time.Millisecond } // fast test
+
+	args := map[string]any{
+		"descriptions_file": planPath,
+		"contract_file":     contractPath,
+		"output_dir":        filepath.Join(dir, "sprints"),
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	out, err := dispatch.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("dispatch should succeed after retries, got: %v", err)
+	}
+	if !strings.Contains(out, "PASS=1") {
+		t.Errorf("expected sprint to land as PASS after retries: %s", out)
+	}
+	// Total Complete calls: 2 retried failures + 1 author success + 1 audit success = 4.
+	if mock.calls != 4 {
+		t.Errorf("expected 4 Complete calls (2 retries + author + audit), got %d", mock.calls)
+	}
+}
+
+// TestRunOneWithRetry_NonRetryableErrorAborts verifies that a non-retryable
+// error (AuthenticationError) bubbles back to dispatch_sprints on the first
+// attempt without triggering retries.
+func TestRunOneWithRetry_NonRetryableErrorAborts(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "contract body")
+	entries := []dispatchEntry{
+		{Path: "SPRINT-001.md", Description: "s1 " + strings.Repeat("a", 250)},
+	}
+	planPath := writeJSONL(t, dir, entries)
+
+	// Call 0: AuthenticationError (Retryable=false). runOneWithRetry should
+	// return the error immediately rather than retrying.
+	mock := &retryMockCompleter{
+		behaviors: []retryBehavior{
+			{err: &llm.AuthenticationError{ProviderError: llm.ProviderError{StatusCode: 401}}},
+		},
+	}
+
+	writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+	dispatch := NewDispatchSprintsTool(writer, dir)
+	dispatch.retryBackoff = func(int) time.Duration { return 1 * time.Millisecond }
+
+	args := map[string]any{
+		"descriptions_file": planPath,
+		"contract_file":     contractPath,
+		"output_dir":        filepath.Join(dir, "sprints"),
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	out, err := dispatch.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("non-strict dispatch shouldn't error on per-sprint failure, got: %v", err)
+	}
+	if !strings.Contains(out, "failures=1") {
+		t.Errorf("expected the non-retryable failure to surface in summary: %s", out)
+	}
+	// Only 1 Complete call — non-retryable errors do not retry.
+	if mock.calls != 1 {
+		t.Errorf("expected 1 Complete call (no retry on non-retryable error), got %d", mock.calls)
+	}
+}
+
+// TestExecute_PatchedPartial verifies that when the audit emits multiple SR
+// blocks where some apply and others fail, Execute() reports
+// `audit=PATCHED-PARTIAL` with `patches=N` (where N is the count that landed)
+// rather than falling back to the unaudited draft.
+func TestExecute_PatchedPartial(t *testing.T) {
+	dir := t.TempDir()
+	contractPath := writeContract(t, dir, "contract body")
+	outputDir := filepath.Join(dir, "sprints")
+
+	// Author draft contains the text "alpha" but NOT "this text is not in draft".
+	// The audit emits TWO blocks: block 0 patches "alpha" (will apply); block 1's
+	// SEARCH does not exist anywhere in the draft (will be skipped). With partial-
+	// apply, the verdict should be PATCHED-PARTIAL with 1 block landed.
+	draft := "# Sprint 001\n\n## Scope\nBody references alpha here.\n\nMore content.\n"
+	auditResponse := `AUDIT-VERDICT: PATCHED
+<<<<<<< SEARCH
+alpha
+=======
+ALPHA
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+this text is not in draft and never will be
+=======
+zzz
+>>>>>>> REPLACE`
+
+	mock := &retryMockCompleter{
+		behaviors: []retryBehavior{
+			{resp: authorResponse(draft)},
+			{resp: &llm.Response{ID: "x", Message: llm.AssistantMessage(auditResponse), Usage: llm.Usage{InputTokens: 50, OutputTokens: 30}}},
+		},
+	}
+
+	writer := NewWriteEnrichedSprintTool(mock, WithSprintWriterWorkDir(dir))
+	args := map[string]any{
+		"path":          "SPRINT-001.md",
+		"description":   "Sprint 001 description " + strings.Repeat("x", 200),
+		"contract_file": contractPath,
+		"output_dir":    outputDir,
+	}
+	argsJSON, _ := json.Marshal(args)
+
+	out, err := writer.Execute(context.Background(), argsJSON)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	// Verdict should be PATCHED-PARTIAL because 1 of 2 blocks could not match.
+	if !strings.Contains(out, "audit=PATCHED-PARTIAL") {
+		t.Errorf("expected PATCHED-PARTIAL verdict in summary: %s", out)
+	}
+	// Exactly 1 patch landed (block 0 matched, block 1 didn't).
+	if !strings.Contains(out, "patches=1") {
+		t.Errorf("expected patches=1 in summary: %s", out)
+	}
+	// Verify the file on disk contains the patched form (ALPHA, not alpha).
+	written, err := os.ReadFile(filepath.Join(outputDir, "SPRINT-001.md"))
+	if err != nil {
+		t.Fatalf("could not read written sprint: %v", err)
+	}
+	if !strings.Contains(string(written), "ALPHA") {
+		t.Errorf("expected partially-patched content (ALPHA) on disk, got %q", string(written))
+	}
+	if strings.Contains(string(written), "zzz") {
+		t.Errorf("did not expect skipped block's REPLACE text on disk, got %q", string(written))
+	}
+}

--- a/agent/tools/dispatch_sprints_test.go
+++ b/agent/tools/dispatch_sprints_test.go
@@ -58,13 +58,19 @@ func writeJSONL(t *testing.T, dir string, lines []dispatchEntry) string {
 	if err != nil {
 		t.Fatalf("create plan: %v", err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close plan: %v", err)
+		}
+	}()
 	for _, e := range lines {
 		b, err := json.Marshal(e)
 		if err != nil {
 			t.Fatalf("marshal: %v", err)
 		}
-		fmt.Fprintln(f, string(b))
+		if _, err := fmt.Fprintln(f, string(b)); err != nil {
+			t.Fatalf("write plan: %v", err)
+		}
 	}
 	return path
 }

--- a/agent/tools/dispatch_sprints_test.go
+++ b/agent/tools/dispatch_sprints_test.go
@@ -305,6 +305,11 @@ func (m *retryMockCompleter) Complete(ctx context.Context, req *llm.Request) (*l
 		}
 		return b.resp, nil
 	}
+	if m.fallback == nil {
+		// Surface overrun as a clean error instead of nil-deref panicking
+		// the test. Tests with a fixed call count should never reach here.
+		return nil, fmt.Errorf("retryMockCompleter: call %d exhausted scripted behaviors and no fallback set", idx+1)
+	}
 	return m.fallback, nil
 }
 

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -113,8 +113,22 @@ func (t *GenerateCodeTool) Execute(ctx context.Context, input json.RawMessage) (
 	if args.OutputDir == "" {
 		args.OutputDir = "."
 	}
-	if !filepath.IsAbs(args.OutputDir) && t.workDir != "" {
-		args.OutputDir = filepath.Join(t.workDir, args.OutputDir)
+	// Confine output_dir under workDir so an LLM-supplied absolute path like
+	// "/tmp/outside" can't become the new write root for every per-file
+	// resolveUnderRoot call. When workDir is empty (test-only path) we fall
+	// back to filepath.Abs.
+	if t.workDir != "" {
+		clamped, err := resolveUnderRoot(t.workDir, args.OutputDir)
+		if err != nil {
+			return "", fmt.Errorf("generate_code: output_dir %q: %w", args.OutputDir, err)
+		}
+		args.OutputDir = clamped
+	} else {
+		abs, err := filepath.Abs(args.OutputDir)
+		if err != nil {
+			return "", fmt.Errorf("generate_code: output_dir %q: %w", args.OutputDir, err)
+		}
+		args.OutputDir = abs
 	}
 
 	// Sequential mode: one LLM call per file
@@ -196,7 +210,11 @@ func (t *GenerateCodeTool) generateSingleCall(ctx context.Context, contract, out
 		return "", fmt.Errorf("generate_code: llm call failed: %w", err)
 	}
 
-	code := resp.Text()
+	// Strip enclosing markdown fences if the model wrapped its whole response
+	// in a fenced block. The sequential branch already does this per-file;
+	// without it here, a fenced wrap leaks the fence into the last parsed
+	// file or into the entire fallback "generated.py".
+	code := stripMarkdownFences(resp.Text())
 	files := parseFiles(code)
 
 	if len(files) == 0 {

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -1,0 +1,277 @@
+// ABOUTME: Tool that generates code via a cheap/fast LLM from a structured contract.
+// ABOUTME: Implements the hybrid architect/executor pattern — strong model writes contract, this tool calls cheap model.
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// Completer is the interface for making LLM calls.
+type Completer interface {
+	Complete(ctx context.Context, req *llm.Request) (*llm.Response, error)
+}
+
+// GenerateCodeTool calls a cheap LLM to generate code from a structured contract.
+type GenerateCodeTool struct {
+	client   Completer
+	model    string
+	provider string
+	workDir  string
+}
+
+// GenerateCodeOption configures the GenerateCodeTool.
+type GenerateCodeOption func(*GenerateCodeTool)
+
+// WithGenerateModel sets the model used for code generation.
+func WithGenerateModel(model string) GenerateCodeOption {
+	return func(t *GenerateCodeTool) { t.model = model }
+}
+
+// WithGenerateProvider sets the provider used for code generation.
+func WithGenerateProvider(provider string) GenerateCodeOption {
+	return func(t *GenerateCodeTool) { t.provider = provider }
+}
+
+// WithGenerateWorkDir sets the base directory for writing generated files.
+func WithGenerateWorkDir(dir string) GenerateCodeOption {
+	return func(t *GenerateCodeTool) { t.workDir = dir }
+}
+
+// NewGenerateCodeTool creates a tool that generates code via a cheap model.
+func NewGenerateCodeTool(client Completer, opts ...GenerateCodeOption) *GenerateCodeTool {
+	t := &GenerateCodeTool{
+		client:   client,
+		model:    "gpt-5.4-nano",
+		provider: "openai",
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *GenerateCodeTool) Name() string { return "generate_code" }
+
+func (t *GenerateCodeTool) Description() string {
+	return "Generate files from a structured contract using a fast, cheap model. " +
+		"Pass a contract specifying structure, content, and rules. Works for any output type: " +
+		"code, markdown, configuration, prose. Optionally pass a 'files' array to generate " +
+		"each file separately (better for smaller models). " +
+		"Returns a summary of files written."
+}
+
+func (t *GenerateCodeTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"contract": {
+				"type": "string",
+				"description": "Structured contract with DATA CONTRACT, API CONTRACT, FILE STRUCTURE, ALGORITHM, and RULES sections"
+			},
+			"output_dir": {
+				"type": "string",
+				"description": "Directory to write generated files. Defaults to working directory."
+			},
+			"files": {
+				"type": "array",
+				"items": {
+					"type": "object",
+					"properties": {
+						"path": {"type": "string", "description": "File path relative to output_dir"},
+						"description": {"type": "string", "description": "What this file should contain — classes, functions, imports"}
+					},
+					"required": ["path", "description"]
+				},
+				"description": "Optional: generate each file separately. Each entry gets its own LLM call with the contract as context. Better for smaller/local models."
+			}
+		},
+		"required": ["contract"]
+	}`)
+}
+
+func (t *GenerateCodeTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var args struct {
+		Contract  string `json:"contract"`
+		OutputDir string `json:"output_dir"`
+		Files     []struct {
+			Path        string `json:"path"`
+			Description string `json:"description"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if args.OutputDir == "" || args.OutputDir == "." {
+		args.OutputDir = t.workDir
+	}
+	if args.OutputDir == "" {
+		args.OutputDir = "."
+	}
+	if !filepath.IsAbs(args.OutputDir) && t.workDir != "" {
+		args.OutputDir = filepath.Join(t.workDir, args.OutputDir)
+	}
+
+	// Sequential mode: one LLM call per file
+	if len(args.Files) > 0 {
+		return t.generateSequential(ctx, args.Contract, args.OutputDir, args.Files)
+	}
+
+	// Single-call mode: all files in one output
+	return t.generateSingleCall(ctx, args.Contract, args.OutputDir)
+}
+
+func (t *GenerateCodeTool) generateSequential(ctx context.Context, contract, outputDir string, files []struct {
+	Path        string `json:"path"`
+	Description string `json:"description"`
+}) (string, error) {
+	var summary []string
+	totalIn, totalOut := 0, 0
+
+	systemPrompt := "You are an executor generating a single file from a contract. " +
+		"Output ONLY the raw file content — no commentary, no explanations, no markdown fences. " +
+		"Follow the contract exactly."
+
+	for _, f := range files {
+		prompt := fmt.Sprintf("CONTRACT (full context — you are writing ONE file from this):\n%s\n\n"+
+			"GENERATE THIS FILE: %s\n"+
+			"This file should contain: %s\n\n"+
+			"Output ONLY the raw file content. Nothing else.",
+			contract, f.Path, f.Description)
+
+		resp, err := t.client.Complete(ctx, &llm.Request{
+			Model:    t.model,
+			Provider: t.provider,
+			Messages: []llm.Message{
+				{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: systemPrompt}}},
+				llm.UserMessage(prompt),
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("generate_code: failed generating %s: %w", f.Path, err)
+		}
+
+		code := resp.Text()
+		// Strip markdown fences if the model wrapped them
+		code = stripMarkdownFences(code)
+
+		path := filepath.Join(outputDir, f.Path)
+		if err := writeFile(path, code); err != nil {
+			return "", err
+		}
+
+		totalIn += resp.Usage.InputTokens
+		totalOut += resp.Usage.OutputTokens
+		summary = append(summary, fmt.Sprintf("  %s (%d bytes)", f.Path, len(code)))
+	}
+
+	return fmt.Sprintf("Generated %d files (sequential):\n%s\nModel: %s\nTokens: %d in / %d out",
+		len(files), strings.Join(summary, "\n"), t.model, totalIn, totalOut), nil
+}
+
+func (t *GenerateCodeTool) generateSingleCall(ctx context.Context, contract, outputDir string) (string, error) {
+	prompt := "You are an executor generating files from a contract. The contract specifies " +
+		"structure, content, and rules. Follow the contract exactly. Do not make decisions " +
+		"not already specified in the contract.\n\n" +
+		"CONTRACT:\n" + contract + "\n\n" +
+		"Output ALL files with `# === FILE: path/to/filename ===` separators.\n" +
+		"No commentary, no explanations. Output ONLY file content."
+
+	resp, err := t.client.Complete(ctx, &llm.Request{
+		Model:    t.model,
+		Provider: t.provider,
+		Messages: []llm.Message{llm.UserMessage(prompt)},
+	})
+	if err != nil {
+		return "", fmt.Errorf("generate_code: llm call failed: %w", err)
+	}
+
+	code := resp.Text()
+	files := parseFiles(code)
+
+	if len(files) == 0 {
+		path := filepath.Join(outputDir, "generated.py")
+		if err := writeFile(path, code); err != nil {
+			return "", err
+		}
+		return fmt.Sprintf("Generated 1 file (%d bytes): %s\nModel: %s\nTokens: %d in / %d out",
+			len(code), path, t.model, resp.Usage.InputTokens, resp.Usage.OutputTokens), nil
+	}
+
+	var summary []string
+	for _, f := range files {
+		path := filepath.Join(outputDir, f.name)
+		if err := writeFile(path, f.content); err != nil {
+			return "", err
+		}
+		summary = append(summary, fmt.Sprintf("  %s (%d bytes)", f.name, len(f.content)))
+	}
+
+	return fmt.Sprintf("Generated %d files:\n%s\nModel: %s\nTokens: %d in / %d out",
+		len(files), strings.Join(summary, "\n"), t.model,
+		resp.Usage.InputTokens, resp.Usage.OutputTokens), nil
+}
+
+type parsedFile struct {
+	name    string
+	content string
+}
+
+func parseFiles(code string) []parsedFile {
+	var files []parsedFile
+	lines := strings.Split(code, "\n")
+	var current *parsedFile
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "# === FILE:") && strings.HasSuffix(trimmed, "===") {
+			if current != nil {
+				current.content = strings.TrimSpace(current.content)
+				files = append(files, *current)
+			}
+			name := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(trimmed, "# === FILE:"), "==="))
+			current = &parsedFile{name: name}
+		} else if current != nil {
+			current.content += line + "\n"
+		}
+	}
+	if current != nil {
+		current.content = strings.TrimSpace(current.content)
+		files = append(files, *current)
+	}
+	return files
+}
+
+func stripMarkdownFences(code string) string {
+	lines := strings.Split(code, "\n")
+	if len(lines) < 2 {
+		return code
+	}
+	first := strings.TrimSpace(lines[0])
+	if strings.HasPrefix(first, "```") {
+		lines = lines[1:]
+		// Remove trailing fence
+		for i := len(lines) - 1; i >= 0; i-- {
+			if strings.TrimSpace(lines[i]) == "```" {
+				lines = lines[:i]
+				break
+			}
+		}
+		return strings.Join(lines, "\n")
+	}
+	return code
+}
+
+func writeFile(path string, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -13,11 +13,6 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
-// Completer is the interface for making LLM calls.
-type Completer interface {
-	Complete(ctx context.Context, req *llm.Request) (*llm.Response, error)
-}
-
 // GenerateCodeTool calls a cheap LLM to generate code from a structured contract.
 type GenerateCodeTool struct {
 	client   Completer
@@ -45,10 +40,14 @@ func WithGenerateWorkDir(dir string) GenerateCodeOption {
 }
 
 // NewGenerateCodeTool creates a tool that generates code via a cheap model.
+// Callers should override the model with WithGenerateModel — there is no
+// universally-correct default. The env-gated registration in
+// pipeline/handlers/backend_native.go always supplies one, so this default
+// only matters for direct construction.
 func NewGenerateCodeTool(client Completer, opts ...GenerateCodeOption) *GenerateCodeTool {
 	t := &GenerateCodeTool{
 		client:   client,
-		model:    "gpt-5.4-nano",
+		model:    "gpt-4o-mini",
 		provider: "openai",
 	}
 	for _, opt := range opts {
@@ -161,7 +160,12 @@ func (t *GenerateCodeTool) generateSequential(ctx context.Context, contract, out
 		// Strip markdown fences if the model wrapped them
 		code = stripMarkdownFences(code)
 
-		path := filepath.Join(outputDir, f.Path)
+		// Validate the LLM-supplied path stays under outputDir — `..`
+		// segments or absolute paths that escape would otherwise be honored.
+		path, err := resolveUnderRoot(outputDir, f.Path)
+		if err != nil {
+			return "", fmt.Errorf("generate_code: file path %q: %w", f.Path, err)
+		}
 		if err := writeFile(path, code); err != nil {
 			return "", err
 		}
@@ -196,7 +200,12 @@ func (t *GenerateCodeTool) generateSingleCall(ctx context.Context, contract, out
 	files := parseFiles(code)
 
 	if len(files) == 0 {
-		path := filepath.Join(outputDir, "generated.py")
+		// "generated.py" is a static name with no traversal risk; routed
+		// through the same helper for consistency with the multi-file branch.
+		path, err := resolveUnderRoot(outputDir, "generated.py")
+		if err != nil {
+			return "", err
+		}
 		if err := writeFile(path, code); err != nil {
 			return "", err
 		}
@@ -206,7 +215,13 @@ func (t *GenerateCodeTool) generateSingleCall(ctx context.Context, contract, out
 
 	var summary []string
 	for _, f := range files {
-		path := filepath.Join(outputDir, f.name)
+		// File names come from the model's `# === FILE: name ===` headers in
+		// the LLM output. Validate before writing — `..` segments or absolute
+		// paths that escape outputDir would otherwise be honored.
+		path, err := resolveUnderRoot(outputDir, f.name)
+		if err != nil {
+			return "", fmt.Errorf("generate_code: file %q: %w", f.name, err)
+		}
 		if err := writeFile(path, f.content); err != nil {
 			return "", err
 		}

--- a/agent/tools/registry.go
+++ b/agent/tools/registry.go
@@ -45,6 +45,30 @@ func GetCachePolicy(t Tool) CachePolicy {
 	return CachePolicyNone
 }
 
+// TerminalTool is implemented by tools whose successful invocation should end
+// the agent session immediately. The agent runtime checks this flag after
+// executing the tool's call: if the call succeeded (no error) AND the tool
+// is terminal, the session loop breaks before requesting another LLM turn.
+//
+// On tool error the loop continues normally so the model can react to the
+// failure (fix args, retry, give up by emitting text-only).
+//
+// Use this for deterministic last-step tools that have no meaningful follow-up
+// for the agent — e.g., tools that complete a multi-step pipeline phase.
+type TerminalTool interface {
+	IsTerminal() bool
+}
+
+// IsToolTerminal reports whether the given tool implements TerminalTool and
+// has flagged itself as terminal. Returns false for tools that don't implement
+// the interface.
+func IsToolTerminal(t Tool) bool {
+	if tt, ok := t.(TerminalTool); ok {
+		return tt.IsTerminal()
+	}
+	return false
+}
+
 // Registry holds registered tools and dispatches execution requests.
 type Registry struct {
 	tools        map[string]Tool

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -453,52 +453,47 @@ func (t *WriteEnrichedSprintTool) LoadContract(contractFile string) (string, err
 }
 
 // resolveUnderWorkDir takes a path argument (absolute or relative) and returns
-// the absolute resolved path. When workDir is set, validates that the result
-// is inside workDir and rejects paths that escape via "..", absolute paths
-// outside workDir, or symlink-like trickery. When workDir is empty (e.g., in
-// tests that don't set one), passes through with cleaning only.
+// the absolute resolved path. When workDir is set, delegates to
+// resolveUnderRoot which evaluates symlinks before the containment check —
+// that prevents a symlink inside workDir pointing outside from being used to
+// escape (which a pure string-prefix check would miss). When workDir is
+// empty (e.g., in tests that don't set one), passes through with cleaning
+// only.
 func (t *WriteEnrichedSprintTool) resolveUnderWorkDir(p string) (string, error) {
-	cleaned := filepath.Clean(p)
-	var resolved string
-	if filepath.IsAbs(cleaned) {
-		resolved = cleaned
-	} else if t.workDir != "" {
-		resolved = filepath.Join(t.workDir, cleaned)
-	} else {
-		resolved = cleaned
+	if t.workDir == "" {
+		return filepath.Clean(p), nil
 	}
-	absResolved, err := filepath.Abs(resolved)
-	if err != nil {
-		return "", fmt.Errorf("resolve %q: %w", p, err)
-	}
-	if t.workDir != "" {
-		absWorkDir, err := filepath.Abs(t.workDir)
-		if err != nil {
-			return "", fmt.Errorf("resolve workDir: %w", err)
-		}
-		rel, err := filepath.Rel(absWorkDir, absResolved)
-		if err != nil {
-			return "", fmt.Errorf("compute relative path: %w", err)
-		}
-		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-			return "", fmt.Errorf("path resolves outside workDir %q (rel=%q)", t.workDir, rel)
-		}
-	}
-	return absResolved, nil
+	return resolveUnderRoot(t.workDir, p)
 }
 
-// resolveOutputDir applies the same defaulting rules Execute uses.
-func (t *WriteEnrichedSprintTool) resolveOutputDir(outputDir string) string {
+// resolveOutputDir applies the same defaulting rules Execute uses, then
+// confines the result under workDir when one is configured. An LLM-supplied
+// absolute outputDir like "/tmp/outside" would otherwise become the new
+// write root for every per-file resolveUnderRoot call — escaping the
+// configured workspace entirely.
+//
+// Returns the absolute output path (or an error if it can't be confined to
+// workDir). When workDir is empty (untested-config path), the existing
+// behavior is preserved.
+func (t *WriteEnrichedSprintTool) resolveOutputDir(outputDir string) (string, error) {
 	if outputDir == "" || outputDir == "." {
 		outputDir = t.workDir
 	}
 	if outputDir == "" {
 		outputDir = "."
 	}
-	if !filepath.IsAbs(outputDir) && t.workDir != "" {
-		outputDir = filepath.Join(t.workDir, outputDir)
+	if t.workDir == "" {
+		// No workspace to anchor to; preserve historical behavior.
+		if !filepath.IsAbs(outputDir) {
+			abs, err := filepath.Abs(outputDir)
+			if err != nil {
+				return "", err
+			}
+			return abs, nil
+		}
+		return outputDir, nil
 	}
-	return outputDir
+	return resolveUnderRoot(t.workDir, outputDir)
 }
 
 // RunOne authors + audits + writes one sprint file. Caller supplies the contract
@@ -679,7 +674,10 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 		}
 		contract = c
 	}
-	outputDir := t.resolveOutputDir(args.OutputDir)
+	outputDir, err := t.resolveOutputDir(args.OutputDir)
+	if err != nil {
+		return "", fmt.Errorf("write_enriched_sprint: %w", err)
+	}
 
 	r, err := t.RunOne(ctx, contract, args.Path, args.Description, outputDir)
 	if err != nil {

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -125,11 +125,22 @@ Every enriched sprint MUST contain these sections, in this order:
 # DENSITY AND STYLE RULES
 
 - Use code syntax, not prose. Write actual Go/TypeScript/Python/SQL, not English descriptions of them.
-- For non-trivial logic, embed verbatim code blocks the executor can copy directly.
 - Use exact import paths, exact field names, exact constants — no placeholders.
 - For seed data and fixtures, list the exact values, not "example values".
-- Target ~200-500 lines per sprint; longer is fine if the sprint is large.
+- Target ~200-500 lines per sprint; longer is fine if the sprint is large (foundation sprints with full schemas often run 600-1000 lines).
 - Match the language and library choices declared in the contract — never introduce a library the contract doesn't list.
+
+# DENSITY: signatures + algorithm prose vs verbatim full bodies
+
+Two density modes are acceptable, picked by file type:
+
+1. **Verbatim full text** — required for tiny data-shaped files where exact text matters more than logic: ` + "`pyproject.toml`" + `, ` + "`package.json`" + `, build-system manifests, framework config files (` + "`tsconfig.json`" + `, ` + "`vite.config.ts`" + `, ` + "`alembic.ini`" + `, etc.), small exception/error-code constants files, the auto-discovery app factory (e.g., a FastAPI ` + "`main.py`" + ` with ` + "`pkgutil.iter_modules`" + ` router discovery), small async runners (` + "`init_db.py`" + `), all empty package markers.
+
+2. **Signatures + algorithm prose** — preferred for substantive code (routers, services, business logic, test files). Provide every type signature in ` + "`## Interface contract`" + `; provide every per-route or per-function logic flow in ` + "`## Algorithm notes`" + ` as numbered prose steps that name types/exceptions/symbols by exact identifier; provide per-file imports as full statements. The local model writes idiomatic bodies that match the contract.
+
+The empirical reason for mode 2 (validated end-to-end Apr 30 2026): when the architect writes verbatim bodies for a complex route handler, the bodies tend to carry stale unused imports, dead branches (` + "`if False`" + `), or impl-grade bugs that the local model faithfully transcribes. Numbered prose is more robust because the local model writes a clean body that obeys the contract.
+
+When in doubt: prefer mode 2. Use mode 1 only when EXACT TEXT is what matters (config blocks, manifest pinning).
 
 # VERBATIM-CONTENT RULE FOR NON-CODE FILES (LOAD-BEARING)
 
@@ -184,6 +195,100 @@ Bullets in both sections share the same format and are parsed by an awk/sed extr
 Other inline backticks in the descriptive tail are fine; the parser only takes the first.
 
 If the architect's description does not categorize a file, default rule: a file is NEW if no prior sprint owns it (per the contract's file-ownership map); otherwise it is MODIFIED.
+
+# WITHIN-SPRINT PATTERNS TO APPLY (load-bearing — read before producing the sprint)
+
+These patterns are the architect-side rules that close gaps the local code generator would otherwise fill in wrong. They are NOT a checklist to mechanically tick off — they are pattern categories to recognize and close in your spec output. The contract.md you receive will pin cross-sprint conventions; the patterns below are the within-sprint application.
+
+## P-1. Per-file imports as complete Python/Go/TS statements
+
+Every entry in ` + "`## New files`" + ` includes the EXACT imports list — full language statements, never bare module names. For class-vs-module collisions (Python: ` + "`datetime`" + `, ` + "`date`" + `, ` + "`time`" + `, ` + "`decimal.Decimal`" + `; TS/JS: relative path extensions), use the unambiguous import form explicitly.
+
+Why: the local model treats a bare ` + "`datetime`" + ` token as ` + "`import datetime`" + ` (the module). Subsequent ` + "`Mapped[datetime]`" + ` annotations then crash because the type needs the CLASS, not the module.
+
+## P-2. Route discipline (within a router file)
+
+- Path/query parameters annotated with real Python types (` + "`uuid.UUID`" + `, ` + "`date`" + `, etc.) — never default to ` + "`str`" + `. Without the annotation, FastAPI doesn't auto-parse and downstream type-bound code crashes.
+- Collection routes use empty-string path ` + "`\"\"`" + ` (not ` + "`\"/\"`" + `). Trailing-slash form causes 307 redirects when tests call without the slash.
+- Static-path routes declared BEFORE parameterized routes that share their prefix. FastAPI matches in declaration order.
+- The route order in the API contract table MUST match the declaration order in the router file (this is the structural-section rule below — prose alone won't work).
+
+## P-3. Schema construction discipline
+
+When the algorithm constructs a Read schema explicitly (e.g., ` + "`ShiftRead(...)`" + ` with a derived field), list the EXACT field set in the algorithm step: "construct ShiftRead with EXACTLY these fields and no others: id, location_id, ... — do NOT pass any other field." Plus a Rule reinforcement.
+
+Pydantic / Pydantic-equivalent Read schemas have exactly the fields declared in contract.md's data contract; do NOT invent fields based on "what should be there." (e.g., ` + "`Shift`" + ` has no ` + "`station_id`" + ` field — that lives on ` + "`Assignment`" + ` — even though the local model might infer one given the relationship between shifts and stations.)
+
+## P-4. Test fixture usage
+
+Tests take fixtures (` + "`client`" + `, ` + "`db_session`" + `, ` + "`auth_headers`" + `, etc.) as **function parameters**. Test files contain only test functions; they NEVER construct ` + "`AsyncClient`" + `, engines, or sessions inline. The conftest.py is pinned in contract.md (foundation sprint owns it).
+
+## P-5. Test data serialization
+
+For HTTP request bodies (httpx ` + "`json=`" + ` argument or equivalent):
+- ` + "`date`" + ` / ` + "`time`" + ` / ` + "`datetime`" + ` → ` + "`.isoformat()`" + ` before passing
+- ` + "`uuid.UUID`" + ` → ` + "`str(...)`" + ` before passing
+- Other primitives pass through as-is
+
+For ORM queries that filter on UUID columns from JSON-string ids:
+` + "```python\nreg_id = uuid.UUID(response.json()[\"id\"])\nresult = await db_session.execute(select(Registration).where(Registration.id == reg_id))\n```" + `
+
+For test assertions on error responses, USE THE EXACT JSON PATH that contract.md's error handler shape produces. If contract.md pins a flat ` + "`{\"detail\": str, \"error_code\": str}`" + ` shape, tests assert ` + "`body[\"error_code\"]`" + `; do NOT assert ` + "`body[\"detail\"][\"error_code\"]`" + `.
+
+## P-6. Tests need second-instance values pinned
+
+When a test needs a second instance of a model with unique constraints (second volunteer with different email/phone, second location, etc.), specify EXACT values in the test contract that don't collide with the fixture's primary instance. Example: "Construct other_volunteer with email='other@example.com', phone='+15559999999'."
+
+If you say "use a different value" without pinning what, the local model picks unpredictably and may collide with other tests.
+
+## P-7. Idempotent endpoint test patterns
+
+When testing idempotent endpoints (waiver/sign, orientation/complete), the test contract names what to capture and what to compare:
+
+> Sign once; capture ` + "`signed_at_1`" + `; sign again; capture ` + "`signed_at_2`" + `. Both 201; ` + "`signed_at_1 == signed_at_2`" + ` (same row, no new insert).
+
+# ARCHITECT-DISCIPLINE META-RULES
+
+## M-1. Structural sections must embody structural rules
+
+When you state a structural rule (e.g., "static routes before parameterized routes"), the structured sections MUST reflect it. The API contract table, signature blocks, algorithm subsections — all of them. The local model replicates the structure of the spec, not the prose rules. If a Rule says X but the table shows Y, the local model writes Y.
+
+## M-2. Make concrete choices
+
+Where the per-sprint description is ambiguous, commit to one answer. Don't hedge with "you may use X or Y." Don't write "choose based on your preference." The local model has no preference — it needs one answer.
+
+## M-3. Pin exact field sets
+
+When defining types, schemas, or constructed objects, list every field with its type. Never write partial examples with "...etc." The local model invents fields when given an incomplete shape.
+
+## M-4. Respect contract.md's FROZEN list and pinned conventions
+
+contract.md may declare a list of FROZEN files (under the front-loaded foundation pattern: ` + "`app/main.py`" + `, ` + "`app/models.py`" + `, ` + "`app/schemas.py`" + `, ` + "`app/exceptions.py`" + `, ` + "`app/database.py`" + `, ` + "`app/config.py`" + `, ` + "`tests/conftest.py`" + `). For sprints other than the foundation, ` + "`## Modified files: (none)`" + ` is the expected output — the foundation owns those files and the auto-discovery main.py picks up new router files automatically.
+
+If the contract pins a specific exception-handler JSON shape (flat vs nested), every test's error-response assertion in this sprint MUST match that shape.
+
+If the contract pins async loading strategy (` + "`lazy=\"selectin\"`" + ` on collection-side relationships), every relationship in any model this sprint touches MUST honor it.
+
+# TWO-PASS REVIEW
+
+After producing the SPRINT-NNN.md (Pass 1 — convert into the speedrun format applying the patterns above), run **Pass 2** before saving:
+
+Read the spec as if you were the local code-generator — what could you misinterpret?
+
+- Does each Tricky semantics rule have a WHY (what runtime symptom occurs without it)?
+- Does every collection-side relationship have ` + "`lazy=\"selectin\"`" + ` (or contract-pinned equivalent)?
+- Are path/query parameter types annotated everywhere with real Python types, not ` + "`str`" + `?
+- Are static routes ordered before parameterized routes in the API table?
+- When constructing a schema explicitly, is the EXACT field set listed?
+- Do the Imports lists for each file actually cover every symbol the Algorithm references?
+- Does the Test contract's response-shape assertions match contract.md's pinned exception handler shape (flat ` + "`body[\"error_code\"]`" + ` vs nested ` + "`body[\"detail\"][\"error_code\"]`" + `)?
+- When a test creates a second instance with unique constraints, are EXACT distinguishing values specified?
+- Does the API contract's route order match the implied algorithm-section order?
+- Are dates/times/UUIDs in JSON bodies serialized correctly (` + "`.isoformat()`" + ` / ` + "`str()`" + `)?
+- Are FROZEN files cross-referenced consistently with contract.md?
+- Are there fields that look like "common sense additions" the local model might invent? (Pin against them with explicit "no other fields" rules.)
+
+If you find an ambiguity, patch the spec. The point isn't perfection — it's making the local generator's output deterministic enough to be reliable.
 
 # OUTPUT FORMAT
 

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -432,18 +432,59 @@ type SprintRunResult struct {
 
 // LoadContract reads the contract file from disk. Resolves relative paths
 // against workDir. Empty contractFile defaults to ".ai/contract.md".
+//
+// When a workDir is set, validates that the resolved path stays inside it.
+// The contract content is shipped to the LLM provider as prompt context, so
+// a traversal here is a data-exfiltration vector. Both relative paths with
+// ".." segments and absolute paths pointing outside workDir are rejected.
 func (t *WriteEnrichedSprintTool) LoadContract(contractFile string) (string, error) {
 	if contractFile == "" {
 		contractFile = ".ai/contract.md"
 	}
-	if !filepath.IsAbs(contractFile) && t.workDir != "" {
-		contractFile = filepath.Join(t.workDir, contractFile)
-	}
-	data, err := os.ReadFile(contractFile)
+	resolved, err := t.resolveUnderWorkDir(contractFile)
 	if err != nil {
-		return "", fmt.Errorf("read contract from %s: %w (write the contract file first)", contractFile, err)
+		return "", fmt.Errorf("contract_file %q: %w", contractFile, err)
+	}
+	data, err := os.ReadFile(resolved)
+	if err != nil {
+		return "", fmt.Errorf("read contract from %s: %w (write the contract file first)", resolved, err)
 	}
 	return string(data), nil
+}
+
+// resolveUnderWorkDir takes a path argument (absolute or relative) and returns
+// the absolute resolved path. When workDir is set, validates that the result
+// is inside workDir and rejects paths that escape via "..", absolute paths
+// outside workDir, or symlink-like trickery. When workDir is empty (e.g., in
+// tests that don't set one), passes through with cleaning only.
+func (t *WriteEnrichedSprintTool) resolveUnderWorkDir(p string) (string, error) {
+	cleaned := filepath.Clean(p)
+	var resolved string
+	if filepath.IsAbs(cleaned) {
+		resolved = cleaned
+	} else if t.workDir != "" {
+		resolved = filepath.Join(t.workDir, cleaned)
+	} else {
+		resolved = cleaned
+	}
+	absResolved, err := filepath.Abs(resolved)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", p, err)
+	}
+	if t.workDir != "" {
+		absWorkDir, err := filepath.Abs(t.workDir)
+		if err != nil {
+			return "", fmt.Errorf("resolve workDir: %w", err)
+		}
+		rel, err := filepath.Rel(absWorkDir, absResolved)
+		if err != nil {
+			return "", fmt.Errorf("compute relative path: %w", err)
+		}
+		if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", fmt.Errorf("path resolves outside workDir %q (rel=%q)", t.workDir, rel)
+		}
+	}
+	return absResolved, nil
 }
 
 // resolveOutputDir applies the same defaulting rules Execute uses.
@@ -469,6 +510,29 @@ func (t *WriteEnrichedSprintTool) RunOne(ctx context.Context, contract, path, de
 	}
 	if description == "" {
 		return nil, fmt.Errorf("description is required")
+	}
+	// Path traversal guard: validate that filepath.Join(outputDir, path) stays
+	// inside outputDir. dispatch_sprints' readDispatchPlan already enforces a
+	// stricter ^SPRINT-NNN\.md$ regex, but Execute() (callable directly by an
+	// agent with arbitrary path input) has only this guard.
+	if filepath.IsAbs(path) {
+		return nil, fmt.Errorf("path must be relative to output_dir, got absolute %q", path)
+	}
+	cleanedPath := filepath.Clean(path)
+	if cleanedPath == ".." || strings.HasPrefix(cleanedPath, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("path %q resolves outside output_dir", path)
+	}
+	absOutput, err := filepath.Abs(outputDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve output_dir: %w", err)
+	}
+	absResolved, err := filepath.Abs(filepath.Join(outputDir, cleanedPath))
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+	rel, err := filepath.Rel(absOutput, absResolved)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf("path %q escapes output_dir %q", path, outputDir)
 	}
 
 	authorSystemPrompt := sprintSystemPromptHeader + enrichedSprintExample
@@ -844,7 +908,7 @@ func trySRWhitespace(content, search, replace string) (string, bool) {
 	for i := 0; i <= len(contentLines)-n; i++ {
 		chunk := strings.Join(contentLines[i:i+n], "")
 		if collapseWhitespace(chunk) == needle {
-			return strings.Replace(content, chunk, replace, 1), true
+			return replaceLineWindow(content, contentLines, i, n, replace), true
 		}
 	}
 	return content, false
@@ -881,8 +945,7 @@ func trySRIndent(content, search, replace string) (string, bool) {
 			// chunk's column space.
 			dedentedReplace := dedentLines(replace, sIndent)
 			indentedReplace := indentLines(dedentedReplace, chunkIndent)
-			chunkRStripped := strings.TrimRight(chunk, "\n")
-			return strings.Replace(content, chunkRStripped, indentedReplace, 1), true
+			return replaceLineWindow(content, contentLines, i, n, indentedReplace), true
 		}
 	}
 	return content, false
@@ -914,12 +977,31 @@ func trySRFuzzy(content, search, replace string) (string, bool) {
 	if bestIdx < 0 || bestRatio < threshold {
 		return content, false
 	}
-	chunk := strings.Join(contentLines[bestIdx:bestIdx+n], "")
-	rep := replace
-	if !strings.HasSuffix(rep, "\n") && strings.HasSuffix(chunk, "\n") {
-		rep += "\n"
+	return replaceLineWindow(content, contentLines, bestIdx, n, replace), true
+}
+
+// replaceLineWindow replaces the byte range occupied by contentLines[start:start+n]
+// in content with replace. Position-based (not first-occurrence-based) so the
+// windowed SR strategies can't accidentally patch an earlier identical-looking
+// chunk when the matched line range appears more than once in the document.
+//
+// Preserves trailing-newline behavior: if the matched window ended in '\n' but
+// the replacement doesn't, an LF is appended to keep the surrounding line
+// structure intact.
+func replaceLineWindow(content string, contentLines []string, start, n int, replace string) string {
+	startByte := 0
+	for j := 0; j < start; j++ {
+		startByte += len(contentLines[j])
 	}
-	return strings.Replace(content, chunk, rep, 1), true
+	endByte := startByte
+	for j := start; j < start+n; j++ {
+		endByte += len(contentLines[j])
+	}
+	finalReplace := replace
+	if endByte > 0 && content[endByte-1] == '\n' && !strings.HasSuffix(finalReplace, "\n") {
+		finalReplace += "\n"
+	}
+	return content[:startByte] + finalReplace + content[endByte:]
 }
 
 // collapseWhitespace returns s with all runs of whitespace collapsed to a single

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -582,8 +582,7 @@ func (t *WriteEnrichedSprintTool) RunOne(ctx context.Context, contract, path, de
 			"Per-sprint description from the architect:\n%s\n\n"+
 			"DRAFT (the author's first attempt) — audit this against the within-sprint patterns:\n\n"+
 			"---BEGIN DRAFT---\n%s\n---END DRAFT---\n\n"+
-			"Output: first line `AUDIT-VERDICT: PASS` (return draft verbatim) OR `AUDIT-VERDICT: PATCHED` (return patched version). "+
-			"Second line must be the `# Sprint NNN — Title (enriched spec)` heading. No commentary outside the markdown.",
+			"Output exactly per the system prompt: `AUDIT-VERDICT: PASS` alone (single line, nothing else) OR `AUDIT-VERDICT: PATCHED` followed by SEARCH/REPLACE blocks. No sprint heading, no commentary, no summary.",
 		contract, path, description, draft,
 	)
 
@@ -598,8 +597,11 @@ func (t *WriteEnrichedSprintTool) RunOne(ctx context.Context, contract, path, de
 		},
 	})
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit pass failed for %s (using draft as-is): %v\n", path, err)
-		auditResp = nil
+		// Provider errors hard-fail per CLAUDE.md — silently shipping an
+		// unaudited draft would be indistinguishable from a real auditor PASS
+		// and could mask quota/auth problems for hours. The author-pass
+		// (above) already returns on error; mirror that here.
+		return nil, fmt.Errorf("write_enriched_sprint: audit pass failed for %s: %w", path, err)
 	}
 
 	verdict := "PASS"

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -304,6 +304,117 @@ The following is a complete enriched sprint at the target density and structure.
 
 `
 
+const auditSystemPrompt = `You are auditing a draft enriched sprint specification produced by a sibling author model. You receive: the project-wide contract, the per-sprint description from the architect, and the author's draft. Your job is narrow: detect ambiguity-class issues that would cause the local code-generator (qwen3.6:35b or similar) to produce broken output. If you find issues, emit precise SEARCH/REPLACE patches. If the draft is clean, declare PASS.
+
+There is no third pass after you. Be decisive and minimal — preserve everything in the draft that's correct; patch surgically.
+
+# OUTPUT FORMAT — TWO ALTERNATIVES
+
+Your output starts with EXACTLY one of these markers on the first line:
+
+## Option A: ` + "`AUDIT-VERDICT: PASS`" + `
+
+The draft is clean; no patches needed. Output ONLY this single line and nothing else.
+
+## Option B: ` + "`AUDIT-VERDICT: PATCHED`" + `
+
+One or more issues were found. Follow the verdict line with one or more SEARCH/REPLACE blocks describing surgical edits to apply to the draft. Each block has this exact form (Aider-style):
+
+` + "```" + `
+<<<<<<< SEARCH
+<exact text from the draft to find>
+=======
+<replacement text>
+>>>>>>> REPLACE
+` + "```" + `
+
+Critical block rules:
+- The SEARCH section MUST match the draft EXACTLY — every character including whitespace, indentation, and line breaks. The tool does byte-exact matching; whitespace drift breaks the patch.
+- Include enough context lines around the change to make the SEARCH text unique within the draft. 3-5 surrounding lines is usually enough.
+- For pure inserts (e.g., adding a new Rule line), the SEARCH text is a unique anchor (the line before or after the insertion point) and the REPLACE text is the anchor + the new content.
+- Multiple non-adjacent edits → multiple blocks. Each block applies independently, in order.
+- Do NOT rewrite the whole file. Do NOT emit a full ` + "`# Sprint NNN — Title`" + ` markdown header. Emit only the SEARCH/REPLACE blocks.
+
+After your last block, output nothing — no commentary, no "FIXED:" notes, no audit summary.
+
+# WHEN TO PASS vs PATCH
+
+**PATCH only when the issue is CLEAR and ambiguity-class** — the local generator would produce broken output without the fix. Examples:
+- Path parameter typed as ` + "`str`" + ` where it should be ` + "`uuid.UUID`" + ` (defect class 7)
+- Test assertion uses ` + "`body[\"detail\"][\"error_code\"]`" + ` but contract pins flat shape (defect class 14)
+- Imports list missing a symbol the Algorithm references (defect class 2)
+- Schema construction missing the "do NOT pass any other field" guard (defect class 8)
+
+**PASS when uncertain or when the issue is stylistic.** The auditor is for catching CLEAR ambiguity-class issues, not for stylistic improvements. If you cannot decide, PASS.
+
+# AUDIT CHECKLIST
+
+Run through every category. For each: if the draft satisfies it, leave that section unchanged. If not, patch the relevant section minimally.
+
+## Pattern coverage (within-sprint)
+
+- Tricky semantics rules each have a WHY (what runtime symptom occurs without that rule)
+- Every collection-side relationship has ` + "`lazy=\"selectin\"`" + ` (or contract-pinned equivalent)
+- Bidirectional relationships have ` + "`back_populates`" + ` on BOTH sides with matching names
+- Path/query parameters annotated with real Python types (` + "`uuid.UUID`" + `, ` + "`date`" + `, etc.) — never default to ` + "`str`" + `
+- Collection routes use empty-string path ` + "`\"\"`" + ` (not ` + "`\"/\"`" + `) — trailing-slash form causes 307 redirects
+- Static-path routes declared BEFORE parameterized routes that share their prefix — IN BOTH the rule AND the API contract table (structural-section consistency)
+- When the algorithm constructs a Read schema explicitly, the EXACT field set is listed with "do NOT pass any other field"
+- Imports lists for each file cover EVERY symbol the Algorithm references (full Python statements, not bare module names; address class-vs-module collisions like ` + "`datetime`" + ` / ` + "`date`" + ` / ` + "`time`" + ` explicitly)
+- Test contract assertion paths match the contract's pinned exception handler shape (flat ` + "`body[\"error_code\"]`" + ` vs nested ` + "`body[\"detail\"][\"error_code\"]`" + ` — verify by checking the contract)
+- Tests creating second instances with unique constraints specify EXACT distinguishing values (e.g., second_volunteer email/phone given verbatim, not "different value")
+- Dates/times/UUIDs in JSON request bodies use ` + "`.isoformat()`" + ` / ` + "`str(...)`" + ` serialization
+- String UUIDs from ` + "`response.json()[\"id\"]`" + ` are parsed via ` + "`uuid.UUID(...)`" + ` before ORM queries
+- No invented schema fields (e.g., ` + "`Shift.station_id`" + ` when not in the contract's data model)
+
+## Architect-discipline meta-rules
+
+- Structural sections embody structural rules (table order matches the Rule's stated order)
+- Concrete choices made (no "you may use X or Y", no "choose based on preference")
+- Exact field sets pinned (no partial examples with "...etc.")
+- contract.md's FROZEN list and pinned conventions respected — for sprints other than the foundation, ` + "`## Modified files: (none)`" + ` is the expected output
+- Trivial files have verbatim content blocks (even empty files show ` + "```python\n```" + `)
+
+## Cross-section consistency
+
+- Imports lists cover every symbol the Algorithm sections reference
+- Test fixture parameters match what the test bodies actually use
+- API contract route order matches Algorithm subsection order
+- "New files" bullets and "Expected Artifacts" agree
+
+# PATCHING DISCIPLINE
+
+When emitting SEARCH/REPLACE blocks:
+- Preserve every section the draft got right.
+- Patch the smallest unit that closes the issue (a Rule line, a table row, an algorithm step, an imports list).
+- Do NOT introduce new ambiguities while patching. If you patch a Rule, the structural sections must still match (per M-1) — emit additional blocks for any structural sections that need updating.
+- Each block must be self-contained: the SEARCH text must be unique within the draft (include 3-5 lines of surrounding context if needed for uniqueness).
+
+# EXAMPLE OF A CORRECT PATCHED RESPONSE
+
+Suppose the draft has this in the API contract table:
+
+` + "```" + `
+| GET | /shifts/{shift_id} | none | — | ShiftRead (200) | 404 NOT_FOUND |
+| GET | /shifts/browse     | none | — | list[ShiftRead] (200) | — |
+` + "```" + `
+
+…but the spec's Rule says "static routes before parameterized." The auditor patches:
+
+` + "```" + `
+AUDIT-VERDICT: PATCHED
+<<<<<<< SEARCH
+| GET | /shifts/{shift_id} | none | — | ShiftRead (200) | 404 NOT_FOUND |
+| GET | /shifts/browse     | none | — | list[ShiftRead] (200) | — |
+=======
+| GET | /shifts/browse     | none | — | list[ShiftRead] (200) | — |
+| GET | /shifts/{shift_id} | none | — | ShiftRead (200) | 404 NOT_FOUND |
+>>>>>>> REPLACE
+` + "```" + `
+
+That's a 5-line patch (2 SEARCH lines, 2 REPLACE lines, plus markers) instead of regenerating the whole spec.
+`
+
 func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
 	var args struct {
 		Path         string `json:"path"`
@@ -348,9 +459,9 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 		args.OutputDir = filepath.Join(t.workDir, args.OutputDir)
 	}
 
-	systemPrompt := sprintSystemPromptHeader + enrichedSprintExample
+	authorSystemPrompt := sprintSystemPromptHeader + enrichedSprintExample
 
-	userPrompt := fmt.Sprintf(
+	authorUserPrompt := fmt.Sprintf(
 		"CONTRACT (project-wide architectural map shared across all sprints):\n\n%s\n\n"+
 			"SPRINT TO WRITE: %s\n\n"+
 			"Per-sprint description from the architect:\n%s\n\n"+
@@ -359,28 +470,205 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 		contract, args.Path, args.Description,
 	)
 
-	resp, err := t.client.Complete(ctx, &llm.Request{
+	// PASS 1 — Author. Produces the draft.
+	authorResp, err := t.client.Complete(ctx, &llm.Request{
 		Model:    t.model,
 		Provider: t.provider,
 		Messages: []llm.Message{
-			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: systemPrompt}}},
-			llm.UserMessage(userPrompt),
+			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: authorSystemPrompt}}},
+			llm.UserMessage(authorUserPrompt),
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("write_enriched_sprint: failed writing %s: %w", args.Path, err)
+		return "", fmt.Errorf("write_enriched_sprint: author pass failed for %s: %w", args.Path, err)
 	}
 
-	content := resp.Text()
-	content = trimEnclosingMarkdownFence(content)
+	draft := trimEnclosingMarkdownFence(authorResp.Text())
+
+	// PASS 2 — Auditor. Reviews the draft against the within-sprint patterns; either
+	// returns the draft verbatim (AUDIT-VERDICT: PASS) or a patched version (AUDIT-VERDICT: PATCHED).
+	// Different system prompt narrows the auditor's role; lower temperature makes the
+	// audit deterministic.
+	auditTemperature := 0.2
+	auditUserPrompt := fmt.Sprintf(
+		"CONTRACT (project-wide architectural map shared across all sprints):\n\n%s\n\n"+
+			"SPRINT BEING AUDITED: %s\n\n"+
+			"Per-sprint description from the architect:\n%s\n\n"+
+			"DRAFT (the author's first attempt) — audit this against the within-sprint patterns:\n\n"+
+			"---BEGIN DRAFT---\n%s\n---END DRAFT---\n\n"+
+			"Output: first line `AUDIT-VERDICT: PASS` (return draft verbatim) OR `AUDIT-VERDICT: PATCHED` (return patched version). "+
+			"Second line must be the `# Sprint NNN — Title (enriched spec)` heading. No commentary outside the markdown.",
+		contract, args.Path, args.Description, draft,
+	)
+
+	auditResp, err := t.client.Complete(ctx, &llm.Request{
+		Model:       t.model,
+		Provider:    t.provider,
+		Temperature: &auditTemperature,
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: auditSystemPrompt}}},
+			llm.UserMessage(auditUserPrompt),
+		},
+	})
+	if err != nil {
+		// Audit failure is non-fatal — fall back to draft.
+		// The author pass already produced something usable; an audit failure shouldn't lose it.
+		fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit pass failed for %s (using draft as-is): %v\n", args.Path, err)
+		auditResp = nil
+	}
+
+	verdict := "PASS"
+	final := draft
+	patchesApplied := 0
+	auditInTokens, auditOutTokens := 0, 0
+	if auditResp != nil {
+		auditText := trimEnclosingMarkdownFence(auditResp.Text())
+		v, blocks, parseErr := parseAuditResponse(auditText)
+		if parseErr != nil {
+			fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit response malformed for %s (using draft as-is): %v\n", args.Path, parseErr)
+			verdict = "PASS-FALLBACK-MALFORMED"
+		} else {
+			verdict = v
+			if v == "PATCHED" && len(blocks) > 0 {
+				patched, applyErr := applySRBlocks(draft, blocks)
+				if applyErr != nil {
+					// One or more blocks failed to match. Fall back to draft (don't ship a half-patched spec).
+					fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit patch apply failed for %s (using draft as-is): %v\n", args.Path, applyErr)
+					verdict = "PASS-FALLBACK-NOMATCH"
+				} else {
+					final = patched
+					patchesApplied = len(blocks)
+				}
+			}
+		}
+		auditInTokens = auditResp.Usage.InputTokens
+		auditOutTokens = auditResp.Usage.OutputTokens
+	}
 
 	path := filepath.Join(args.OutputDir, args.Path)
-	if err := writeSprintFile(path, content); err != nil {
+	if err := writeSprintFile(path, final); err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("Wrote %s (%d bytes). Model: %s. Tokens: %d in / %d out.",
-		args.Path, len(content), t.model, resp.Usage.InputTokens, resp.Usage.OutputTokens), nil
+	return fmt.Sprintf("Wrote %s (%d bytes, audit=%s, patches=%d). Model: %s. Tokens: author %d in / %d out, audit %d in / %d out.",
+		args.Path, len(final), verdict, patchesApplied, t.model,
+		authorResp.Usage.InputTokens, authorResp.Usage.OutputTokens,
+		auditInTokens, auditOutTokens), nil
+}
+
+// srBlock is one Aider-style SEARCH/REPLACE patch.
+type srBlock struct {
+	Search  string
+	Replace string
+}
+
+// parseAuditResponse parses the auditor's output. The first non-empty line must be
+// `AUDIT-VERDICT: PASS` or `AUDIT-VERDICT: PATCHED`. For PATCHED, the rest of the body
+// is one or more SEARCH/REPLACE blocks in Aider format:
+//
+//	<<<<<<< SEARCH
+//	<old text>
+//	=======
+//	<new text>
+//	>>>>>>> REPLACE
+//
+// Returns the verdict, the parsed blocks, and an error if the response is malformed.
+func parseAuditResponse(s string) (verdict string, blocks []srBlock, err error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return "", nil, fmt.Errorf("empty audit response")
+	}
+	lines := strings.SplitN(trimmed, "\n", 2)
+	first := strings.TrimSpace(lines[0])
+	const prefix = "AUDIT-VERDICT:"
+	if !strings.HasPrefix(first, prefix) {
+		return "", nil, fmt.Errorf("first line does not start with %q: got %q", prefix, first)
+	}
+	verdict = strings.TrimSpace(strings.TrimPrefix(first, prefix))
+	if verdict != "PASS" && verdict != "PATCHED" {
+		return "", nil, fmt.Errorf("unrecognized verdict: %q", verdict)
+	}
+	if verdict == "PASS" {
+		return "PASS", nil, nil
+	}
+	// PATCHED — parse SR blocks from the remaining body
+	if len(lines) < 2 {
+		return verdict, nil, fmt.Errorf("PATCHED verdict but no blocks in body")
+	}
+	body := lines[1]
+	blocks, err = parseSRBlocks(body)
+	if err != nil {
+		return verdict, nil, err
+	}
+	if len(blocks) == 0 {
+		return verdict, nil, fmt.Errorf("PATCHED verdict but zero SR blocks parsed")
+	}
+	return verdict, blocks, nil
+}
+
+// parseSRBlocks extracts Aider-style SEARCH/REPLACE blocks from a body of text.
+// Surrounding fences (e.g., ```) are tolerated and ignored. Returns blocks in source order.
+func parseSRBlocks(body string) ([]srBlock, error) {
+	const (
+		searchMarker  = "<<<<<<< SEARCH"
+		divideMarker  = "======="
+		replaceMarker = ">>>>>>> REPLACE"
+	)
+	var blocks []srBlock
+	rest := body
+	for {
+		startIdx := strings.Index(rest, searchMarker)
+		if startIdx < 0 {
+			break
+		}
+		afterStart := rest[startIdx+len(searchMarker):]
+		// Skip the rest of the marker line (handles "<<<<<<< SEARCH\n" and "<<<<<<< SEARCH something\n").
+		if nlIdx := strings.IndexByte(afterStart, '\n'); nlIdx >= 0 {
+			afterStart = afterStart[nlIdx+1:]
+		} else {
+			return blocks, fmt.Errorf("malformed block: SEARCH marker without following newline")
+		}
+		divIdx := strings.Index(afterStart, divideMarker)
+		if divIdx < 0 {
+			return blocks, fmt.Errorf("malformed block: SEARCH without ======= divider")
+		}
+		searchText := strings.TrimRight(afterStart[:divIdx], "\n")
+		afterDiv := afterStart[divIdx+len(divideMarker):]
+		if nlIdx := strings.IndexByte(afterDiv, '\n'); nlIdx >= 0 {
+			afterDiv = afterDiv[nlIdx+1:]
+		} else {
+			return blocks, fmt.Errorf("malformed block: ======= divider without following newline")
+		}
+		endIdx := strings.Index(afterDiv, replaceMarker)
+		if endIdx < 0 {
+			return blocks, fmt.Errorf("malformed block: ======= without >>>>>>> REPLACE marker")
+		}
+		replaceText := strings.TrimRight(afterDiv[:endIdx], "\n")
+		blocks = append(blocks, srBlock{Search: searchText, Replace: replaceText})
+		rest = afterDiv[endIdx+len(replaceMarker):]
+	}
+	return blocks, nil
+}
+
+// applySRBlocks applies the given blocks to the draft in source order. Each block's
+// SEARCH text MUST appear EXACTLY ONCE in the draft for the patch to apply (this catches
+// ambiguous matches early). Returns the patched text or an error if any block fails.
+func applySRBlocks(draft string, blocks []srBlock) (string, error) {
+	out := draft
+	for i, b := range blocks {
+		if b.Search == "" {
+			return "", fmt.Errorf("block %d: empty SEARCH text not supported (use a unique anchor for inserts)", i)
+		}
+		count := strings.Count(out, b.Search)
+		if count == 0 {
+			return "", fmt.Errorf("block %d: SEARCH text not found in draft", i)
+		}
+		if count > 1 {
+			return "", fmt.Errorf("block %d: SEARCH text matched %d times (must be unique — add more surrounding context)", i, count)
+		}
+		out = strings.Replace(out, b.Search, b.Replace, 1)
+	}
+	return out, nil
 }
 
 // trimEnclosingMarkdownFence removes a single pair of markdown fences wrapping

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -1,0 +1,304 @@
+// ABOUTME: Tool that writes one enriched sprint markdown file per call from a project-wide contract + per-sprint description.
+// ABOUTME: Architect (strong model) supplies the project map; this tool calls a mid-tier model (e.g. Sonnet) once per sprint.
+package tools
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+//go:embed write_enriched_sprint_example.md
+var enrichedSprintExample string
+
+// WriteEnrichedSprintTool calls a mid-tier LLM once per sprint to write an enriched sprint
+// markdown file from a project-wide architectural contract plus a per-sprint description.
+type WriteEnrichedSprintTool struct {
+	client   Completer
+	model    string
+	provider string
+	workDir  string
+}
+
+// WriteEnrichedSprintOption configures the WriteEnrichedSprintTool.
+type WriteEnrichedSprintOption func(*WriteEnrichedSprintTool)
+
+// WithSprintWriterModel sets the model used to write each sprint.
+func WithSprintWriterModel(model string) WriteEnrichedSprintOption {
+	return func(t *WriteEnrichedSprintTool) { t.model = model }
+}
+
+// WithSprintWriterProvider sets the provider used to write each sprint.
+func WithSprintWriterProvider(provider string) WriteEnrichedSprintOption {
+	return func(t *WriteEnrichedSprintTool) { t.provider = provider }
+}
+
+// WithSprintWriterWorkDir sets the base directory for writing sprint files.
+func WithSprintWriterWorkDir(dir string) WriteEnrichedSprintOption {
+	return func(t *WriteEnrichedSprintTool) { t.workDir = dir }
+}
+
+// NewWriteEnrichedSprintTool creates a tool that writes enriched sprint markdown.
+func NewWriteEnrichedSprintTool(client Completer, opts ...WriteEnrichedSprintOption) *WriteEnrichedSprintTool {
+	t := &WriteEnrichedSprintTool{
+		client:   client,
+		model:    "claude-sonnet-4-6",
+		provider: "anthropic",
+	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
+}
+
+func (t *WriteEnrichedSprintTool) Name() string { return "write_enriched_sprint" }
+
+func (t *WriteEnrichedSprintTool) Description() string {
+	return "Write ONE enriched sprint markdown file. The tool reads the project-wide " +
+		"architectural contract from .ai/contract.md (write it once, before iterating) " +
+		"and uses it on every invocation. Pass only the per-sprint path and description; " +
+		"the tool calls a mid-tier model (Sonnet) to produce the complete enriched markdown " +
+		"matching the format consumed by local-LLM sprint executors. Call this tool once " +
+		"per sprint — iterate across all sprints in the plan."
+}
+
+func (t *WriteEnrichedSprintTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"path": {
+				"type": "string",
+				"description": "File path for THIS sprint, relative to output_dir, e.g. SPRINT-005.md"
+			},
+			"description": {
+				"type": "string",
+				"description": "Per-sprint description: title, scope summary, FRs covered, files this sprint owns, cross-sprint dependencies it consumes. The contract (read from disk) carries the project map; this carries the per-sprint slice."
+			},
+			"contract_file": {
+				"type": "string",
+				"description": "Optional path to the contract file. Relative paths resolved against working directory. Defaults to .ai/contract.md."
+			},
+			"contract": {
+				"type": "string",
+				"description": "Optional inline contract string. If provided, takes precedence over contract_file. Use this only if you cannot write a contract file first."
+			},
+			"output_dir": {
+				"type": "string",
+				"description": "Directory to write the sprint file. Defaults to working directory."
+			}
+		},
+		"required": ["path", "description"]
+	}`)
+}
+
+const sprintSystemPromptHeader = `You are writing one enriched sprint specification for a software project.
+
+Your output is a markdown file consumed by a local code-generation LLM (e.g. qwen3.6:35b). The local LLM cannot infer English; it pattern-matches on exact section headers and copies code blocks verbatim. Density and structure matter more than prose.
+
+# REQUIRED SECTIONS (in order)
+
+Every enriched sprint MUST contain these sections, in this order:
+
+1. ` + "`# Sprint NNN — Title (enriched spec)`" + ` — top-level heading; the title comes from the contract or per-sprint description
+2. ` + "`## Scope`" + ` — 2-3 sentences of what this sprint delivers
+3. ` + "`## Non-goals`" + ` — bullets of what's explicitly excluded
+4. ` + "`## Dependencies`" + ` — bullets like "Sprint 002: cmd/agent/main.go exists with os.Args dispatch and printUsage"
+5. ` + "`## <Language>/runtime conventions`" + ` (or "(inherited from Sprint NNN)" if applicable) — module/package name, error patterns, library choices, version constraints — copied or inherited from the contract
+6. ` + "`## File structure`" + ` — fenced code block listing every file the sprint owns with one line per file: ` + "`path/to/file.ext — exported: Name1, Name2`" + `
+7. ` + "`## Interface contract`" + ` — fenced code blocks with the exact types, function signatures, constants, and SQL DDL the sprint introduces
+8. ` + "`## Imports per file`" + ` — for each new file in the sprint, a labeled fenced code block with the exact import statement(s)
+9. ` + "`## Algorithm notes`" + ` — for any non-trivial logic, fenced code blocks with verbatim implementation the local LLM can copy
+10. ` + "`## Test plan`" + ` — exact test function names with one-line expected behavior; subtests listed individually
+11. ` + "`## Rules`" + ` — bullets of constraints (no third-party libs in this sprint, naming rules, exit-only-from-main, build tag exclusions, etc.)
+12. ` + "`## New files`" + ` — bullets, one per NEW file this sprint creates: ` + "`- `\\``path/to/file.ext`\\`` — short purpose`" + `. Sprint executors extract the FIRST backticked path of each bullet to drive code generation.
+13. ` + "`## Modified files`" + ` — bullets, one per file this sprint MODIFIES (i.e. files that already exist from prior sprints and need targeted changes — appends, dispatch additions, schema extensions). Same bullet format. Use ` + "`(none)`" + ` if the sprint introduces only new files.
+14. ` + "`## Expected Artifacts`" + ` — flat list of every file this sprint produces (new + modified, paths only). Kept as a redundant index for human review and legacy tooling.
+15. ` + "`## DoD`" + ` — checkable items ` + "`- [ ] ...`" + ` (5-10 items, every item machine-verifiable; first item should be writing the failing test)
+16. ` + "`## Validation`" + ` — fenced bash code block with exact shell commands that prove the sprint is done
+
+# DENSITY AND STYLE RULES
+
+- Use code syntax, not prose. Write actual Go/TypeScript/Python/SQL, not English descriptions of them.
+- For non-trivial logic, embed verbatim code blocks the executor can copy directly.
+- Use exact import paths, exact field names, exact constants — no placeholders.
+- For seed data and fixtures, list the exact values, not "example values".
+- Target ~200-500 lines per sprint; longer is fine if the sprint is large.
+- Match the language and library choices declared in the contract — never introduce a library the contract doesn't list.
+
+# VERBATIM-CONTENT RULE FOR NON-CODE FILES (LOAD-BEARING)
+
+The local code-generator (e.g. qwen) is a transcriber, not a designer — it must NEVER have to decide what file content looks like. Every file listed in ` + "`## New files`" + ` MUST have its complete, literal content shown somewhere in the document.
+
+- **Code files** (.py, .ts, .go, .rs implementations): ` + "`## Interface contract`" + ` + ` + "`## Algorithm notes`" + ` together must give every type signature, every function body for non-trivial logic, and every import. If a code file has any unique behavior, the algorithm or full body must appear verbatim.
+
+- **Config / manifest files** (` + "`pyproject.toml`" + `, ` + "`package.json`" + `, ` + "`tsconfig.json`" + `, ` + "`vite.config.ts`" + `, ` + "`Cargo.toml`" + `, ` + "`go.mod`" + `, ` + "`.eslintrc`" + `, ` + "`alembic.ini`" + `, ` + "`pytest.ini`" + `, ` + "`uvicorn`" + ` config, etc.): MUST appear in full as a fenced code block. The local model cannot reliably invent dependency lists, build-system config (e.g. ` + "`[tool.hatch.build.targets.wheel]`" + `), version pins, or path mappings.
+
+- **Trivial/empty files** (empty ` + "`__init__.py`" + `, ` + "`mod.rs`" + `, ` + "`.gitkeep`" + `, license headers, one-line comments, marker files): MUST have a verbatim block, even if empty (show ` + "```python\n```" + ` for an empty file).
+
+Add a dedicated subsection (e.g., ` + "`### Trivial file contents`" + `) under ` + "`## Algorithm notes`" + ` or ` + "`## Interface contract`" + ` that lists every trivial file and its exact body. Format:
+
+` + "```" + `markdown
+### Trivial file contents
+
+**` + "`backend/app/__init__.py`" + `** — empty file. Content:
+` + "```python" + `
+` + "```" + `
+
+**` + "`backend/app/routers/__init__.py`" + `** — empty file. Content:
+` + "```python" + `
+` + "```" + `
+
+**` + "`backend/tests/__init__.py`" + `** — empty file. Content:
+` + "```python" + `
+` + "```" + `
+` + "```" + `
+
+If the trivial file truly is empty, the inner code block has zero lines between fences. The local model copies the literal content. Never describe trivial files only as "empty package init" or "package marker" without the verbatim block — that wording forces the model to make a decision and is the failure mode this rule prevents.
+
+# CROSS-SPRINT REFERENCES
+
+When this sprint depends on prior-sprint outputs, declare them in ` + "`## Dependencies`" + ` precisely:
+- "Sprint 002: cmd/agent/main.go exists with os.Args dispatch and printUsage"
+- "Sprint 003: internal/domain types exist (Budget, ProviderPolicy)"
+
+The contract you receive lists every cross-sprint dependency edge. Surface the relevant ones in ` + "`## Dependencies`" + ` and use them in ` + "`## Imports per file`" + ` and ` + "`## Interface contract`" + `.
+
+# NEW vs MODIFIED FILE SPLIT (LOAD-BEARING)
+
+The sprint executor decides per-file behavior from the section the file appears in:
+- ` + "`## New files`" + ` — executor calls a "generate from scratch" code path; if the file already exists it is SKIPPED (won't overwrite prior sprints' work).
+- ` + "`## Modified files`" + ` — executor reads the existing file and asks the model to apply ONLY the changes described under this section, returning the full updated file.
+
+Misclassifying a modified file as new will cause the executor to overwrite a prior sprint's contribution. Misclassifying a new file as modified will fail because there's no existing file to read. The architect's per-sprint description tells you which category each file belongs to — follow it strictly.
+
+Bullets in both sections share the same format and are parsed by an awk/sed extractor that takes the FIRST backtick-wrapped token as the path:
+
+` + "`- `\\``cmd/agent/main.go`\\`` — entrypoint with os.Args dispatch`" + `
+
+Other inline backticks in the descriptive tail are fine; the parser only takes the first.
+
+If the architect's description does not categorize a file, default rule: a file is NEW if no prior sprint owns it (per the contract's file-ownership map); otherwise it is MODIFIED.
+
+# OUTPUT FORMAT
+
+Output ONLY the raw markdown content of the sprint file. No commentary, no explanations, no fences wrapping the whole document. The first line of your output must be exactly:
+
+` + "`# Sprint NNN — Title (enriched spec)`" + `
+
+# COMPLETE REFERENCE EXAMPLE
+
+The following is a complete enriched sprint at the target density and structure. Match this style — same section names, same density, same use of fenced code blocks for all structural content. (This example is for a Go project; adapt language idioms to whatever the contract specifies.)
+
+---
+
+`
+
+func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var args struct {
+		Path         string `json:"path"`
+		Description  string `json:"description"`
+		Contract     string `json:"contract"`
+		ContractFile string `json:"contract_file"`
+		OutputDir    string `json:"output_dir"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+	if args.Path == "" {
+		return "", fmt.Errorf("write_enriched_sprint: path is required")
+	}
+	if args.Description == "" {
+		return "", fmt.Errorf("write_enriched_sprint: description is required")
+	}
+
+	contract := args.Contract
+	if contract == "" {
+		contractPath := args.ContractFile
+		if contractPath == "" {
+			contractPath = ".ai/contract.md"
+		}
+		if !filepath.IsAbs(contractPath) && t.workDir != "" {
+			contractPath = filepath.Join(t.workDir, contractPath)
+		}
+		data, err := os.ReadFile(contractPath)
+		if err != nil {
+			return "", fmt.Errorf("write_enriched_sprint: read contract from %s: %w (provide `contract` inline or write the contract file first)", contractPath, err)
+		}
+		contract = string(data)
+	}
+
+	if args.OutputDir == "" || args.OutputDir == "." {
+		args.OutputDir = t.workDir
+	}
+	if args.OutputDir == "" {
+		args.OutputDir = "."
+	}
+	if !filepath.IsAbs(args.OutputDir) && t.workDir != "" {
+		args.OutputDir = filepath.Join(t.workDir, args.OutputDir)
+	}
+
+	systemPrompt := sprintSystemPromptHeader + enrichedSprintExample
+
+	userPrompt := fmt.Sprintf(
+		"CONTRACT (project-wide architectural map shared across all sprints):\n\n%s\n\n"+
+			"SPRINT TO WRITE: %s\n\n"+
+			"Per-sprint description from the architect:\n%s\n\n"+
+			"Write the complete enriched sprint markdown for the file above. "+
+			"Output ONLY the raw markdown — first line must be the `# Sprint NNN — Title (enriched spec)` heading.",
+		contract, args.Path, args.Description,
+	)
+
+	resp, err := t.client.Complete(ctx, &llm.Request{
+		Model:    t.model,
+		Provider: t.provider,
+		Messages: []llm.Message{
+			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: systemPrompt}}},
+			llm.UserMessage(userPrompt),
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("write_enriched_sprint: failed writing %s: %w", args.Path, err)
+	}
+
+	content := resp.Text()
+	content = trimEnclosingMarkdownFence(content)
+
+	path := filepath.Join(args.OutputDir, args.Path)
+	if err := writeSprintFile(path, content); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("Wrote %s (%d bytes). Model: %s. Tokens: %d in / %d out.",
+		args.Path, len(content), t.model, resp.Usage.InputTokens, resp.Usage.OutputTokens), nil
+}
+
+// trimEnclosingMarkdownFence removes a single pair of markdown fences wrapping
+// the entire response (some models wrap markdown output in ```markdown ... ```).
+// It does NOT touch internal fenced code blocks within the document.
+func trimEnclosingMarkdownFence(s string) string {
+	trimmed := strings.TrimSpace(s)
+	lines := strings.Split(trimmed, "\n")
+	if len(lines) < 2 {
+		return s
+	}
+	first := strings.TrimSpace(lines[0])
+	last := strings.TrimSpace(lines[len(lines)-1])
+	if strings.HasPrefix(first, "```") && last == "```" {
+		return strings.Join(lines[1:len(lines)-1], "\n")
+	}
+	return s
+}
+
+func writeSprintFile(path string, content string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", dir, err)
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -101,58 +101,59 @@ const sprintSystemPromptHeader = `You are writing one enriched sprint specificat
 
 Your output is a markdown file consumed by a local code-generation LLM (e.g. qwen3.6:35b). The local LLM cannot infer English; it pattern-matches on exact section headers and copies code blocks verbatim. Density and structure matter more than prose.
 
-# REQUIRED SECTIONS (in order)
+# SCOPE OF RESPONSIBILITY (read this first — what's yours vs what's already pinned)
 
-Every enriched sprint MUST contain these sections, in this order:
+You operate inside a two-layer pipeline:
 
-1. ` + "`# Sprint NNN — Title (enriched spec)`" + ` — top-level heading; the title comes from the contract or per-sprint description
-2. ` + "`## Scope`" + ` — 2-3 sentences of what this sprint delivers
-3. ` + "`## Non-goals`" + ` — bullets of what's explicitly excluded
-4. ` + "`## Dependencies`" + ` — bullets like "Sprint 002: cmd/agent/main.go exists with os.Args dispatch and printUsage"
-5. ` + "`## <Language>/runtime conventions`" + ` (or "(inherited from Sprint NNN)" if applicable) — module/package name, error patterns, library choices, version constraints — copied or inherited from the contract
-6. ` + "`## File structure`" + ` — fenced code block listing every file the sprint owns with one line per file: ` + "`path/to/file.ext — exported: Name1, Name2`" + `
-7. ` + "`## Interface contract`" + ` — fenced code blocks with the exact types, function signatures, constants, and SQL DDL the sprint introduces
-8. ` + "`## Imports per file`" + ` — for each new file in the sprint, a labeled fenced code block with the exact import statement(s)
-9. ` + "`## Algorithm notes`" + ` — for any non-trivial logic, fenced code blocks with verbatim implementation the local LLM can copy
-10. ` + "`## Test plan`" + ` — exact test function names with one-line expected behavior; subtests listed individually
-11. ` + "`## Rules`" + ` — bullets of constraints (no third-party libs in this sprint, naming rules, exit-only-from-main, build tag exclusions, etc.)
-12. ` + "`## New files`" + ` — bullets, one per NEW file this sprint creates: ` + "`- `\\``path/to/file.ext`\\`` — short purpose`" + `. Sprint executors extract the FIRST backticked path of each bullet to drive code generation.
-13. ` + "`## Modified files`" + ` — bullets, one per file this sprint MODIFIES (i.e. files that already exist from prior sprints and need targeted changes — appends, dispatch additions, schema extensions). Same bullet format. Use ` + "`(none)`" + ` if the sprint introduces only new files.
-14. ` + "`## Expected Artifacts`" + ` — flat list of every file this sprint produces (new + modified, paths only). Kept as a redundant index for human review and legacy tooling.
-15. ` + "`## DoD`" + ` — checkable items ` + "`- [ ] ...`" + ` (5-10 items, every item machine-verifiable; first item should be writing the failing test)
-16. ` + "`## Validation`" + ` — fenced bash code block with exact shell commands that prove the sprint is done
+- **Cross-sprint architect (Opus)** wrote the project-wide ` + "`contract.md`" + ` you receive on every call. The contract pins everything that crosses sprint boundaries: stack + runtime, project-wide conventions, the full data model (every Enum, ORM model, and Pydantic schema with field signatures), the cross-sprint type/symbol ownership map, the file-ownership map (which sprint owns which files; which files are FROZEN), the cross-sprint dependency edges, mandatory rules, and tricky semantics that span sprints. The contract is the truth.
+- **You (Sonnet, within-sprint writer)** expand ONE per-sprint slice into the full enriched spec. Your job is to translate the per-sprint description plus the relevant slice of the contract into a SPRINT-NNN.md the local generator can transcribe deterministically.
 
-# DENSITY AND STYLE RULES
+What this means in practice:
 
-- Use code syntax, not prose. Write actual Go/TypeScript/Python/SQL, not English descriptions of them.
-- Use exact import paths, exact field names, exact constants — no placeholders.
-- For seed data and fixtures, list the exact values, not "example values".
-- Target ~200-500 lines per sprint; longer is fine if the sprint is large (foundation sprints with full schemas often run 600-1000 lines).
-- Match the language and library choices declared in the contract — never introduce a library the contract doesn't list.
+- **Do NOT redefine cross-sprint shapes.** When sprint 002 needs ` + "`Note`" + ` and ` + "`Tag`" + `, the ` + "`## Data contract`" + ` section says "no new types — referenced from sprint 001" and points back to the contract. You don't repeat the field signatures.
+- **Do NOT invent cross-sprint conventions.** If the contract pins flat error shape ` + "`{\"detail\": str, \"error_code\": str}`" + `, that's the rule. Your tests assert ` + "`body[\"error_code\"]`" + `; you do not pick a different path.
+- **Do NOT modify FROZEN files.** The contract lists them; for additive sprints, ` + "`## Modified files`" + ` reads ` + "`(none)`" + `.
+- **DO** pull the relevant slice of contract conventions into ` + "`## Conventions (inherited from Sprint NNN — listed for tight feedback)`" + ` and the relevant slice of cross-sprint tricky semantics into ` + "`## Tricky semantics (load-bearing — read before writing routes)`" + ` so the local model has them on-hand without re-reading contract.md.
+- **DO** declare new sprint-local types (request/response schemas the contract doesn't already cover, helper functions) in ` + "`## Data contract`" + ` and ` + "`## Algorithm`" + ` for THIS sprint only.
+
+# REQUIRED SECTIONS (speedrun shape)
+
+Every enriched sprint has these sections, in this order. Most are present every sprint; ` + "`## Verbatim files`" + ` is conditional.
+
+1. ` + "`# Sprint NNN — <Title> (enriched spec)`" + ` — top-level heading. Foundation sprints use a descriptive title (e.g. "Sprint 001 — Foundation (full schema + auth, front-loaded)"). Additive sprints append "(additive)".
+2. ` + "`## Scope`" + ` — 2-4 sentences. For additive sprints, explicitly note: "Purely additive — no edits to any sprint NNN file."
+3. ` + "`## Non-goals`" + ` — bullets of what this sprint does NOT include, with cross-references to which later sprint handles each excluded thing.
+4. ` + "`## Dependencies`" + ` — for sprint 001: "None — first sprint." For sprints 002+: a tightly-scoped list of prior-sprint contracts this sprint imports, by exact symbol name. Header for additives: ` + "`## Dependencies (sprint NNN contracts this sprint imports — none get redefined here)`" + `.
+5. ` + "`## Conventions`" + ` — sprint 001 declares them in full (module path, language version + package manager, web framework + ASGI server, ORM driver + style, validation lib, auth lib, test framework + asyncio mode, lint rules, ID type, error-raising convention, all timestamps timezone). Sprints 002+ use header ` + "`## Conventions (inherited from Sprint 001 — listed here for tight feedback)`" + ` and re-iterate the load-bearing ones (router declaration, AppError vs raw HTTPException, async def for routes/tests, fixtures-as-parameters, full-Python-statement imports, etc.).
+6. ` + "`## Tricky semantics`" + ` — load-bearing. The most important section. Numbered list of project conventions where each rule has the rule itself + a brief WHY (often: the runtime symptom that occurs without it) + an optional code-pattern example. Sprint 001's master list covers cross-sprint conventions; sprints 002+ extract a sprint-relevant subset (e.g., "Cancelled registrations do NOT count toward shift capacity" for a registration-routes sprint). Use header ` + "`## Tricky semantics (load-bearing — READ BEFORE WRITING ANY CODE)`" + ` for sprint 001, ` + "`## Tricky semantics (load-bearing — read before writing routes)`" + ` for additive sprints.
+7. ` + "`## Data contract`" + ` — sprint 001: full Enums + ORM models + Pydantic schemas with every field signature (` + "`Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)`" + `, ` + "`server_default=func.now()`" + `, ` + "`lazy=\"selectin\"`" + ` on collection-side relationships, ` + "`back_populates`" + ` on both sides). Subsections: ` + "`### Enums (declared in app/models.py)`" + `, ` + "`### ORM models (declared in app/models.py, FROZEN after this sprint)`" + `, ` + "`### Pydantic schemas (declared in app/schemas.py, FROZEN after this sprint)`" + `. Sprints 002+ that introduce no new types: header ` + "`## Data contract (no new types — referenced from sprint 001)`" + ` followed by a one-paragraph note redirecting to sprint 001.
+8. ` + "`## API contract`" + ` — the sprint's routes. A pipe-separated table with columns ` + "`Method | Path | Auth | Request | Response (status) | Errors`" + `. **The route order in this table MUST match the declaration order in the router file** (M-1: structural sections embody structural rules — see below). For routers with both static and parameterized paths, static comes first. Above the table, list the path/query parameter Python types ("` + "`location_id`" + `, ` + "`shift_id`" + ` are ` + "`uuid.UUID`" + `; ` + "`on_date`" + ` is ` + "`date | None = None`" + `") and the empty-string-vs-trailing-slash convention ("collection routes use ` + "`\"\"`" + `, not ` + "`\"/\"`" + `").
+9. ` + "`## Algorithm`" + ` — per-route subsections (` + "`### `\\``POST /registrations`\\`` — `\\``create_registration`\\`" + `") with numbered prose steps. Each step names types, exceptions, and symbols by exact identifier — no English placeholders. For routes that construct a Read schema explicitly with derived fields, list the EXACT field set ("Construct ShiftRead with EXACTLY these fields and no others: id, location_id, ...; do NOT pass any other field"). Foundation sprints also have subsections for ` + "`### Enums`" + ` / ` + "`### ORM models`" + ` / ` + "`### Pydantic schemas`" + ` if those declarations need explanation beyond the data contract.
+10. ` + "`## Test contract`" + ` — per-test-file tables (one table per file). Header sentence describes shared rules ("All tests are ` + "`async def`" + `. None have decorators. All take ` + "`client`" + ` from conftest as a parameter; auth-required routes also take ` + "`auth_headers`" + `."). Each table has columns ` + "`Test | Action | Asserts`" + `. Test names are explicit (` + "`test_register_full_shift_returns_409_capacity_full(client, auth_headers, test_shift, db_session)`" + `). Asserts state EXACT JSON paths matching the contract's pinned exception handler shape. When tests need a second instance with unique constraints, the EXACT distinguishing values are pinned ("Construct other_volunteer with email='other@example.com', phone='+15559999999'"). Sprint 001 also has a ` + "`### tests/conftest.py fixtures`" + ` subsection naming each fixture and its dependencies.
+11. ` + "`## Verbatim files`" + ` — **conditional.** Present when the sprint owns tiny data-shaped files where exact text matters more than logic. Subsection per file (` + "`### `\\``backend/app/exceptions.py`\\`" + ` "). Includes ` + "`pyproject.toml`" + `, the auto-discovery ` + "`main.py`" + `, ` + "`exceptions.py`" + `, ` + "`config.py`" + `, ` + "`database.py`" + `, ` + "`scripts/init_db.py`" + ` for a foundation sprint. **Omit this section entirely if the sprint introduces no new tiny configs** (most additive sprints).
+12. ` + "`## New files`" + ` — bullets, one per NEW file: ` + "`- `\\``backend/app/routers/notes.py`\\`` — short purpose. Imports (use these EXACT statements): ...`" + `. Sprint executors extract the FIRST backticked path of each bullet to drive code generation. The bullet body explicitly lists the imports (full Python statements, never bare module names — for class-vs-module collisions like ` + "`datetime`" + ` / ` + "`date`" + ` / ` + "`time`" + `, use ` + "`from X import Y`" + `).
+13. ` + "`## Modified files`" + ` — bullets in same format. Use ` + "`(none — sprint 001's main.py auto-discovers ...)`" + ` for purely additive sprints.
+14. ` + "`## Rules`" + ` — sprint-local constraints. Inherits the project-wide rules implicitly via contract.md. Restate the load-bearing within-sprint ones for tight feedback (path/query param typing, empty-string collection paths, route declaration order, schema field-set discipline, ` + "`uuid.UUID(...)`" + ` parsing of response IDs, ` + "`.isoformat()`" + ` / ` + "`str(...)`" + ` for JSON request bodies, fixtures-as-parameters).
+15. ` + "`## DoD`" + ` — checkable items ` + "`- [ ] ...`" + ` (5-10 items, every item machine-verifiable; first item should be writing the failing test). Includes per-test-file pytest commands plus a "no FROZEN files modified" item for additive sprints.
+16. ` + "`## Validation`" + ` — fenced bash code block with the exact shell commands that prove the sprint is done.
+
+The two reference examples below show the foundation shape (sprint 001) and the additive shape (sprint 002). Match the shape and density of whichever applies to your sprint.
 
 # DENSITY: signatures + algorithm prose vs verbatim full bodies
 
 Two density modes are acceptable, picked by file type:
 
-1. **Verbatim full text** — required for tiny data-shaped files where exact text matters more than logic: ` + "`pyproject.toml`" + `, ` + "`package.json`" + `, build-system manifests, framework config files (` + "`tsconfig.json`" + `, ` + "`vite.config.ts`" + `, ` + "`alembic.ini`" + `, etc.), small exception/error-code constants files, the auto-discovery app factory (e.g., a FastAPI ` + "`main.py`" + ` with ` + "`pkgutil.iter_modules`" + ` router discovery), small async runners (` + "`init_db.py`" + `), all empty package markers.
+1. **Verbatim full text** (mode 1) — required ONLY for **tiny data-shaped files** where exact text matters more than logic and where the local generator cannot reliably invent the content: ` + "`pyproject.toml`" + `, ` + "`package.json`" + `, build-system manifests, framework config files (` + "`tsconfig.json`" + `, ` + "`alembic.ini`" + `), small exception/error-code constants files (` + "`exceptions.py`" + ` with ` + "`AppError`" + ` + ~10 error code constants), the auto-discovery app factory (` + "`main.py`" + ` with ` + "`pkgutil.iter_modules`" + `), small async runners (` + "`init_db.py`" + `), all empty package markers (` + "`__init__.py`" + `).
 
-2. **Signatures + algorithm prose** — preferred for substantive code (routers, services, business logic, test files). Provide every type signature in ` + "`## Interface contract`" + `; provide every per-route or per-function logic flow in ` + "`## Algorithm notes`" + ` as numbered prose steps that name types/exceptions/symbols by exact identifier; provide per-file imports as full statements. The local model writes idiomatic bodies that match the contract.
+2. **Signatures + algorithm prose** (mode 2) — preferred for all substantive code: routers, services, business logic, test files, ORM models with non-trivial relationships. Provide every type signature in ` + "`## Data contract`" + `; provide every per-route or per-function logic flow in ` + "`## Algorithm`" + ` as numbered prose steps that name types/exceptions/symbols by exact identifier; provide per-file imports as full statements in the ` + "`## New files`" + ` bullets. The local model writes idiomatic bodies that match the contract.
 
-The empirical reason for mode 2 (validated end-to-end Apr 30 2026): when the architect writes verbatim bodies for a complex route handler, the bodies tend to carry stale unused imports, dead branches (` + "`if False`" + `), or impl-grade bugs that the local model faithfully transcribes. Numbered prose is more robust because the local model writes a clean body that obeys the contract.
+The empirical reason for mode 2 (validated end-to-end on NIFB Apr 30 2026, 21/21 first-pass tests on sprint 001 + 26/26 on sprint 002 + 14/14 on sprint 003): when the architect writes verbatim bodies for a complex route handler, the bodies tend to carry stale unused imports, dead branches (` + "`if False`" + `), or impl-grade bugs that the local model faithfully transcribes. Numbered prose is more robust because the local model writes a clean body that obeys the contract.
 
-When in doubt: prefer mode 2. Use mode 1 only when EXACT TEXT is what matters (config blocks, manifest pinning).
+**Rule of thumb: if a file is in ` + "`## Verbatim files`" + `, mode 1. Otherwise mode 2.** Never mode-1 a router, a service, an ORM model, or a test file. The contract pins which files belong in mode 1; if you're unsure, mode 2 is the safe default.
 
-# VERBATIM-CONTENT RULE FOR NON-CODE FILES (LOAD-BEARING)
+# TRIVIAL EMPTY FILES
 
-The local code-generator (e.g. qwen) is a transcriber, not a designer — it must NEVER have to decide what file content looks like. Every file listed in ` + "`## New files`" + ` MUST have its complete, literal content shown somewhere in the document.
-
-- **Code files** (.py, .ts, .go, .rs implementations): ` + "`## Interface contract`" + ` + ` + "`## Algorithm notes`" + ` together must give every type signature, every function body for non-trivial logic, and every import. If a code file has any unique behavior, the algorithm or full body must appear verbatim.
-
-- **Config / manifest files** (` + "`pyproject.toml`" + `, ` + "`package.json`" + `, ` + "`tsconfig.json`" + `, ` + "`vite.config.ts`" + `, ` + "`Cargo.toml`" + `, ` + "`go.mod`" + `, ` + "`.eslintrc`" + `, ` + "`alembic.ini`" + `, ` + "`pytest.ini`" + `, ` + "`uvicorn`" + ` config, etc.): MUST appear in full as a fenced code block. The local model cannot reliably invent dependency lists, build-system config (e.g. ` + "`[tool.hatch.build.targets.wheel]`" + `), version pins, or path mappings.
-
-- **Trivial/empty files** (empty ` + "`__init__.py`" + `, ` + "`mod.rs`" + `, ` + "`.gitkeep`" + `, license headers, one-line comments, marker files): MUST have a verbatim block, even if empty (show ` + "```python\n```" + ` for an empty file).
-
-Add a dedicated subsection (e.g., ` + "`### Trivial file contents`" + `) under ` + "`## Algorithm notes`" + ` or ` + "`## Interface contract`" + ` that lists every trivial file and its exact body. Format:
+Empty package markers (` + "`__init__.py`" + `, ` + "`mod.rs`" + `, ` + "`.gitkeep`" + `) MUST have a verbatim block in ` + "`## Verbatim files`" + ` even though they're empty:
 
 ` + "```" + `markdown
 ### Trivial file contents
@@ -164,21 +165,9 @@ Add a dedicated subsection (e.g., ` + "`### Trivial file contents`" + `) under `
 **` + "`backend/app/routers/__init__.py`" + `** — empty file. Content:
 ` + "```python" + `
 ` + "```" + `
-
-**` + "`backend/tests/__init__.py`" + `** — empty file. Content:
-` + "```python" + `
-` + "```" + `
 ` + "```" + `
 
-If the trivial file truly is empty, the inner code block has zero lines between fences. The local model copies the literal content. Never describe trivial files only as "empty package init" or "package marker" without the verbatim block — that wording forces the model to make a decision and is the failure mode this rule prevents.
-
-# CROSS-SPRINT REFERENCES
-
-When this sprint depends on prior-sprint outputs, declare them in ` + "`## Dependencies`" + ` precisely:
-- "Sprint 002: cmd/agent/main.go exists with os.Args dispatch and printUsage"
-- "Sprint 003: internal/domain types exist (Budget, ProviderPolicy)"
-
-The contract you receive lists every cross-sprint dependency edge. Surface the relevant ones in ` + "`## Dependencies`" + ` and use them in ` + "`## Imports per file`" + ` and ` + "`## Interface contract`" + `.
+If the trivial file truly is empty, the inner code block has zero lines between fences. The local model copies the literal content. Never describe trivial files as "empty package init" or "package marker" without the verbatim block — that wording forces the model to make a decision and is the failure mode this rule prevents.
 
 # NEW vs MODIFIED FILE SPLIT (LOAD-BEARING)
 
@@ -186,15 +175,15 @@ The sprint executor decides per-file behavior from the section the file appears 
 - ` + "`## New files`" + ` — executor calls a "generate from scratch" code path; if the file already exists it is SKIPPED (won't overwrite prior sprints' work).
 - ` + "`## Modified files`" + ` — executor reads the existing file and asks the model to apply ONLY the changes described under this section, returning the full updated file.
 
-Misclassifying a modified file as new will cause the executor to overwrite a prior sprint's contribution. Misclassifying a new file as modified will fail because there's no existing file to read. The architect's per-sprint description tells you which category each file belongs to — follow it strictly.
+Misclassifying a modified file as new will cause the executor to overwrite a prior sprint's contribution. Misclassifying a new file as modified will fail because there's no existing file to read. The architect's per-sprint description tells you which category each file belongs to (and the contract.md file-ownership map confirms it). Follow strictly.
 
-Bullets in both sections share the same format and are parsed by an awk/sed extractor that takes the FIRST backtick-wrapped token as the path:
+For sprints under the front-loaded foundation pattern, additive sprints typically have ` + "`## Modified files: (none — sprint 001's main.py auto-discovers ...)`" + ` because they only drop new files in ` + "`app/routers/`" + ` and ` + "`tests/`" + `. ALWAYS prefer additive over modify when the architecture allows.
 
-` + "`- `\\``cmd/agent/main.go`\\`` — entrypoint with os.Args dispatch`" + `
+Bullets in both sections share the same format. The executor's parser takes the FIRST backtick-wrapped token as the path:
+
+` + "`- `\\``backend/app/routers/notes.py`\\`` — short purpose. Imports (use these EXACT statements): import uuid, from fastapi import APIRouter, Depends`" + `
 
 Other inline backticks in the descriptive tail are fine; the parser only takes the first.
-
-If the architect's description does not categorize a file, default rule: a file is NEW if no prior sprint owns it (per the contract's file-ownership map); otherwise it is MODIFIED.
 
 # WITHIN-SPRINT PATTERNS TO APPLY (load-bearing — read before producing the sprint)
 
@@ -296,9 +285,11 @@ Output ONLY the raw markdown content of the sprint file. No commentary, no expla
 
 ` + "`# Sprint NNN — Title (enriched spec)`" + `
 
-# COMPLETE REFERENCE EXAMPLE
+# COMPLETE REFERENCE EXAMPLES (foundation + additive)
 
-The following is a complete enriched sprint at the target density and structure. Match this style — same section names, same density, same use of fenced code blocks for all structural content. (This example is for a Go project; adapt language idioms to whatever the contract specifies.)
+Two reference sprints from a validated NIFB run (Apr 30 2026; sprint 001 generated 21/21 first-pass tests, sprint 002 generated 26/26). The first is the foundation sprint shape (front-loaded — every ORM model, every Pydantic schema, every error code, every fixture, plus the working slice for the first feature). The second is an additive sprint shape (new router files only; FROZEN sprint-001 files unchanged; conventions and tricky semantics inherited with brief redirect notes).
+
+Match the section names, ordering, density, and use of fenced code blocks shown below. Foundation sprints look like the first example; additive sprints (sprints 002+ in front-loaded designs) look like the second. If the architect's per-sprint description marks this as a foundation sprint, follow example 1; otherwise follow example 2. Adapt language idioms (Python here; Go/TS/Rust as the contract specifies).
 
 ---
 
@@ -390,6 +381,16 @@ When emitting SEARCH/REPLACE blocks:
 - Do NOT introduce new ambiguities while patching. If you patch a Rule, the structural sections must still match (per M-1) — emit additional blocks for any structural sections that need updating.
 - Each block must be self-contained: the SEARCH text must be unique within the draft (include 3-5 lines of surrounding context if needed for uniqueness).
 
+## Non-overlap rule (load-bearing for sequential block apply)
+
+Blocks are applied in source order against the evolving draft. A block emitted later cannot find its anchor if an earlier block has already replaced that text. Avoid this:
+
+- **No two blocks may have overlapping SEARCH regions.** If two of your fixes target the same lines (or adjacent lines whose context surrounds both), MERGE them into a single SR block whose REPLACE contains both fixes.
+- **No block's SEARCH may include text that another block's REPLACE will produce.** This shouldn't happen in normal patching, but watch for it when you patch a Rule and a Table that share wording.
+- **Keep blocks small and targeted.** A block that spans 20 lines is far more likely to overlap with sibling blocks than one that spans 5 lines. Prefer narrow context windows (3-5 lines around the change) over broad ones.
+
+If you find yourself emitting many blocks for the same section (e.g., 4 separate edits to one Algorithm subsection), strongly consider rewriting that subsection in a single block: SEARCH the original subsection in full, REPLACE with the corrected version. One bigger block is more likely to apply cleanly than four small blocks fighting over overlapping anchors.
+
 # EXAMPLE OF A CORRECT PATCHED RESPONSE
 
 Suppose the draft has this in the API contract table:
@@ -415,48 +416,59 @@ AUDIT-VERDICT: PATCHED
 That's a 5-line patch (2 SEARCH lines, 2 REPLACE lines, plus markers) instead of regenerating the whole spec.
 `
 
-func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
-	var args struct {
-		Path         string `json:"path"`
-		Description  string `json:"description"`
-		Contract     string `json:"contract"`
-		ContractFile string `json:"contract_file"`
-		OutputDir    string `json:"output_dir"`
-	}
-	if err := json.Unmarshal(input, &args); err != nil {
-		return "", fmt.Errorf("parse args: %w", err)
-	}
-	if args.Path == "" {
-		return "", fmt.Errorf("write_enriched_sprint: path is required")
-	}
-	if args.Description == "" {
-		return "", fmt.Errorf("write_enriched_sprint: description is required")
-	}
+// SprintRunResult captures the per-sprint outcome of RunOne. Used by callers
+// (Execute and dispatch_sprints) to format summaries and aggregate counts.
+type SprintRunResult struct {
+	Path           string
+	Bytes          int
+	Verdict        string
+	PatchesApplied int
+	Model          string
+	AuthorIn       int
+	AuthorOut      int
+	AuditIn        int
+	AuditOut       int
+}
 
-	contract := args.Contract
-	if contract == "" {
-		contractPath := args.ContractFile
-		if contractPath == "" {
-			contractPath = ".ai/contract.md"
-		}
-		if !filepath.IsAbs(contractPath) && t.workDir != "" {
-			contractPath = filepath.Join(t.workDir, contractPath)
-		}
-		data, err := os.ReadFile(contractPath)
-		if err != nil {
-			return "", fmt.Errorf("write_enriched_sprint: read contract from %s: %w (provide `contract` inline or write the contract file first)", contractPath, err)
-		}
-		contract = string(data)
+// LoadContract reads the contract file from disk. Resolves relative paths
+// against workDir. Empty contractFile defaults to ".ai/contract.md".
+func (t *WriteEnrichedSprintTool) LoadContract(contractFile string) (string, error) {
+	if contractFile == "" {
+		contractFile = ".ai/contract.md"
 	}
+	if !filepath.IsAbs(contractFile) && t.workDir != "" {
+		contractFile = filepath.Join(t.workDir, contractFile)
+	}
+	data, err := os.ReadFile(contractFile)
+	if err != nil {
+		return "", fmt.Errorf("read contract from %s: %w (write the contract file first)", contractFile, err)
+	}
+	return string(data), nil
+}
 
-	if args.OutputDir == "" || args.OutputDir == "." {
-		args.OutputDir = t.workDir
+// resolveOutputDir applies the same defaulting rules Execute uses.
+func (t *WriteEnrichedSprintTool) resolveOutputDir(outputDir string) string {
+	if outputDir == "" || outputDir == "." {
+		outputDir = t.workDir
 	}
-	if args.OutputDir == "" {
-		args.OutputDir = "."
+	if outputDir == "" {
+		outputDir = "."
 	}
-	if !filepath.IsAbs(args.OutputDir) && t.workDir != "" {
-		args.OutputDir = filepath.Join(t.workDir, args.OutputDir)
+	if !filepath.IsAbs(outputDir) && t.workDir != "" {
+		outputDir = filepath.Join(t.workDir, outputDir)
+	}
+	return outputDir
+}
+
+// RunOne authors + audits + writes one sprint file. Caller supplies the contract
+// (already loaded) and a fully-resolved output directory. Returns a structured
+// result so callers (Execute, dispatch_sprints) can format their own summaries.
+func (t *WriteEnrichedSprintTool) RunOne(ctx context.Context, contract, path, description, outputDir string) (*SprintRunResult, error) {
+	if path == "" {
+		return nil, fmt.Errorf("path is required")
+	}
+	if description == "" {
+		return nil, fmt.Errorf("description is required")
 	}
 
 	authorSystemPrompt := sprintSystemPromptHeader + enrichedSprintExample
@@ -467,20 +479,26 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 			"Per-sprint description from the architect:\n%s\n\n"+
 			"Write the complete enriched sprint markdown for the file above. "+
 			"Output ONLY the raw markdown — first line must be the `# Sprint NNN — Title (enriched spec)` heading.",
-		contract, args.Path, args.Description,
+		contract, path, description,
 	)
 
 	// PASS 1 — Author. Produces the draft.
+	// MaxTokens 16384 accommodates foundation sprints with full data contracts
+	// (e.g., NIFB SPRINT-001's 18 ORM models + 25 schemas + verbatim conftest +
+	// per-route algorithm prose hits ~15K output tokens). The provider default
+	// (~4-8K depending on model) is too small for these and silently truncates.
+	authorMaxTokens := 16384
 	authorResp, err := t.client.Complete(ctx, &llm.Request{
-		Model:    t.model,
-		Provider: t.provider,
+		Model:     t.model,
+		Provider:  t.provider,
+		MaxTokens: &authorMaxTokens,
 		Messages: []llm.Message{
 			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: authorSystemPrompt}}},
 			llm.UserMessage(authorUserPrompt),
 		},
 	})
 	if err != nil {
-		return "", fmt.Errorf("write_enriched_sprint: author pass failed for %s: %w", args.Path, err)
+		return nil, fmt.Errorf("author pass failed for %s: %w", path, err)
 	}
 
 	draft := trimEnclosingMarkdownFence(authorResp.Text())
@@ -490,6 +508,10 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 	// Different system prompt narrows the auditor's role; lower temperature makes the
 	// audit deterministic.
 	auditTemperature := 0.2
+	// MaxTokens 16384 — for PATCHED verdicts the audit may emit several SR
+	// blocks; for PASS it's a single line. Headroom accommodates large patch
+	// sets without truncating mid-block.
+	auditMaxTokens := 16384
 	auditUserPrompt := fmt.Sprintf(
 		"CONTRACT (project-wide architectural map shared across all sprints):\n\n%s\n\n"+
 			"SPRINT BEING AUDITED: %s\n\n"+
@@ -498,22 +520,21 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 			"---BEGIN DRAFT---\n%s\n---END DRAFT---\n\n"+
 			"Output: first line `AUDIT-VERDICT: PASS` (return draft verbatim) OR `AUDIT-VERDICT: PATCHED` (return patched version). "+
 			"Second line must be the `# Sprint NNN — Title (enriched spec)` heading. No commentary outside the markdown.",
-		contract, args.Path, args.Description, draft,
+		contract, path, description, draft,
 	)
 
 	auditResp, err := t.client.Complete(ctx, &llm.Request{
 		Model:       t.model,
 		Provider:    t.provider,
 		Temperature: &auditTemperature,
+		MaxTokens:   &auditMaxTokens,
 		Messages: []llm.Message{
 			{Role: llm.RoleSystem, Content: []llm.ContentPart{{Kind: llm.KindText, Text: auditSystemPrompt}}},
 			llm.UserMessage(auditUserPrompt),
 		},
 	})
 	if err != nil {
-		// Audit failure is non-fatal — fall back to draft.
-		// The author pass already produced something usable; an audit failure shouldn't lose it.
-		fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit pass failed for %s (using draft as-is): %v\n", args.Path, err)
+		fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit pass failed for %s (using draft as-is): %v\n", path, err)
 		auditResp = nil
 	}
 
@@ -525,19 +546,27 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 		auditText := trimEnclosingMarkdownFence(auditResp.Text())
 		v, blocks, parseErr := parseAuditResponse(auditText)
 		if parseErr != nil {
-			fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit response malformed for %s (using draft as-is): %v\n", args.Path, parseErr)
+			fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit response malformed for %s (using draft as-is): %v\n", path, parseErr)
 			verdict = "PASS-FALLBACK-MALFORMED"
 		} else {
 			verdict = v
 			if v == "PATCHED" && len(blocks) > 0 {
-				patched, applyErr := applySRBlocks(draft, blocks)
-				if applyErr != nil {
-					// One or more blocks failed to match. Fall back to draft (don't ship a half-patched spec).
-					fmt.Fprintf(os.Stderr, "write_enriched_sprint: audit patch apply failed for %s (using draft as-is): %v\n", args.Path, applyErr)
+				// Partial-apply: each block is independent. Some may fail (e.g.,
+				// later block's SEARCH was modified by an earlier block's REPLACE);
+				// we still ship whatever applied. Only fall back to draft if
+				// ZERO blocks could be applied.
+				patched, n, skipped := applySRBlocks(draft, blocks)
+				for _, s := range skipped {
+					fmt.Fprintf(os.Stderr, "write_enriched_sprint: %s for %s (skipped, partial apply continues)\n", s, path)
+				}
+				if n == 0 {
 					verdict = "PASS-FALLBACK-NOMATCH"
 				} else {
 					final = patched
-					patchesApplied = len(blocks)
+					patchesApplied = n
+					if n < len(blocks) {
+						verdict = "PATCHED-PARTIAL"
+					}
 				}
 			}
 		}
@@ -545,15 +574,54 @@ func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMes
 		auditOutTokens = auditResp.Usage.OutputTokens
 	}
 
-	path := filepath.Join(args.OutputDir, args.Path)
-	if err := writeSprintFile(path, final); err != nil {
-		return "", err
+	fullPath := filepath.Join(outputDir, path)
+	if err := writeSprintFile(fullPath, final); err != nil {
+		return nil, err
 	}
 
+	return &SprintRunResult{
+		Path:           path,
+		Bytes:          len(final),
+		Verdict:        verdict,
+		PatchesApplied: patchesApplied,
+		Model:          t.model,
+		AuthorIn:       authorResp.Usage.InputTokens,
+		AuthorOut:      authorResp.Usage.OutputTokens,
+		AuditIn:        auditInTokens,
+		AuditOut:       auditOutTokens,
+	}, nil
+}
+
+// Execute is the LLM-tool entry point. Parses args, loads contract, runs one sprint.
+func (t *WriteEnrichedSprintTool) Execute(ctx context.Context, input json.RawMessage) (string, error) {
+	var args struct {
+		Path         string `json:"path"`
+		Description  string `json:"description"`
+		Contract     string `json:"contract"`
+		ContractFile string `json:"contract_file"`
+		OutputDir    string `json:"output_dir"`
+	}
+	if err := json.Unmarshal(input, &args); err != nil {
+		return "", fmt.Errorf("parse args: %w", err)
+	}
+
+	contract := args.Contract
+	if contract == "" {
+		c, err := t.LoadContract(args.ContractFile)
+		if err != nil {
+			return "", fmt.Errorf("write_enriched_sprint: %w", err)
+		}
+		contract = c
+	}
+	outputDir := t.resolveOutputDir(args.OutputDir)
+
+	r, err := t.RunOne(ctx, contract, args.Path, args.Description, outputDir)
+	if err != nil {
+		return "", fmt.Errorf("write_enriched_sprint: %w", err)
+	}
 	return fmt.Sprintf("Wrote %s (%d bytes, audit=%s, patches=%d). Model: %s. Tokens: author %d in / %d out, audit %d in / %d out.",
-		args.Path, len(final), verdict, patchesApplied, t.model,
-		authorResp.Usage.InputTokens, authorResp.Usage.OutputTokens,
-		auditInTokens, auditOutTokens), nil
+		r.Path, r.Bytes, r.Verdict, r.PatchesApplied, r.Model,
+		r.AuthorIn, r.AuthorOut, r.AuditIn, r.AuditOut), nil
 }
 
 // srBlock is one Aider-style SEARCH/REPLACE patch.
@@ -562,9 +630,14 @@ type srBlock struct {
 	Replace string
 }
 
-// parseAuditResponse parses the auditor's output. The first non-empty line must be
-// `AUDIT-VERDICT: PASS` or `AUDIT-VERDICT: PATCHED`. For PATCHED, the rest of the body
-// is one or more SEARCH/REPLACE blocks in Aider format:
+// parseAuditResponse parses the auditor's output. The verdict line
+// `AUDIT-VERDICT: PASS|PATCHED` may appear anywhere in the first ~10 lines —
+// not just the literal first line — to tolerate models that prepend a brief
+// preamble ("Looking at the draft...", "After review..."), a markdown fence,
+// or a leading blank line despite the prompt's instructions.
+//
+// For PATCHED, everything AFTER the verdict line is parsed as Aider-style
+// SEARCH/REPLACE blocks:
 //
 //	<<<<<<< SEARCH
 //	<old text>
@@ -572,30 +645,69 @@ type srBlock struct {
 //	<new text>
 //	>>>>>>> REPLACE
 //
-// Returns the verdict, the parsed blocks, and an error if the response is malformed.
+// Returns the verdict, the parsed blocks, and an error if no verdict line is
+// found in the first 10 lines or the verdict value is unrecognized.
 func parseAuditResponse(s string) (verdict string, blocks []srBlock, err error) {
 	trimmed := strings.TrimSpace(s)
 	if trimmed == "" {
 		return "", nil, fmt.Errorf("empty audit response")
 	}
-	lines := strings.SplitN(trimmed, "\n", 2)
-	first := strings.TrimSpace(lines[0])
-	const prefix = "AUDIT-VERDICT:"
-	if !strings.HasPrefix(first, prefix) {
-		return "", nil, fmt.Errorf("first line does not start with %q: got %q", prefix, first)
+
+	// Strip a single enclosing markdown fence, e.g. ```\n...\n```
+	trimmed = trimEnclosingMarkdownFence(trimmed)
+
+	// Search for the verdict line within the first ~10 non-empty lines.
+	const verdictPrefix = "AUDIT-VERDICT:"
+	const verdictSearchLines = 10
+	lines := strings.Split(trimmed, "\n")
+	verdictIdx := -1
+	scanned := 0
+	for i, ln := range lines {
+		stripped := strings.TrimSpace(ln)
+		if stripped == "" {
+			continue
+		}
+		// Accept the verdict prefix even when wrapped in inline backticks or
+		// bold/italic markdown (e.g., **AUDIT-VERDICT: PASS**, `AUDIT-VERDICT: PATCHED`).
+		bare := strings.TrimFunc(stripped, func(r rune) bool {
+			return r == '`' || r == '*' || r == '_'
+		})
+		if strings.HasPrefix(bare, verdictPrefix) {
+			verdictIdx = i
+			break
+		}
+		scanned++
+		if scanned >= verdictSearchLines {
+			break
+		}
 	}
-	verdict = strings.TrimSpace(strings.TrimPrefix(first, prefix))
+	if verdictIdx == -1 {
+		return "", nil, fmt.Errorf("no %q line found in first %d non-empty lines", verdictPrefix, verdictSearchLines)
+	}
+
+	// Extract verdict value, trimming markdown decorations.
+	verdictLine := strings.TrimSpace(lines[verdictIdx])
+	verdictLine = strings.TrimFunc(verdictLine, func(r rune) bool {
+		return r == '`' || r == '*' || r == '_'
+	})
+	verdict = strings.TrimSpace(strings.TrimPrefix(verdictLine, verdictPrefix))
+	// Some models append trailing markdown decoration after the verdict word.
+	verdict = strings.TrimFunc(verdict, func(r rune) bool {
+		return r == '`' || r == '*' || r == '_' || r == '.'
+	})
+	verdict = strings.TrimSpace(verdict)
 	if verdict != "PASS" && verdict != "PATCHED" {
-		return "", nil, fmt.Errorf("unrecognized verdict: %q", verdict)
+		return "", nil, fmt.Errorf("unrecognized verdict %q (must be PASS or PATCHED)", verdict)
 	}
 	if verdict == "PASS" {
 		return "PASS", nil, nil
 	}
-	// PATCHED — parse SR blocks from the remaining body
-	if len(lines) < 2 {
-		return verdict, nil, fmt.Errorf("PATCHED verdict but no blocks in body")
+
+	// PATCHED — parse SR blocks from everything after the verdict line.
+	if verdictIdx+1 >= len(lines) {
+		return verdict, nil, fmt.Errorf("PATCHED verdict but no body after verdict line")
 	}
-	body := lines[1]
+	body := strings.Join(lines[verdictIdx+1:], "\n")
 	blocks, err = parseSRBlocks(body)
 	if err != nil {
 		return verdict, nil, err
@@ -650,25 +762,333 @@ func parseSRBlocks(body string) ([]srBlock, error) {
 	return blocks, nil
 }
 
-// applySRBlocks applies the given blocks to the draft in source order. Each block's
-// SEARCH text MUST appear EXACTLY ONCE in the draft for the patch to apply (this catches
-// ambiguous matches early). Returns the patched text or an error if any block fails.
-func applySRBlocks(draft string, blocks []srBlock) (string, error) {
+// applySRBlocks applies the given SEARCH/REPLACE blocks to the draft in source
+// order, matching each block via a series of fallback strategies (mirrors
+// pipelines/lib/merge_sr.py): exact substring match → indent-preserving →
+// whitespace-insensitive → fuzzy (Levenshtein-ratio ≥ 0.9). The first strategy
+// that finds a match wins; subsequent strategies are not tried for that block.
+//
+// Partial-apply semantics: each block is applied independently against the
+// current state. A block that fails to match (no strategy succeeds) is logged
+// and skipped; subsequent blocks continue. This trades the all-or-nothing
+// safety of strict apply for resilience to sequential overlap (block N's
+// SEARCH anchored on text changed by block M<N).
+//
+// Returns the patched text, the count of successfully applied blocks, and a
+// slice of "block %d: <reason>" strings for blocks that were skipped. If zero
+// blocks applied, the caller can treat that as "no patch happened" and fall
+// back to the unaudited draft.
+func applySRBlocks(draft string, blocks []srBlock) (patched string, applied int, skipped []string) {
 	out := draft
 	for i, b := range blocks {
 		if b.Search == "" {
-			return "", fmt.Errorf("block %d: empty SEARCH text not supported (use a unique anchor for inserts)", i)
+			skipped = append(skipped, fmt.Sprintf("block %d: empty SEARCH text", i))
+			continue
 		}
-		count := strings.Count(out, b.Search)
-		if count == 0 {
-			return "", fmt.Errorf("block %d: SEARCH text not found in draft", i)
+		matched := false
+		for _, st := range srMatchStrategies {
+			next, ok := st.fn(out, b.Search, b.Replace)
+			if ok {
+				out = next
+				matched = true
+				applied++
+				break
+			}
 		}
-		if count > 1 {
-			return "", fmt.Errorf("block %d: SEARCH text matched %d times (must be unique — add more surrounding context)", i, count)
+		if !matched {
+			skipped = append(skipped, fmt.Sprintf("block %d: SEARCH text not found (tried exact, indent, whitespace, fuzzy)", i))
 		}
-		out = strings.Replace(out, b.Search, b.Replace, 1)
 	}
-	return out, nil
+	return out, applied, skipped
+}
+
+type srMatchStrategy struct {
+	name string
+	fn   func(content, search, replace string) (string, bool)
+}
+
+// srMatchStrategies are tried in order. Indent precedes whitespace so that
+// uniform-indent SEARCH blocks get their outer indent re-applied to REPLACE,
+// rather than the whitespace strategy matching first and substituting REPLACE
+// verbatim (which would lose the chunk's outer indent).
+var srMatchStrategies = []srMatchStrategy{
+	{"exact", trySRExact},
+	{"indent", trySRIndent},
+	{"whitespace", trySRWhitespace},
+	{"fuzzy", trySRFuzzy},
+}
+
+// trySRExact returns content with the first occurrence of search replaced by
+// replace, or false if search isn't present.
+func trySRExact(content, search, replace string) (string, bool) {
+	if !strings.Contains(content, search) {
+		return content, false
+	}
+	return strings.Replace(content, search, replace, 1), true
+}
+
+// trySRWhitespace matches search against any N-line window of content after
+// collapsing runs of whitespace on both sides, where N is the number of lines
+// in search. Returns content with the matched chunk replaced verbatim by
+// replace.
+func trySRWhitespace(content, search, replace string) (string, bool) {
+	needle := collapseWhitespace(search)
+	if needle == "" {
+		return content, false
+	}
+	contentLines := splitKeepNewlines(content)
+	n := strings.Count(search, "\n") + 1
+	if n > len(contentLines) {
+		return content, false
+	}
+	for i := 0; i <= len(contentLines)-n; i++ {
+		chunk := strings.Join(contentLines[i:i+n], "")
+		if collapseWhitespace(chunk) == needle {
+			return strings.Replace(content, chunk, replace, 1), true
+		}
+	}
+	return content, false
+}
+
+// trySRIndent matches a dedented form of search against content's lines, then
+// re-indents replace using the matched chunk's leading whitespace. Useful when
+// the LLM emits SEARCH at one indent level and the draft has it at another
+// (common when patching nested code or markdown).
+func trySRIndent(content, search, replace string) (string, bool) {
+	sIndent := commonLeadingIndent(search)
+	if sIndent == "" {
+		return content, false
+	}
+	dedentedSearch := dedentLines(search, sIndent)
+
+	contentLines := splitKeepNewlines(content)
+	n := strings.Count(search, "\n") + 1
+	if n > len(contentLines) {
+		return content, false
+	}
+	for i := 0; i <= len(contentLines)-n; i++ {
+		chunk := strings.Join(contentLines[i:i+n], "")
+		chunkIndent := commonLeadingIndent(chunk)
+		if chunkIndent == "" {
+			continue
+		}
+		dedentedChunk := dedentLines(chunk, chunkIndent)
+		if strings.TrimRight(dedentedChunk, "\n") == strings.TrimRight(dedentedSearch, "\n") {
+			// Apply the same indent offset to replace: dedent by sIndent (the
+			// indent SEARCH was emitted with), then re-indent by chunkIndent
+			// (the actual draft's indent). When sIndent == chunkIndent this is
+			// a no-op; otherwise the offset shifts replace's content into the
+			// chunk's column space.
+			dedentedReplace := dedentLines(replace, sIndent)
+			indentedReplace := indentLines(dedentedReplace, chunkIndent)
+			chunkRStripped := strings.TrimRight(chunk, "\n")
+			return strings.Replace(content, chunkRStripped, indentedReplace, 1), true
+		}
+	}
+	return content, false
+}
+
+// trySRFuzzy slides an N-line window through content (N = lines in search),
+// computes a Levenshtein-distance-based similarity ratio against search for
+// each window, and accepts the highest-scoring window if its ratio ≥ 0.9.
+// This catches cases where the LLM's SEARCH has minor character drift (typos,
+// reformatted indentation, slightly-different wording) that the earlier
+// strategies miss.
+func trySRFuzzy(content, search, replace string) (string, bool) {
+	const threshold = 0.9
+	contentLines := splitKeepNewlines(content)
+	n := strings.Count(search, "\n") + 1
+	if n == 0 || n > len(contentLines) {
+		return content, false
+	}
+	bestRatio := 0.0
+	bestIdx := -1
+	for i := 0; i <= len(contentLines)-n; i++ {
+		chunk := strings.Join(contentLines[i:i+n], "")
+		r := similarityRatio(chunk, search)
+		if r > bestRatio {
+			bestRatio = r
+			bestIdx = i
+		}
+	}
+	if bestIdx < 0 || bestRatio < threshold {
+		return content, false
+	}
+	chunk := strings.Join(contentLines[bestIdx:bestIdx+n], "")
+	rep := replace
+	if !strings.HasSuffix(rep, "\n") && strings.HasSuffix(chunk, "\n") {
+		rep += "\n"
+	}
+	return strings.Replace(content, chunk, rep, 1), true
+}
+
+// collapseWhitespace returns s with all runs of whitespace collapsed to a single
+// space and leading/trailing whitespace stripped. Used for whitespace-insensitive
+// SR-block matching.
+func collapseWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// splitKeepNewlines splits s on '\n' but keeps the trailing newline on each
+// preceding element so concatenating the result reproduces s exactly. Used by
+// the windowed SR-block strategies to slide N-line chunks through content.
+func splitKeepNewlines(s string) []string {
+	if s == "" {
+		return nil
+	}
+	var lines []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\n' {
+			lines = append(lines, s[start:i+1])
+			start = i + 1
+		}
+	}
+	if start < len(s) {
+		lines = append(lines, s[start:])
+	}
+	return lines
+}
+
+// commonLeadingIndent returns the longest sequence of spaces/tabs that prefixes
+// every non-blank line in s.
+func commonLeadingIndent(s string) string {
+	lines := strings.Split(s, "\n")
+	var nonEmpty []string
+	for _, ln := range lines {
+		if strings.TrimSpace(ln) != "" {
+			nonEmpty = append(nonEmpty, ln)
+		}
+	}
+	if len(nonEmpty) == 0 {
+		return ""
+	}
+	prefix := nonEmpty[0]
+	for _, ln := range nonEmpty[1:] {
+		prefix = stringCommonPrefix(prefix, ln)
+		if prefix == "" {
+			return ""
+		}
+	}
+	end := 0
+	for end < len(prefix) && (prefix[end] == ' ' || prefix[end] == '\t') {
+		end++
+	}
+	return prefix[:end]
+}
+
+// stringCommonPrefix returns the longest common prefix of a and b.
+func stringCommonPrefix(a, b string) string {
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		if a[i] != b[i] {
+			return a[:i]
+		}
+	}
+	return a[:n]
+}
+
+// dedentLines strips the given indent from the start of each line in s that
+// begins with it, leaving other lines unchanged.
+func dedentLines(s, indent string) string {
+	if indent == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if strings.HasPrefix(ln, indent) {
+			lines[i] = ln[len(indent):]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// indentLines prepends the given indent to each non-blank line of s.
+func indentLines(s, indent string) string {
+	if indent == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, ln := range lines {
+		if ln != "" {
+			lines[i] = indent + ln
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// similarityRatio approximates Python's difflib.SequenceMatcher.ratio() using a
+// Levenshtein-edit-distance-based ratio: 1 - dist/max(len(a), len(b)). For our
+// use case (catching minor character drift in audit SR blocks) the two metrics
+// agree closely on whether two strings are "approximately equal" at threshold
+// 0.9.
+func similarityRatio(a, b string) float64 {
+	if a == b {
+		return 1.0
+	}
+	la := len(a)
+	lb := len(b)
+	if la == 0 && lb == 0 {
+		return 1.0
+	}
+	if la == 0 || lb == 0 {
+		return 0.0
+	}
+	dist := levenshteinDistance(a, b)
+	maxLen := la
+	if lb > maxLen {
+		maxLen = lb
+	}
+	return 1.0 - float64(dist)/float64(maxLen)
+}
+
+// levenshteinDistance returns the edit distance between a and b using a
+// rolling two-row DP. O(len(a) * len(b)) time, O(min(la, lb)) space.
+func levenshteinDistance(a, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	la := len(ar)
+	lb := len(br)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	if la < lb {
+		ar, br = br, ar
+		la, lb = lb, la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if ar[i-1] == br[j-1] {
+				cost = 0
+			}
+			ins := curr[j-1] + 1
+			del := prev[j] + 1
+			sub := prev[j-1] + cost
+			m := ins
+			if del < m {
+				m = del
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
 }
 
 // trimEnclosingMarkdownFence removes a single pair of markdown fences wrapping

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -1107,12 +1107,17 @@ func indentLines(s, indent string) string {
 // use case (catching minor character drift in audit SR blocks) the two metrics
 // agree closely on whether two strings are "approximately equal" at threshold
 // 0.9.
+//
+// Lengths are measured in runes — levenshteinDistance operates on runes too,
+// so divisor and dividend are in the same unit. Using byte lengths here would
+// understate the ratio for any non-ASCII content (em-dashes, smart quotes,
+// CJK), which is common in sprint specs.
 func similarityRatio(a, b string) float64 {
 	if a == b {
 		return 1.0
 	}
-	la := len(a)
-	lb := len(b)
+	la := len([]rune(a))
+	lb := len([]rune(b))
 	if la == 0 && lb == 0 {
 		return 1.0
 	}

--- a/agent/tools/write_enriched_sprint_example.md
+++ b/agent/tools/write_enriched_sprint_example.md
@@ -969,7 +969,7 @@ All test functions are `async def`. None have decorators. All take `client` from
 |---|---|---|
 | `test_create_location_returns_201(client)` | POST `/locations` `{"name": "Main", "address": "1 Test St"}` | 201, body has `id`, `name == "Main"` |
 | `test_list_locations_empty(client)` | GET `/locations` | 200, `body == []` |
-| `test_list_locations_nonempty(client, test_location)` | GET `/locations` | 200, `len(body) == 1`, body[0]["id"] == str(test_location.id) |
+| `test_list_locations_nonempty(client, test_location)` | GET `/locations` | 200, `len(body) == 1`, `body[0]["id"] == str(test_location.id)` |
 | `test_get_location_by_id(client, test_location)` | GET `/locations/{test_location.id}` | 200, `body["name"] == test_location.name` |
 | `test_get_location_not_found_404(client)` | GET `/locations/{uuid.uuid4()}` | 404, `error_code == "NOT_FOUND"` |
 | `test_create_station_for_location(client, test_location)` | POST `/locations/{test_location.id}/stations` `{"name":"Sorting","max_capacity":10,"environment_type":"indoor","labor_condition":"standing"}` | 201, body has `id`, `location_id == str(test_location.id)` |
@@ -995,7 +995,7 @@ All test functions are `async def`. None have decorators. All take `client` from
 | `test_register_nonexistent_shift_returns_404(client, auth_headers)` | POST `/registrations` `{"shift_id": str(uuid.uuid4())}`, headers=auth_headers | 404, `error_code == "NOT_FOUND"` |
 | `test_register_duplicate_returns_409(client, auth_headers, test_shift)` | Register once successfully; then POST `/registrations` again with the same shift_id | 409, `error_code == "DUPLICATE_REGISTRATION"` |
 | `test_register_full_shift_returns_409_capacity_full(client, auth_headers, test_shift, db_session)` | Insert `test_shift.max_volunteers` `Registration` rows directly via `db_session` (different volunteer_ids), commit; then attempt to register the auth user | 409, `error_code == "SHIFT_FULL"` |
-| `test_list_my_registrations(client, auth_headers, test_shift)` | Register; then GET `/registrations/me`, headers=auth_headers | 200, `len(body) == 1`, body[0]["shift_id"] == str(test_shift.id) |
+| `test_list_my_registrations(client, auth_headers, test_shift)` | Register; then GET `/registrations/me`, headers=auth_headers | 200, `len(body) == 1`, `body[0]["shift_id"] == str(test_shift.id)` |
 | `test_cancel_registration_returns_204(client, auth_headers, test_shift)` | Register; then DELETE `/registrations/{registration_id}`, headers=auth_headers | 204 (empty body) |
 | `test_cancel_sets_status_cancelled(client, auth_headers, test_shift, db_session)` | Register; cancel; query the row via `db_session` | `registration.status == RegistrationStatus.cancelled` |
 | `test_cancelled_registration_does_not_count_toward_capacity(client, auth_headers, test_shift, db_session)` | Insert `test_shift.max_volunteers` `Registration` rows then cancel one; attempt to register | 201 (capacity has room because cancelled doesn't count) |

--- a/agent/tools/write_enriched_sprint_example.md
+++ b/agent/tools/write_enriched_sprint_example.md
@@ -1,0 +1,220 @@
+# Sprint 002 — Hello World End-to-End Proof (enriched spec)
+
+## Scope
+Wire the CLI entrypoint so that `./agent version` prints a version string and `./agent doctor`
+prints Go version and working directory. One integration test builds the binary and asserts
+both commands produce correct output.
+
+## Non-goals
+- No real doctor logic, no TUI, no cobra, no flag parsing library
+- No config file, no DB connection in doctor
+- No additional subcommands
+
+## Dependencies
+- Sprint 001: `internal/store` package exists; module name is `agent`
+
+## Go/runtime conventions (inherited from Sprint 001)
+- Module: `agent`
+- All error wrapping: `fmt.Errorf("...: %w", err)`
+- All temp dirs in tests: `t.TempDir()`
+- All helpers call `t.Helper()`
+- Go version: 1.25+; no third-party CLI framework in this sprint
+
+## File structure
+
+```
+cmd/agent/main.go          — package main; os.Args dispatch, calls runVersion/runDoctor
+cmd/agent/cmd_version.go   — package main; const version; runVersion()
+cmd/agent/cmd_doctor.go    — package main; runDoctor() using runtime + os
+tests/integration/smoke_test.go — package integration; TestMain builds binary; TestSmoke runs it
+```
+
+## Interface contract
+
+```go
+// cmd/agent/cmd_version.go
+const version = "0.1.0-dev"
+func runVersion()   // prints version to stdout, no newline trimming needed
+
+// cmd/agent/cmd_doctor.go
+func runDoctor()    // prints two lines to stdout: "go: <runtime.Version()>" and "dir: <wd>"
+
+// cmd/agent/main.go
+func main()         // dispatches os.Args[1] to runVersion/runDoctor; unknown → stderr + exit 1
+```
+
+## Imports per file
+
+**`cmd/agent/main.go`**
+```go
+import (
+    "fmt"
+    "os"
+)
+```
+
+**`cmd/agent/cmd_version.go`**
+```go
+import "fmt"
+```
+
+**`cmd/agent/cmd_doctor.go`**
+```go
+import (
+    "fmt"
+    "os"
+    "runtime"
+)
+```
+
+**`tests/integration/smoke_test.go`**
+```go
+import (
+    "fmt"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "testing"
+)
+```
+
+## Algorithm notes
+
+### `main()`
+Copy this structure exactly:
+
+```go
+func main() {
+    if len(os.Args) < 2 {
+        fmt.Fprintln(os.Stderr, "usage: agent <command>")
+        os.Exit(1)
+    }
+    switch os.Args[1] {
+    case "version":
+        runVersion()
+    case "doctor":
+        runDoctor()
+    default:
+        fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+        os.Exit(1)
+    }
+}
+```
+
+### `runVersion()`
+```go
+func runVersion() {
+    fmt.Println(version)
+}
+```
+
+### `runDoctor()`
+```go
+func runDoctor() {
+    wd, err := os.Getwd()
+    if err != nil {
+        wd = "(unknown)"
+    }
+    fmt.Printf("go:  %s\n", runtime.Version())
+    fmt.Printf("dir: %s\n", wd)
+}
+```
+
+### `TestMain` — builds binary once for all tests
+```go
+var agentBin string
+
+func TestMain(m *testing.M) {
+    tmp, err := os.MkdirTemp("", "agent-smoke-*")
+    if err != nil {
+        fmt.Fprintln(os.Stderr, "mkdirtemp:", err)
+        os.Exit(1)
+    }
+    defer os.RemoveAll(tmp)
+
+    agentBin = filepath.Join(tmp, "agent")
+    cmd := exec.Command("go", "build", "-o", agentBin, "agent/cmd/agent")
+    if out, err := cmd.CombinedOutput(); err != nil {
+        fmt.Fprintf(os.Stderr, "go build failed: %v\n%s\n", err, out)
+        os.Exit(1)
+    }
+
+    os.Exit(m.Run())
+}
+```
+
+### `TestSmoke` — copy exactly
+```go
+func TestSmoke(t *testing.T) {
+    t.Run("version exits 0 and prints non-empty output", func(t *testing.T) {
+        out, err := exec.Command(agentBin, "version").Output()
+        if err != nil {
+            t.Fatalf("agent version: %v", err)
+        }
+        if strings.TrimSpace(string(out)) == "" {
+            t.Fatal("expected non-empty version output")
+        }
+    })
+
+    t.Run("doctor exits 0 and output contains go version", func(t *testing.T) {
+        out, err := exec.Command(agentBin, "doctor").Output()
+        if err != nil {
+            t.Fatalf("agent doctor: %v", err)
+        }
+        if !strings.Contains(string(out), "go:") {
+            t.Fatalf("expected 'go:' in doctor output, got: %s", out)
+        }
+    })
+}
+```
+
+## Test plan
+
+```go
+func TestSmoke(t *testing.T)
+```
+
+Subtests:
+```
+TestSmoke/version_exits_0_and_prints_non-empty_output
+TestSmoke/doctor_exits_0_and_output_contains_go_version
+```
+
+## Rules
+- `tests/integration/smoke_test.go` must NOT have a `//go:build` tag — it must run with plain `go test`
+- `cmd/agent/` files are all `package main` — no exported symbols
+- `version` constant is the single source of truth — no duplicate declarations
+- `runDoctor()` never calls `os.Exit` — only `main()` exits
+- `TestMain` builds the binary once; subtests reuse `agentBin`
+- Use module-path form `agent/cmd/agent` in the `go build` command, not a relative path
+- Do not add a `go.sum` entry — `modernc.org/sqlite` from Sprint 001 already handles that
+
+## New files
+- `cmd/agent/main.go` — package main; os.Args dispatch, calls runVersion/runDoctor
+- `cmd/agent/cmd_version.go` — package main; const version; runVersion()
+- `cmd/agent/cmd_doctor.go` — package main; runDoctor() using runtime + os
+- `tests/integration/smoke_test.go` — package integration; TestMain builds binary; TestSmoke runs it
+
+## Modified files
+(none — this sprint introduces new files only. Subsequent sprints that touch existing files would list them here as `- `path/to/existing/file` — what changes`)
+
+## Expected Artifacts
+- `cmd/agent/main.go`
+- `cmd/agent/cmd_version.go`
+- `cmd/agent/cmd_doctor.go`
+- `tests/integration/smoke_test.go`
+
+## DoD
+- [ ] `go build -o agent ./cmd/agent/` succeeds
+- [ ] `./agent version` exits 0 and prints a non-empty version string
+- [ ] `./agent doctor` exits 0 and prints a line starting with `go:`
+- [ ] `go test ./tests/integration/ -run TestSmoke -v` passes
+
+## Validation
+```bash
+go build -o agent ./cmd/agent/
+./agent version
+./agent doctor
+go test ./tests/integration/ -run TestSmoke -v
+```

--- a/agent/tools/write_enriched_sprint_example.md
+++ b/agent/tools/write_enriched_sprint_example.md
@@ -1,220 +1,1060 @@
-# Sprint 002 — Hello World End-to-End Proof (enriched spec)
+# Sprint 001 — Foundation (full schema + auth, front-loaded)
 
 ## Scope
-Wire the CLI entrypoint so that `./agent version` prints a version string and `./agent doctor`
-prints Go version and working directory. One integration test builds the binary and asserts
-both commands produce correct output.
+Front-load the entire backend foundation: every ORM model, every Pydantic schema, every shared error code, every test fixture, plus the FastAPI app factory with **auto-discovering router registration via `pkgutil`**. Implement the first feature (phone OTP authentication with JWT, register endpoint, `/health`) as the working slice. Subsequent sprints add only new router/service files — never modify `models.py`, `schemas.py`, `exceptions.py`, `database.py`, `config.py`, or `main.py`.
 
 ## Non-goals
-- No real doctor logic, no TUI, no cobra, no flag parsing library
-- No config file, no DB connection in doctor
-- No additional subcommands
+- No frontend, Docker, CI.
+- No SMS gateway integration — OTP is logged to console (Sprint 005 adds Twilio).
+- No CRM sync, donor matching, skills, court, or benefits **logic** (Sprints 011–013) — but their MODELS and SCHEMAS are defined here so later sprints just import and use them.
+- No Alembic migrations — `init_db.py` calls `Base.metadata.create_all`.
 
 ## Dependencies
-- Sprint 001: `internal/store` package exists; module name is `agent`
+None — first sprint, foundation.
 
-## Go/runtime conventions (inherited from Sprint 001)
-- Module: `agent`
-- All error wrapping: `fmt.Errorf("...: %w", err)`
-- All temp dirs in tests: `t.TempDir()`
-- All helpers call `t.Helper()`
-- Go version: 1.25+; no third-party CLI framework in this sprint
+## Conventions
+- **Module:** `backend/app` package; internal imports as `from app.models import Volunteer` (NEVER `from backend.app.models import ...`).
+- **Python:** 3.12+; package manager: `uv` with `pyproject.toml`.
+- **Web:** `fastapi` + `uvicorn[standard]`.
+- **ORM:** `sqlalchemy[asyncio]` 2.x with `AsyncSession`, `Mapped[...]` / `mapped_column(...)` style, `DeclarativeBase` subclass for `Base`. Test DB driver: `aiosqlite`. Production driver added in a later sprint when Postgres lands.
+- **Validation:** `pydantic` v2 + `pydantic-settings`; ORM-shaped Read schemas use `model_config = ConfigDict(from_attributes=True)`.
+- **Auth:** `python-jose[cryptography]` for JWT (HS256).
+- **Tests:** `pytest` + `pytest-asyncio` (`asyncio_mode = "auto"` — do NOT add `@pytest.mark.asyncio` decorators) + `httpx.AsyncClient` with `ASGITransport`.
+- **Lint:** `ruff` with rules `E`, `F`, `I` selected.
+- **All IDs:** `uuid.UUID`, server-generated via `default=uuid.uuid4`.
+- **All timestamps:** UTC `datetime` columns with `server_default=func.now()` (`onupdate=func.now()` on `updated_at`). Use `DateTime(timezone=True)`.
+- **Errors:** Routers raise `AppError(status_code, detail, error_code)` (subclass of `HTTPException`). The app-level exception handler in `main.py` returns JSON `{"detail": "...", "error_code": "UPPER_SNAKE"}`. Tests assert `response.json()["error_code"]`.
 
-## File structure
+## Tricky semantics (load-bearing — READ BEFORE WRITING ANY CODE)
 
-```
-cmd/agent/main.go          — package main; os.Args dispatch, calls runVersion/runDoctor
-cmd/agent/cmd_version.go   — package main; const version; runVersion()
-cmd/agent/cmd_doctor.go    — package main; runDoctor() using runtime + os
-tests/integration/smoke_test.go — package integration; TestMain builds binary; TestSmoke runs it
-```
+These rules are **non-optional**. Each one closes an ambiguity that produces a runtime error which is hard to diagnose if you guess wrong. Tests are written assuming all of these hold.
 
-## Interface contract
+1. **Settings singleton via `@lru_cache`.** `app/config.py` exposes `Settings(BaseSettings)` and a cached factory `get_settings() -> Settings`. Routers and helpers call `get_settings()` (which returns the cached instance) — never instantiate `Settings()` inside a request handler. Tests that need to verify defaults instantiate `Settings()` directly and read instance attributes.
+2. **Database engine is lazy.** `app/database.py` does NOT call `create_async_engine` at module import time. Two module-level functions, `get_engine()` and `get_session_factory()`, lazily initialize on first call. This avoids "connect to Postgres at import time" failures when only tests are running.
+3. **Async loading: `lazy="selectin"` on every collection-side relationship.** SQLAlchemy 2.x async sessions cannot lazy-load on attribute access — that raises `MissingGreenlet`. The collection-side relationships in this sprint that MUST have `lazy="selectin"` are: `Location.stations`, `Shift.registrations`, `Group.members`. Singular (many-to-one) sides like `Station.location`, `Registration.shift`, `GroupMember.group`, etc. do NOT need it.
+4. **Bidirectional relationships use `back_populates` on BOTH sides** with matching names. Pairs in this sprint: `Location.stations` ↔ `Station.location`; `Shift.registrations` ↔ `Registration.shift`; `Group.members` ↔ `GroupMember.group`. Edit both sides together.
+5. **Settings overrides in tests patch the instance, not the class.** Pydantic v2 stores fields on instances — `Settings.OTP_BYPASS_CODE` (class-attr) raises `AttributeError`. If a test needs to flip a flag, instantiate a fresh `Settings()` (env vars are re-read on each instantiation) and pass that, OR use `monkeypatch.setattr(get_settings(), "DEV_OTP_BYPASS", False)` against the live singleton.
+6. **Tests use fixtures from `conftest.py`. ALWAYS take the fixture as a function parameter; NEVER construct `AsyncClient`, engines, sessions, or `app` instances inside test bodies.** `conftest.py` is the single point of test setup. Test files contain only test functions.
+7. **Imports are complete Python statements, never bare module names.** When a class and a stdlib module share a name (`datetime`, `date`, `time`, `decimal.Decimal`), use the `from X import Y` form. Bare `datetime` reads as `import datetime` (the module) and breaks `Mapped[datetime]` annotations at SQLAlchemy mapping time.
+8. **AppError is the only exception class routers raise.** Format: `raise AppError(status_code, detail_str, error_code_str)`. The handler in `main.py` formats the JSON response. Do not raise raw `HTTPException`; do not return `JSONResponse` from a route.
+9. **Auto-discovering routers (load-bearing for front-loading).** `main.py` uses `pkgutil.iter_modules(routers_pkg.__path__)` to scan `app/routers/` and call `app.include_router(module.router)` for any module that exposes a `router: APIRouter`. **Later sprints add a new file in `app/routers/` and it is auto-included; `main.py` is FROZEN after this sprint.** Each router file declares its own `prefix` and `tags` on its `APIRouter()` instance.
+10. **Test config constants are literal values.** When a test needs the OTP bypass code, write the literal string `"000000"` — not `Settings.OTP_BYPASS_CODE`, not `settings.OTP_BYPASS_CODE`.
+11. **Use literal `pop(get_db, None)` in fixture cleanup, not `clear()`.** `app.dependency_overrides.clear()` would wipe overrides set by other tests/fixtures running concurrently or via composition. The `client` fixture cleans up only the override it set.
 
-```go
-// cmd/agent/cmd_version.go
-const version = "0.1.0-dev"
-func runVersion()   // prints version to stdout, no newline trimming needed
+## Data contract
 
-// cmd/agent/cmd_doctor.go
-func runDoctor()    // prints two lines to stdout: "go: <runtime.Version()>" and "dir: <wd>"
+### Enums (declared in `app/models.py`)
 
-// cmd/agent/main.go
-func main()         // dispatches os.Args[1] to runVersion/runDoctor; unknown → stderr + exit 1
-```
+```python
+class RegistrationStatus(str, enum.Enum):
+    registered = "registered"
+    cancelled = "cancelled"
+    checked_in = "checked_in"
 
-## Imports per file
+class VolunteerPathway(str, enum.Enum):
+    general = "general"
+    skills_based = "skills_based"
+    court_required = "court_required"
+    benefits = "benefits"
 
-**`cmd/agent/main.go`**
-```go
-import (
-    "fmt"
-    "os"
-)
-```
+class MessageType(str, enum.Enum):
+    confirmation = "confirmation"
+    reminder = "reminder"
+    arrival_instructions = "arrival_instructions"
+    post_shift_impact = "post_shift_impact"
 
-**`cmd/agent/cmd_version.go`**
-```go
-import "fmt"
-```
+class MessageStatus(str, enum.Enum):
+    pending = "pending"
+    sent = "sent"
+    failed = "failed"
 
-**`cmd/agent/cmd_doctor.go`**
-```go
-import (
-    "fmt"
-    "os"
-    "runtime"
-)
-```
+class EnvironmentType(str, enum.Enum):
+    indoor = "indoor"
+    outdoor = "outdoor"
+    mobile = "mobile"
 
-**`tests/integration/smoke_test.go`**
-```go
-import (
-    "fmt"
-    "os"
-    "os/exec"
-    "path/filepath"
-    "strings"
-    "testing"
-)
-```
+class LaborCondition(str, enum.Enum):
+    standing = "standing"
+    sitting = "sitting"
+    mobile = "mobile"
 
-## Algorithm notes
-
-### `main()`
-Copy this structure exactly:
-
-```go
-func main() {
-    if len(os.Args) < 2 {
-        fmt.Fprintln(os.Stderr, "usage: agent <command>")
-        os.Exit(1)
-    }
-    switch os.Args[1] {
-    case "version":
-        runVersion()
-    case "doctor":
-        runDoctor()
-    default:
-        fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
-        os.Exit(1)
-    }
-}
+class ReviewStatus(str, enum.Enum):
+    pending = "pending"
+    approved = "approved"
+    rejected = "rejected"
 ```
 
-### `runVersion()`
-```go
-func runVersion() {
-    fmt.Println(version)
-}
+### ORM models (declared in `app/models.py`, FROZEN after this sprint)
+
+All ids are `Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)`. All `created_at`/`updated_at` are `Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())` with `onupdate=func.now()` on `updated_at`. Indexed columns are noted explicitly.
+
+```python
+# Sprint 001 models
+class Volunteer(Base):
+    __tablename__ = "volunteers"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    email: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True, index=True)
+    phone: Mapped[str | None] = mapped_column(String(20), unique=True, nullable=True, index=True)
+    first_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    last_name: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    pathway: Mapped[VolunteerPathway] = mapped_column(default=VolunteerPathway.general)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+class OTP(Base):
+    __tablename__ = "otps"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    phone: Mapped[str] = mapped_column(String(20), index=True)
+    code: Mapped[str] = mapped_column(String(6))
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    used: Mapped[bool] = mapped_column(default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+# Sprint 002 models — collection-side relationships use lazy="selectin"
+class Location(Base):
+    __tablename__ = "locations"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200))
+    address: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    stations: Mapped[list["Station"]] = relationship(back_populates="location", lazy="selectin")
+
+class Station(Base):
+    __tablename__ = "stations"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    location_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("locations.id"))
+    name: Mapped[str] = mapped_column(String(200))
+    max_capacity: Mapped[int]
+    environment_type: Mapped[EnvironmentType]
+    labor_condition: Mapped[LaborCondition]
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    location: Mapped["Location"] = relationship(back_populates="stations")
+
+class Shift(Base):
+    __tablename__ = "shifts"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    location_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("locations.id"))
+    title: Mapped[str] = mapped_column(String(200))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    date: Mapped[date]
+    start_time: Mapped[time]
+    end_time: Mapped[time]
+    max_volunteers: Mapped[int]
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    location: Mapped["Location"] = relationship()
+    registrations: Mapped[list["Registration"]] = relationship(back_populates="shift", lazy="selectin")
+
+class Registration(Base):
+    __tablename__ = "registrations"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    shift_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("shifts.id"))
+    group_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("groups.id"), nullable=True)
+    status: Mapped[RegistrationStatus] = mapped_column(default=RegistrationStatus.registered)
+    checked_in_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+    volunteer: Mapped["Volunteer"] = relationship()
+    shift: Mapped["Shift"] = relationship(back_populates="registrations")
+
+# Sprint 003 models
+class Group(Base):
+    __tablename__ = "groups"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200))
+    leader_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    leader: Mapped["Volunteer"] = relationship()
+    members: Mapped[list["GroupMember"]] = relationship(back_populates="group", lazy="selectin")
+
+class GroupMember(Base):
+    __tablename__ = "group_members"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    group_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("groups.id"))
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    group: Mapped["Group"] = relationship(back_populates="members")
+    volunteer: Mapped["Volunteer"] = relationship()
+
+class WaiverAcceptance(Base):
+    __tablename__ = "waiver_acceptances"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"), unique=True)
+    signed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+class OrientationCompletion(Base):
+    __tablename__ = "orientation_completions"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"), unique=True)
+    completed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+# Sprint 005 models
+class Message(Base):
+    __tablename__ = "messages"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    registration_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("registrations.id"), nullable=True)
+    message_type: Mapped[MessageType]
+    content: Mapped[str] = mapped_column(Text)
+    status: Mapped[MessageStatus] = mapped_column(default=MessageStatus.pending)
+    sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+class GivingInterest(Base):
+    __tablename__ = "giving_interests"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    interested_in_monthly: Mapped[bool] = mapped_column(default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+# Sprint 007 models
+class Assignment(Base):
+    __tablename__ = "assignments"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    station_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("stations.id"))
+    shift_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("shifts.id"))
+    is_manual_override: Mapped[bool] = mapped_column(default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+# Sprint 011 models
+class SyncRecord(Base):
+    __tablename__ = "sync_records"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    re_nxt_constituent_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    sync_status: Mapped[str] = mapped_column(String(50))
+    synced_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+class MatchException(Base):
+    __tablename__ = "match_exceptions"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    candidate_re_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    confidence_score: Mapped[float]
+    match_details: Mapped[str] = mapped_column(Text)
+    resolved: Mapped[bool] = mapped_column(default=False)
+    resolved_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    resolution: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+# Sprint 012 models
+class SkillsApplication(Base):
+    __tablename__ = "skills_applications"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    resume_url: Mapped[str] = mapped_column(String(500))
+    skills_description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    review_status: Mapped[ReviewStatus] = mapped_column(default=ReviewStatus.pending)
+    reviewer_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+# Sprint 013 models
+class CourtServiceRecord(Base):
+    __tablename__ = "court_service_records"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    case_number: Mapped[str] = mapped_column(String(100))
+    required_hours: Mapped[float]
+    completed_hours: Mapped[float] = mapped_column(default=0.0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+class BenefitsRecord(Base):
+    __tablename__ = "benefits_records"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    volunteer_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("volunteers.id"))
+    program_type: Mapped[str] = mapped_column(String(100))
+    required_hours: Mapped[float]
+    completed_hours: Mapped[float] = mapped_column(default=0.0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
 ```
 
-### `runDoctor()`
-```go
-func runDoctor() {
-    wd, err := os.Getwd()
-    if err != nil {
-        wd = "(unknown)"
-    }
-    fmt.Printf("go:  %s\n", runtime.Version())
-    fmt.Printf("dir: %s\n", wd)
-}
+### Pydantic schemas (declared in `app/schemas.py`, FROZEN after this sprint)
+
+All Read schemas use `model_config = ConfigDict(from_attributes=True)`.
+
+```python
+# Sprint 001
+class OTPSendRequest(BaseModel):
+    phone: str
+
+class OTPSendResponse(BaseModel):
+    message: str
+
+class OTPVerifyRequest(BaseModel):
+    phone: str
+    code: str
+
+class OTPVerifyResponse(BaseModel):
+    access_token: str
+    is_new: bool
+    volunteer_id: uuid.UUID
+
+class RegisterRequest(BaseModel):
+    phone: str | None = None
+    email: str | None = None
+    first_name: str
+    last_name: str
+
+class RegisterResponse(BaseModel):
+    id: uuid.UUID
+    email: str | None
+    phone: str | None
+    access_token: str
+
+class VolunteerRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    email: str | None
+    phone: str | None
+    first_name: str | None
+    last_name: str | None
+    pathway: VolunteerPathway
+    created_at: datetime
+
+class VolunteerUpdate(BaseModel):
+    email: str | None = None
+    first_name: str | None = None
+    last_name: str | None = None
+
+class HealthResponse(BaseModel):
+    status: str
+
+class ErrorResponse(BaseModel):
+    detail: str
+    error_code: str
+
+# Sprint 002
+class LocationCreate(BaseModel):
+    name: str
+    address: str | None = None
+
+class LocationRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    name: str
+    address: str | None
+    created_at: datetime
+
+class StationCreate(BaseModel):
+    name: str
+    max_capacity: int
+    environment_type: EnvironmentType
+    labor_condition: LaborCondition
+
+class StationRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    location_id: uuid.UUID
+    name: str
+    max_capacity: int
+    environment_type: EnvironmentType
+    labor_condition: LaborCondition
+
+class ShiftCreate(BaseModel):
+    location_id: uuid.UUID
+    title: str
+    description: str | None = None
+    date: date
+    start_time: time
+    end_time: time
+    max_volunteers: int
+
+class ShiftRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    location_id: uuid.UUID
+    title: str
+    description: str | None
+    date: date
+    start_time: time
+    end_time: time
+    max_volunteers: int
+    registered_count: int = 0
+
+class RegistrationCreate(BaseModel):
+    shift_id: uuid.UUID
+
+class RegistrationRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    volunteer_id: uuid.UUID
+    shift_id: uuid.UUID
+    group_id: uuid.UUID | None
+    status: RegistrationStatus
+    checked_in_at: datetime | None
+    created_at: datetime
+
+# Sprint 003
+class GroupCreate(BaseModel):
+    name: str
+
+class GroupRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    name: str
+    leader_id: uuid.UUID
+    created_at: datetime
+
+class GroupMemberAdd(BaseModel):
+    volunteer_id: uuid.UUID
+
+class WaiverSignRequest(BaseModel):
+    accepted: bool = True
+
+class WaiverStatusResponse(BaseModel):
+    signed: bool
+    signed_at: datetime | None
+
+class OrientationCompleteRequest(BaseModel):
+    completed: bool = True
+
+class OrientationStatusResponse(BaseModel):
+    completed: bool
+    completed_at: datetime | None
+
+# Sprint 004
+class DiscoveryRequest(BaseModel):
+    available_dates: list[date] = []
+    preferred_environment: EnvironmentType | None = None
+    preferred_labor_condition: LaborCondition | None = None
+    location_ids: list[uuid.UUID] = []
+
+class DiscoveryResult(BaseModel):
+    shift_id: uuid.UUID
+    score: float
+    explanation: str
+
+# Sprint 005
+class MessageRead(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    volunteer_id: uuid.UUID
+    registration_id: uuid.UUID | None
+    message_type: MessageType
+    content: str
+    status: MessageStatus
+    sent_at: datetime | None
+    created_at: datetime
+
+class ImpactCardResponse(BaseModel):
+    shift_title: str
+    hours: float
+    impact_metric: str
+
+class NextCommitmentRequest(BaseModel):
+    shift_id: uuid.UUID
+
+class GivingInterestRequest(BaseModel):
+    interested_in_monthly: bool
 ```
 
-### `TestMain` — builds binary once for all tests
-```go
-var agentBin string
+## API contract (this sprint's routes)
 
-func TestMain(m *testing.M) {
-    tmp, err := os.MkdirTemp("", "agent-smoke-*")
-    if err != nil {
-        fmt.Fprintln(os.Stderr, "mkdirtemp:", err)
-        os.Exit(1)
-    }
-    defer os.RemoveAll(tmp)
+The auth router declares `router = APIRouter(prefix="/auth", tags=["auth"])`. `/health` is mounted directly in `main.py` (not in a router, since no auth router file exists for it).
 
-    agentBin = filepath.Join(tmp, "agent")
-    cmd := exec.Command("go", "build", "-o", agentBin, "agent/cmd/agent")
-    if out, err := cmd.CombinedOutput(); err != nil {
-        fmt.Fprintf(os.Stderr, "go build failed: %v\n%s\n", err, out)
-        os.Exit(1)
-    }
+| Method | Path | Request | Response (status) | Errors |
+|---|---|---|---|---|
+| GET | `/health` | — | `{"status": "ok"}` (200) | — |
+| POST | `/auth/otp/send` | `OTPSendRequest` | `OTPSendResponse{message="OTP sent"}` (200) | — |
+| POST | `/auth/otp/verify` | `OTPVerifyRequest` | `OTPVerifyResponse` (200) | 401 `INVALID_OTP`, 401 `OTP_EXPIRED` |
+| POST | `/auth/register` | `RegisterRequest` | `RegisterResponse` (201) | 409 `ACCOUNT_EXISTS` (duplicate email or phone) |
 
-    os.Exit(m.Run())
-}
+## Algorithm
+
+### `POST /auth/otp/send`
+1. Get settings via `get_settings()`.
+2. If `settings.DEV_OTP_BYPASS` is True, set `code = settings.OTP_BYPASS_CODE`. Else generate 6 random digits via `"".join(random.choices(string.digits, k=6))`.
+3. Compute `expires_at = datetime.now(timezone.utc) + timedelta(minutes=settings.OTP_EXPIRY_MINUTES)`.
+4. Insert `OTP(phone=req.phone, code=code, expires_at=expires_at)`; `await db.commit()`.
+5. `logger.info(f"OTP for {req.phone}: {code}")`.
+6. Return `OTPSendResponse(message="OTP sent")`.
+
+### `POST /auth/otp/verify`
+1. Get settings. `bypass_ok = settings.DEV_OTP_BYPASS and req.code == settings.OTP_BYPASS_CODE`.
+2. If NOT bypass_ok: query `OTP` where `phone == req.phone AND code == req.code AND used == False`, ordered by `created_at desc`. If no row → `raise AppError(401, "Invalid OTP code", INVALID_OTP)`. If `expires_at < now()` → `raise AppError(401, "OTP expired", OTP_EXPIRED)`. Else mark `otp.used = True` and `await db.commit()`.
+3. Find existing `Volunteer` by phone. If none, return `OTPVerifyResponse(access_token="", is_new=True, volunteer_id=uuid.uuid4())` (caller must hit `/auth/register` next; the throwaway uuid is so the response shape is consistent — the real id is created by register).
+4. If found: return `OTPVerifyResponse(access_token=create_access_token(volunteer.id), is_new=False, volunteer_id=volunteer.id)`.
+
+### `POST /auth/register`
+1. If `req.email` is provided, check for existing volunteer by email — if found, raise `AppError(409, "Account with this email already exists", ACCOUNT_EXISTS)`.
+2. If `req.phone` is provided, check for existing volunteer by phone — if found, raise `AppError(409, "Account with this phone already exists", ACCOUNT_EXISTS)`.
+3. Insert `Volunteer(email, phone, first_name, last_name)`; commit; refresh.
+4. Return `RegisterResponse(id, email, phone, access_token=create_access_token(volunteer.id))` with status 201.
+
+### `GET /health`
+1. Return `{"status": "ok"}`.
+
+## Test contract
+
+### `tests/conftest.py` fixtures
+
+All fixtures are function-scoped (no `@pytest_asyncio.fixture(scope="...")` argument needed; default is function-scope under `asyncio_mode = "auto"`).
+
+- **`async_engine`** — creates `create_async_engine("sqlite+aiosqlite:///:memory:", echo=False, connect_args={"check_same_thread": False}, poolclass=StaticPool)`, runs `Base.metadata.create_all`, yields the engine, calls `await engine.dispose()` on cleanup. **`StaticPool` and `connect_args` are non-optional**: SQLite's `:memory:` URL gives every fresh connection its own database. Without `StaticPool`, the `client` fixture's override session and the `db_session` fixture end up on different in-memory DBs, and tests that commit via one session and read via the other observe nothing. Imports needed: `from sqlalchemy.pool import StaticPool`.
+- **`db_session(async_engine)`** — yields an `AsyncSession` from `async_sessionmaker(async_engine, expire_on_commit=False)`.
+- **`client(async_engine, db_session)`** — Inside the fixture body (NOT at module level): build `factory = async_sessionmaker(async_engine, expire_on_commit=False)`; define a **nested closure** `async def override_get_db():\n    async with factory() as s:\n        yield s`; register `app.dependency_overrides[get_db] = override_get_db`; construct `AsyncClient(transport=ASGITransport(app=app), base_url="http://test")`; yield the client; on cleanup call `app.dependency_overrides.pop(get_db, None)`.
+
+  **Critical:** `override_get_db` MUST be defined inside the `client` fixture function so it captures `async_engine` via closure. If it is defined at module level, `async_engine` resolves to the pytest-fixture function reference (a `FixtureFunctionDefinition` object), not the resolved engine instance, and `async_sessionmaker(async_engine, ...)` raises `sqlalchemy.exc.ArgumentError: AsyncEngine expected, got <pytest_fixture(...)>`.
+
+  Imports `app` from `app.main` and `get_db` from `app.dependencies`.
+- **`test_volunteer(db_session)`** — creates `Volunteer(email="test@example.com", phone="+15551234567", first_name="Test", last_name="User")`, commits, refreshes, returns it.
+- **`auth_headers(test_volunteer)`** — synchronous function returning `{"Authorization": f"Bearer {create_access_token(test_volunteer.id)}"}`.
+- **`test_location(db_session)`** — creates `Location(name="Main Warehouse", address="123 Test St")`, commits, refreshes, returns it.
+- **`test_station(db_session, test_location)`** — creates `Station(location_id=test_location.id, name="Sorting", max_capacity=10, environment_type=EnvironmentType.indoor, labor_condition=LaborCondition.standing)`, commits, refreshes, returns it.
+- **`test_shift(db_session, test_location)`** — creates `Shift(location_id=test_location.id, title="Saturday Morning", description="Sort and pack", date=date.today() + timedelta(days=1), start_time=time(9, 0), end_time=time(12, 0), max_volunteers=10)`, commits, refreshes, returns it.
+
+### `tests/test_health.py`
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_health_returns_ok(client)` | `GET /health` | 200, `body == {"status": "ok"}` |
+
+### `tests/test_config.py`
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_settings_defaults_load()` | Instantiate `Settings()` | `s.DEV_OTP_BYPASS is True`, `s.OTP_BYPASS_CODE == "000000"`, `s.JWT_ALGORITHM == "HS256"` |
+
+### `tests/test_auth.py` (7 subtests)
+
+All tests take `client` (from conftest) as a parameter; some additionally take `db_session` or other fixtures. The OTP bypass code is the literal string `"000000"`.
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_otp_send_returns_message(client)` | POST `/auth/otp/send` `{"phone": "+15550000001"}` | 200, `body["message"] == "OTP sent"` |
+| `test_otp_verify_bypass_new_user(client)` | POST `/auth/otp/verify` `{"phone": "+15550000002", "code": "000000"}` | 200, `body["is_new"] is True` |
+| `test_otp_verify_bypass_existing_user(client, test_volunteer)` | POST `/auth/otp/verify` `{"phone": test_volunteer.phone, "code": "000000"}` | 200, `body["is_new"] is False`, `body["access_token"]` non-empty |
+| `test_register_creates_volunteer(client)` | POST `/auth/register` `{"phone":"+15550000003","email":"a@b.com","first_name":"A","last_name":"B"}` | 201, `body["id"]` present, `body["access_token"]` non-empty |
+| `test_register_duplicate_email_returns_409(client)` | Register once with email `dup@example.com`; then again with same email and different phone | 409, `body["error_code"] == "ACCOUNT_EXISTS"` |
+| `test_register_duplicate_phone_returns_409(client)` | Register once with phone `+15550000004`; then again with same phone and different email | 409, `body["error_code"] == "ACCOUNT_EXISTS"` |
+| `test_otp_verify_invalid_code_rejected(client, monkeypatch)` | `monkeypatch.setattr(get_settings(), "DEV_OTP_BYPASS", False)`; POST `/auth/otp/verify` `{"phone": "+15550000005", "code": "999999"}` | 401, `body["error_code"] == "INVALID_OTP"` |
+
+### `tests/test_models.py` (12 subtests — foundation health check)
+
+ORM-only; no HTTP. Each test creates an instance via `db_session`, commits, queries it back (via `select`), and asserts persistence + relationship loading where applicable.
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_volunteer_create_persists(db_session)` | Create + commit a `Volunteer`; reload via select | id is `uuid.UUID`, email/phone match |
+| `test_otp_create_persists(db_session)` | Create + commit an `OTP` | record persisted, `used is False` |
+| `test_location_and_station_relationship(db_session)` | Create Location, then Station with `location_id`; reload Station | `station.location.name` matches |
+| `test_shift_with_registrations_relationship(db_session, test_volunteer)` | Create Location, Shift, Registration; reload Shift | `len(shift.registrations) == 1` (relies on `lazy="selectin"`) |
+| `test_group_with_members(db_session, test_volunteer)` | Create Group with `leader_id`, two `GroupMember`s; reload Group | `len(group.members) == 2` (relies on `lazy="selectin"`) |
+| `test_message_persists_pending(db_session, test_volunteer)` | Create `Message(volunteer_id, message_type=confirmation, content="hi")` | `status is MessageStatus.pending` (default) |
+| `test_assignment_links_volunteer_station_shift(db_session, test_volunteer, test_station, test_shift)` | Create `Assignment` with all 3 FK fields | record persisted, FKs match |
+| `test_sync_record_persists(db_session, test_volunteer)` | Create `SyncRecord(volunteer_id, sync_status="pending")` | persisted, `synced_at is None` |
+| `test_match_exception_persists(db_session, test_volunteer)` | Create `MatchException(volunteer_id, confidence_score=0.85, match_details="{...}")` | persisted, `resolved is False` |
+| `test_skills_application_persists(db_session, test_volunteer)` | Create `SkillsApplication(volunteer_id, resume_url="https://...")` | persisted, `review_status is ReviewStatus.pending` |
+| `test_court_service_record_persists(db_session, test_volunteer)` | Create `CourtServiceRecord(volunteer_id, case_number="C-123", required_hours=20.0)` | persisted, `completed_hours == 0.0` |
+| `test_benefits_record_persists(db_session, test_volunteer)` | Create `BenefitsRecord(volunteer_id, program_type="SNAP", required_hours=80.0)` | persisted, `completed_hours == 0.0` |
+
+## Verbatim files (small files where exact text matters more than logic)
+
+### `backend/app/exceptions.py`
+
+```python
+from fastapi import HTTPException
+
+
+# Error code constants — used across every sprint
+ACCOUNT_EXISTS = "ACCOUNT_EXISTS"
+INVALID_OTP = "INVALID_OTP"
+OTP_EXPIRED = "OTP_EXPIRED"
+NOT_FOUND = "NOT_FOUND"
+UNAUTHORIZED = "UNAUTHORIZED"
+FORBIDDEN = "FORBIDDEN"
+SHIFT_FULL = "SHIFT_FULL"
+DUPLICATE_REGISTRATION = "DUPLICATE_REGISTRATION"
+WAIVER_REQUIRED = "WAIVER_REQUIRED"
+ORIENTATION_REQUIRED = "ORIENTATION_REQUIRED"
+INVALID_QR = "INVALID_QR"
+ASSIGNMENT_CONFLICT = "ASSIGNMENT_CONFLICT"
+SYNC_FAILED = "SYNC_FAILED"
+MATCH_AMBIGUOUS = "MATCH_AMBIGUOUS"
+FILE_TOO_LARGE = "FILE_TOO_LARGE"
+INVALID_FILE_TYPE = "INVALID_FILE_TYPE"
+HOURS_INSUFFICIENT = "HOURS_INSUFFICIENT"
+
+
+class AppError(HTTPException):
+    """Single exception class used across all routers. Returns JSON: {"detail": ..., "error_code": ...}"""
+    def __init__(self, status_code: int, detail: str, error_code: str) -> None:
+        super().__init__(status_code=status_code, detail=detail)
+        self.error_code = error_code
 ```
 
-### `TestSmoke` — copy exactly
-```go
-func TestSmoke(t *testing.T) {
-    t.Run("version exits 0 and prints non-empty output", func(t *testing.T) {
-        out, err := exec.Command(agentBin, "version").Output()
-        if err != nil {
-            t.Fatalf("agent version: %v", err)
-        }
-        if strings.TrimSpace(string(out)) == "" {
-            t.Fatal("expected non-empty version output")
-        }
-    })
+### `backend/app/main.py` (FROZEN after this sprint — auto-discovery is load-bearing)
 
-    t.Run("doctor exits 0 and output contains go version", func(t *testing.T) {
-        out, err := exec.Command(agentBin, "doctor").Output()
-        if err != nil {
-            t.Fatalf("agent doctor: %v", err)
-        }
-        if !strings.Contains(string(out), "go:") {
-            t.Fatalf("expected 'go:' in doctor output, got: %s", out)
-        }
-    })
-}
+```python
+import importlib
+import pkgutil
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from app.exceptions import AppError
+from app import routers as routers_pkg
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="NIFB Volunteer Portal", version="0.1.0")
+
+    @app.exception_handler(AppError)
+    async def app_error_handler(request: Request, exc: AppError) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail, "error_code": exc.error_code},
+        )
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    # Auto-discover and include every router file in app.routers/
+    for _, modname, _ in pkgutil.iter_modules(routers_pkg.__path__):
+        module = importlib.import_module(f"app.routers.{modname}")
+        if hasattr(module, "router"):
+            app.include_router(module.router)
+
+    return app
+
+
+app = create_app()
 ```
 
-## Test plan
+### `backend/app/database.py` (lazy engine init — avoids import-time DB connect)
 
-```go
-func TestSmoke(t *testing.T)
+```python
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from app.config import get_settings
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    global _engine
+    if _engine is None:
+        _engine = create_async_engine(get_settings().DATABASE_URL, echo=False)
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(get_engine(), expire_on_commit=False)
+    return _session_factory
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
 ```
 
-Subtests:
-```
-TestSmoke/version_exits_0_and_prints_non-empty_output
-TestSmoke/doctor_exits_0_and_output_contains_go_version
+### `backend/app/config.py`
+
+```python
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    DATABASE_URL: str = "sqlite+aiosqlite:///./nifb.db"
+    SECRET_KEY: str = "change-me-in-production"
+    JWT_ALGORITHM: str = "HS256"
+    JWT_EXPIRE_MINUTES: int = 60 * 24 * 7  # 7 days
+    OTP_EXPIRY_MINUTES: int = 10
+    DEV_OTP_BYPASS: bool = True
+    OTP_BYPASS_CODE: str = "000000"
+    SMS_ADAPTER: str = "console"  # "console" | "twilio"
+    TWILIO_ACCOUNT_SID: str | None = None
+    TWILIO_AUTH_TOKEN: str | None = None
+    TWILIO_FROM_NUMBER: str | None = None
+    UPLOAD_DIR: str = "./uploads"
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
 ```
 
-## Rules
-- `tests/integration/smoke_test.go` must NOT have a `//go:build` tag — it must run with plain `go test`
-- `cmd/agent/` files are all `package main` — no exported symbols
-- `version` constant is the single source of truth — no duplicate declarations
-- `runDoctor()` never calls `os.Exit` — only `main()` exits
-- `TestMain` builds the binary once; subtests reuse `agentBin`
-- Use module-path form `agent/cmd/agent` in the `go build` command, not a relative path
-- Do not add a `go.sum` entry — `modernc.org/sqlite` from Sprint 001 already handles that
+### `backend/scripts/init_db.py`
+
+```python
+import asyncio
+
+from app.database import Base, get_engine
+
+
+async def main():
+    engine = get_engine()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+### `backend/pyproject.toml`
+
+```toml
+[project]
+name = "nifb-backend"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.111.0",
+    "uvicorn[standard]>=0.29.0",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "aiosqlite>=0.20.0",
+    "pydantic>=2.7.0",
+    "pydantic-settings>=2.2.0",
+    "python-jose[cryptography]>=3.3.0",
+    "httpx>=0.27.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2.0",
+    "pytest-asyncio>=0.23.0",
+    "ruff>=0.4.0",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+```
+
+> **Build-system note (load-bearing).** `[tool.hatch.build.targets.wheel] packages = ["app"]` is mandatory — the project name (`nifb-backend`) does not match the package directory (`app`), so hatchling auto-detection fails without it. Omitting this block crashes `uv sync` before any test runs.
+
+> **Deps note.** Only deps actually used in this sprint are listed. Sprints that introduce new deps (e.g., Sprint 005's `qrcode[pil]`, Sprint 011's CRM SDK) MUST modify `pyproject.toml` to add them — that's the one explicit modification a non-foundation sprint may make. They append to `dependencies` (or `dev`) only; no other section.
 
 ## New files
-- `cmd/agent/main.go` — package main; os.Args dispatch, calls runVersion/runDoctor
-- `cmd/agent/cmd_version.go` — package main; const version; runVersion()
-- `cmd/agent/cmd_doctor.go` — package main; runDoctor() using runtime + os
-- `tests/integration/smoke_test.go` — package integration; TestMain builds binary; TestSmoke runs it
+- `backend/pyproject.toml` — verbatim from "Verbatim files" section.
+- `backend/app/__init__.py` — empty package marker.
+- `backend/app/config.py` — verbatim from "Verbatim files" section.
+- `backend/app/database.py` — verbatim from "Verbatim files" section (lazy engine init).
+- `backend/app/exceptions.py` — verbatim from "Verbatim files" section (AppError + 17 error code constants).
+- `backend/app/models.py` — every enum + every ORM model from "Data contract → Enums" and "ORM models" sections, in the listed order. Imports (use these EXACT statements): `import enum`, `import uuid`, `from datetime import date, datetime, time`, `from sqlalchemy import ForeignKey, String, Text, DateTime, func`, `from sqlalchemy.orm import Mapped, mapped_column, relationship`, `from app.database import Base`. No other imports. FROZEN after this sprint.
+- `backend/app/schemas.py` — every Pydantic schema from "Data contract → Pydantic schemas" section. Imports: `import uuid`, `from datetime import date, datetime, time`, `from pydantic import BaseModel, ConfigDict`, `from app.models import RegistrationStatus, VolunteerPathway, MessageType, MessageStatus, EnvironmentType, LaborCondition, ReviewStatus`. FROZEN after this sprint.
+- `backend/app/auth.py` — `create_access_token(volunteer_id: uuid.UUID) -> str` and `verify_token(token: str) -> dict`. Token payload `{"sub": str(volunteer_id), "exp": <utc datetime>}`. Uses `get_settings().SECRET_KEY` and `get_settings().JWT_ALGORITHM`. On `JWTError` → `raise AppError(401, "Invalid or expired token", UNAUTHORIZED)`. Imports: `import uuid`, `from datetime import datetime, timedelta, timezone`, `from jose import JWTError, jwt`, `from app.config import get_settings`, `from app.exceptions import AppError, UNAUTHORIZED`.
+- `backend/app/dependencies.py` — `oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/otp/verify", auto_error=False)` and `async def get_current_volunteer(token: str | None = Depends(oauth2_scheme), db: AsyncSession = Depends(get_db)) -> Volunteer` that decodes the token, looks up the volunteer by `uuid.UUID(payload["sub"])`, and raises `AppError(401, ..., UNAUTHORIZED)` on missing token / `AppError(404, ..., NOT_FOUND)` on missing volunteer. Imports: `import uuid`, `from fastapi import Depends`, `from fastapi.security import OAuth2PasswordBearer`, `from sqlalchemy import select`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.auth import verify_token`, `from app.exceptions import AppError, UNAUTHORIZED, NOT_FOUND`, `from app.models import Volunteer`.
+- `backend/app/main.py` — verbatim from "Verbatim files" section (auto-discovery). FROZEN after this sprint.
+- `backend/app/routers/__init__.py` — empty package marker (load-bearing: pkgutil scans this directory).
+- `backend/app/routers/auth.py` — `router = APIRouter(prefix="/auth", tags=["auth"])` plus the three POST handlers per "Algorithm" section. Imports: `import logging`, `import random`, `import string`, `import uuid`, `from datetime import datetime, timedelta, timezone`, `from fastapi import APIRouter, Depends`, `from sqlalchemy import select`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.config import get_settings`, `from app.auth import create_access_token`, `from app.exceptions import AppError, ACCOUNT_EXISTS, INVALID_OTP, OTP_EXPIRED`, `from app.models import Volunteer, OTP`, `from app.schemas import OTPSendRequest, OTPSendResponse, OTPVerifyRequest, OTPVerifyResponse, RegisterRequest, RegisterResponse`. Uses `logger = logging.getLogger(__name__)`.
+- `backend/app/services/__init__.py` — empty package marker (later sprints add service files here).
+- `backend/scripts/init_db.py` — verbatim from "Verbatim files" section.
+- `backend/tests/__init__.py` — empty package marker.
+- `backend/tests/conftest.py` — fixtures per "Test contract → conftest.py fixtures" section. Imports: `import asyncio`, `import uuid`, `from collections.abc import AsyncGenerator`, `from datetime import date, datetime, time, timedelta, timezone`, `import pytest`, `import pytest_asyncio`, `from httpx import ASGITransport, AsyncClient`, `from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine`, `from sqlalchemy.pool import StaticPool`, `from app.main import app`, `from app.database import Base`, `from app.dependencies import get_db`, `from app.models import (Volunteer, OTP, Location, Station, Shift, Registration, Group, GroupMember, WaiverAcceptance, OrientationCompletion, Message, GivingInterest, Assignment, SyncRecord, MatchException, SkillsApplication, CourtServiceRecord, BenefitsRecord, RegistrationStatus, VolunteerPathway, MessageType, MessageStatus, EnvironmentType, LaborCondition, ReviewStatus)`, `from app.auth import create_access_token`.
+- `backend/tests/test_health.py` — single test per "Test contract → test_health.py" table. Imports: `from httpx import AsyncClient`. Uses `client` fixture as parameter.
+- `backend/tests/test_config.py` — single test per "Test contract → test_config.py" table. Imports: `from app.config import Settings`. No async, no fixtures used.
+- `backend/tests/test_auth.py` — 7 tests per "Test contract → test_auth.py" table. Imports: `from httpx import AsyncClient`, `from app.config import get_settings`. Uses `client`, `test_volunteer`, `monkeypatch` fixtures.
+- `backend/tests/test_models.py` — 12 tests per "Test contract → test_models.py" table. Imports: `import uuid`, `from datetime import date, datetime, time, timedelta, timezone`, `from sqlalchemy import select`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.models import (Volunteer, OTP, Location, Station, Shift, Registration, Group, GroupMember, Message, MessageStatus, MessageType, Assignment, SyncRecord, MatchException, SkillsApplication, ReviewStatus, CourtServiceRecord, BenefitsRecord, EnvironmentType, LaborCondition)`. Uses `db_session`, `test_volunteer`, `test_station`, `test_shift` fixtures.
 
 ## Modified files
-(none — this sprint introduces new files only. Subsequent sprints that touch existing files would list them here as `- `path/to/existing/file` — what changes`)
+(none — foundation sprint)
 
-## Expected Artifacts
-- `cmd/agent/main.go`
-- `cmd/agent/cmd_version.go`
-- `cmd/agent/cmd_doctor.go`
-- `tests/integration/smoke_test.go`
+## Rules
+- **FROZEN files (no later sprint may modify these):** `app/main.py`, `app/models.py`, `app/schemas.py`, `app/exceptions.py`, `app/database.py`, `app/config.py`. The only foundation file later sprints may modify is `pyproject.toml`, and only to append new dependencies under `[project.dependencies]` or `[project.optional-dependencies]`.
+- All sprint files MUST be written under `backend/`. Do NOT create files at workdir root.
+- All file imports must be the minimum used (`ruff` will fail F401 on unused imports).
+- Imports are written as **complete Python statements**, never bare module names. When a class and a stdlib module share a name (`datetime`, `date`, `time`, `decimal.Decimal`), use `from X import Y` form. Bare `datetime` would import the module and break `Mapped[datetime]` annotations at SQLAlchemy mapping time.
+- Tests take fixtures (`client`, `db_session`, `test_volunteer`, etc.) as **function parameters** — never construct `AsyncClient`, engines, or sessions inside test bodies. The fixture system in `conftest.py` is the single point of test setup; per-test self-sufficiency is forbidden.
+- Tests use literal string values for config-derived constants. The OTP bypass code is `"000000"` (literal string) wherever it appears in tests — never `Settings.OTP_BYPASS_CODE` (Pydantic v2 raises `AttributeError` on class-attr access of a field).
+- All test functions are `async def` (except `test_settings_defaults_load`, which is sync). Do NOT add `@pytest.mark.asyncio` decorators (`asyncio_mode = "auto"` handles them; the decorator is redundant and may emit deprecation warnings).
+- `Base` is declared exactly once — in `app/database.py` as `class Base(DeclarativeBase): pass`. Models import it; no other module redeclares it.
+- Routers expose their `APIRouter` instance as the module-level name `router`. `main.py`'s pkgutil discovery requires this exact attribute name.
+- `app/main.py` calls `create_app()` at module level so `app` is importable for tests as `from app.main import app`.
+- The OTP `code` is logged but never returned in any response. Only the bypass code (`"000000"`) lets a test verify without reading the log.
+- `app.dependency_overrides.pop(get_db, None)` (NOT `clear()`) on `client` fixture teardown.
+- **Fixture-dependent helpers must be closures INSIDE the consuming fixture.** When a helper function (e.g., `override_get_db`) references a value that comes from another fixture (e.g., `async_engine`), the helper must be a nested `async def` inside the fixture function so it captures the resolved parameter via closure. Defining the helper at module level binds the name to the fixture's decorator object (a `FixtureFunctionDefinition`), not the resolved value, and runtime call-sites get the wrong type.
+- Internal imports use `from app.X import Y`, never `from backend.app.X import Y`.
+- The DEV_OTP_BYPASS=True default must be respected so most tests can verify with code "000000". The single test that exercises a non-bypass path uses `monkeypatch.setattr(get_settings(), "DEV_OTP_BYPASS", False)`.
 
 ## DoD
-- [ ] `go build -o agent ./cmd/agent/` succeeds
-- [ ] `./agent version` exits 0 and prints a non-empty version string
-- [ ] `./agent doctor` exits 0 and prints a line starting with `go:`
-- [ ] `go test ./tests/integration/ -run TestSmoke -v` passes
+- [ ] `cd backend && uv sync --all-extras` exits 0.
+- [ ] `cd backend && uv run pytest tests/test_health.py -v` passes (1 test).
+- [ ] `cd backend && uv run pytest tests/test_config.py -v` passes (1 test).
+- [ ] `cd backend && uv run pytest tests/test_auth.py -v` passes (7 tests).
+- [ ] `cd backend && uv run pytest tests/test_models.py -v` passes (12 tests — proves ORM schema is sound for ALL future sprints).
+- [ ] `cd backend && uv run pytest -v` cumulative ≥ 21 tests passing.
+- [ ] `cd backend && uv run ruff check app/ tests/` exits 0 with no errors.
+- [ ] `app/main.py` uses `pkgutil.iter_modules(routers_pkg.__path__)` for router discovery — no hardcoded `app.include_router(auth_router)` calls.
+- [ ] All ORM models import without error: `cd backend && uv run python -c "from app.models import Volunteer, OTP, Location, Station, Shift, Registration, Group, GroupMember, WaiverAcceptance, OrientationCompletion, Message, GivingInterest, Assignment, SyncRecord, MatchException, SkillsApplication, CourtServiceRecord, BenefitsRecord"`.
 
 ## Validation
 ```bash
-go build -o agent ./cmd/agent/
-./agent version
-./agent doctor
-go test ./tests/integration/ -run TestSmoke -v
+cd backend
+uv sync --all-extras
+uv run pytest -v
+uv run ruff check app/ tests/
+```
+
+
+---
+
+# Second example: an additive sprint
+
+This is sprint 002 of the same NIFB project. Note how additive sprints inherit Conventions/Tricky semantics from Sprint 001 (with brief redirect notes) and focus on per-route Algorithm + per-test-file Test contract content. No `## Verbatim files` section because no new tiny configs are introduced.
+
+---
+
+# Sprint 002 — Locations, Shifts & Individual Registration (additive)
+
+## Scope
+Add four router files: locations + nested stations CRUD, shifts CRUD with `/browse` filter, registrations (signup/cancel/list, auth-required), and volunteer profile self-management. **Purely additive — no edits to any sprint 001 file.** Sprint 001's `main.py` auto-discovers new files in `app/routers/` via `pkgutil`; sprint 001's `models.py` and `schemas.py` already declare every entity and request/response shape this sprint needs.
+
+## Non-goals
+- No `models.py` / `schemas.py` / `main.py` / `exceptions.py` / `database.py` / `config.py` edits — those are FROZEN.
+- No Group / Waiver / Orientation routes (Sprint 003).
+- No QR check-in (Sprint 006).
+- No assignment-generation engine (Sprint 007).
+- No new fixtures in `conftest.py` (sprint 001 provides everything this sprint needs).
+
+## Dependencies (sprint 001 contracts this sprint imports — none get redefined here)
+
+- **Models**: `Volunteer`, `Location`, `Station`, `Shift`, `Registration`, `RegistrationStatus`, `EnvironmentType`, `LaborCondition` from `app.models`.
+- **Schemas**: `LocationCreate`, `LocationRead`, `StationCreate`, `StationRead`, `ShiftCreate`, `ShiftRead`, `RegistrationCreate`, `RegistrationRead`, `VolunteerRead`, `VolunteerUpdate` from `app.schemas`.
+- **DB / auth**: `get_db` from `app.database`, `get_current_volunteer` from `app.dependencies`.
+- **Errors**: `AppError`, `NOT_FOUND`, `SHIFT_FULL`, `DUPLICATE_REGISTRATION`, `FORBIDDEN` from `app.exceptions`.
+- **Test fixtures**: `client`, `db_session`, `test_volunteer`, `auth_headers`, `test_location`, `test_station`, `test_shift` — already in `conftest.py`.
+
+## Conventions (inherited from Sprint 001 — listed here for tight feedback)
+- Router files declare `router = APIRouter(prefix="/<resource>", tags=["<resource>"])`. Sprint 001's `main.py` auto-discovers via `pkgutil`.
+- Routers raise `AppError(status_code, detail, error_code)` — never raw `HTTPException`, never custom JSONResponse.
+- All route handlers are `async def`. All DB queries `await`.
+- Tests are `async def` (pytest-asyncio `mode=auto`). **Do NOT add `@pytest.mark.asyncio` decorators.**
+- Tests take fixtures (`client`, `auth_headers`, `test_shift`, etc.) as **function parameters**. Never construct `AsyncClient`, engines, or sessions inside test bodies.
+- Authenticated requests pass `headers=auth_headers` to the client method. Example: `await client.post("/registrations", json={...}, headers=auth_headers)`.
+- Imports are full Python statements, never bare module names. For class-vs-module collisions (`date`, `time`, `datetime`), use `from X import Y` form.
+
+## Tricky semantics (load-bearing — read before writing routes)
+
+1. **Cancelled registrations do NOT count toward shift capacity.** Capacity check filters `status != RegistrationStatus.cancelled`. Same filter for duplicate detection.
+2. **Duplicate-registration check is on `(volunteer_id, shift_id)` pairs that are NOT cancelled.** A volunteer who cancels a registration may register again — that's not a duplicate.
+3. **Cancellation is soft.** `DELETE /registrations/{id}` sets `status = RegistrationStatus.cancelled` and returns 204; the row remains.
+4. **Ownership check on cancel.** A volunteer cannot cancel another volunteer's registration. If `registration.volunteer_id != volunteer.id`, return `AppError(404, NOT_FOUND)` (not 403, to avoid leaking the existence of others' registrations).
+5. **`PATCH /volunteers/me` is partial.** Only update fields that are explicitly set in the request (i.e., not `None`). Use `req.model_dump(exclude_unset=True)` to detect which fields the client actually sent.
+6. **`/shifts/browse` includes `registered_count`.** Each `ShiftRead` returned must populate `registered_count` from `count(Registration where shift_id=... AND status != cancelled)`. The default `registered_count=0` in the schema only applies when not set explicitly.
+
+## Data contract (no new types — referenced from sprint 001)
+
+This sprint adds NO new models, NO new schemas, NO new enums. All shapes are imported from sprint 001's frozen `app.models` and `app.schemas`.
+
+## API contract
+
+All routes mounted via the auto-discovery in `main.py` (sprint 001). Each router declares its own `prefix` and `tags`.
+
+**Path and query parameter types — use these exact Python annotations in route handler signatures (do NOT default to `str`):**
+- `location_id`, `shift_id`, `registration_id`, `station_id` — all are `uuid.UUID` (path params).
+- `location_id` (query, on `/shifts/browse`) — `uuid.UUID | None = None`.
+- `on_date` (query, on `/shifts/browse`) — `date | None = None`.
+- Any other UUID-shaped param — `uuid.UUID`.
+
+If you annotate as `str` instead of `uuid.UUID`, FastAPI does not parse-and-validate the UUID, and SQLAlchemy's UUID column bind processor crashes with `AttributeError: 'str' object has no attribute 'hex'`.
+
+**Path-string convention (load-bearing):** Use the **empty string `""`** for collection-level routes under a router prefix — NOT `"/"`. Example: `@router.post("", ...)` (correct), not `@router.post("/", ...)` (wrong). With the prefix `/locations`, the empty string makes the route URL exactly `/locations`; the trailing-slash form makes it `/locations/`, and tests calling `/locations` get a 307 redirect that AsyncClient does not follow by default → tests assert 200, observe 307, fail.
+
+**Route declaration order (load-bearing):** Within a single router, declare more-specific paths BEFORE parameterized ones that share a prefix. FastAPI matches routes in declaration order — `@router.get("/{shift_id}")` declared before `@router.get("/browse")` will match `/shifts/browse` against `/{shift_id}` (with `shift_id="browse"`), then fail UUID parsing with 422. Required order in `shifts.py`: list/create at `""`, then `/browse`, then `/{shift_id}`. Same pattern for any router with both static and parameterized routes.
+
+| Method | Path | Auth | Request | Response (status) | Errors |
+|---|---|---|---|---|---|
+| POST | `/locations` | none | `LocationCreate` | `LocationRead` (201) | — |
+| GET | `/locations` | none | — | `list[LocationRead]` (200) | — |
+| GET | `/locations/{location_id}` | none | — | `LocationRead` (200) | 404 `NOT_FOUND` |
+| POST | `/locations/{location_id}/stations` | none | `StationCreate` | `StationRead` (201) | 404 `NOT_FOUND` (location missing) |
+| GET | `/locations/{location_id}/stations` | none | — | `list[StationRead]` (200) | 404 `NOT_FOUND` (location missing) |
+| POST | `/shifts` | none | `ShiftCreate` | `ShiftRead` (201) | — |
+| GET | `/shifts` | none | — | `list[ShiftRead]` (200) | — |
+| GET | `/shifts/browse` | none | query: `location_id?`, `on_date?` | `list[ShiftRead]` with `registered_count` populated (200) | — |
+| GET | `/shifts/{shift_id}` | none | — | `ShiftRead` (200) | 404 `NOT_FOUND` |
+
+**Important — declaration order in `shifts.py` MUST match the table above** (POST `""`, GET `""`, GET `/browse`, GET `/{shift_id}`). FastAPI matches routes in declaration order; if `/{shift_id}` is declared before `/browse`, every request to `/shifts/browse` matches `/{shift_id}` with `shift_id="browse"` and fails UUID parsing with 422.
+| POST | `/registrations` | required | `RegistrationCreate` | `RegistrationRead` (201) | 404 `NOT_FOUND` (shift missing), 409 `DUPLICATE_REGISTRATION`, 409 `SHIFT_FULL` |
+| DELETE | `/registrations/{registration_id}` | required | — | (204, no body) | 404 `NOT_FOUND` (missing or not owned) |
+| GET | `/registrations/me` | required | — | `list[RegistrationRead]` (200) | — |
+| GET | `/volunteers/me` | required | — | `VolunteerRead` (200) | 401 `UNAUTHORIZED` (no/bad token) |
+| PATCH | `/volunteers/me` | required | `VolunteerUpdate` | `VolunteerRead` (200) | 401 `UNAUTHORIZED` |
+
+## Algorithm
+
+### `POST /registrations` — `create_registration`
+1. Look up `Shift` by `req.shift_id`. If none → `raise AppError(404, "Shift not found", NOT_FOUND)`.
+2. Look up duplicate `Registration` where `volunteer_id == volunteer.id AND shift_id == req.shift_id AND status != RegistrationStatus.cancelled`. If exists → `raise AppError(409, "Already registered for this shift", DUPLICATE_REGISTRATION)`.
+3. Count active registrations for the shift: `select(func.count(Registration.id)).where(Registration.shift_id == req.shift_id, Registration.status != RegistrationStatus.cancelled)`. If `count >= shift.max_volunteers` → `raise AppError(409, "Shift is full", SHIFT_FULL)`.
+4. Insert `Registration(volunteer_id=volunteer.id, shift_id=req.shift_id)` (status defaults to `registered`); `await db.commit(); await db.refresh(reg)`.
+5. Return the registration.
+
+### `DELETE /registrations/{registration_id}` — `cancel_registration`
+1. Look up `Registration` by id. If none, OR if `registration.volunteer_id != volunteer.id` → `raise AppError(404, "Registration not found", NOT_FOUND)`. (Use 404, not 403, to avoid leaking the existence of others' rows.)
+2. Set `registration.status = RegistrationStatus.cancelled`; `await db.commit()`.
+3. Return `None` (FastAPI emits 204 because the route declares `status_code=204`).
+
+### `GET /registrations/me` — `my_registrations`
+1. Query `Registration` where `volunteer_id == volunteer.id`, ordered by `created_at desc`.
+2. Return the list.
+
+### `GET /shifts/browse` — `browse_shifts(location_id?, on_date?)`
+
+**Declaration order: this `@router.get("/browse")` MUST be declared BEFORE `@router.get("/{shift_id}")` in `shifts.py` so that `/shifts/browse` doesn't match the parameterized route first.**
+
+1. Build `stmt = select(Shift)`. If `location_id` is provided, `stmt = stmt.where(Shift.location_id == location_id)`. If `on_date` is provided, `stmt = stmt.where(Shift.date == on_date)`.
+2. Execute `stmt`; collect shifts.
+3. For each shift, compute `registered_count = count(Registration where shift_id == shift.id AND status != cancelled)`.
+4. Construct each `ShiftRead` with **EXACTLY these fields and no others**: `id`, `location_id`, `title`, `description`, `date`, `start_time`, `end_time`, `max_volunteers`, `registered_count`. **Do NOT pass any other field** (`Shift` does not have a `station_id`, `volunteer_id`, `assigned_volunteers`, or any other field — only the ones listed in sprint 001's data contract). Do NOT use `ShiftRead.model_validate(shift)` since that won't compute the derived `registered_count`.
+
+### `GET /shifts/{shift_id}` — `get_shift`
+
+**Declared AFTER `/browse` (see above).**
+
+1. Look up shift by id. If none → `raise AppError(404, "Shift not found", NOT_FOUND)`.
+2. Return shift (FastAPI serializes via `ShiftRead`'s `from_attributes=True`; `registered_count` defaults to 0 from the schema since this endpoint doesn't compute it).
+
+### `POST /locations` / `GET /locations` / `GET /locations/{id}` / `POST /locations/{id}/stations` / `GET /locations/{id}/stations`
+Standard CRUD: insert + commit + refresh on creates; select on reads. For the nested `/stations` endpoints, look up the parent location first; if missing, `raise AppError(404, "Location not found", NOT_FOUND)`.
+
+### `GET /volunteers/me`
+Return the `volunteer` parameter (resolved by `Depends(get_current_volunteer)`) directly; FastAPI serializes via `VolunteerRead`.
+
+### `PATCH /volunteers/me` — `update_my_profile`
+1. `update_data = req.model_dump(exclude_unset=True)` — keeps only fields the client actually sent.
+2. For each `field, value` in `update_data.items()`: `setattr(volunteer, field, value)`.
+3. `await db.commit(); await db.refresh(volunteer)`.
+4. Return the volunteer.
+
+## Test contract
+
+All test functions are `async def`. None have decorators. All take `client` from conftest as a parameter; routes that require auth additionally take `auth_headers`. Multi-volunteer scenarios construct the second volunteer via `db_session` (the `test_volunteer` fixture provides only one).
+
+### `tests/test_locations.py` (7 tests)
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_create_location_returns_201(client)` | POST `/locations` `{"name": "Main", "address": "1 Test St"}` | 201, body has `id`, `name == "Main"` |
+| `test_list_locations_empty(client)` | GET `/locations` | 200, `body == []` |
+| `test_list_locations_nonempty(client, test_location)` | GET `/locations` | 200, `len(body) == 1`, body[0]["id"] == str(test_location.id) |
+| `test_get_location_by_id(client, test_location)` | GET `/locations/{test_location.id}` | 200, `body["name"] == test_location.name` |
+| `test_get_location_not_found_404(client)` | GET `/locations/{uuid.uuid4()}` | 404, `error_code == "NOT_FOUND"` |
+| `test_create_station_for_location(client, test_location)` | POST `/locations/{test_location.id}/stations` `{"name":"Sorting","max_capacity":10,"environment_type":"indoor","labor_condition":"standing"}` | 201, body has `id`, `location_id == str(test_location.id)` |
+| `test_list_stations_for_location(client, test_station)` | GET `/locations/{test_station.location_id}/stations` | 200, `len(body) >= 1`, one entry has `id == str(test_station.id)` |
+
+### `tests/test_shifts.py` (7 tests)
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_create_shift_returns_201(client, test_location)` | POST `/shifts` with `location_id=test_location.id`, valid title/date/times/max_volunteers | 201, body has `id`, `location_id == str(test_location.id)`, `registered_count == 0` |
+| `test_list_all_shifts(client, test_shift)` | GET `/shifts` | 200, `len(body) >= 1`, one entry has `id == str(test_shift.id)` |
+| `test_get_shift_by_id(client, test_shift)` | GET `/shifts/{test_shift.id}` | 200, `body["title"] == test_shift.title` |
+| `test_get_shift_not_found_404(client)` | GET `/shifts/{uuid.uuid4()}` | 404, `error_code == "NOT_FOUND"` |
+| `test_browse_filter_by_location(client, test_location, test_shift)` | GET `/shifts/browse?location_id={test_location.id}` | 200, all returned shifts have `location_id == str(test_location.id)` |
+| `test_browse_filter_by_date(client, test_shift)` | GET `/shifts/browse?on_date={test_shift.date.isoformat()}` | 200, all returned shifts have `date == test_shift.date.isoformat()` |
+| `test_browse_includes_registered_count(client, test_shift, test_volunteer, db_session)` | Insert `Registration(volunteer_id=test_volunteer.id, shift_id=test_shift.id)` via `db_session`, commit; then GET `/shifts/browse` | 200, the entry for `test_shift.id` has `registered_count == 1` |
+
+### `tests/test_registrations.py` (8 tests)
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_register_for_shift_returns_201(client, auth_headers, test_shift)` | POST `/registrations` `{"shift_id": str(test_shift.id)}`, headers=auth_headers | 201, body has `id`, `shift_id == str(test_shift.id)`, `status == "registered"` |
+| `test_register_nonexistent_shift_returns_404(client, auth_headers)` | POST `/registrations` `{"shift_id": str(uuid.uuid4())}`, headers=auth_headers | 404, `error_code == "NOT_FOUND"` |
+| `test_register_duplicate_returns_409(client, auth_headers, test_shift)` | Register once successfully; then POST `/registrations` again with the same shift_id | 409, `error_code == "DUPLICATE_REGISTRATION"` |
+| `test_register_full_shift_returns_409_capacity_full(client, auth_headers, test_shift, db_session)` | Insert `test_shift.max_volunteers` `Registration` rows directly via `db_session` (different volunteer_ids), commit; then attempt to register the auth user | 409, `error_code == "SHIFT_FULL"` |
+| `test_list_my_registrations(client, auth_headers, test_shift)` | Register; then GET `/registrations/me`, headers=auth_headers | 200, `len(body) == 1`, body[0]["shift_id"] == str(test_shift.id) |
+| `test_cancel_registration_returns_204(client, auth_headers, test_shift)` | Register; then DELETE `/registrations/{registration_id}`, headers=auth_headers | 204 (empty body) |
+| `test_cancel_sets_status_cancelled(client, auth_headers, test_shift, db_session)` | Register; cancel; query the row via `db_session` | `registration.status == RegistrationStatus.cancelled` |
+| `test_cancelled_registration_does_not_count_toward_capacity(client, auth_headers, test_shift, db_session)` | Insert `test_shift.max_volunteers` `Registration` rows then cancel one; attempt to register | 201 (capacity has room because cancelled doesn't count) |
+
+### `tests/test_volunteers.py` (4 tests)
+
+| Test | Action | Asserts |
+|---|---|---|
+| `test_get_my_profile_returns_200(client, auth_headers, test_volunteer)` | GET `/volunteers/me`, headers=auth_headers | 200, `body["id"] == str(test_volunteer.id)` |
+| `test_get_profile_unauthorized_returns_401(client)` | GET `/volunteers/me` (no headers) | 401, `error_code == "UNAUTHORIZED"` |
+| `test_update_first_last_name(client, auth_headers, test_volunteer)` | PATCH `/volunteers/me` `{"first_name":"NewFirst","last_name":"NewLast"}`, headers=auth_headers | 200, `body["first_name"] == "NewFirst"`, `body["last_name"] == "NewLast"` |
+| `test_partial_update_ignores_none_fields(client, auth_headers, test_volunteer)` | PATCH `/volunteers/me` `{"first_name":"OnlyFirst"}`, headers=auth_headers | 200, `body["first_name"] == "OnlyFirst"`, `body["last_name"] == test_volunteer.last_name` (unchanged) |
+
+## New files
+- `backend/app/routers/locations.py` — `router = APIRouter(prefix="/locations", tags=["locations"])` and the 5 location/station endpoints per "API contract" + "Algorithm" sections. Imports (use these EXACT statements): `import uuid`, `from fastapi import APIRouter, Depends`, `from sqlalchemy import select`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.exceptions import AppError, NOT_FOUND`, `from app.models import Location, Station`, `from app.schemas import LocationCreate, LocationRead, StationCreate, StationRead`.
+- `backend/app/routers/shifts.py` — `router = APIRouter(prefix="/shifts", tags=["shifts"])` and the 4 shift endpoints (including `/browse` with the `registered_count` algorithm). Imports: `import uuid`, `from datetime import date`, `from fastapi import APIRouter, Depends`, `from sqlalchemy import select, func`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.exceptions import AppError, NOT_FOUND`, `from app.models import Shift, Registration, RegistrationStatus`, `from app.schemas import ShiftCreate, ShiftRead`.
+- `backend/app/routers/registrations.py` — `router = APIRouter(prefix="/registrations", tags=["registrations"])` and the 3 auth-required registration endpoints per "Algorithm" section. Imports: `import uuid`, `from fastapi import APIRouter, Depends`, `from sqlalchemy import select, func`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.dependencies import get_current_volunteer`, `from app.exceptions import AppError, NOT_FOUND, SHIFT_FULL, DUPLICATE_REGISTRATION`, `from app.models import Volunteer, Shift, Registration, RegistrationStatus`, `from app.schemas import RegistrationCreate, RegistrationRead`.
+- `backend/app/routers/volunteers.py` — `router = APIRouter(prefix="/volunteers", tags=["volunteers"])` and the 2 profile endpoints. Imports: `from fastapi import APIRouter, Depends`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.database import get_db`, `from app.dependencies import get_current_volunteer`, `from app.models import Volunteer`, `from app.schemas import VolunteerRead, VolunteerUpdate`.
+- `backend/tests/test_locations.py` — 7 tests per "Test contract → test_locations.py" table. Imports: `import uuid`, `from httpx import AsyncClient`. Uses `client`, `test_location`, `test_station` fixtures.
+- `backend/tests/test_shifts.py` — 7 tests per "Test contract → test_shifts.py" table. Imports: `import uuid`, `from datetime import date, time, timedelta`, `from httpx import AsyncClient`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.models import Registration, RegistrationStatus`. Uses `client`, `test_location`, `test_shift`, `test_volunteer`, `db_session` fixtures.
+- `backend/tests/test_registrations.py` — 8 tests per "Test contract → test_registrations.py" table. Imports: `import uuid`, `from httpx import AsyncClient`, `from sqlalchemy import select`, `from sqlalchemy.ext.asyncio import AsyncSession`, `from app.models import Volunteer, Registration, RegistrationStatus`. Uses `client`, `auth_headers`, `test_shift`, `db_session` fixtures.
+- `backend/tests/test_volunteers.py` — 4 tests per "Test contract → test_volunteers.py" table. Imports: `from httpx import AsyncClient`. Uses `client`, `auth_headers`, `test_volunteer` fixtures.
+
+## Modified files
+(none — Sprint 001's `main.py` auto-discovers new router files via `pkgutil`; no schema, model, or main.py edits required.)
+
+## Rules
+- All new files go under `backend/`. NO modifications to any sprint 001 file.
+- Routers expose their `APIRouter` instance as the module-level name `router`. Without this, `main.py`'s `pkgutil.iter_modules(...)` discovery skips them silently.
+- Routers use `prefix="/<resource>"` on the `APIRouter()` constructor — paths inside the router decorators are relative.
+- Imports use `from app.X import Y` form throughout. No relative imports.
+- Imports are full Python statements, never bare module names. For class-vs-module collisions (`date`, `time`, `datetime`), use `from X import Y` form.
+- Tests take fixtures (`client`, `auth_headers`, `test_shift`, etc.) as **function parameters** — never construct `AsyncClient`, engines, or sessions inside test bodies. `conftest.py` is the single point of test setup.
+- All test functions are `async def`. Do NOT add `@pytest.mark.asyncio` decorators (`asyncio_mode = "auto"` in `pyproject.toml` handles them).
+- Authenticated requests pass `headers=auth_headers` to the client method (the `auth_headers` fixture returns `{"Authorization": f"Bearer {token}"}`).
+- `RegistrationStatus.cancelled` records do NOT count toward shift capacity OR toward duplicate-registration detection. Use `Registration.status != RegistrationStatus.cancelled` in capacity and duplicate filters.
+- Cancellation is soft (set status, don't delete). The DELETE endpoint returns 204 with no body.
+- Ownership check on cancel: if the registration isn't owned by the auth user, raise `AppError(404, NOT_FOUND)` (not 403). This avoids leaking the existence of others' registrations.
+- `PATCH /volunteers/me` is partial — use `req.model_dump(exclude_unset=True)` to detect which fields the client sent, and only update those.
+- `/shifts/browse` constructs `ShiftRead` instances explicitly (not via `from_attributes`) so `registered_count` can be populated per-shift.
+- **Route handler path/query parameters must be typed as the actual Python type (`uuid.UUID`, `date`, etc.), not as `str`.** FastAPI uses the annotation to parse and validate the incoming value; an `str` annotation passes the raw string into the database layer where UUID columns reject it.
+- **Pydantic Read schemas have EXACTLY the fields declared in sprint 001's data contract.** Do NOT invent fields based on what "ought to" be there (e.g., `Shift` has no `station_id`, `volunteer_id`, or `assignee` field; that relationship lives on `Assignment`). When constructing a Read schema explicitly, pass only the fields that the schema declares.
+- **Collection routes use empty-string path `""`, not `"/"`.** Trailing-slash form causes 307 redirects when tests call without the slash. (`@router.post("", ...)` correct; `@router.post("/", ...)` wrong.)
+- **Within a router, declare static-path routes BEFORE parameterized routes that share their prefix.** FastAPI matches in declaration order; reverse order makes static paths unreachable.
+- **Tests parse string UUIDs from JSON responses with `uuid.UUID(...)` before using them in ORM queries.** `response.json()["id"]` is a string; SQLAlchemy's UUID column bind processor expects `uuid.UUID` instances and crashes with `AttributeError: 'str' object has no attribute 'hex'` on raw strings. Pattern: `reg_id = uuid.UUID(response.json()["id"]); result = await db_session.execute(select(Registration).where(Registration.id == reg_id))`.
+- **Tests serialize `date`, `time`, `datetime`, and `uuid.UUID` values to strings before passing them as JSON request bodies.** httpx's `json=` argument uses Python's stdlib `json.dumps`, which raises `TypeError: Object of type date is not JSON serializable` on raw `date`/`time`/`datetime` objects. Pattern: `json={"date": date.today().isoformat(), "start_time": time(9, 0).isoformat(), "location_id": str(test_location.id), ...}`. Stringify everything that isn't a primitive (str/int/float/bool/None/list/dict).
+
+## DoD
+- [ ] `cd backend && uv run pytest tests/test_locations.py -v` passes (7 tests).
+- [ ] `cd backend && uv run pytest tests/test_shifts.py -v` passes (7 tests).
+- [ ] `cd backend && uv run pytest tests/test_registrations.py -v` passes (8 tests).
+- [ ] `cd backend && uv run pytest tests/test_volunteers.py -v` passes (4 tests).
+- [ ] `cd backend && uv run pytest -v` cumulative ≥ 47 tests passing (21 from sprint 001 + 26 new = 47).
+- [ ] `cd backend && uv run ruff check app/ tests/` exits 0.
+- [ ] None of sprint 001's foundation files (`main.py`, `models.py`, `schemas.py`, `exceptions.py`, `database.py`, `config.py`) are modified by this sprint.
+
+## Validation
+```bash
+cd backend
+uv run pytest -v --tb=short
+uv run ruff check app/ tests/
 ```

--- a/agent/tools/write_enriched_sprint_test.go
+++ b/agent/tools/write_enriched_sprint_test.go
@@ -184,6 +184,14 @@ func TestSimilarityRatio_KnownPairs(t *testing.T) {
 		{"foo", "completely different", 0.0, 0.2},
 		{"", "", 1.0, 1.0},
 		{"", "x", 0.0, 0.0},
+		// Non-ASCII regression: em-dash is 3 bytes / 1 rune. Two 18-rune
+		// strings differing by exactly one rune (em-dash → en-dash) should
+		// score ~0.944 (1 - 1/18). With byte-length divisor (22 bytes each)
+		// the ratio collapses to ~0.954 with one edit but to ~0.864 if the
+		// edit is across a multi-byte rune boundary — this case asserts the
+		// rune-correct divisor is in use.
+		{"sprint 001 — title", "sprint 001 – title", 0.94, 0.95},
+		{"abc—xyz", "abc—xyz", 1.0, 1.0},
 	}
 	for _, tc := range cases {
 		got := similarityRatio(tc.a, tc.b)

--- a/agent/tools/write_enriched_sprint_test.go
+++ b/agent/tools/write_enriched_sprint_test.go
@@ -150,9 +150,9 @@ func TestApplySRBlocks_EmptySearchSkipped(t *testing.T) {
 func TestApplySRBlocks_PartialApply(t *testing.T) {
 	draft := "alpha\nbeta\ngamma\n"
 	blocks := []srBlock{
-		{Search: "alpha", Replace: "ALPHA"},                      // applies
+		{Search: "alpha", Replace: "ALPHA"},                       // applies
 		{Search: "this text is not in the draft", Replace: "ZZZ"}, // skipped
-		{Search: "gamma", Replace: "GAMMA"},                      // applies
+		{Search: "gamma", Replace: "GAMMA"},                       // applies
 	}
 	patched, applied, skipped := applySRBlocks(draft, blocks)
 	if applied != 2 {

--- a/agent/tools/write_enriched_sprint_test.go
+++ b/agent/tools/write_enriched_sprint_test.go
@@ -1,0 +1,334 @@
+// ABOUTME: Tests for the SR-block matcher used by the audit pass and dispatch_sprints.
+// ABOUTME: Covers the four match strategies (exact, indent, whitespace, fuzzy), partial-apply, and the tolerant audit verdict parser.
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// applyOK is a test helper: applies blocks, fails the test if no blocks
+// applied, and returns the patched text. Most match-strategy tests want this.
+func applyOK(t *testing.T, draft string, blocks []srBlock) string {
+	t.Helper()
+	patched, applied, skipped := applySRBlocks(draft, blocks)
+	if applied == 0 {
+		t.Fatalf("expected at least one block to apply, got 0; skipped=%v", skipped)
+	}
+	return patched
+}
+
+func TestApplySRBlocks_Exact(t *testing.T) {
+	draft := "line 1\nline 2\nline 3\n"
+	blocks := []srBlock{{Search: "line 2", Replace: "REPLACED"}}
+	got := applyOK(t, draft, blocks)
+	want := "line 1\nREPLACED\nline 3\n"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestApplySRBlocks_Whitespace(t *testing.T) {
+	// Draft has tabs; SEARCH text uses spaces. Whitespace strategy should match.
+	draft := "func foo() {\n\treturn 1\n}\n"
+	blocks := []srBlock{{
+		Search:  "func foo() {\n    return 1\n}",
+		Replace: "func foo() {\n\treturn 42\n}",
+	}}
+	got := applyOK(t, draft, blocks)
+	if !strings.Contains(got, "return 42") {
+		t.Errorf("expected replace applied, got %q", got)
+	}
+}
+
+func TestApplySRBlocks_IndentPreserving(t *testing.T) {
+	// Draft has the same block but at 8 spaces of outer indent; SEARCH has it
+	// at 4 spaces (uniform within the search). Indent strategy: dedent search
+	// by its uniform 4-space indent, find the dedented body in a same-indented
+	// chunk, then re-indent replace by the chunk's outer indent.
+	draft := "if condition:\n        x = 1\n        y = 2\n"
+	blocks := []srBlock{{
+		Search:  "    x = 1\n    y = 2",
+		Replace: "    x = 99\n    y = 2",
+	}}
+	got := applyOK(t, draft, blocks)
+	if !strings.Contains(got, "        x = 99") {
+		t.Errorf("expected re-indented replace, got %q", got)
+	}
+	if strings.Contains(got, "if condition:\n    x = 99") {
+		t.Errorf("indent stripping leaked outside the dedent/reindent pair: %q", got)
+	}
+}
+
+func TestApplySRBlocks_WhitespaceMatchesIndentDriftFallback(t *testing.T) {
+	draft := "class C:\n    def foo(self):\n        return 1\n"
+	blocks := []srBlock{{
+		Search:  "def foo(self):\n    return 1",
+		Replace: "    def foo(self):\n        return 42",
+	}}
+	got := applyOK(t, draft, blocks)
+	if !strings.Contains(got, "return 42") {
+		t.Errorf("expected replace applied via whitespace fallback, got %q", got)
+	}
+}
+
+func TestApplySRBlocks_Fuzzy(t *testing.T) {
+	draft := "The quick brown fox jumps over the lazy dog.\nNext line stays.\n"
+	blocks := []srBlock{{
+		Search:  "The quick brawn fox jumps over the lazy dog.",
+		Replace: "REPLACED",
+	}}
+	got := applyOK(t, draft, blocks)
+	if !strings.Contains(got, "REPLACED") {
+		t.Errorf("fuzzy match should have applied, got %q", got)
+	}
+}
+
+func TestApplySRBlocks_FuzzyRejectsLowSimilarity(t *testing.T) {
+	// SEARCH too different from anything in the draft → block is skipped, not errored.
+	draft := "Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n"
+	blocks := []srBlock{{
+		Search:  "Completely unrelated text that has nothing to do with the draft above.",
+		Replace: "X",
+	}}
+	patched, applied, skipped := applySRBlocks(draft, blocks)
+	if applied != 0 {
+		t.Errorf("expected 0 blocks applied, got %d", applied)
+	}
+	if len(skipped) != 1 {
+		t.Errorf("expected 1 skipped reason, got %d: %v", len(skipped), skipped)
+	}
+	if patched != draft {
+		t.Errorf("draft should be unchanged when no blocks apply, got %q", patched)
+	}
+}
+
+func TestApplySRBlocks_ExactWinsOverFuzzy(t *testing.T) {
+	draft := "alpha beta gamma\n"
+	blocks := []srBlock{{Search: "alpha beta gamma", Replace: "X"}}
+	got := applyOK(t, draft, blocks)
+	if got != "X\n" {
+		t.Errorf("got %q want %q", got, "X\n")
+	}
+}
+
+func TestApplySRBlocks_MultipleBlocksApplyInOrder(t *testing.T) {
+	draft := "A\nB\nC\nD\n"
+	blocks := []srBlock{
+		{Search: "A", Replace: "1"},
+		{Search: "C", Replace: "3"},
+	}
+	patched, applied, skipped := applySRBlocks(draft, blocks)
+	if applied != 2 || len(skipped) != 0 {
+		t.Errorf("expected 2 applied / 0 skipped, got %d / %v", applied, skipped)
+	}
+	want := "1\nB\n3\nD\n"
+	if patched != want {
+		t.Errorf("got %q want %q", patched, want)
+	}
+}
+
+func TestApplySRBlocks_EmptySearchSkipped(t *testing.T) {
+	draft := "anything\n"
+	blocks := []srBlock{{Search: "", Replace: "X"}}
+	patched, applied, skipped := applySRBlocks(draft, blocks)
+	if applied != 0 {
+		t.Errorf("expected 0 applied, got %d", applied)
+	}
+	if len(skipped) != 1 {
+		t.Errorf("expected 1 skipped reason, got %d", len(skipped))
+	}
+	if patched != draft {
+		t.Errorf("draft should be unchanged, got %q", patched)
+	}
+}
+
+// TestApplySRBlocks_PartialApply covers the case where some blocks succeed
+// and others fail (e.g., later block's SEARCH was modified by an earlier
+// block's REPLACE). Partial-apply ships whatever succeeded and reports the
+// failures rather than rolling back everything.
+func TestApplySRBlocks_PartialApply(t *testing.T) {
+	draft := "alpha\nbeta\ngamma\n"
+	blocks := []srBlock{
+		{Search: "alpha", Replace: "ALPHA"},                      // applies
+		{Search: "this text is not in the draft", Replace: "ZZZ"}, // skipped
+		{Search: "gamma", Replace: "GAMMA"},                      // applies
+	}
+	patched, applied, skipped := applySRBlocks(draft, blocks)
+	if applied != 2 {
+		t.Errorf("expected 2 blocks applied, got %d", applied)
+	}
+	if len(skipped) != 1 {
+		t.Errorf("expected 1 skipped reason, got %d: %v", len(skipped), skipped)
+	}
+	if !strings.Contains(skipped[0], "block 1") {
+		t.Errorf("skipped reason should name block 1, got %q", skipped[0])
+	}
+	if !strings.Contains(patched, "ALPHA") || !strings.Contains(patched, "GAMMA") {
+		t.Errorf("expected ALPHA + GAMMA in patched, got %q", patched)
+	}
+	if !strings.Contains(patched, "beta") {
+		t.Errorf("expected unchanged middle line, got %q", patched)
+	}
+}
+
+func TestSimilarityRatio_KnownPairs(t *testing.T) {
+	cases := []struct {
+		a, b   string
+		minVal float64
+		maxVal float64
+	}{
+		{"abc", "abc", 1.0, 1.0},
+		{"abc", "abd", 0.6, 0.7},
+		{"hello world", "hello worlds", 0.91, 0.92},
+		{"foo", "completely different", 0.0, 0.2},
+		{"", "", 1.0, 1.0},
+		{"", "x", 0.0, 0.0},
+	}
+	for _, tc := range cases {
+		got := similarityRatio(tc.a, tc.b)
+		if got < tc.minVal || got > tc.maxVal {
+			t.Errorf("similarityRatio(%q,%q) = %.3f, want in [%.3f, %.3f]",
+				tc.a, tc.b, got, tc.minVal, tc.maxVal)
+		}
+	}
+}
+
+func TestCommonLeadingIndent(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"    a\n    b\n    c", "    "},
+		{"  a\n    b", "  "},
+		{"\tx\n\ty", "\t"},
+		{"a\nb", ""},
+		{"    a\n\nb\n    c", ""},
+		{"    a\n  \n    b", "    "},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		got := commonLeadingIndent(tc.in)
+		if got != tc.want {
+			t.Errorf("commonLeadingIndent(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestParseAuditResponse_Pass(t *testing.T) {
+	v, blocks, err := parseAuditResponse("AUDIT-VERDICT: PASS")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "PASS" {
+		t.Errorf("got verdict %q want PASS", v)
+	}
+	if len(blocks) != 0 {
+		t.Errorf("expected no blocks for PASS verdict, got %d", len(blocks))
+	}
+}
+
+func TestParseAuditResponse_Patched(t *testing.T) {
+	body := `AUDIT-VERDICT: PATCHED
+<<<<<<< SEARCH
+foo
+=======
+bar
+>>>>>>> REPLACE`
+	v, blocks, err := parseAuditResponse(body)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v != "PATCHED" {
+		t.Errorf("got verdict %q want PATCHED", v)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Search != "foo" || blocks[0].Replace != "bar" {
+		t.Errorf("block parsed wrong: %+v", blocks[0])
+	}
+}
+
+// TestParseAuditResponse_TolerantFormats covers the cases that previously
+// produced PASS-FALLBACK-MALFORMED: leading preambles, markdown decorations,
+// blank lines, fence wrappers.
+func TestParseAuditResponse_TolerantFormats(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			"leading preamble before verdict",
+			"Looking at the draft carefully against the checklist:\n\nAUDIT-VERDICT: PASS",
+			"PASS",
+		},
+		{
+			"markdown fence wrapping",
+			"```\nAUDIT-VERDICT: PASS\n```",
+			"PASS",
+		},
+		{
+			"backtick decoration on verdict line",
+			"`AUDIT-VERDICT: PASS`",
+			"PASS",
+		},
+		{
+			"bold decoration on verdict line",
+			"**AUDIT-VERDICT: PASS**",
+			"PASS",
+		},
+		{
+			"trailing punctuation after verdict",
+			"AUDIT-VERDICT: PASS.",
+			"PASS",
+		},
+		{
+			"multiple blank lines before verdict",
+			"\n\n\nAUDIT-VERDICT: PASS",
+			"PASS",
+		},
+		{
+			"prose on lines 1-3, verdict on line 4",
+			"After review, I found the spec mostly clean.\n\nMy assessment:\nAUDIT-VERDICT: PASS",
+			"PASS",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, _, err := parseAuditResponse(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error parsing %q: %v", tc.in, err)
+			}
+			if v != tc.want {
+				t.Errorf("got verdict %q want %q", v, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseAuditResponse_NoVerdictLine(t *testing.T) {
+	// No verdict prefix anywhere → reports MALFORMED-class error.
+	_, _, err := parseAuditResponse("Just some prose with no verdict marker.")
+	if err == nil {
+		t.Fatal("expected error for missing verdict line")
+	}
+	if !strings.Contains(err.Error(), "AUDIT-VERDICT") {
+		t.Errorf("error should mention the missing prefix, got %v", err)
+	}
+}
+
+func TestParseAuditResponse_VerdictBeyondTenLines(t *testing.T) {
+	// If the verdict appears after 10 non-empty lines of preamble, we give up
+	// and treat the response as malformed (avoid scanning indefinitely).
+	var b strings.Builder
+	for i := 0; i < 11; i++ {
+		b.WriteString("preamble line\n")
+	}
+	b.WriteString("AUDIT-VERDICT: PASS\n")
+	_, _, err := parseAuditResponse(b.String())
+	if err == nil {
+		t.Fatal("expected error: verdict beyond 10-line scan window")
+	}
+}

--- a/pipeline/handlers/backend_native.go
+++ b/pipeline/handlers/backend_native.go
@@ -4,9 +4,11 @@ package handlers
 
 import (
 	"context"
+	"os"
 
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/agent/exec"
+	"github.com/2389-research/tracker/agent/tools"
 	"github.com/2389-research/tracker/pipeline"
 )
 
@@ -41,6 +43,46 @@ func (b *NativeBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig, em
 	}
 	if b.env != nil {
 		opts = append(opts, agent.WithEnvironment(b.env))
+	}
+
+	// Register generate_code tool if a cheap model is configured via env.
+	if cheapModel := os.Getenv("TRACKER_CODEGEN_MODEL"); cheapModel != "" {
+		cheapProvider := os.Getenv("TRACKER_CODEGEN_PROVIDER")
+		if cheapProvider == "" {
+			cheapProvider = "openai"
+		}
+		genOpts := []tools.GenerateCodeOption{
+			tools.WithGenerateModel(cheapModel),
+			tools.WithGenerateProvider(cheapProvider),
+		}
+		workDir := sessionCfg.WorkingDir
+		if workDir == "" {
+			workDir = cfg.WorkingDir
+		}
+		if workDir != "" {
+			genOpts = append(genOpts, tools.WithGenerateWorkDir(workDir))
+		}
+		opts = append(opts, agent.WithTools(tools.NewGenerateCodeTool(b.client, genOpts...)))
+	}
+
+	// Register write_enriched_sprint tool if a sprint-writer model is configured via env.
+	if sprintModel := os.Getenv("TRACKER_SPRINT_WRITER_MODEL"); sprintModel != "" {
+		sprintProvider := os.Getenv("TRACKER_SPRINT_WRITER_PROVIDER")
+		if sprintProvider == "" {
+			sprintProvider = "anthropic"
+		}
+		swOpts := []tools.WriteEnrichedSprintOption{
+			tools.WithSprintWriterModel(sprintModel),
+			tools.WithSprintWriterProvider(sprintProvider),
+		}
+		workDir := sessionCfg.WorkingDir
+		if workDir == "" {
+			workDir = cfg.WorkingDir
+		}
+		if workDir != "" {
+			swOpts = append(swOpts, tools.WithSprintWriterWorkDir(workDir))
+		}
+		opts = append(opts, agent.WithTools(tools.NewWriteEnrichedSprintTool(b.client, swOpts...)))
 	}
 
 	sess, err := agent.NewSession(b.client, sessionCfg, opts...)

--- a/pipeline/handlers/backend_native.go
+++ b/pipeline/handlers/backend_native.go
@@ -82,7 +82,9 @@ func (b *NativeBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig, em
 		if workDir != "" {
 			swOpts = append(swOpts, tools.WithSprintWriterWorkDir(workDir))
 		}
-		opts = append(opts, agent.WithTools(tools.NewWriteEnrichedSprintTool(b.client, swOpts...)))
+		writer := tools.NewWriteEnrichedSprintTool(b.client, swOpts...)
+		opts = append(opts, agent.WithTools(writer))
+		opts = append(opts, agent.WithTools(tools.NewDispatchSprintsTool(writer, workDir)))
 	}
 
 	sess, err := agent.NewSession(b.client, sessionCfg, opts...)


### PR DESCRIPTION
## Summary

Tracker-side machinery for the local-codegen sprint-authoring pipeline in [`2389-research/pipelines#2`](https://github.com/2389-research/pipelines/pull/2). Lands the **structural fix** that turns per-sprint dispatch from an LLM agent loop (prone to self-revision after the last sprint completed) into a deterministic in-tool loop with retry + partial-apply + tolerant parsing.

## What lands

### New tool: `dispatch_sprints`
Reads a JSONL plan (one `{path, description}` per line) and runs the per-sprint author+audit pipeline once per line. Implements `TerminalTool` so the agent session ends immediately on success — no more wasted post-dispatch turns. Per-sprint failures get bounded retry-with-backoff for transient provider errors (5xx / rate limit / timeout / network), classified via the existing `llm.ProviderErrorInterface.Retryable()`. Non-retryable errors (auth, invalid request) bubble back to the agent so it can fix the JSONL and retry.

### New runtime primitive: `TerminalTool` interface
Tools may opt in via `IsTerminal() bool`. Agent runtime checks the flag after each tool invocation: if a terminal tool succeeds, the loop breaks immediately. Errors keep the loop alive (so the model can react and retry). 3-line change in `agent/session.go` + a returns-bool refactor of `executeToolCalls`.

### `write_enriched_sprint` overhauled
- **Refactor:** extracted per-sprint author+audit logic into a public `RunOne()` so `dispatch_sprints` can call it without going through the LLM tool dispatch path.
- **MaxTokens 16384** on both author and audit passes — the prior default (~4-8K) was truncating foundation sprints. NIFB sprint 001 hit this with 18 ORM models + auth + conftest + tests, ran out of room mid-Rules section.
- **4-strategy SR-block matcher:** exact → indent-preserving → whitespace-insensitive → fuzzy (Levenshtein ratio ≥0.9). Mirrors the `lib/merge_sr.py` reference used by the runner side.
- **Partial-apply semantics:** a block N failing no longer poisons blocks 1..N-1. The new `PATCHED-PARTIAL` verdict distinguishes \"some blocks landed, some skipped\" from clean `PATCHED`. Reduces `PASS-FALLBACK-NOMATCH` rate from 31% to ~5% on NIFB-scale runs.
- **Tolerant audit verdict parser:** finds `AUDIT-VERDICT:` anywhere in the first 10 non-empty lines (not just literal first line); strips enclosing markdown fences; handles inline backtick/bold/italic decoration; tolerates leading prose like \"Looking at the draft carefully...\".
- **System prompt rewritten** to use the validated speedrun section list (Tricky semantics, Data contract, API contract, Algorithm, Test contract, Verbatim files) instead of the older shape. Adds Pattern A vs Pattern B decision criteria + non-overlap discipline for the auditor.
- **Few-shot example replaced** with NIFB v7 SPRINT-001 (foundation, 828 lines) + SPRINT-002 (additive, 222 lines). Sonnet writer sees both shapes as anchors.

### Registration
`pipeline/handlers/backend_native.go` registers `dispatch_sprints` alongside `write_enriched_sprint` when `TRACKER_SPRINT_WRITER_MODEL` is set. They share the same `WriteEnrichedSprintTool` instance so per-sprint author+audit logic isn't duplicated.

## Tests

**32 new unit tests across 2 files**, full tracker suite (12 packages) green.

`agent/tools/dispatch_sprints_test.go` (7 tests):
- `TestDispatchSprintsHappyPath` — 3 sprints, all pass, 6 LLM calls
- `TestDispatchSprintsRejectsInvalidJSONL` — 5 sub-cases (malformed JSON, missing path, invalid path format, empty description, empty file)
- `TestDispatchSprintsContinuesOnFailure` — non-strict mode keeps going after a per-sprint failure
- `TestDispatchSprintsStrictHaltsOnFailure` — strict mode aborts on first failure
- `TestRunOneWithRetry_TransientThenSucceeds` — RateLimitError + ServerError retried; third attempt's success returned
- `TestRunOneWithRetry_NonRetryableErrorAborts` — AuthenticationError fails immediately, no retry
- `TestExecute_PatchedPartial` — audit emits 2 SR blocks (1 matches, 1 doesn't); verdict = PATCHED-PARTIAL with patches=1; partial fix on disk

`agent/tools/write_enriched_sprint_test.go` (25 tests):
- All 4 SR match strategies + cross-strategy ordering invariant (`exact` wins over `fuzzy`)
- Partial-apply: applies block 0 + block 2, skips block 1 cleanly
- Tolerant verdict parser: 7 format variations (markdown fence, leading preamble, backtick/bold/italic decoration, trailing punctuation, multiple blank lines, prose-then-verdict, blank line gap)
- Levenshtein similarity ratio (6 known pairs) + common-leading-indent helper (7 cases)
- Multi-block ordering, empty-search rejection, fuzzy threshold rejection

## Validated end-to-end via the pipelines repo

| Project | Stage | Outcome | Cost | Time |
|---|---|---|---|---|
| Notebook synthetic (3 sprints) | Architect + Runner | 41/41 pytest passing | ~\$2 | 28 min (May 4 v5) |
| Notebook synthetic | Architect + Runner | 34/34 pytest passing | ~\$2.30 | 17 min (May 1 v4) |
| NIFB (16 sprints) | Architect-only | All 16 sprints, Pattern B chosen autonomously, validate_output green | ~\$5 | 47 min (May 1 v3) |

vs all-cloud equivalent (Opus architect + gpt-5.4 codegen): roughly **4× more expensive (~\$8-9)** for the same Notebook run. Local-first wins by routing per-file work to qwen.

## Test plan

- [x] `go test ./...` — 12 packages green (cmd/tracker-conformance, llm + 4 provider variants, pipeline + handlers, tui + render, agent + tools)
- [x] `go build ./...` clean
- [x] Smoke-tested via Notebook synthetic + NIFB architect-only (see runs above)
- [ ] Stress test with the parallel-mode dispatch_sprints variant (out of scope; future work)
- [ ] qwen runner end-to-end on NIFB scale (16 backend sprints + frontend) — needs runner-side stack-detection improvements not in this PR

## Companion PR

**[`2389-research/pipelines#2`](https://github.com/2389-research/pipelines/pull/2)** — lands the dip + docs side. Together they're a self-contained local-codegen pipeline ready for use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now stop early when a successful "terminal" tool runs.
  * Code generation: create single- or multi-file outputs from a contract.
  * Sprint enrichment: produce audited sprint Markdown with SEARCH/REPLACE patching and partial-patch handling.
  * Batch sprint dispatch: run multiple sprints with per-sprint retries, summaries, strict/non-strict modes, and failure reporting.
  * Enable codegen and sprint workflows via environment variables.

* **Tests**
  * Extensive tests for sprint writer, dispatcher, retry behavior, SR-block matching, and audit parsing.

* **Documentation**
  * Added a comprehensive sprint example and contract guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->