### PR TITLE
refactor(google): coalesce split finish + usage chunks into one EventFinish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,18 +16,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can too), the parser now buffers the finish reason in
   `geminiStreamState.pendingFinish` instead of emitting it immediately.
   When the trailing usage chunk arrives, both are emitted together as
-  one event. If the stream ends with a buffered finish but no usage
-  chunk (real Google's typical pattern, plus truncated upstreams), the
-  parser flushes the deferred finish on scanner exit so callers still
-  see a terminal event. Net effect: the `llm finish` trace line now
-  prints exactly once per turn regardless of upstream chunking shape,
-  fixing the duplicate-line cosmetic artifact called out in the
-  previous Fixed entry. Two new regression tests pin the behavior end
-  to end (`TestAdapterStreamTrailingUsageChunkEmitsSingleFinish` for
-  the split case; `TestAdapterStreamFinishWithoutUsageChunk` for the
-  no-trailing-usage case). Also extracts a `usageFromMeta` helper since
-  the same `geminiUsageMeta` → `*llm.Usage` conversion now happens at
-  three call sites.
+  one event. A `flushPendingFinish` helper on `*geminiStreamState`
+  guarantees the buffered reason is emitted before every early-return
+  path — clean stream exit, scanner error, and JSON parse error — so
+  partial-failure streams still produce a terminal `EventFinish` ahead
+  of the `EventError`, preserving the prior behavior for accumulator
+  bookkeeping. The combined-chunk path also defensively clears
+  `pendingFinish` to guard against a hypothetical split-then-combined
+  upstream emitting a duplicate finish at stream end. Net effect: the
+  `llm finish` trace line now prints exactly once per turn regardless of
+  upstream chunking shape, fixing the duplicate-line cosmetic artifact
+  called out in the Fixed entry below. Four new regression tests pin the
+  behavior end to end (`TestAdapterStreamTrailingUsageChunkEmitsSingleFinish`
+  for the split case; `TestAdapterStreamFinishWithoutUsageChunk` for the
+  no-trailing-usage case; `TestAdapterStreamCombinedAfterSplitClearsPending`
+  for the defensive pending-clear; `TestAdapterStreamParseErrorFlushesPendingFinish`
+  for the parse-error flush ordering). Also extracts a `usageFromMeta`
+  helper since the same `geminiUsageMeta` → `*llm.Usage` conversion now
+  happens at three call sites.
+
+- **Bedrock Gateway integration guide refreshed** for upstream gateway fixes
+  [#4](https://github.com/2389-research/gateway/issues/4) and
+  [#5](https://github.com/2389-research/gateway/issues/5) (closed
+  2026-04-30). The gateway now accepts both Cloudflare AI Gateway native
+  routing prefixes (`/anthropic`, `/openai`, `/google-ai-studio`,
+  `/compat`) and Gemini's `/v1beta/models/...` paths, so tracker's
+  `--gateway-url` flag works end-to-end against
+  `https://bedrock-gateway.2389-research-inc.workers.dev` and
+  `provider: gemini` is no longer broken. Smoke-tested with a
+  single-agent dip pipeline: `provider: anthropic` and `provider: gemini`
+  both completed against the live gateway. `docs/bedrock-gateway.md`
+  rewritten to lead with the recommended `--gateway-url` recipe; the old
+  "Why not `--gateway-url`?" section removed; the compatibility matrix
+  flips Gemini to working; the "404 on every request" and "Gemini
+  `/v1beta` 404" troubleshooting entries dropped. The `provider: openai`
+  (Responses API) row stays as broken pending gateway
+  [#3](https://github.com/2389-research/gateway/issues/3), which was
+  reopened after we discovered it had been auto-closed by an unrelated
+  commit's "Fix #3" wording referring to a bot-review item, not the
+  GitHub issue.
 
 ### Fixed
 
@@ -55,29 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   correct. New regression test `TestAdapterStreamTrailingUsageChunk`
   pins the trailing-chunk case end-to-end through
   `StreamAccumulator.Response()`.
-
-### Changed
-
-- **Bedrock Gateway integration guide refreshed** for upstream gateway fixes
-  [#4](https://github.com/2389-research/gateway/issues/4) and
-  [#5](https://github.com/2389-research/gateway/issues/5) (closed
-  2026-04-30). The gateway now accepts both Cloudflare AI Gateway native
-  routing prefixes (`/anthropic`, `/openai`, `/google-ai-studio`,
-  `/compat`) and Gemini's `/v1beta/models/...` paths, so tracker's
-  `--gateway-url` flag works end-to-end against
-  `https://bedrock-gateway.2389-research-inc.workers.dev` and
-  `provider: gemini` is no longer broken. Smoke-tested with a
-  single-agent dip pipeline: `provider: anthropic` and `provider: gemini`
-  both completed against the live gateway. `docs/bedrock-gateway.md`
-  rewritten to lead with the recommended `--gateway-url` recipe; the old
-  "Why not `--gateway-url`?" section removed; the compatibility matrix
-  flips Gemini to working; the "404 on every request" and "Gemini
-  `/v1beta` 404" troubleshooting entries dropped. The `provider: openai`
-  (Responses API) row stays as broken pending gateway
-  [#3](https://github.com/2389-research/gateway/issues/3), which was
-  reopened after we discovered it had been auto-closed by an unrelated
-  commit's "Fix #3" wording referring to a bot-review item, not the
-  GitHub issue.
 
 ## [0.25.0] - 2026-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Gemini SSE parser coalesces split finish + usage chunks into a single
+  `EventFinish`.** Follow-up polish to the earlier trailing-usage fix:
+  when an upstream emits the finish reason and the `usageMetadata` in
+  two separate chunks (the 2389 Bedrock Gateway does this; real Google
+  can too), the parser now buffers the finish reason in
+  `geminiStreamState.pendingFinish` instead of emitting it immediately.
+  When the trailing usage chunk arrives, both are emitted together as
+  one event. If the stream ends with a buffered finish but no usage
+  chunk (real Google's typical pattern, plus truncated upstreams), the
+  parser flushes the deferred finish on scanner exit so callers still
+  see a terminal event. Net effect: the `llm finish` trace line now
+  prints exactly once per turn regardless of upstream chunking shape,
+  fixing the duplicate-line cosmetic artifact called out in the
+  previous Fixed entry. Two new regression tests pin the behavior end
+  to end (`TestAdapterStreamTrailingUsageChunkEmitsSingleFinish` for
+  the split case; `TestAdapterStreamFinishWithoutUsageChunk` for the
+  no-trailing-usage case). Also extracts a `usageFromMeta` helper since
+  the same `geminiUsageMeta` → `*llm.Usage` conversion now happens at
+  three call sites.
+
 ### Fixed
 
 - **Gemini token usage no longer reports 0 when the upstream emits

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -171,11 +171,16 @@ func (a *Adapter) Close() error {
 
 // parseSSE reads SSE events from the Gemini streaming response.
 // Gemini sends each chunk as a complete JSON object in an SSE data line.
-// geminiStreamState tracks mutable state across SSE chunks.
+// geminiStreamState tracks mutable state across SSE chunks. pendingFinish
+// buffers the finish reason from a candidate chunk that arrived without
+// usage so it can be coalesced with the trailing usageMetadata chunk that
+// some upstreams (notably the 2389 Bedrock Gateway) emit separately —
+// callers see a single EventFinish carrying both reason and usage.
 type geminiStreamState struct {
-	first      bool
-	textActive bool
-	textID     string
+	first         bool
+	textActive    bool
+	textID        string
+	pendingFinish *llm.FinishReason
 }
 
 func (a *Adapter) parseSSE(body io.Reader, ch chan<- llm.StreamEvent, emitProviderEvents bool) {
@@ -197,6 +202,15 @@ func (a *Adapter) parseSSE(body io.Reader, ch chan<- llm.StreamEvent, emitProvid
 
 	if err := scanner.Err(); err != nil && !isContextError(err) {
 		ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: SSE scan error: %w", err)}
+		return
+	}
+
+	// Stream ended cleanly with a buffered finish reason but no usage chunk
+	// ever arrived (e.g. real Google API without split chunks, or a truncated
+	// upstream). Emit the deferred finish so callers see a terminal event.
+	if state.pendingFinish != nil {
+		ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: state.pendingFinish}
+		state.pendingFinish = nil
 	}
 }
 
@@ -218,19 +232,17 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 	}
 
 	if len(chunk.Candidates) == 0 {
-		// Some upstreams (notably the 2389 Bedrock Gateway) emit usageMetadata
-		// as a standalone trailing chunk after the finish chunk. Emit it as a
-		// usage-only EventFinish so the accumulator records it — processFinish
-		// merges Usage onto whatever finish reason the prior chunk set.
+		// Trailing usage-only chunk (notably the 2389 Bedrock Gateway). If a
+		// finish reason was buffered from a prior chunk, coalesce both into a
+		// single EventFinish; otherwise emit a usage-only finish so the
+		// accumulator records it.
 		if chunk.UsageMetadata != nil {
 			ch <- llm.StreamEvent{
-				Type: llm.EventFinish,
-				Usage: &llm.Usage{
-					InputTokens:  chunk.UsageMetadata.PromptTokenCount,
-					OutputTokens: chunk.UsageMetadata.CandidatesTokenCount,
-					TotalTokens:  chunk.UsageMetadata.TotalTokenCount,
-				},
+				Type:         llm.EventFinish,
+				FinishReason: state.pendingFinish,
+				Usage:        usageFromMeta(chunk.UsageMetadata),
 			}
+			state.pendingFinish = nil
 		}
 		return false
 	}
@@ -251,15 +263,29 @@ func (a *Adapter) processCandidate(candidate geminiCandidate, chunk *geminiRespo
 			state.textActive = false
 		}
 		fr := translateFinishReason(candidate.FinishReason, hasToolCallParts(candidate.Content.Parts))
-		var usage *llm.Usage
 		if chunk.UsageMetadata != nil {
-			usage = &llm.Usage{
-				InputTokens:  chunk.UsageMetadata.PromptTokenCount,
-				OutputTokens: chunk.UsageMetadata.CandidatesTokenCount,
-				TotalTokens:  chunk.UsageMetadata.TotalTokenCount,
-			}
+			// Combined upstream: reason + usage in the same chunk. Emit now.
+			ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: &fr, Usage: usageFromMeta(chunk.UsageMetadata)}
+			return
 		}
-		ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: &fr, Usage: usage}
+		// Split upstream: usage is expected in a trailing chunk. Buffer the
+		// reason so processSSELine can coalesce on arrival, and parseSSE can
+		// flush at stream end if no usage chunk ever lands.
+		state.pendingFinish = &fr
+	}
+}
+
+// usageFromMeta builds the unified Usage struct from Gemini's usageMetadata
+// shape. Returns nil for nil input so callers can pass through without a
+// guard.
+func usageFromMeta(meta *geminiUsageMeta) *llm.Usage {
+	if meta == nil {
+		return nil
+	}
+	return &llm.Usage{
+		InputTokens:  meta.PromptTokenCount,
+		OutputTokens: meta.CandidatesTokenCount,
+		TotalTokens:  meta.TotalTokenCount,
 	}
 }
 

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -183,6 +183,20 @@ type geminiStreamState struct {
 	pendingFinish *llm.FinishReason
 }
 
+// flushPendingFinish emits any buffered finish reason as a terminal
+// EventFinish and clears the buffer. Called before every early-return
+// path (scan error, JSON parse error, clean stream exit) so callers see
+// a terminal finish even when no trailing usage chunk arrives. Emit
+// order matters: flush before any EventError so accumulators record the
+// finish reason for the work that completed before the stream broke.
+func (s *geminiStreamState) flushPendingFinish(ch chan<- llm.StreamEvent) {
+	if s.pendingFinish == nil {
+		return
+	}
+	ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: s.pendingFinish}
+	s.pendingFinish = nil
+}
+
 func (a *Adapter) parseSSE(body io.Reader, ch chan<- llm.StreamEvent, emitProviderEvents bool) {
 	scanner := bufio.NewScanner(body)
 	scanner.Buffer(make([]byte, 0, 256*1024), 1024*1024)
@@ -201,17 +215,15 @@ func (a *Adapter) parseSSE(body io.Reader, ch chan<- llm.StreamEvent, emitProvid
 	}
 
 	if err := scanner.Err(); err != nil && !isContextError(err) {
+		state.flushPendingFinish(ch)
 		ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: SSE scan error: %w", err)}
 		return
 	}
 
 	// Stream ended cleanly with a buffered finish reason but no usage chunk
 	// ever arrived (e.g. real Google API without split chunks, or a truncated
-	// upstream). Emit the deferred finish so callers see a terminal event.
-	if state.pendingFinish != nil {
-		ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: state.pendingFinish}
-		state.pendingFinish = nil
-	}
+	// upstream). Flush the deferred finish so callers see a terminal event.
+	state.flushPendingFinish(ch)
 }
 
 // processSSELine handles a single SSE data line. Returns true if scanning should stop.
