### PR TITLE
chore(deps): bump dippin-lang v0.24.0 → v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **dippin-lang dependency bumped v0.24.0 → v0.25.0**. Picks up the v1.1 `.dipx` format clarifications and three bug fixes that affect tracker's bundle-load path: cycle detection now walks every manifest-listed workflow (was: only entry-reachable, could miss cycles in unreachable workflows that `parseAllWorkflows` had already loaded); `dipx.Open` enriches `ErrManifestInvalid` / `ErrUnsupportedFormatVersion` errors with the bundle path; `dipx.Pack` correctly classifies subgraph parse failures as `ErrSubgraphParse` instead of `ErrEntryParse`. Also adds context-cancellation checks through Open/Pack hot paths. `Source.Workflow` gained a `ctx` parameter (breaking for `Source`-interface consumers); tracker uses `Bundle.Entry()` / `Bundle.Lookup()` directly so no code change needed at the call sites. `PinnedDippinVersion` constant updated to match.
+
 ## [0.28.0] - 2026-05-13
 
 This release closes the five-issue follow-up arc from the [#208](https://github.com/2389-research/tracker/issues/208) design review. All additions are backward-compatible: the activity-log relocation (#213) falls back to the legacy path for archived runs, and the new lint (#211) / routing channels (#210, #212) are opt-in.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.24.0
+	github.com/2389-research/dippin-lang v0.25.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/2389-research/dippin-lang v0.24.0 h1:ZxLTmNt+8mhcX3pyYiiwjMLCkoU4xAU4TRISiJGyjkI=
-github.com/2389-research/dippin-lang v0.24.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.25.0 h1:kkeK2Yqwasao4Wauo+xfz70DWhD+tuDWro5i8tJxgT0=
+github.com/2389-research/dippin-lang v0.25.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -22,7 +22,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod.
 // Keep in sync with the require line in go.mod.
-const PinnedDippinVersion = "v0.24.0"
+const PinnedDippinVersion = "v0.25.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
## Summary

Bumps the Go module dependency to dippin-lang [v0.25.0](https://github.com/2389-research/dippin-lang/releases/tag/v0.25.0), released 2026-05-11 (`.dipx` format v1.1).

## What tracker gets from this bump

Three real bug fixes that touch tracker's bundle-load surface:

1. **Cycle detection now covers every manifest-listed workflow.** `dipx.Open`'s cycle walker was rooted only at `m.Entry`, but `parseAllWorkflows` already loaded every manifest-listed file. A cycle in an entry-unreachable workflow could slip through. Tracker iterates `manifest.Files` in `LoadDipxBundle` (`pipeline/dipx_load.go:62`) — this fix means any cycle in the bundle is guaranteed to be caught before tracker's IR-to-Graph conversion runs.

2. **`dipx.Open` enriches `ErrManifestInvalid` / `ErrUnsupportedFormatVersion` with the bundle path.** Previously `BundleError.Path` was empty or a JSON field name (e.g. `"format_version"`); operators now always see the bundle file in error messages.

3. **`dipx.Pack` correctly classifies subgraph parse failures as `ErrSubgraphParse`** (was: every parse failure surfaced as `ErrEntryParse`). Improves error attribution; doesn't change tracker's behavior since tracker is a Pack consumer not invoker.

Plus context-cancellation checks through `verifyAllHashes` / `walkSourceTree` / `writeBundle` (cancellable mid-loop, was cancel-only-between-major-phases).

## Breaking change in v0.25.0 that does NOT affect tracker

dippin-lang's v0.25.0 CHANGELOG calls out the `Source.Workflow(ctx, ...)` signature change as breaking for Tracker. Verified by grep — tracker doesn't use the `Source` interface anywhere; `LoadDipxBundle` uses `bundle.Entry()` and `bundle.Lookup()` directly off `*dipx.Bundle`. No code changes needed at call sites.

## What changed in tracker

- `go.mod` / `go.sum` — dependency version bump
- `tracker_doctor.go:25` — `PinnedDippinVersion` constant `v0.24.0` → `v0.25.0` so `TestPinnedDippinVersionMatchesGoMod` passes
- `CHANGELOG.md` — `[Unreleased]` entry documenting the bump

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -short -count=1` — all 19 packages pass
- [x] `dippin doctor` A grade on the three core pipelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Dependency update includes API signature changes requiring code updates for compatibility.

* **Bug Fixes**
  * Enhanced cycle detection across workflows with enriched error reporting.
  * Corrected parsing error classification and improved context-cancellation handling in critical paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/225)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->