### PR TITLE
release: v0.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.2] - 2026-05-18
+
 ### Changed
 
-- **dippin-lang dependency bumped v0.26.0 → v0.27.0**. Picks up the 2026-05-18 model/pricing catalog refresh and the grok-4-1-fast-* redirect fix (callable model IDs survive their target's rename). No IR or adapter changes — drop-in. `PinnedDippinVersion` in `tracker_doctor.go` updated in lockstep so `tracker doctor`'s dippin-version check matches.
+- **dippin-lang dependency bumped v0.26.0 → v0.27.0** ([#242](https://github.com/2389-research/tracker/pull/242)). Picks up the 2026-05-18 model/pricing catalog refresh and the grok-4-1-fast-* redirect fix (callable model IDs survive their target's rename). No IR or adapter changes — drop-in. `PinnedDippinVersion` in `tracker_doctor.go` updated in lockstep so `tracker doctor`'s dippin-version check matches. Combined with v0.29.1's lint deduplication, DIP108 now covers the full current catalog — workflows using `gemini-3-flash-preview`, redirected grok IDs, and other recent models validate clean.
 
 ## [0.29.1] - 2026-05-18
 


### PR DESCRIPTION
## Summary

Cuts v0.29.2. Doc-only — `[Unreleased]` → `[0.29.2] - 2026-05-18` in CHANGELOG. README "What's new" stays on v0.29.0 since this is a patch release.

The dep bump landed in:
- #242 — `chore(deps): bump dippin-lang to v0.27.0`

v0.29.1 and v0.29.2 ship the same coherent change for a workflow author: `tracker validate` / `simulate` / `doctor` stop false-positiving on current model names. v0.29.1 was the structural fix (delete tracker's stale catalog, defer to dippin). v0.29.2 picks up dippin-lang's refreshed catalog so the deferral actually covers 2026-05-18 models like `gemini-3-flash-preview` and redirected `grok-4-1-fast-*` IDs.

## Release checklist (post-merge)

- [ ] Tag merge commit: `git tag -a v0.29.2 <sha> -m "release: v0.29.2" && git push origin v0.29.2`
- [ ] GoReleaser publishes binaries + GitHub release entry
- [ ] Refresh `gh-pages` with v0.29.1 + v0.29.2 changelog content (batched, since v0.29.1's site refresh was deferred to land alongside v0.29.2)

## Pre-release verification

- [x] `go build ./...` clean
- [x] `go test ./... -short` all 18 packages green
- [x] `dippin doctor` A on all three core pipelines (`ask_and_execute` 95/100, `build_product` 100/100, `build_product_with_superspec` 100/100 — identical to v0.29.1)
- [x] `dippin simulate -all-paths` clean on all three core pipelines (56 / 100 / 100 paths enumerated — identical to v0.29.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->