### PR TITLE
chore(deps): bump dippin-lang to v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **dippin-lang dependency bumped v0.26.0 → v0.27.0**. Picks up the 2026-05-18 model/pricing catalog refresh and the grok-4-1-fast-* redirect fix (callable model IDs survive their target's rename). No IR or adapter changes — drop-in. `PinnedDippinVersion` in `tracker_doctor.go` updated in lockstep so `tracker doctor`'s dippin-version check matches.
+
 ## [0.29.1] - 2026-05-18
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.26.0
+	github.com/2389-research/dippin-lang v0.27.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/2389-research/dippin-lang v0.26.0 h1:cD8dIREtnXvGREnAl//NqmPoteJpdGZzL+Fjum1ToP4=
-github.com/2389-research/dippin-lang v0.26.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.27.0 h1:T80hsv2KWG4JhOKW5OXjOPO7E5Ujp8d2X7ok35cf9qQ=
+github.com/2389-research/dippin-lang v0.27.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -23,7 +23,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod.
 // Keep in sync with the require line in go.mod.
-const PinnedDippinVersion = "v0.26.0"
+const PinnedDippinVersion = "v0.27.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
## Summary

Picks up dippin-lang v0.27.0 — a catalog refresh. No IR or adapter changes; drop-in upgrade.

**What's in v0.27** (per [dippin-lang release notes](https://github.com/2389-research/dippin-lang/releases/tag/v0.27.0)):
- 2026-05-18 model / pricing catalog refresh
- Bug fix: redirected `grok-4-1-fast-*` IDs stay callable when their target gets renamed

**Why this matters for tracker:** the catalog refresh is what makes DIP108 cover current model names. Now that tracker defers all DIP-coded lint to dippin (#240), bumping dippin is the only way the catalog moves forward — and any new model dippin recognizes is automatically recognized by `tracker validate` / `simulate` / `doctor`.

`PinnedDippinVersion` in `tracker_doctor.go` bumped in lockstep so `TestPinnedDippinVersionMatchesGoMod` stays green and `tracker doctor`'s dippin-version mismatch check uses the new pin.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean (one pre-existing DOT deprecation note, not in scope)
- [x] `go test ./... -short -count=1` — all 18 packages green
- [x] `dippin doctor` A grade on all three canonical pipelines (95 / 100 / 100 — identical to v0.26.0)
- [x] `dippin simulate -all-paths` enumeration counts unchanged (56 / 100 / 100)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Updated model and pricing catalog with the latest data.
  * Fixed grok redirect functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->