### PR TITLE
fix(google): emit usage-only EventFinish for trailing usageMetadata chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Gemini token usage no longer reports 0 when the upstream emits
+  `usageMetadata` as a standalone trailing SSE chunk.** Tracker's
+  `llm/google/adapter.go` SSE parser bailed on any chunk with no
+  `candidates` array, which dropped trailing usage-only chunks on the
+  floor — so `StreamAccumulator` only saw the candidate chunks (with no
+  usage attached) and the final `Usage{}` came out empty. Surfaced while
+  smoke-testing tracker against the [2389 Bedrock Gateway](https://github.com/2389-research/gateway)
+  where the gateway's `:streamGenerateContent?alt=sse` reply is three
+  chunks: text → `finishReason:"STOP"` → `usageMetadata`. The accumulator
+  contract already supports `processFinish` being called twice (first
+  sets `finishReason`, second updates `usage` without overwriting
+  reason), so the fix is a 10-line patch in `processSSELine`: when a
+  candidate-less chunk carries `UsageMetadata`, emit a usage-only
+  `EventFinish`. End-to-end verified against the live bedrock gateway —
+  a single-agent `provider: gemini` smoke run now reports
+  `1,408 in / 4 out` instead of `0 in / 0 out`, and tracker's
+  per-provider cost rollup is correct (no double-counting because
+  `AggregateUsage` folds per-node `SessionStats`, not per `TraceEvent`).
+  Net visible artifact: the `llm finish` trace line now prints twice on
+  affected gateways — first with `reason=stop` and no tokens, second
+  with `tokens=N/N` and no reason — but the final accumulated state is
+  correct. New regression test `TestAdapterStreamTrailingUsageChunk`
+  pins the trailing-chunk case end-to-end through
+  `StreamAccumulator.Response()`.
+
 ## [0.25.0] - 2026-05-05
 
 ### Added

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -218,6 +218,20 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 	}
 
 	if len(chunk.Candidates) == 0 {
+		// Some upstreams (notably the 2389 Bedrock Gateway) emit usageMetadata
+		// as a standalone trailing chunk after the finish chunk. Emit it as a
+		// usage-only EventFinish so the accumulator records it — processFinish
+		// merges Usage onto whatever finish reason the prior chunk set.
+		if chunk.UsageMetadata != nil {
+			ch <- llm.StreamEvent{
+				Type: llm.EventFinish,
+				Usage: &llm.Usage{
+					InputTokens:  chunk.UsageMetadata.PromptTokenCount,
+					OutputTokens: chunk.UsageMetadata.CandidatesTokenCount,
+					TotalTokens:  chunk.UsageMetadata.TotalTokenCount,
+				},
+			}
+		}
 		return false
 	}
 

--- a/llm/google/adapter_test.go
+++ b/llm/google/adapter_test.go
@@ -521,6 +521,53 @@ func TestAdapterName(t *testing.T) {
 	}
 }
 
+// Some upstreams (notably the 2389 Bedrock Gateway) emit usageMetadata as
+// a standalone trailing SSE chunk after the finish chunk. Verify the
+// parser threads that into the final accumulated Usage instead of dropping
+// it on the floor.
+func TestAdapterStreamTrailingUsageChunk(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"index":0}]}`,
+		"",
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}]}`,
+		"",
+		`data: {"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":4,"totalTokenCount":13}}`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	acc := llm.NewStreamAccumulator()
+	for evt := range ch {
+		acc.Process(evt)
+	}
+
+	resp := acc.Response()
+	if resp.Usage.InputTokens != 9 {
+		t.Errorf("expected InputTokens=9, got %d", resp.Usage.InputTokens)
+	}
+	if resp.Usage.OutputTokens != 4 {
+		t.Errorf("expected OutputTokens=4, got %d", resp.Usage.OutputTokens)
+	}
+	if resp.Usage.TotalTokens != 13 {
+		t.Errorf("expected TotalTokens=13, got %d", resp.Usage.TotalTokens)
+	}
+	if resp.FinishReason.Reason != "stop" {
+		t.Errorf("expected finish reason 'stop', got %q", resp.FinishReason.Reason)
+	}
+}
+
 func TestAdapterStreamToolCall(t *testing.T) {
 	sseData := strings.Join([]string{
 		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"test.go"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,


### PR DESCRIPTION
## Summary

- Fixes a Gemini token-usage bug surfaced while smoke-testing tracker against the [2389 Bedrock Gateway](https://github.com/2389-research/gateway): `provider: gemini` calls reported `0 in / 0 out` regardless of actual usage.
- Root cause: `llm/google/adapter.go` `processSSELine` early-returned on any chunk with no `candidates`, which drops trailing usage-only chunks on the floor. The gateway's `:streamGenerateContent?alt=sse` reply is three chunks: text → `finishReason:STOP` → `usageMetadata`. Real Google can do this too per Gemini's streaming spec.
- Fix: when a candidate-less chunk carries `UsageMetadata`, emit a usage-only `EventFinish`. `StreamAccumulator.processFinish` already supports being called twice (first sets finishReason, second updates usage), so no contract changes were needed.

## Verification

End-to-end against the live bedrock gateway with a single-agent `provider: gemini` smoke pipeline:

| | Before | After |
|---|---|---|
| Tokens reported | `0 in / 0 out` | `1,408 in / 4 out` |
| Per-provider cost rollup | $0 (under-reports) | correct |

Per-node `SessionStats` are summed by `AggregateUsage`, not per `TraceEvent`, so the second `EventFinish` doesn't double-count cost. The visible artifact is that the `llm finish` trace line now prints twice on affected gateways — first with `reason=stop` and no tokens, second with `tokens=N/N` and no reason. Cosmetic.

## Test plan

- [x] New regression test `TestAdapterStreamTrailingUsageChunk` pins the trailing-chunk case end-to-end through `StreamAccumulator.Response()`.
- [x] `go build ./...` clean
- [x] `go test ./... -short` — all 17 packages green
- [x] `go vet ./...` clean
- [x] Live smoke against `bedrock-gateway.2389-research-inc.workers.dev` with `provider: gemini` confirms `1408/4` tokens flow through

## Note for #204

[#204](https://github.com/2389-research/tracker/pull/204) (docs refresh) documents a Gemini-token-usage-reports-0 caveat that this PR resolves. If both PRs merge, the caveat in `docs/bedrock-gateway.md` should be dropped — happy to either rebase #204 on this branch or send a 1-line follow-up after both merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gemini token usage metrics reporting when usage data is emitted as a standalone trailing Server-Sent Event chunk following the primary response finish event.

* **Tests**
  * Added regression test validating correct accumulation and reporting of token usage from trailing Server-Sent Event chunks containing only metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->