### PR TITLE
Update maxTok for OpenAI in tracker_doctor.go

### DIFF
--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -363,7 +363,7 @@ func probeProvider(ctx context.Context, p providerDef, key string) (bool, string
 	defer client.Close()
 	probeCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
-	maxTok := 1
+	maxTok := 16
 	req := &llm.Request{
 		Model:     p.defaultModel,
 		Messages:  []llm.Message{llm.UserMessage("ping")},


### PR DESCRIPTION
`tracker doctor` always fails for OpenAI.  Apparently it's because OpenAI's Responses API requires max_output_tokens >= 16, so 1 returns HTTP 400 with Invalid 'max_output_tokens': integer below minimum.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication verification configuration for enhanced LLM provider compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->