### PR TITLE
test(agent/exec): property-based tests for tailBuffer (closes #214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Property-based tests for `tailBuffer`** (closes [#214](https://github.com/2389-research/tracker/issues/214)). New dev dep `pgregory.net/rapid` v1.3.0 and `agent/exec/tail_buffer_property_test.go` cover the tail-window invariant across arbitrary write sequences: for any sequence of `Write` calls with total `N` bytes and `limit` `L`, `tb.String()` equals the last `min(N, L)` bytes of the concatenation. A second property pins `Truncated()` and `BytesDropped()` against the same invariant. Generalizes the ~12 hand-rolled example-based boundary tests in `tail_buffer_test.go` to the full state space — catches off-by-one boundary errors, write-boundary state corruption, and ring-buffer wrap-around bugs (the class of bugs PR #215 went through several iterations to get right). 100 random cases per property; fast (< 2ms per property).
+
 ## [0.27.0] - 2026-05-13
 
 ### Fixed

--- a/agent/exec/tail_buffer_property_test.go
+++ b/agent/exec/tail_buffer_property_test.go
@@ -1,0 +1,89 @@
+// ABOUTME: Property-based tests for tailBuffer using pgregory.net/rapid.
+// ABOUTME: Covers the tail-window invariant across arbitrary write sequences (issue #214 / #208).
+package exec
+
+import (
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// TestTailBuffer_TailInvariant_Rapid pins the core invariant: after any
+// sequence of Write calls, tb.String() equals the last min(total, limit)
+// bytes of the concatenation of those writes. This generalizes the
+// example-based tests in tail_buffer_test.go — which pin ~12 specific
+// boundary cases — and catches off-by-one boundary errors, write-
+// boundary state corruption, and the ring-buffer wrap-around case that
+// PR #215 went through several iterations to get right.
+func TestTailBuffer_TailInvariant_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		// Limit bounded to keep the test fast while still exercising
+		// boundaries around the realistic per-stream cap (64KB) plus
+		// well below and a touch above it.
+		limit := rapid.IntRange(1, 70000).Draw(t, "limit")
+		// Each individual write up to 8KB; total writes up to ~30 so the
+		// total bytes can comfortably exceed limit for the wrap path.
+		writes := rapid.SliceOfN(
+			rapid.SliceOfN(rapid.Byte(), 0, 8192),
+			0, 30,
+		).Draw(t, "writes")
+
+		tb := newTailBuffer(limit)
+		var concat []byte
+		for _, w := range writes {
+			if _, err := tb.Write(w); err != nil {
+				t.Fatalf("Write returned error: %v", err)
+			}
+			concat = append(concat, w...)
+		}
+
+		want := concat
+		if len(want) > limit {
+			want = want[len(want)-limit:]
+		}
+		got := []byte(tb.String())
+		if string(got) != string(want) {
+			t.Fatalf("tail mismatch: limit=%d total=%d\n got len=%d\nwant len=%d",
+				limit, len(concat), len(got), len(want))
+		}
+	})
+}
+
+// TestTailBuffer_TruncatedFlag_Rapid pins the Truncated() invariant: it
+// reports true iff total bytes written exceeded limit. (BytesDropped is
+// covered transitively by the tail invariant + this flag.)
+func TestTailBuffer_TruncatedFlag_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		limit := rapid.IntRange(1, 70000).Draw(t, "limit")
+		writes := rapid.SliceOfN(
+			rapid.SliceOfN(rapid.Byte(), 0, 8192),
+			0, 30,
+		).Draw(t, "writes")
+
+		tb := newTailBuffer(limit)
+		total := 0
+		for _, w := range writes {
+			if _, err := tb.Write(w); err != nil {
+				t.Fatalf("Write returned error: %v", err)
+			}
+			total += len(w)
+		}
+
+		wantTruncated := total > limit
+		gotTruncated := tb.Truncated()
+		if gotTruncated != wantTruncated {
+			t.Fatalf("Truncated() = %v, want %v (limit=%d total=%d)",
+				gotTruncated, wantTruncated, limit, total)
+		}
+
+		wantDropped := 0
+		if total > limit {
+			wantDropped = total - limit
+		}
+		gotDropped := tb.BytesDropped()
+		if gotDropped != wantDropped {
+			t.Fatalf("BytesDropped() = %d, want %d (limit=%d total=%d)",
+				gotDropped, wantDropped, limit, total)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mattn/go-isatty v0.0.20
 	golang.org/x/term v0.41.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -110,3 +110,5 @@ golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
 golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=
 mvdan.cc/sh/v3 v3.13.1 h1:DP3TfgZhDkT7lerUdnp6PTGKyxxzz6T+cOlY/xEvfWk=
 mvdan.cc/sh/v3 v3.13.1/go.mod h1:lXJ8SexMvEVcHCoDvAGLZgFJ9Wsm2sulmoNEXGhYZD0=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=


### PR DESCRIPTION
## Summary

Closes [#214](https://github.com/2389-research/tracker/issues/214). Adds property-based tests for `tailBuffer` using `pgregory.net/rapid`, the class of bug PR #215 went through several iterations to get right.

The example-based tests in `tail_buffer_test.go` pin ~12 specific boundary cases (marker at byte 0 / 65534 / 65535 / 65536 / 65537, marker spanning the write boundary, marker straddling the ring-wrap boundary, etc.) — each is load-bearing but inherently incomplete. Two new properties generalize them to the full state space:

- **Tail invariant**: for any sequence of `Write` calls with total `N` bytes and limit `L`, `tb.String()` equals the last `min(N, L)` bytes of the concatenation. Catches off-by-one boundary errors, write-boundary state corruption, and ring-buffer wrap-around bugs.
- **Truncated/Dropped invariant**: `Truncated()` is true iff `total > limit`; `BytesDropped() == max(0, total - limit)`.

100 random cases per property; each runs in under 2ms. Limits sampled up to 70k (covers the realistic 64KB per-stream cap plus boundaries above and below).

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -short` — all 19 packages green
- [x] `go test ./agent/exec/ -run 'TestTailBuffer_.*_Rapid' -v` — both properties pass 100 random cases
- [x] Tests run fast (< 2ms per property)

## Files

- `agent/exec/tail_buffer_property_test.go` (new)
- `go.mod` + `go.sum` — `pgregory.net/rapid v1.3.0`
- `CHANGELOG.md` — Unreleased / Added entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for tail buffer functionality with comprehensive validation across diverse write patterns and edge cases
  * Enhanced verification of truncation flag accuracy and dropped bytes calculation consistency

* **Chores**
  * Updated testing dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/219)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->