### PR TITLE
fix(workflows): make Start/Done passthroughs in built-in workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Built-in workflows no longer run an unconstrained agent in `Start` / `Done`** (#230). `workflows/ask_and_execute.dip`, `workflows/build_product.dip`, and `workflows/build_product_with_superspec.dip` (and their `examples/` mirrors) defined Start/Done as `agent` nodes with `prompt: Initialize pipeline.` / `prompt: Pipeline complete.`. Because the prompt attribute was present, `ensureStartExitNodes` skipped the passthrough handler and these nodes became real codergen sessions — system message limited to the file-path reminder, full tool access (read/write/bash/glob/edit/grep_search), no per-node turn cap. A real `build_product` run was observed spending ~10 minutes and ~39k output tokens inside `Start`, implementing an entire separate Go project from a SPEC.md found on disk, before getting `context canceled` and being classified `outcome: retry`. Dropping the prompt lines makes Start/Done passthroughs (matching `deep_review.dip`, which was already correct). `dippin doctor` scores went A → 100/100 on both `build_product` files; `ask_and_execute` stays at 95 (unrelated warning). The broader engine policy gaps surfaced by this incident — `outcome: retry` on cancellation, no default `max_turns` cap, runaway nodes invisible to `tracker diagnose`, missing tool-call args in `activity.jsonl`, suspect per-node token accounting — are tracked in #230 for separate follow-up.
+
 ## [0.28.1] - 2026-05-14
 
 Maintenance release picking up dippin-lang v0.25.0's bundle-load fixes. No tracker-side feature changes; no breaking changes.

--- a/examples/ask_and_execute.dip
+++ b/examples/ask_and_execute.dip
@@ -11,11 +11,9 @@ workflow AskAndExecute
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ─── Phase 1: Understand ───────────────────────────────────
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -12,11 +12,9 @@ workflow BuildProduct
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ─── Phase 1: Read & Plan ──────────────────────────────────
 

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -12,11 +12,9 @@ workflow BuildProductWithSuperspec
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ═══════════════════════════════════════════════════════════════
   # Phase 1: Read, Plan, Scaffold

--- a/workflows/ask_and_execute.dip
+++ b/workflows/ask_and_execute.dip
@@ -11,11 +11,9 @@ workflow AskAndExecute
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ─── Phase 1: Understand ───────────────────────────────────
 

--- a/workflows/build_product.dip
+++ b/workflows/build_product.dip
@@ -12,11 +12,9 @@ workflow BuildProduct
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ─── Phase 1: Read & Plan ──────────────────────────────────
 

--- a/workflows/build_product_with_superspec.dip
+++ b/workflows/build_product_with_superspec.dip
@@ -12,11 +12,9 @@ workflow BuildProductWithSuperspec
 
   agent Start
     label: Start
-    prompt: Initialize pipeline.
 
   agent Done
     label: Done
-    prompt: Pipeline complete.
 
   # ═══════════════════════════════════════════════════════════════
   # Phase 1: Read, Plan, Scaffold


### PR DESCRIPTION
## Summary

- Three of the four built-in workflows (`ask_and_execute`, `build_product`, `build_product_with_superspec`) defined `Start` as `agent` with `prompt: Initialize pipeline.` and `Done` with `prompt: Pipeline complete.` — which caused `ensureStartExitNodes` to skip the passthrough handler and turn them into real codergen sessions.
- In a real `build_product` run (issue #230) this caused the Start node to spend ~9m42s and ~39k output tokens implementing an entire separate Go project from a SPEC.md found on disk, before getting `context canceled`.
- Dropping the `prompt:` lines makes Start/Done passthroughs, matching `deep_review.dip` which was already correct. Also keeps `examples/*.dip` in sync with `workflows/*.dip`.

## What this does NOT fix

The engine policy gaps surfaced by the same incident — default `max_turns` cap, `outcome: retry` on `context canceled`, runaway-node detection in `tracker diagnose`, tool-call arg logging in `activity.jsonl`, suspect per-node token accounting — remain tracked in #230 for separate follow-up. This PR is just the workflow defect.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -short` — all 19 packages pass
- [x] `dippin doctor`: `build_product` A → **100/100**, `build_product_with_superspec` A → **100/100**, `ask_and_execute` A 95/100 (unchanged — unrelated warning)
- [ ] Manual smoke: run `tracker build_product` against a tiny SPEC.md and confirm `Start` advances to `Setup` immediately instead of doing dev work

Refs #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected built-in workflow behavior where Start/Done nodes were incorrectly treated as active agent sessions, causing unnecessary token consumption. These nodes now properly bypass processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/231)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->