@@ -222,6 +234,7 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 
 	var chunk geminiResponse
 	if err := json.Unmarshal(data, &chunk); err != nil {
+		state.flushPendingFinish(ch)
 		ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: parse SSE chunk: %w", err)}
 		return true
 	}
@@ -265,6 +278,11 @@ func (a *Adapter) processCandidate(candidate geminiCandidate, chunk *geminiRespo
 		fr := translateFinishReason(candidate.FinishReason, hasToolCallParts(candidate.Content.Parts))
 		if chunk.UsageMetadata != nil {
 			// Combined upstream: reason + usage in the same chunk. Emit now.
+			// Clear any earlier-buffered finish so the stream-end flush
+			// doesn't emit a duplicate terminal event (defensive — only
+			// reachable if an upstream emits split-then-combined finish
+			// chunks in the same stream).
+			state.pendingFinish = nil
 			ch <- llm.StreamEvent{Type: llm.EventFinish, FinishReason: &fr, Usage: usageFromMeta(chunk.UsageMetadata)}
 			return
 		}

--- a/llm/google/adapter_test.go
+++ b/llm/google/adapter_test.go
@@ -658,6 +658,96 @@ func TestAdapterStreamFinishWithoutUsageChunk(t *testing.T) {
 	}
 }
 
+// Defensive: if a split-style chunk buffers a finish reason and then a
+// later candidate chunk emits a combined (reason + usage) finish, the
+// buffered reason must be cleared so the stream-end flush doesn't emit
+// a duplicate EventFinish.
+func TestAdapterStreamCombinedAfterSplitClearsPending(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}]}`,
+		"",
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}],"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":4,"totalTokenCount":13}}`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	var finishEvents []llm.StreamEvent
+	for evt := range ch {
+		if evt.Type == llm.EventFinish {
+			finishEvents = append(finishEvents, evt)
+		}
+	}
+
+	if len(finishEvents) != 1 {
+		t.Fatalf("expected exactly 1 EventFinish, got %d", len(finishEvents))
+	}
+}
+
+// When an SSE chunk fails to parse after a finish reason was buffered,
+// the parser must flush the buffered finish before emitting the error,
+// so callers (StreamAccumulator, trace observers) still see a terminal
+// EventFinish for the work that completed before the stream broke.
+func TestAdapterStreamParseErrorFlushesPendingFinish(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}]}`,
+		"",
+		`data: {not-valid-json`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	var events []llm.StreamEvent
+	for evt := range ch {
+		events = append(events, evt)
+	}
+
+	finishIdx, errIdx := -1, -1
+	for i, e := range events {
+		if e.Type == llm.EventFinish && finishIdx < 0 {
+			finishIdx = i
+		}
+		if e.Type == llm.EventError && errIdx < 0 {
+			errIdx = i
+		}
+	}
+	if finishIdx < 0 {
+		t.Fatalf("expected an EventFinish before EventError, got events: %+v", events)
+	}
+	if errIdx < 0 {
+		t.Fatalf("expected an EventError after the bad chunk, got events: %+v", events)
+	}
+	if finishIdx > errIdx {
+		t.Errorf("EventFinish (idx %d) must precede EventError (idx %d)", finishIdx, errIdx)
+	}
+	if events[finishIdx].FinishReason == nil || events[finishIdx].FinishReason.Reason != "stop" {
+		t.Errorf("expected flushed finish reason 'stop', got %+v", events[finishIdx].FinishReason)
+	}
+}
+
 func TestAdapterStreamToolCall(t *testing.T) {
 	sseData := strings.Join([]string{
 		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"test.go"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,

--- a/llm/google/adapter_test.go
+++ b/llm/google/adapter_test.go
@@ -568,6 +568,96 @@ func TestAdapterStreamTrailingUsageChunk(t *testing.T) {
 	}
 }
 
+// Even when an upstream splits the finish chunk and the usageMetadata
+// chunk, the parser should coalesce them into a single EventFinish so
+// downstream observers (trace log, NDJSON cost events) don't see a
+// duplicate "llm finish" entry. The combined event must carry both the
+// finish reason and the usage.
+func TestAdapterStreamTrailingUsageChunkEmitsSingleFinish(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"index":0}]}`,
+		"",
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}]}`,
+		"",
+		`data: {"usageMetadata":{"promptTokenCount":9,"candidatesTokenCount":4,"totalTokenCount":13}}`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	var finishEvents []llm.StreamEvent
+	for evt := range ch {
+		if evt.Type == llm.EventFinish {
+			finishEvents = append(finishEvents, evt)
+		}
+	}
+
+	if len(finishEvents) != 1 {
+		t.Fatalf("expected exactly 1 EventFinish, got %d: %+v", len(finishEvents), finishEvents)
+	}
+	fe := finishEvents[0]
+	if fe.FinishReason == nil || fe.FinishReason.Reason != "stop" {
+		t.Errorf("expected finish reason 'stop' on the single event, got %+v", fe.FinishReason)
+	}
+	if fe.Usage == nil {
+		t.Fatal("expected usage on the single finish event")
+	}
+	if fe.Usage.InputTokens != 9 || fe.Usage.OutputTokens != 4 || fe.Usage.TotalTokens != 13 {
+		t.Errorf("usage mismatch: got %+v, want In=9 Out=4 Total=13", fe.Usage)
+	}
+}
+
+// Defensive: if the stream ends with a buffered finish reason and no
+// trailing usage chunk ever arrives, the parser must still emit a final
+// EventFinish carrying the reason (with nil usage) so callers see a
+// terminal event.
+func TestAdapterStreamFinishWithoutUsageChunk(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"ok"}]},"index":0}]}`,
+		"",
+		`data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP","index":0}]}`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	var finishEvents []llm.StreamEvent
+	for evt := range ch {
+		if evt.Type == llm.EventFinish {
+			finishEvents = append(finishEvents, evt)
+		}
+	}
+
+	if len(finishEvents) != 1 {
+		t.Fatalf("expected exactly 1 EventFinish, got %d", len(finishEvents))
+	}
+	if finishEvents[0].FinishReason == nil || finishEvents[0].FinishReason.Reason != "stop" {
+		t.Errorf("expected finish reason 'stop', got %+v", finishEvents[0].FinishReason)
+	}
+}
+
 func TestAdapterStreamToolCall(t *testing.T) {
 	sseData := strings.Join([]string{
 		`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"read_file","args":{"path":"test.go"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,


### PR DESCRIPTION
## Summary

- Follow-up polish to [#205](https://github.com/2389-research/tracker/pull/205). When an upstream splits the streaming reply into separate finish-reason and `usageMetadata` chunks (the 2389 Bedrock Gateway does this; real Google can too), the SSE parser used to emit two `EventFinish` events. The accumulator merged them correctly, but the trace log printed a duplicate "llm finish" line per turn.
- Now: buffer the finish reason in `geminiStreamState.pendingFinish` when the candidate chunk has no usage. Coalesce both into a single `EventFinish` when the trailing usage chunk arrives. Flush the buffered reason on stream end if no usage chunk ever lands (real Google's typical pattern + truncated upstreams).
- Extracts a `usageFromMeta` helper since the `geminiUsageMeta` → `*llm.Usage` conversion now lives at three call sites.

## Verification

End-to-end smoke against the live bedrock gateway with `provider: gemini`:

| | Before this PR | After this PR |
|---|---|---|
| `llm finish` lines per turn | 2 (`reason=stop`, then `tokens=1408/4`) | 1 (`reason=stop tokens=1408/4`) |
| Final accumulated usage | correct (1408/4) | correct (1408/4) |

## Test plan

- [x] New regression test `TestAdapterStreamTrailingUsageChunkEmitsSingleFinish` asserts exactly one `EventFinish` for the split-chunk case
- [x] New regression test `TestAdapterStreamFinishWithoutUsageChunk` asserts the stream-end flush path (finish reason, no trailing usage)
- [x] Existing `TestAdapterStream` and `TestAdapterStreamToolCall` (combined-chunk case) still pass
- [x] `go build ./...`, `go test ./... -short`, `go vet ./...` all clean
- [x] Live smoke against `bedrock-gateway.2389-research-inc.workers.dev` confirms single trace line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gemini SSE parsing now buffers and coalesces split finish reason and trailing usage into a single terminal finish, and flushes pending finishes on stream end or parse errors to prevent duplicate finish traces.

* **Tests**
  * Added four end-to-end regression tests covering split-finish/usage, no-usage, pending-clear, and parse-error flush ordering.

* **Documentation**
  * Updated changelog and Bedrock Gateway guide to reflect routing prefix fixes and removed outdated incompatibility notes; OpenAI Responses API row remains broken and is being tracked.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/206)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->