### PR TITLE
fix(writes): self-healing extraction cascade for declared writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Self-healing JSON extraction cascade for declared writes** (PR #201). When an LLM responds with prose instead of valid JSON for a node with `writes:`, the runner now attempts: (1) direct JSON parse; (2) extraction of any ```...``` fenced block whose content parses as a JSON object — iterating fences so a `text`/`bash` preamble doesn't block discovery of a later `json` fence; (3) balanced-brace scan for the first top-level `{…}` span that parses as an object (handles prose with stray brace pairs around real JSON without picking the wrong span); (4) single-key fallback to the raw response with a `writes_warning` (not `writes_error`) so the pipeline survives. Multi-key writes still hard-fail since prose can't be distributed. The fallback is gated on "no extractable JSON found" — a model that returned valid JSON missing the declared key gets a hard contract failure with a specific error, not a silent fallback. Fallback values are capped at 8 KiB to keep large tool stdout out of `status.json` / `activity.jsonl` / checkpoints.
+
+### Changed
+
+- **`writes:` declarations are rejected when they collide with the `tool_command` safe-key allowlist** (`outcome`, `preferred_label`, `human_response`, `interview_answers`) (PR #201). Previously a workflow author could declare `writes: outcome` on an agent or tool node and funnel LLM-controlled content into a reserved name, bypassing the sanitization that exists exactly to keep LLM output out of shell input. The new `pipeline.IsToolCommandSafeCtxKey` accessor is checked before any value is written; collision sets `writes_error` and fails the node. No existing pipelines used these collisions.
+
 ## [0.24.2] - 2026-05-03
 
 ### Fixed

--- a/docs/architecture/context-flow.md
+++ b/docs/architecture/context-flow.md
@@ -107,11 +107,17 @@ tool ExtractMeta
 
 Runtime contract:
 
-- If `writes:` is declared, the node output must be valid top-level JSON object for extraction.
-- Every declared key must be present; missing keys hard-fail the node.
+- If `writes:` is declared, the runner runs an extraction cascade against the node's output:
+    1. **Direct JSON parse** — the response IS a top-level JSON object. The fast path.
+    2. **Fenced-block extraction** — the response contains one or more ```...``` blocks; the runner walks every fence pair and accepts the first whose content parses as a JSON object. A non-JSON preamble fence (`text`, `bash`, etc.) does not block discovery of a later `json` fence.
+    3. **Balanced-brace scan** — no fences, but a top-level `{…}` span exists in mixed prose. The scanner finds the first balanced span (skipping `{` inside `[…]` arrays and inside JSON string values) that parses as a JSON object.
+    4. **Single-key prose fallback** — only when no JSON object was found by any prior step AND the node declares exactly one writes key, the raw response is stored under that key with a `writes_warning` set in the context. The fallback value is capped at 8 KiB. Multi-key writes do not fall back — prose can't be distributed across multiple keys.
+- Every declared key must be present in the extracted JSON. A model that returns valid JSON missing the declared key hard-fails the node with a specific `writes_error` ("contained extractable JSON but failed the writes contract") — the prose fallback does NOT fire in this case, since the model intentionally produced JSON.
+- `writes:` keys cannot collide with the `tool_command` safe-key allowlist (`outcome`, `preferred_label`, `human_response`, `interview_answers`). The runner rejects such declarations at runtime to prevent LLM output from landing in reserved names that bypass shell-input sanitization.
 - String fields are stored as plain strings; non-strings are stored as compact JSON text.
-- Extra produced fields are allowed and surfaced as warnings.
-- Backward-compatible built-ins (`last_response`, `tool_stdout`, `interview_answers`, etc.) are still written.
+- Extra produced fields (in the JSON but not declared) are allowed and surfaced via `writes_warning`.
+- Two reserved context keys carry the cascade signal: `writes_error` (hard failure — the node returned `OutcomeFail`) and `writes_warning` (cascade healed but with caveats — extras present, fallback used). Both are plain context keys; downstream nodes can branch on them via `${ctx.writes_error}` / `${ctx.writes_warning}`.
+- Backward-compatible built-ins (`last_response`, `tool_stdout`, `interview_answers`, etc.) are still written regardless of the cascade outcome.
 
 For human interview mode, `writes:` extraction uses the collected interview answers object (question IDs and normalized question-text keys mapped to answers).
 For other human modes (`freeform`, `choice`, `yes_no`), `writes:` extraction is not applied automatically; rely on built-in human response keys unless handler behavior is extended.

--- a/pipeline/context_writes.go
+++ b/pipeline/context_writes.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -110,35 +111,32 @@ func ExtractJSONFromText(text string) (string, bool) {
 	return "", false
 }
 
-// extractFencedJSON walks every ```...``` fenced block in text and returns
-// the first one whose content parses as a JSON object. Iterating (rather
-// than stopping at the first fence) is necessary because LLMs commonly
-// emit a ```text or ```bash preamble before the answer, and stopping at
-// the first fence would silently drop the real result.
+// fencedBlockRE matches a Markdown-style fenced code block. The opening
+// fence is followed by an optional language tag (alphanumerics, '_', '-',
+// '+', '.') and trailing whitespace up to a newline — this strict shape
+// distinguishes a real opening fence from stray backticks in prose like
+// "Use ``` to denote code". (?s) lets `.` cross newlines; the `+?` is
+// non-greedy so we capture the smallest body up to the next ```.
+var fencedBlockRE = regexp.MustCompile("(?s)```[A-Za-z0-9_+.\\-]*[ \\t]*\\r?\\n(.+?)```")
+
+// extractFencedJSON walks every ```...``` fenced code block in text and
+// returns the first one whose content parses as a JSON object. Iterating
+// (rather than stopping at the first match) is necessary because LLMs
+// commonly emit a ```text or ```bash preamble before the answer; stopping
+// at the first fence would silently drop the real result.
+//
+// The opening fence is required to have the canonical "fence + optional
+// language tag + newline" shape, so stray inline backticks in prose don't
+// kick off extraction in the wrong place. (Without that constraint, an
+// odd number of stray fences in the input would misalign every subsequent
+// pair.)
 func extractFencedJSON(text string) string {
-	const fence = "```"
-	rest := text
-	for {
-		// Skip to and past the next opening fence.
-		_, after, ok := strings.Cut(rest, fence)
-		if !ok {
-			return ""
-		}
-		// Skip the language-tag line (everything up to the first newline).
-		_, body, ok := strings.Cut(after, "\n")
-		if !ok {
-			return ""
-		}
-		// Take content up to the next fence as the candidate.
-		candidate, tail, ok := strings.Cut(body, fence)
-		if !ok {
-			return ""
-		}
-		if c := strings.TrimSpace(candidate); c != "" && isJSONObject(c) {
+	for _, m := range fencedBlockRE.FindAllStringSubmatch(text, -1) {
+		if c := strings.TrimSpace(m[1]); c != "" && isJSONObject(c) {
 			return c
 		}
-		rest = tail
 	}
+	return ""
 }
 
 // extractBracedJSON scans text for the first balanced top-level {…} span

--- a/pipeline/context_writes.go
+++ b/pipeline/context_writes.go
@@ -87,70 +87,171 @@ func normalizeDeclaredKeys(keys []string) []string {
 	return out
 }
 
-// ExtractJSONFromText tries to find a valid JSON object embedded in text.
-// It first looks for ```json fenced blocks, then falls back to finding the
-// outermost { ... } substring. Returns the extracted JSON string and true
-// if a valid JSON object was found, or ("", false) otherwise.
+// ExtractJSONFromText tries to find a valid JSON OBJECT embedded in text. It
+// iterates ```...``` fenced blocks first (returning the first whose content
+// parses as a JSON object — so a non-JSON fence ahead of a valid JSON fence
+// doesn't block discovery), then falls back to scanning for top-level {…}
+// spans (preferring the first balanced span that parses, not the
+// outermost-brace shortcut, which fails when prose contains stray brace
+// pairs around real JSON).
+//
+// Returns the extracted JSON string and true if a valid JSON object was
+// found, or ("", false) otherwise.
+//
+// Intended for use by pipeline handlers; the Go-package boundary requires
+// it to be exported, but it isn't part of the stable embedder API.
 func ExtractJSONFromText(text string) (string, bool) {
-	// Try fenced JSON blocks first (```json ... ``` or ``` ... ```)
 	if extracted := extractFencedJSON(text); extracted != "" {
 		return extracted, true
 	}
-	// Try outermost braces
-	if extracted := extractOutermostJSON(text); extracted != "" {
+	if extracted := extractBracedJSON(text); extracted != "" {
 		return extracted, true
 	}
 	return "", false
 }
 
-// extractFencedJSON looks for a ```json or ``` fenced block containing valid JSON.
+// extractFencedJSON walks every ```...``` fenced block in text and returns
+// the first one whose content parses as a JSON object. Iterating (rather
+// than stopping at the first fence) is necessary because LLMs commonly
+// emit a ```text or ```bash preamble before the answer, and stopping at
+// the first fence would silently drop the real result.
 func extractFencedJSON(text string) string {
-	fence := "```"
-	start := strings.Index(text, fence)
-	if start < 0 {
-		return ""
+	const fence = "```"
+	rest := text
+	for {
+		// Skip to and past the next opening fence.
+		_, after, ok := strings.Cut(rest, fence)
+		if !ok {
+			return ""
+		}
+		// Skip the language-tag line (everything up to the first newline).
+		_, body, ok := strings.Cut(after, "\n")
+		if !ok {
+			return ""
+		}
+		// Take content up to the next fence as the candidate.
+		candidate, tail, ok := strings.Cut(body, fence)
+		if !ok {
+			return ""
+		}
+		if c := strings.TrimSpace(candidate); c != "" && isJSONObject(c) {
+			return c
+		}
+		rest = tail
 	}
-	// Skip past the opening fence and any language tag on the same line
-	contentStart := strings.Index(text[start+len(fence):], "\n")
-	if contentStart < 0 {
-		return ""
-	}
-	contentStart += start + len(fence) + 1 // +1 for the newline
-
-	// Find closing fence
-	end := strings.Index(text[contentStart:], fence)
-	if end < 0 {
-		return ""
-	}
-	candidate := strings.TrimSpace(text[contentStart : contentStart+end])
-	if candidate == "" {
-		return ""
-	}
-	// Validate it's a JSON object
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
-		return ""
-	}
-	return candidate
 }
 
-// extractOutermostJSON finds the first '{' and last '}' in the text and
-// checks whether the substring between them is a valid JSON object.
-func extractOutermostJSON(text string) string {
-	first := strings.IndexByte(text, '{')
-	if first < 0 {
-		return ""
+// extractBracedJSON scans text for the first balanced top-level {…} span
+// that parses as a JSON object. Unlike a first-`{` / last-`}` shortcut,
+// this handles prose like:
+//
+//	"Wrote {file1} and {file2}, then produced {\"x\": 1}. Done."
+//
+// where the outermost-brace approach picks an invalid span and returns
+// nothing even though a real JSON object is present.
+//
+// Top-level JSON arrays are NOT decomposed: `[{"a":1}]` returns "" because
+// the user supplied an array, not an object. Inner braces inside string
+// literals and arrays are skipped via state tracking so they can't kick off
+// an extraction.
+func extractBracedJSON(text string) string {
+	inString := false
+	escaped := false
+	arrayDepth := 0
+	for i := 0; i < len(text); i++ {
+		c := text[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '[':
+			arrayDepth++
+		case ']':
+			if arrayDepth > 0 {
+				arrayDepth--
+			}
+		case '{':
+			if arrayDepth > 0 {
+				// Inside a JSON array — skip; we don't decompose arrays.
+				continue
+			}
+			end, ok := matchBalancedBrace(text, i)
+			if !ok {
+				continue
+			}
+			candidate := text[i : end+1]
+			if isJSONObject(candidate) {
+				return candidate
+			}
+		}
 	}
-	last := strings.LastIndexByte(text, '}')
-	if last <= first {
-		return ""
+	return ""
+}
+
+// matchBalancedBrace returns the index of the '}' that closes the '{' at
+// start, or (0, false) if the braces are unbalanced. JSON-string content
+// is honored — a '{' or '}' inside a "..." string doesn't affect the depth.
+func matchBalancedBrace(text string, start int) (int, bool) {
+	if start >= len(text) || text[start] != '{' {
+		return 0, false
 	}
-	candidate := text[first : last+1]
+	depth := 0
+	inString := false
+	escaped := false
+	for i := start; i < len(text); i++ {
+		c := text[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inString {
+			switch c {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// isJSONObject reports whether s parses as a JSON object (not an array,
+// scalar, or null). Used to gate extraction-helper return values.
+func isJSONObject(s string) bool {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "{") {
+		return false
+	}
 	var obj map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
-		return ""
+	if err := json.Unmarshal([]byte(s), &obj); err != nil {
+		return false
 	}
-	return candidate
+	return obj != nil
 }
 
 func rawJSONValueToContext(raw json.RawMessage) string {

--- a/pipeline/context_writes.go
+++ b/pipeline/context_writes.go
@@ -87,6 +87,72 @@ func normalizeDeclaredKeys(keys []string) []string {
 	return out
 }
 
+// ExtractJSONFromText tries to find a valid JSON object embedded in text.
+// It first looks for ```json fenced blocks, then falls back to finding the
+// outermost { ... } substring. Returns the extracted JSON string and true
+// if a valid JSON object was found, or ("", false) otherwise.
+func ExtractJSONFromText(text string) (string, bool) {
+	// Try fenced JSON blocks first (```json ... ``` or ``` ... ```)
+	if extracted := extractFencedJSON(text); extracted != "" {
+		return extracted, true
+	}
+	// Try outermost braces
+	if extracted := extractOutermostJSON(text); extracted != "" {
+		return extracted, true
+	}
+	return "", false
+}
+
+// extractFencedJSON looks for a ```json or ``` fenced block containing valid JSON.
+func extractFencedJSON(text string) string {
+	fence := "```"
+	start := strings.Index(text, fence)
+	if start < 0 {
+		return ""
+	}
+	// Skip past the opening fence and any language tag on the same line
+	contentStart := strings.Index(text[start+len(fence):], "\n")
+	if contentStart < 0 {
+		return ""
+	}
+	contentStart += start + len(fence) + 1 // +1 for the newline
+
+	// Find closing fence
+	end := strings.Index(text[contentStart:], fence)
+	if end < 0 {
+		return ""
+	}
+	candidate := strings.TrimSpace(text[contentStart : contentStart+end])
+	if candidate == "" {
+		return ""
+	}
+	// Validate it's a JSON object
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
+		return ""
+	}
+	return candidate
+}
+
+// extractOutermostJSON finds the first '{' and last '}' in the text and
+// checks whether the substring between them is a valid JSON object.
+func extractOutermostJSON(text string) string {
+	first := strings.IndexByte(text, '{')
+	if first < 0 {
+		return ""
+	}
+	last := strings.LastIndexByte(text, '}')
+	if last <= first {
+		return ""
+	}
+	candidate := text[first : last+1]
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(candidate), &obj); err != nil {
+		return ""
+	}
+	return candidate
+}
+
 func rawJSONValueToContext(raw json.RawMessage) string {
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {

--- a/pipeline/context_writes.go
+++ b/pipeline/context_writes.go
@@ -111,13 +111,22 @@ func ExtractJSONFromText(text string) (string, bool) {
 	return "", false
 }
 
-// fencedBlockRE matches a Markdown-style fenced code block. The opening
-// fence is followed by an optional language tag (alphanumerics, '_', '-',
-// '+', '.') and trailing whitespace up to a newline — this strict shape
-// distinguishes a real opening fence from stray backticks in prose like
-// "Use ``` to denote code". (?s) lets `.` cross newlines; the `+?` is
-// non-greedy so we capture the smallest body up to the next ```.
-var fencedBlockRE = regexp.MustCompile("(?s)```[A-Za-z0-9_+.\\-]*[ \\t]*\\r?\\n(.+?)```")
+// fencedBlockRE matches a Markdown-style fenced code block. The opener
+// must sit at the start of input or follow a newline (with optional
+// leading whitespace), then ``` followed by an optional language tag
+// (alphanumerics, '_', '-', '+', '.') and trailing whitespace up to a
+// newline — this strict shape distinguishes a real opening fence from
+// stray backticks in prose like "Use ``` to denote code". (?s) lets `.`
+// cross newlines; the `+?` is non-greedy so we capture the smallest body
+// up to the next ```.
+//
+// LIMITATION: a JSON string value containing the literal sequence ```
+// will truncate the body at that occurrence, since the regex isn't
+// JSON-aware. The cascade in ExtractJSONFromText falls through to
+// extractBracedJSON in that case, which IS JSON-aware (tracks string
+// state via matchBalancedBrace) and recovers the object. Pinned by
+// TestExtractFencedJSON_TripleBacktickInsideStringFallsThroughToBraces.
+var fencedBlockRE = regexp.MustCompile("(?s)(?:^|\\n)[ \\t]*```[A-Za-z0-9_+.\\-]*[ \\t]*\\r?\\n(.+?)```")
 
 // extractFencedJSON walks every ```...``` fenced code block in text and
 // returns the first one whose content parses as a JSON object. Iterating

--- a/pipeline/context_writes_test.go
+++ b/pipeline/context_writes_test.go
@@ -213,6 +213,20 @@ func TestExtractJSONFromText_NDJSONReturnsFirstObject(t *testing.T) {
 	}
 }
 
+// White-box test: prove extractFencedJSON itself handles stray inline
+// backticks in prose. Without this, TestExtractJSONFromText_StrayBackticksBeforeFence
+// passes only because extractBracedJSON rescues it, leaving the bug in
+// the fenced helper invisible. The regex requires the language-tag-then-
+// newline shape, so stray "Use ``` to denote code" backticks are rejected
+// as opening fences.
+func TestExtractFencedJSON_StrayBackticksRejectedAsOpener(t *testing.T) {
+	text := "We use ``` to denote code in this codebase. The result:\n```json\n{\"answer\": 42}\n```\n"
+	got := extractFencedJSON(text)
+	if got != `{"answer": 42}` {
+		t.Fatalf("extractFencedJSON should find the real fenced block past the stray backticks, got %q", got)
+	}
+}
+
 // Braces inside string values must not throw off depth counting.
 func TestExtractJSONFromText_BracesInsideStringValue(t *testing.T) {
 	text := `Done: {"path": "/tmp/dir/{name}.txt", "ok": true} extra`

--- a/pipeline/context_writes_test.go
+++ b/pipeline/context_writes_test.go
@@ -143,3 +143,84 @@ func TestExtractJSONFromText_EmptyString(t *testing.T) {
 		t.Fatal("expected ok=false for empty string")
 	}
 }
+
+// Regression: the previous extractFencedJSON stopped at the first ``` fence,
+// so a non-JSON preamble fence (```text or ```bash) ahead of the real
+// ```json block silently disabled extraction. CodeRabbit pr-feedback finding.
+func TestExtractJSONFromText_MultipleFences_FirstNotJSON(t *testing.T) {
+	text := "Preamble:\n```text\nthis is not json\n```\n\nReal answer:\n```json\n{\"k\": \"v\"}\n```\n"
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true; second fence is valid JSON")
+	}
+	if got != `{"k": "v"}` {
+		t.Fatalf("got %q, want second fence content", got)
+	}
+}
+
+// Regression: stray backticks in prose before the real fenced block used to
+// cause the extractor to read between the stray fence and the real opening
+// fence and give up. The iterating implementation handles it.
+func TestExtractJSONFromText_StrayBackticksBeforeFence(t *testing.T) {
+	text := "We use ``` to denote code in this codebase. The result:\n```json\n{\"answer\": 42}\n```\n"
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != `{"answer": 42}` {
+		t.Fatalf("got %q, want fence content", got)
+	}
+}
+
+// extractBracedJSON should pick the first balanced top-level JSON object,
+// not the first-`{`/last-`}` shortcut. Prose that contains stray brace
+// pairs around real JSON used to defeat the previous outermost-brace
+// strategy because the substring spanned all of it and failed to parse.
+func TestExtractJSONFromText_BracedSpanWithStrayPairs(t *testing.T) {
+	text := `Wrote {file1} and {file2}, then produced {"x": 1, "y": "z"}. Done.`
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true; a real JSON object exists in the prose")
+	}
+	if got != `{"x": 1, "y": "z"}` {
+		t.Fatalf("got %q, want the real JSON object", got)
+	}
+}
+
+// Top-level JSON arrays and scalars should NOT be accepted — the writes
+// contract is "JSON object". This pins the rejection so a future change to
+// json.Unmarshal target type doesn't silently broaden acceptance.
+func TestExtractJSONFromText_RejectsArrayAndScalar(t *testing.T) {
+	for _, in := range []string{`[{"a":1}]`, `"hello"`, `42`, `null`, `true`} {
+		if _, ok := ExtractJSONFromText(in); ok {
+			t.Errorf("expected ok=false for non-object %q", in)
+		}
+	}
+}
+
+// Multiple complete JSON objects on separate lines (NDJSON-ish): the
+// previous outermost-brace strategy spanned all of them and returned "".
+// The balanced-brace scan returns the FIRST parseable object — better than
+// silently dropping everything.
+func TestExtractJSONFromText_NDJSONReturnsFirstObject(t *testing.T) {
+	text := "{\"a\":1}\n{\"b\":2}\n"
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected first object to be returned")
+	}
+	if got != `{"a":1}` {
+		t.Fatalf("got %q, want first object", got)
+	}
+}
+
+// Braces inside string values must not throw off depth counting.
+func TestExtractJSONFromText_BracesInsideStringValue(t *testing.T) {
+	text := `Done: {"path": "/tmp/dir/{name}.txt", "ok": true} extra`
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != `{"path": "/tmp/dir/{name}.txt", "ok": true}` {
+		t.Fatalf("got %q", got)
+	}
+}

--- a/pipeline/context_writes_test.go
+++ b/pipeline/context_writes_test.go
@@ -227,6 +227,62 @@ func TestExtractFencedJSON_StrayBackticksRejectedAsOpener(t *testing.T) {
 	}
 }
 
+// White-box: with two valid fenced JSON blocks, the FIRST is returned.
+// Pins the documented "first valid fence wins" semantic so a future
+// "last fence wins" preference change can't sneak in unnoticed.
+func TestExtractFencedJSON_TwoValidFences_FirstWins(t *testing.T) {
+	text := "First answer:\n```json\n{\"first\": true}\n```\n\nRevised:\n```json\n{\"second\": true}\n```\n"
+	got := extractFencedJSON(text)
+	if got != `{"first": true}` {
+		t.Fatalf("expected first valid fence to win, got %q", got)
+	}
+}
+
+// LIMITATION test: a literal ``` inside a JSON string value truncates
+// the regex body, so extractFencedJSON itself fails. The cascade in
+// ExtractJSONFromText is supposed to fall through to extractBracedJSON
+// (which IS string-aware) and recover the object. Pin both halves.
+func TestExtractFencedJSON_TripleBacktickInsideStringFallsThroughToBraces(t *testing.T) {
+	text := "```json\n{\"snippet\": \"use ``` to fence\", \"k\": 1}\n```"
+
+	// Half 1: extractFencedJSON itself can't handle this — confirm it returns "".
+	if got := extractFencedJSON(text); got != "" {
+		t.Errorf("extractFencedJSON not expected to handle ``` inside string; got %q", got)
+	}
+
+	// Half 2: ExtractJSONFromText cascade rescues via extractBracedJSON.
+	// Note: the prefix "json" before the JSON object IS in the text — but
+	// the braced scanner finds the first balanced {…} span, which IS the
+	// real object.
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected cascade to fall through to braced scan and succeed")
+	}
+	want := `{"snippet": "use ` + "```" + ` to fence", "k": 1}`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// Truncated fenced block (open fence with no closer): regex won't match,
+// braced scan attempts the body. Pin the deterministic outcome so a
+// future change can't accidentally start matching runaway spans.
+func TestExtractJSONFromText_TruncatedFenceFallsThrough(t *testing.T) {
+	text := "```json\n{\"k\": 1}\nno-close-fence-and-no-other-json"
+	// extractFencedJSON returns "" because there's no closing fence.
+	if got := extractFencedJSON(text); got != "" {
+		t.Fatalf("extractFencedJSON should return empty on unclosed fence, got %q", got)
+	}
+	// The cascade should still find the {"k": 1} object via braced scan.
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected braced fallback to recover the object")
+	}
+	if got != `{"k": 1}` {
+		t.Fatalf("got %q, want braced-recovered object", got)
+	}
+}
+
 // Braces inside string values must not throw off depth counting.
 func TestExtractJSONFromText_BracesInsideStringValue(t *testing.T) {
 	text := `Done: {"path": "/tmp/dir/{name}.txt", "ok": true} extra`

--- a/pipeline/context_writes_test.go
+++ b/pipeline/context_writes_test.go
@@ -63,3 +63,83 @@ func TestExtractDeclaredWritesCompactsNonStringValues(t *testing.T) {
 		t.Fatalf("meta = %q, want compact json object", got)
 	}
 }
+
+// --- ExtractJSONFromText tests ---
+
+func TestExtractJSONFromText_FencedJSONBlock(t *testing.T) {
+	text := "Here is the analysis:\n```json\n{\"spec_analysis\": \"the summary\"}\n```\nDone."
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true for fenced json block")
+	}
+	if got != `{"spec_analysis": "the summary"}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractJSONFromText_FencedBlockNoLanguage(t *testing.T) {
+	text := "Result:\n```\n{\"key\": \"val\"}\n```\n"
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true for fenced block without language tag")
+	}
+	if got != `{"key": "val"}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractJSONFromText_OutermostBraces(t *testing.T) {
+	text := `Done. Here is the result: {"spec_analysis": "summary of findings"} and that is all.`
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true for outermost braces")
+	}
+	if got != `{"spec_analysis": "summary of findings"}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractJSONFromText_OutermostBracesNested(t *testing.T) {
+	text := `Output: {"key": {"nested": true}, "list": [1,2]} end`
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true for nested braces")
+	}
+	if got != `{"key": {"nested": true}, "list": [1,2]}` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestExtractJSONFromText_NoParsableJSON(t *testing.T) {
+	text := "Done — `.ai/spec_analysis.md` has been created.\n\nSummary:\n- 104 functional requirements\n- 11 components"
+	_, ok := ExtractJSONFromText(text)
+	if ok {
+		t.Fatal("expected ok=false for pure prose")
+	}
+}
+
+func TestExtractJSONFromText_BracesButInvalidJSON(t *testing.T) {
+	text := "I wrote {file1} and {file2} to disk."
+	_, ok := ExtractJSONFromText(text)
+	if ok {
+		t.Fatal("expected ok=false when braces don't contain valid JSON")
+	}
+}
+
+func TestExtractJSONFromText_FencedPreferredOverBraces(t *testing.T) {
+	text := "Preamble with {\"wrong\": true} inline.\n```json\n{\"right\": true}\n```\nEnd."
+	got, ok := ExtractJSONFromText(text)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != `{"right": true}` {
+		t.Fatalf("expected fenced block to win, got %q", got)
+	}
+}
+
+func TestExtractJSONFromText_EmptyString(t *testing.T) {
+	_, ok := ExtractJSONFromText("")
+	if ok {
+		t.Fatal("expected ok=false for empty string")
+	}
+}

--- a/pipeline/expand.go
+++ b/pipeline/expand.go
@@ -17,6 +17,16 @@ var toolCommandSafeCtxKeys = map[string]bool{
 	"interview_answers": true,
 }
 
+// IsToolCommandSafeCtxKey reports whether key is on the tool_command safe-key
+// allowlist. The allowlist exists so that LLM-origin ctx.* keys cannot be
+// expanded into shell input. Workflow authors that declare a `writes:` key
+// colliding with this list would funnel LLM output into a reserved name and
+// bypass the sanitization gate; declared-writes processing uses this to
+// reject such collisions before they're written.
+func IsToolCommandSafeCtxKey(key string) bool {
+	return toolCommandSafeCtxKeys[key]
+}
+
 // ExpandVariables replaces ${namespace.key} patterns with values from the provided sources.
 // Supports three namespaces:
 //   - ctx: runtime context (from PipelineContext)

--- a/pipeline/handlers/declared_writes.go
+++ b/pipeline/handlers/declared_writes.go
@@ -11,6 +11,12 @@ const (
 	contextKeyWritesError   = "writes_error"
 	contextKeyWritesWarning = "writes_warning"
 	maxWritesErrorRawLen    = 512
+	// maxFallbackValueBytes caps the size of the raw-response fallback value
+	// that lands in a context key. Without a cap, a 10MB tool stdout (the
+	// hard ceiling) or unbounded LLM response would be persisted into
+	// status.json, activity.jsonl, checkpoints, and inlined into downstream
+	// prompts.
+	maxFallbackValueBytes = 8192
 )
 
 func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, rawJSON string, source string) (failed bool) {
@@ -19,21 +25,45 @@ func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, 
 		return false
 	}
 
-	// Try direct JSON parse first.
+	// Reject writes-key collisions with the tool_command safe-key allowlist.
+	// The allowlist (outcome, preferred_label, human_response,
+	// interview_answers) is enforced fail-closed in tool_command expansion to
+	// keep LLM output out of shell input. A workflow that declared
+	// `writes: outcome` would funnel LLM-controlled content into the reserved
+	// name and bypass the gate — refuse the node rather than silently land
+	// the data.
+	for _, key := range writes {
+		if pipeline.IsToolCommandSafeCtxKey(key) {
+			contextUpdates[contextKeyWritesError] = fmt.Sprintf(
+				"node %q: declared writes key %q collides with the tool_command safe-key allowlist; reserved keys cannot be set from declared writes",
+				node.ID, key,
+			)
+			return true
+		}
+	}
+
+	// Healing cascade: direct JSON → embedded JSON → raw fallback.
 	updates, extras, err := pipeline.ExtractDeclaredWrites(writes, rawJSON)
 
 	// If direct parse failed, try extracting JSON embedded in the text.
+	// Track whether extraction surfaced any JSON object — even if that JSON
+	// turned out to be missing the declared key, we don't want to silently
+	// fall back to raw prose (that would mask a real contract failure).
+	foundExtractableJSON := false
 	if err != nil {
 		if extracted, ok := pipeline.ExtractJSONFromText(rawJSON); ok {
+			foundExtractableJSON = true
 			updates, extras, err = pipeline.ExtractDeclaredWrites(writes, extracted)
 		}
 	}
 
-	// If still failed and single write key, fall back to using the raw
-	// response as the value. This handles the common case where an LLM
-	// writes to a file and responds with prose instead of JSON.
-	if err != nil && len(writes) == 1 {
-		contextUpdates[writes[0]] = rawJSON
+	// Single-key fallback: only when no JSON was extractable AT ALL. A model
+	// that returned valid JSON missing the declared key gets a hard contract
+	// failure (below) rather than silently shipping the entire raw response
+	// under a name it doesn't fit. Cap the fallback value size so tool
+	// stdout or long LLM responses don't bloat downstream artifacts.
+	if err != nil && len(writes) == 1 && !foundExtractableJSON {
+		contextUpdates[writes[0]] = capFallbackValue(rawJSON)
 		contextUpdates[contextKeyWritesWarning] = fmt.Sprintf(
 			"node %q: writes extraction fell back to raw response for key %q (no JSON found in output)",
 			node.ID, writes[0],
@@ -42,7 +72,18 @@ func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, 
 	}
 
 	if err != nil {
-		contextUpdates[contextKeyWritesError] = formatWritesError(node.ID, writes, source, err, rawJSON)
+		// If we DID find extractable JSON but it failed the contract, the
+		// generic "raw output not parseable as JSON" message would mislead.
+		// Distinguish the two failure modes so `tracker diagnose` can guide
+		// the user to the actual problem.
+		if foundExtractableJSON {
+			contextUpdates[contextKeyWritesError] = fmt.Sprintf(
+				"node %q declared writes: [%s]\n%s contained extractable JSON but failed the writes contract: %v",
+				node.ID, strings.Join(writes, ", "), source, err,
+			)
+		} else {
+			contextUpdates[contextKeyWritesError] = formatWritesError(node.ID, writes, source, err, rawJSON)
+		}
 		return true
 	}
 
@@ -72,6 +113,21 @@ func dedupeDeclaredWrites(writes []string) []string {
 		deduped = append(deduped, write)
 	}
 	return deduped
+}
+
+// capFallbackValue caps a raw-response fallback value at maxFallbackValueBytes.
+// Without a cap, a multi-megabyte tool stdout or long LLM response would land
+// in a context key and from there into status.json, activity.jsonl,
+// checkpoints, and downstream prompts. Truncation marker tells the user the
+// stored value isn't the whole response.
+func capFallbackValue(s string) string {
+	if len(s) <= maxFallbackValueBytes {
+		return s
+	}
+	return fmt.Sprintf(
+		"%s\n\n…(truncated at %d bytes; original was %d bytes)",
+		s[:maxFallbackValueBytes], maxFallbackValueBytes, len(s),
+	)
 }
 
 func formatWritesError(nodeID string, writes []string, source string, parseErr error, raw string) string {

--- a/pipeline/handlers/declared_writes.go
+++ b/pipeline/handlers/declared_writes.go
@@ -25,17 +25,26 @@ func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, 
 		return false
 	}
 
-	// Reject writes-key collisions with the tool_command safe-key allowlist.
-	// The allowlist (outcome, preferred_label, human_response,
-	// interview_answers) is enforced fail-closed in tool_command expansion to
-	// keep LLM output out of shell input. A workflow that declared
-	// `writes: outcome` would funnel LLM-controlled content into the reserved
-	// name and bypass the gate — refuse the node rather than silently land
-	// the data.
+	// Reject writes-key collisions with two reserved sets:
+	//
+	//   1. The tool_command safe-key allowlist (outcome, preferred_label,
+	//      human_response, interview_answers) — enforced fail-closed in
+	//      tool_command expansion to keep LLM output out of shell input. A
+	//      workflow declaring `writes: outcome` would funnel LLM-controlled
+	//      content into the reserved name and bypass the gate.
+	//
+	//   2. The declared-writes signal keys (writes_error, writes_warning) —
+	//      these are runtime observability keys set by this function for
+	//      `tracker diagnose` and downstream nodes to branch on. Allowing a
+	//      workflow to set them via writes would let an LLM spoof a failure
+	//      / healed-warning signal that wasn't real, undermining diagnose UX.
+	//
+	// Either collision is treated as an authoring error: refuse the node
+	// rather than silently land the data.
 	for _, key := range writes {
-		if pipeline.IsToolCommandSafeCtxKey(key) {
+		if pipeline.IsToolCommandSafeCtxKey(key) || isReservedWritesSignalKey(key) {
 			contextUpdates[contextKeyWritesError] = fmt.Sprintf(
-				"node %q: declared writes key %q collides with the tool_command safe-key allowlist; reserved keys cannot be set from declared writes",
+				"node %q: declared writes key %q collides with a reserved name; tool_command safe-key allowlist (outcome/preferred_label/human_response/interview_answers) and writes signal keys (writes_error/writes_warning) cannot be set from declared writes",
 				node.ID, key,
 			)
 			return true
@@ -97,6 +106,14 @@ func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, 
 		)
 	}
 	return false
+}
+
+// isReservedWritesSignalKey reports whether key is one of the runtime
+// observability signal names used by applyDeclaredWrites itself. Workflow
+// authors must not declare these as writes targets — the runtime owns
+// them, and letting an LLM set them would spoof the signal.
+func isReservedWritesSignalKey(key string) bool {
+	return key == contextKeyWritesError || key == contextKeyWritesWarning
 }
 
 func dedupeDeclaredWrites(writes []string) []string {

--- a/pipeline/handlers/declared_writes.go
+++ b/pipeline/handlers/declared_writes.go
@@ -19,7 +19,28 @@ func applyDeclaredWrites(node *pipeline.Node, contextUpdates map[string]string, 
 		return false
 	}
 
+	// Try direct JSON parse first.
 	updates, extras, err := pipeline.ExtractDeclaredWrites(writes, rawJSON)
+
+	// If direct parse failed, try extracting JSON embedded in the text.
+	if err != nil {
+		if extracted, ok := pipeline.ExtractJSONFromText(rawJSON); ok {
+			updates, extras, err = pipeline.ExtractDeclaredWrites(writes, extracted)
+		}
+	}
+
+	// If still failed and single write key, fall back to using the raw
+	// response as the value. This handles the common case where an LLM
+	// writes to a file and responds with prose instead of JSON.
+	if err != nil && len(writes) == 1 {
+		contextUpdates[writes[0]] = rawJSON
+		contextUpdates[contextKeyWritesWarning] = fmt.Sprintf(
+			"node %q: writes extraction fell back to raw response for key %q (no JSON found in output)",
+			node.ID, writes[0],
+		)
+		return false
+	}
+
 	if err != nil {
 		contextUpdates[contextKeyWritesError] = formatWritesError(node.ID, writes, source, err, rawJSON)
 		return true

--- a/pipeline/handlers/declared_writes_test.go
+++ b/pipeline/handlers/declared_writes_test.go
@@ -148,6 +148,88 @@ func TestApplyDeclaredWrites_DirectJSONStillWorks(t *testing.T) {
 	}
 }
 
+// Regression for CodeRabbit's "single-key fallback masks contract failures"
+// finding. When ExtractJSONFromText surfaces valid JSON that simply lacks the
+// declared key, the old code fell back to raw — silently shipping the entire
+// prose response under a name it didn't fit. The fix gates the fallback on
+// !foundExtractableJSON; this test pins it.
+func TestApplyDeclaredWrites_ExtractedJSONMissingKeyHardFails(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "n1",
+		Attrs: map[string]string{"writes": "spec_analysis"},
+	}
+	// Prose containing valid JSON, but the JSON has the wrong key.
+	raw := "Result: {\"other_key\": \"x\"} done."
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if !failed {
+		t.Fatal("expected failure when extracted JSON lacks the declared key")
+	}
+	if _, ok := ctx[contextKeyWritesError]; !ok {
+		t.Fatal("expected writes_error to be set")
+	}
+	if _, ok := ctx["spec_analysis"]; ok {
+		t.Fatal("expected spec_analysis to NOT be set (raw fallback should be inhibited)")
+	}
+	// Error message should reflect the actual failure mode.
+	msg := ctx[contextKeyWritesError]
+	if !strings.Contains(msg, "extractable JSON but failed the writes contract") {
+		t.Fatalf("expected specific error referencing extractable-but-noncontract JSON, got: %s", msg)
+	}
+}
+
+// Defense against a workflow author declaring a writes key that collides
+// with the tool_command safe-key allowlist. Without this guard, an LLM could
+// land arbitrary content in `outcome` / `human_response` etc, bypassing
+// the sanitization that exists exactly for shell input.
+func TestApplyDeclaredWrites_RejectsSafeKeyCollision(t *testing.T) {
+	for _, key := range []string{"outcome", "preferred_label", "human_response", "interview_answers"} {
+		t.Run(key, func(t *testing.T) {
+			node := &pipeline.Node{
+				ID:    "n1",
+				Attrs: map[string]string{"writes": key},
+			}
+			ctx := map[string]string{}
+			failed := applyDeclaredWrites(node, ctx, `{"`+key+`": "x"}`, "Response JSON")
+			if !failed {
+				t.Fatalf("expected failure for writes-key collision with %q", key)
+			}
+			if _, ok := ctx[key]; ok {
+				t.Fatalf("expected %q to NOT be written; collision must be rejected before any value lands", key)
+			}
+			msg := ctx[contextKeyWritesError]
+			if !strings.Contains(msg, "safe-key allowlist") {
+				t.Fatalf("expected error to mention safe-key allowlist, got: %s", msg)
+			}
+		})
+	}
+}
+
+// Regression for the correctness reviewer's "uncapped fallback bloats
+// artifacts" finding. A 50KB raw response landing in a single context key
+// would propagate to status.json, activity.jsonl, checkpoints, and downstream
+// prompts. Cap is enforced at maxFallbackValueBytes.
+func TestApplyDeclaredWrites_FallbackValueIsCapped(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "n1",
+		Attrs: map[string]string{"writes": "blob"},
+	}
+	// Build a >maxFallbackValueBytes raw response with no JSON anywhere.
+	raw := strings.Repeat("a", maxFallbackValueBytes*3)
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if failed {
+		t.Fatalf("expected single-key prose fallback to succeed, got: %s", ctx[contextKeyWritesError])
+	}
+	got := ctx["blob"]
+	if len(got) >= len(raw) {
+		t.Fatalf("expected fallback to be truncated, got len=%d (raw len=%d)", len(got), len(raw))
+	}
+	if !strings.Contains(got, "truncated") {
+		t.Fatal("expected truncation marker in capped fallback")
+	}
+}
+
 type assertErr string
 
 func (e assertErr) Error() string { return string(e) }

--- a/pipeline/handlers/declared_writes_test.go
+++ b/pipeline/handlers/declared_writes_test.go
@@ -40,9 +40,10 @@ func TestDedupeDeclaredWrites_PreservesOrder(t *testing.T) {
 }
 
 func TestApplyDeclaredWrites_DedupesWritesInErrorMessage(t *testing.T) {
+	// Use two distinct keys (with one duplicated) so multi-key path triggers error.
 	node := &pipeline.Node{
 		ID:    "n1",
-		Attrs: map[string]string{"writes": "commit_sha, commit_sha"},
+		Attrs: map[string]string{"writes": "commit_sha, branch, commit_sha"},
 	}
 	contextUpdates := map[string]string{}
 	failed := applyDeclaredWrites(node, contextUpdates, "not json", "Tool stdout JSON")
@@ -50,11 +51,100 @@ func TestApplyDeclaredWrites_DedupesWritesInErrorMessage(t *testing.T) {
 		t.Fatal("expected failure")
 	}
 	msg := contextUpdates[contextKeyWritesError]
-	if strings.Contains(msg, "commit_sha, commit_sha") {
+	if strings.Contains(msg, "commit_sha, branch, commit_sha") {
 		t.Fatalf("expected deduped writes in error message, got %q", msg)
 	}
-	if !strings.Contains(msg, "declared writes: [commit_sha]") {
+	if !strings.Contains(msg, "declared writes: [commit_sha, branch]") {
 		t.Fatalf("expected deduped declared writes in error message, got %q", msg)
+	}
+}
+
+// --- Healing / fallback tests ---
+
+func TestApplyDeclaredWrites_ExtractsFromFencedJSON(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "analyze_spec",
+		Attrs: map[string]string{"writes": "spec_analysis"},
+	}
+	raw := "Here is the analysis:\n```json\n{\"spec_analysis\": \"the summary\"}\n```\nDone."
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if failed {
+		t.Fatalf("expected success after fenced JSON extraction, got error: %s", ctx[contextKeyWritesError])
+	}
+	if got := ctx["spec_analysis"]; got != "the summary" {
+		t.Fatalf("spec_analysis = %q, want %q", got, "the summary")
+	}
+}
+
+func TestApplyDeclaredWrites_ExtractsFromOutermostBraces(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "n1",
+		Attrs: map[string]string{"writes": "result"},
+	}
+	raw := `I computed the result: {"result": "42"} and that is all.`
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if failed {
+		t.Fatalf("expected success after brace extraction, got error: %s", ctx[contextKeyWritesError])
+	}
+	if got := ctx["result"]; got != "42" {
+		t.Fatalf("result = %q, want %q", got, "42")
+	}
+}
+
+func TestApplyDeclaredWrites_SingleKeyFallbackToRaw(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "analyze_spec",
+		Attrs: map[string]string{"writes": "spec_analysis"},
+	}
+	// Pure prose, no JSON anywhere — the NIFB failure case
+	raw := "Done — `.ai/spec_analysis.md` has been created.\n\nSummary:\n- 104 functional requirements"
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if failed {
+		t.Fatalf("expected warning (not failure) for single-key fallback, got error: %s", ctx[contextKeyWritesError])
+	}
+	if got := ctx["spec_analysis"]; got != raw {
+		t.Fatalf("expected raw response as fallback value, got %q", got)
+	}
+	if _, ok := ctx[contextKeyWritesWarning]; !ok {
+		t.Fatal("expected writes_warning to be set for fallback")
+	}
+	if _, ok := ctx[contextKeyWritesError]; ok {
+		t.Fatal("expected no writes_error for single-key fallback")
+	}
+}
+
+func TestApplyDeclaredWrites_MultiKeyStillFailsOnProse(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "n1",
+		Attrs: map[string]string{"writes": "key_a, key_b"},
+	}
+	raw := "Done. Everything is written."
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if !failed {
+		t.Fatal("expected failure for multi-key writes with no JSON")
+	}
+	if _, ok := ctx[contextKeyWritesError]; !ok {
+		t.Fatal("expected writes_error to be set")
+	}
+}
+
+func TestApplyDeclaredWrites_DirectJSONStillWorks(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "n1",
+		Attrs: map[string]string{"writes": "val"},
+	}
+	raw := `{"val": "hello"}`
+	ctx := map[string]string{}
+	failed := applyDeclaredWrites(node, ctx, raw, "Response JSON")
+	if failed {
+		t.Fatalf("expected success for direct JSON, got error: %s", ctx[contextKeyWritesError])
+	}
+	if got := ctx["val"]; got != "hello" {
+		t.Fatalf("val = %q, want %q", got, "hello")
 	}
 }
 

--- a/pipeline/handlers/declared_writes_test.go
+++ b/pipeline/handlers/declared_writes_test.go
@@ -179,27 +179,46 @@ func TestApplyDeclaredWrites_ExtractedJSONMissingKeyHardFails(t *testing.T) {
 }
 
 // Defense against a workflow author declaring a writes key that collides
-// with the tool_command safe-key allowlist. Without this guard, an LLM could
-// land arbitrary content in `outcome` / `human_response` etc, bypassing
-// the sanitization that exists exactly for shell input.
-func TestApplyDeclaredWrites_RejectsSafeKeyCollision(t *testing.T) {
-	for _, key := range []string{"outcome", "preferred_label", "human_response", "interview_answers"} {
-		t.Run(key, func(t *testing.T) {
+// with a reserved name. Two sets are reserved:
+//
+//   - Tool_command safe-key allowlist (outcome, preferred_label,
+//     human_response, interview_answers) — security: shell-interpolation
+//     gate must not be bypassed by an LLM landing prose under those names.
+//   - Writes signal keys (writes_error, writes_warning) — integrity:
+//     runtime owns these; spoofing them would mislead `tracker diagnose`
+//     and downstream branch-on-error logic.
+//
+// The check fires before any value is written, so the rejection is
+// fail-closed: the safe key never sees content even on the failing path.
+func TestApplyDeclaredWrites_RejectsReservedKeyCollision(t *testing.T) {
+	cases := []struct {
+		key      string
+		category string
+	}{
+		{"outcome", "tool_command safe-key"},
+		{"preferred_label", "tool_command safe-key"},
+		{"human_response", "tool_command safe-key"},
+		{"interview_answers", "tool_command safe-key"},
+		{"writes_error", "writes signal"},
+		{"writes_warning", "writes signal"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.key, func(t *testing.T) {
 			node := &pipeline.Node{
 				ID:    "n1",
-				Attrs: map[string]string{"writes": key},
+				Attrs: map[string]string{"writes": tc.key},
 			}
 			ctx := map[string]string{}
-			failed := applyDeclaredWrites(node, ctx, `{"`+key+`": "x"}`, "Response JSON")
+			failed := applyDeclaredWrites(node, ctx, `{"`+tc.key+`": "x"}`, "Response JSON")
 			if !failed {
-				t.Fatalf("expected failure for writes-key collision with %q", key)
+				t.Fatalf("expected failure for writes-key collision with %q (%s)", tc.key, tc.category)
 			}
-			if _, ok := ctx[key]; ok {
-				t.Fatalf("expected %q to NOT be written; collision must be rejected before any value lands", key)
+			if got, ok := ctx[tc.key]; ok && got == "x" {
+				t.Fatalf("expected %q to NOT carry the LLM-supplied value; collision must be rejected before any value lands", tc.key)
 			}
 			msg := ctx[contextKeyWritesError]
-			if !strings.Contains(msg, "safe-key allowlist") {
-				t.Fatalf("expected error to mention safe-key allowlist, got: %s", msg)
+			if !strings.Contains(msg, "reserved name") {
+				t.Fatalf("expected error to mention reserved name, got: %s", msg)
 			}
 		})
 	}

--- a/pipeline/handlers/tool_test.go
+++ b/pipeline/handlers/tool_test.go
@@ -154,7 +154,7 @@ func TestToolHandlerDeclaredWritesExtracted(t *testing.T) {
 	}
 }
 
-func TestToolHandlerDeclaredWritesInvalidJSONFails(t *testing.T) {
+func TestToolHandlerDeclaredWritesSingleKeyFallsBackToRaw(t *testing.T) {
 	env := toolTestEnv(t, map[string]exec.CommandResult{
 		"echo nope": {Stdout: "nope\n", ExitCode: 0},
 	})
@@ -165,6 +165,36 @@ func TestToolHandlerDeclaredWritesInvalidJSONFails(t *testing.T) {
 		Attrs: map[string]string{
 			"tool_command": "echo nope",
 			"writes":       "commit_sha",
+		},
+	}
+
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Single-key writes with non-JSON output falls back to raw value with warning.
+	if outcome.Status != pipeline.OutcomeSuccess {
+		t.Fatalf("status = %q, want success (single-key fallback)", outcome.Status)
+	}
+	if got := outcome.ContextUpdates["commit_sha"]; got != "nope" {
+		t.Fatalf("commit_sha = %q, want %q", got, "nope")
+	}
+	if outcome.ContextUpdates[contextKeyWritesWarning] == "" {
+		t.Fatal("expected writes_warning to be set for fallback")
+	}
+}
+
+func TestToolHandlerDeclaredWritesMultiKeyInvalidJSONFails(t *testing.T) {
+	env := toolTestEnv(t, map[string]exec.CommandResult{
+		"echo nope": {Stdout: "nope\n", ExitCode: 0},
+	})
+	h := NewToolHandler(env)
+	node := &pipeline.Node{
+		ID:    "extract",
+		Shape: "parallelogram",
+		Attrs: map[string]string{
+			"tool_command": "echo nope",
+			"writes":       "commit_sha, branch",
 		},
 	}
 

--- a/pipeline/handlers/tool_test.go
+++ b/pipeline/handlers/tool_test.go
@@ -182,6 +182,11 @@ func TestToolHandlerDeclaredWritesSingleKeyFallsBackToRaw(t *testing.T) {
 	if outcome.ContextUpdates[contextKeyWritesWarning] == "" {
 		t.Fatal("expected writes_warning to be set for fallback")
 	}
+	// tool_stdout must still be published regardless of the writes
+	// cascade outcome — `tracker diagnose` and the engine rely on it.
+	if got := outcome.ContextUpdates[pipeline.ContextKeyToolStdout]; got != "nope" {
+		t.Fatalf("tool_stdout = %q, want %q (must be set independently of writes processing)", got, "nope")
+	}
 }
 
 func TestToolHandlerDeclaredWritesMultiKeyInvalidJSONFails(t *testing.T) {
@@ -207,6 +212,12 @@ func TestToolHandlerDeclaredWritesMultiKeyInvalidJSONFails(t *testing.T) {
 	}
 	if outcome.ContextUpdates[contextKeyWritesError] == "" {
 		t.Fatal("expected writes_error to be set")
+	}
+	// tool_stdout must still be published even when writes processing
+	// hard-fails — `tracker diagnose` needs the raw command output to
+	// help the user debug what went wrong.
+	if got := outcome.ContextUpdates[pipeline.ContextKeyToolStdout]; got != "nope" {
+		t.Fatalf("tool_stdout = %q, want %q (must be set independently of writes processing)", got, "nope")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When an LLM responds with prose instead of JSON, `applyDeclaredWrites` now tries a 3-layer extraction cascade before giving up: fenced ```json blocks, outermost `{…}` substring, then single-key fallback to raw response
- Single-key writes that can't find any JSON fall back to using the raw response as the value with a `writes_warning` (not `writes_error`), keeping the pipeline alive
- Multi-key writes with no parsable JSON still hard-fail since there's no way to distribute prose across multiple keys

**Root cause:** The NIFB spec-to-sprints run (`harper-nifb`, run `c78eb408d6d4`) failed at `analyze_spec` because the agent wrote `.ai/spec_analysis.md` successfully but responded in prose ("Done — ...") instead of JSON. The runner's `json.Unmarshal` hard-failed on the first character and killed the node.

## Test plan

- [x] 8 new tests for `ExtractJSONFromText` (fenced blocks, bare fences, outermost braces, nested braces, pure prose, invalid braces, fence priority, empty string)
- [x] 5 new tests for `applyDeclaredWrites` healing paths (fenced extraction, brace extraction, single-key fallback, multi-key still fails, direct JSON still works)
- [x] Updated existing tool handler test to verify single-key fallback + added new multi-key failure test
- [x] Full `go test ./...` passes (all 17 packages)
- [x] Pre-commit hooks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved JSON extraction from tool/LLM output: fenced code blocks, balanced top-level {…} spans, and NDJSON-first-object behavior.

* **Improvements**
  * Single-key declared writes can fall back to a capped raw response with a warning; multi-key missing/invalid JSON yields errors.
  * Non-object JSON (arrays/scalars) rejected; fenced blocks take precedence.
  * Validation rejects declared write keys that collide with reserved tool-command keys.

* **Documentation**
  * Updated docs and changelog describing cascade, failure modes, and fallback limits.

* **Tests**
  * Expanded coverage for extraction, fallback, validation, dedupe, and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->