### PR TITLE
docs(architecture): bundle identity stamping for .dipx (v0.26.0)

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -29,7 +29,7 @@ transitions.
 | [`context-flow.md`](./context-flow.md) | User-facing model of context, fidelity, scoping, declared `reads:`/`writes:`, and safe-key restrictions. |
 | [`tui.md`](./tui.md) | Bubbletea state machine, sidebar, activity log, modal content types (hybrid, review, interview), verbosity cycling, zen mode, search. |
 | [`backends.md`](./backends.md) | `AgentBackend` interface and the three implementations: native (`agent.Session`), claude-code (subprocess + NDJSON), ACP (Agent Client Protocol). Environment scoping and per-node override semantics. |
-| [`artifacts.md`](./artifacts.md) | Workdir layout, `checkpoint.json`, `activity.jsonl`, `status.json` per node, stage `prompt.md` / `response.md`, git-backed history, bundle export. |
+| [`artifacts.md`](./artifacts.md) | Workdir layout, `checkpoint.json`, `activity.jsonl`, `status.json` per node, stage `prompt.md` / `response.md`, git-backed history, bundle export, `.dipx` bundle identity stamping (v0.26.0+). |
 
 ## Where to start
 

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -72,6 +72,7 @@ Sources:
 - `source: "pipeline"` — engine lifecycle events (stage started/completed/failed/retrying, edge decisions, checkpoint saved/failed, cost updated, budget exceeded, pipeline completed/failed).
 - `source: "agent"` — `agent.Event` values forwarded via `WriteAgentEvent` (tool calls, text deltas, LLM request/finish, errors).
 - `source: "llm"` — provider-level trace (`TraceRequestStart`, `TraceFinish`, etc.).
+- `source: "cli"` — CLI-level audit entries that precede engine emissions (`bundle_mismatch_forced` when resume proceeds past a bundle-identity mismatch via `--force-bundle-mismatch`).
 
 Each entry carries `ts`, `type`, optional `run_id` / `node_id` / `message` / `error`, and type-specific fields:
 
@@ -79,6 +80,7 @@ Each entry carries `ts`, `type`, optional `run_id` / `node_id` / `message` / `er
 - **Cost snapshots**: `total_tokens`, `total_cost_usd`, `provider_totals`, `wall_elapsed_ms`.
 - **Tokens per request**: `token_input`, `token_output`.
 - **Tool output**: `tool_name`, `content`, `provider`, `model`.
+- **Bundle identity** (v0.26.0+): `bundle_identity` (`sha256:<hex>`) on every line when the run was started against a `.dipx` bundle. Empty for plain `.dip` runs. Stamped via three composable layers in `pipeline/handlers/stamping.go` (engine emit, parallel/manager_loop emissions, raw agent/llm JSONL writes) so post-hoc auditors can group activity by bundle.
 
 `tracker.ParseActivityLine` ([tracker_activity.go](../../tracker_activity.go)) is the canonical decoder. It handles two timestamp formats (RFC3339Nano and `2006-01-02T15:04:05.000Z07:00`) because the file has both historically — do not feed `ActivityEntry` through `json.Unmarshal` directly.
 
@@ -97,6 +99,7 @@ type Checkpoint struct {
     RestartCount   int
     EdgeSelections map[string]string // nodeID → selected edge target
     FallbackTaken  map[string]bool   // goal-gate fallback tracking
+    BundleIdentity string            // sha256:<hex>, empty for non-.dipx runs (v0.26.0+)
 }
 ```
 


### PR DESCRIPTION
Follow-up doc refresh for the v0.26.0 release (#216 / #209).

## Changes

- **artifacts.md**:
  - New \`source: \"cli\"\` value documented in the activity.jsonl source list, with \`bundle_mismatch_forced\` as the prototypical entry.
  - New \`bundle_identity\` field on per-line shape, citing the three-layer stamping in \`pipeline/handlers/stamping.go\`.
  - \`Checkpoint\` struct example gains the new \`BundleIdentity\` field (v0.26.0+).
- **README.md**: artifacts.md TOC entry mentions bundle identity stamping.

The user-facing dipx docs are already in:
- \`CHANGELOG.md\` / \`README.md\` (release PR #216)
- \`docs/plans/2026-05-11-native-dipx-bundle-support*.md\` (landed in #209)
- gh-pages \`changelog.html\` / \`cli.html\` / \`index.html\` (gh-pages commit 04a1e3e)
- gh-pages \`architecture.html\` — see next gh-pages commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation covering bundle identity tracking for `.dipx` bundles (v0.26.0+)
  * Added documentation for new `bundle_identity` field enabling post-hoc bundle-based grouping in run data
  * Documented CLI audit log entries with source attribution for resume scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->