### PR TITLE
feat(agent): honor tool_access: none from dippin v0.32.0 (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `agent.builtInToolsForConfig` returns `nil` when restricted (no built-in tools registered).
   - `agent.NewSession` clears the tool registry after all options apply — catches `WithTools(...)` bypass. Defense in depth: built-ins gate + post-WithTools clear + executeToolCalls early-exit means three independent paths block dispatch.
   - `agent.Session.doLLMCall` sets `request.Tools = nil` and `request.ToolChoice = ToolChoiceNone()` so the API itself blocks tool invocation.
-  - `agent.Session.initConversation` swaps the default `"File tool arguments (read, write, edit, glob, grep_search) MUST use paths relative..."` prefix for a tool-free prompt that names no tools at all (system-prompt scrub — no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch`).
+  - `agent.Session.initConversation` swaps the default `"File tool arguments (read, write, edit, glob, grep_search) MUST use paths relative..."` prefix for a tool-free variant when restricted. Scope: only the built-in prefix is scrubbed — a caller-supplied `SessionConfig.SystemPrompt` is still appended verbatim. The registry-empty + ToolChoice=none + dispatch-shortcircuit defenses do NOT depend on the prompt scrub; the scrub is defense-in-depth, not load-bearing.
   - `agent.Session.executeToolCalls` short-circuits when restricted — if the LLM emits tool calls despite `ToolChoice=none` (mock, retry, provider that ignored the signal), zero of them execute. Emits an error event for visibility.
   - **Params-bypass defense** at `pipeline/handlers/codergen.go`: `applyToolLists` and `applyPermissionMode` early-return when `tool_access` is set, so `allowed_tools`/`disallowed_tools`/`permission_mode=bypassPermissions` Params keys can't re-enable the tools the directive intends to deny.
   - **Backend compatibility:**
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `TestSessionToolAccess_RestrictedRegistry_EmptyAfterWithTools` — registry is empty even when `WithTools(read, write, bash)` is called.
     - `TestSessionToolAccess_FailClosedOnTypo` — `noen`, `None`, `  none  `, `NONE`, `off`, `x` all disable tools.
     - `TestSessionToolAccess_EmptyMeansUnrestricted` — empty string leaves tools registered normally.
-    - `TestSessionToolAccess_SystemPromptScrub` — assembled system prompt contains no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch`.
+    - `TestSessionToolAccess_SystemPromptScrub` — assembled system prompt contains no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch` for the built-in prefix path (i.e. when SystemPrompt is either empty or doesn't name tools itself).
     - `TestApplyToolLists_BypassDefense` + `TestApplyPermissionMode_BypassDefense` — Params keys ignored under `tool_access: none`.
     - `TestApplyClaudeCodeToolAccess` — DisallowedTools populated with canonical names.
     - `TestACPBackend_RefusesToolAccess` — ACP returns error referencing #258 and the directive value.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`tool_access: none` runtime enforcement on agent nodes** ([#258](https://github.com/2389-research/tracker/issues/258), joint with [dippin-lang#41](https://github.com/2389-research/dippin-lang/issues/41)). Bounds the v0.28.2 single-agent multi-tool-call vector: when an LLM emits multiple tool calls in one response, tracker would dispatch all of them before `max_turns` checked the cap. With `tool_access: none` set on an agent node, tracker now hands the LLM **zero tools** so the response comes back as plain text. Implementation:
+  - `agent.SessionConfig.ToolAccess` (`string`) — populated from the dippin adapter; canonical case-insensitive, whitespace-trimmed. Any non-empty value disables tools (fail-closed for typos — `noen`, `None`, `off`, `x` all trip the restriction so a lint-skipped misspelling can't ship full tools). Helper: `SessionConfig.IsToolAccessRestricted()`.
+  - `agent.builtInToolsForConfig` returns `nil` when restricted (no built-in tools registered).
+  - `agent.NewSession` clears the tool registry after all options apply — catches `WithTools(...)` bypass. Defense in depth: built-ins gate + post-WithTools clear + executeToolCalls early-exit means three independent paths block dispatch.
+  - `agent.Session.doLLMCall` sets `request.Tools = nil` and `request.ToolChoice = ToolChoiceNone()` so the API itself blocks tool invocation.
+  - `agent.Session.initConversation` swaps the default `"File tool arguments (read, write, edit, glob, grep_search) MUST use paths relative..."` prefix for a tool-free prompt that names no tools at all (system-prompt scrub — no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch`).
+  - `agent.Session.executeToolCalls` short-circuits when restricted — if the LLM emits tool calls despite `ToolChoice=none` (mock, retry, provider that ignored the signal), zero of them execute. Emits an error event for visibility.
+  - **Params-bypass defense** at `pipeline/handlers/codergen.go`: `applyToolLists` and `applyPermissionMode` early-return when `tool_access` is set, so `allowed_tools`/`disallowed_tools`/`permission_mode=bypassPermissions` Params keys can't re-enable the tools the directive intends to deny.
+  - **Backend compatibility:**
+    - **Native backend** — full honor via `agent.SessionConfig.ToolAccess`.
+    - **claude-code backend** — best-effort enumeration: `applyClaudeCodeToolAccess` populates `DisallowedTools` with the canonical Claude Code tool names (`Bash`, `Edit`, `Glob`, `Grep`, `NotebookEdit`, `Read`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `Write`) so the CLI denies the surface.
+    - **ACP backend** — refuses session creation with a clear error pointing to #258. ACP's deny-equivalent spelling hasn't been verified against each upstream agent (claude-code-acp, codex-acp, gemini); per the spec's "fallback unsupported → refuse" rule, refusing is safer than shipping a soft-no that silently allows execution.
+  - **Tests** (`agent/tool_access_test.go`, `pipeline/handlers/tool_access_test.go`):
+    - `TestSessionToolAccess_RedTeamMultiToolCall` — the dispositive v0.28.2 test. Mock LLM returns a single response containing three tool calls (`bash`, `write`, `bash`). Assert: zero tool executions, `result.TotalToolCalls() == 0`, request had no tools, `ToolChoice.Mode == "none"`.
+    - `TestSessionToolAccess_RestrictedRegistry_EmptyAfterWithTools` — registry is empty even when `WithTools(read, write, bash)` is called.
+    - `TestSessionToolAccess_FailClosedOnTypo` — `noen`, `None`, `  none  `, `NONE`, `off`, `x` all disable tools.
+    - `TestSessionToolAccess_EmptyMeansUnrestricted` — empty string leaves tools registered normally.
+    - `TestSessionToolAccess_SystemPromptScrub` — assembled system prompt contains no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch`.
+    - `TestApplyToolLists_BypassDefense` + `TestApplyPermissionMode_BypassDefense` — Params keys ignored under `tool_access: none`.
+    - `TestApplyClaudeCodeToolAccess` — DisallowedTools populated with canonical names.
+    - `TestACPBackend_RefusesToolAccess` — ACP returns error referencing #258 and the directive value.
+  - **Joint-release coordination:** this lands on tracker `main` but is **not** tagged. The dippin-lang #41 PR will bump `go.mod` to the new tracker tag, then tag dippin v0.32.0 immediately after. No advisory window — the dippin field doesn't ship in a tagged release until tracker enforcement is also tagged.
+
 ### Changed
 
 - **`build_product` workflow: closed Gap 7 from the #233 audit (interface-method reachability)** ([#233](https://github.com/2389-research/tracker/issues/233)). The audit caught three Go interface methods defined and unit-tested but never called from production code: `AuthStatus(ctx) error` (Appendix A I9), `IsRebaseInProgress() bool` (I10), `DiffStat` (similar shape). Tests passed because the same agent wrote impl and tests; the workflow had no check that defined interface methods have a non-test caller. New mechanism:

--- a/agent/config.go
+++ b/agent/config.go
@@ -80,14 +80,27 @@ type SessionConfig struct {
 
 	// ToolAccess restricts the agent's tool surface. When non-empty (any value),
 	// the session registers zero tools, sets ToolChoice=none on LLM requests,
-	// scrubs tool-naming text from the system prompt, and rejects Params bypass
-	// keys (allowed_tools, disallowed_tools, tool_choice, permission_mode).
+	// scrubs the built-in tool-naming prefix from the system prompt, and rejects
+	// Params bypass keys (allowed_tools, disallowed_tools, permission_mode).
+	//
 	// Defends the v0.28.2 single-agent multi-tool-call vector: an LLM emitting
 	// multiple tool calls in one response cannot execute any of them because
-	// the registry is empty by construction. Canonical: case-insensitive,
-	// whitespace-trimmed. Only recognized spelling is "none"; any other
-	// non-empty value still disables tools (fail-closed for typos). Default: ""
-	// (unrestricted). Issue: github.com/2389-research/tracker#258.
+	// the registry is empty by construction.
+	//
+	// Canonical: case-insensitive, whitespace-trimmed. Only recognized spelling
+	// is "none"; any other non-empty value still disables tools (fail-closed for
+	// typos). Default: "" (unrestricted).
+	//
+	// System-prompt scope: tracker only scrubs its own built-in basePrompt
+	// (which names "read", "write", etc. for path-relative semantics). A
+	// caller-supplied SystemPrompt is appended verbatim — if it names tools,
+	// the assembled prompt will still contain those tokens. The registry +
+	// ToolChoice + dispatch-shortcircuit defenses do not depend on the prompt
+	// scrub; the scrub is defense-in-depth against the LLM noticing tool
+	// affordances. Callers who need a fully scrubbed assembled prompt should
+	// audit their own SystemPrompt under restriction.
+	//
+	// Issue: github.com/2389-research/tracker#258.
 	ToolAccess string
 }
 

--- a/agent/config.go
+++ b/agent/config.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -76,6 +77,26 @@ type SessionConfig struct {
 	// loop and keeps that plan in conversation context for subsequent turns.
 	// Default: false.
 	PlanBeforeExecute bool
+
+	// ToolAccess restricts the agent's tool surface. When non-empty (any value),
+	// the session registers zero tools, sets ToolChoice=none on LLM requests,
+	// scrubs tool-naming text from the system prompt, and rejects Params bypass
+	// keys (allowed_tools, disallowed_tools, tool_choice, permission_mode).
+	// Defends the v0.28.2 single-agent multi-tool-call vector: an LLM emitting
+	// multiple tool calls in one response cannot execute any of them because
+	// the registry is empty by construction. Canonical: case-insensitive,
+	// whitespace-trimmed. Only recognized spelling is "none"; any other
+	// non-empty value still disables tools (fail-closed for typos). Default: ""
+	// (unrestricted). Issue: github.com/2389-research/tracker#258.
+	ToolAccess string
+}
+
+// IsToolAccessRestricted reports whether ToolAccess is set to any non-empty
+// canonical value. Used by the session to gate tool registration, ToolChoice,
+// and system-prompt assembly. Fail-closed: any non-empty value (including
+// typos) returns true.
+func (c SessionConfig) IsToolAccessRestricted() bool {
+	return strings.TrimSpace(c.ToolAccess) != ""
 }
 
 // Checkpoint defines a message to inject at a specific turn-budget fraction.

--- a/agent/profile.go
+++ b/agent/profile.go
@@ -7,6 +7,12 @@ import (
 )
 
 func builtInToolsForConfig(cfg SessionConfig, env exec.ExecutionEnvironment) []tools.Tool {
+	// tool_access enforcement (issue #258): any non-empty value disables
+	// the built-in tool registry. Fail-closed for typos — only the empty
+	// string means unrestricted.
+	if cfg.IsToolAccessRestricted() {
+		return nil
+	}
 	switch resolvedProvider(cfg) {
 	case "openai":
 		return []tools.Tool{

--- a/agent/session.go
+++ b/agent/session.go
@@ -100,6 +100,17 @@ func NewSession(client Completer, config SessionConfig, opts ...SessionOption) (
 	s.initToolCache()
 	s.registerSpawnTool()
 
+	// tool_access enforcement (issue #258): after every registration path
+	// (built-ins, WithTools, spawn_agent), clear the registry if access is
+	// restricted. Defense in depth — builtInToolsForConfig already returns
+	// nil under restriction, but WithTools and the spawn tool bypass that
+	// guard. The empty registry plus ToolChoice=none on the request gives
+	// fail-closed behavior even if a caller mis-orders WithTools.
+	if s.config.IsToolAccessRestricted() {
+		s.registry = tools.NewRegistry()
+		s.registry.SetOutputLimits(s.config.ToolOutputLimits)
+	}
+
 	return s, nil
 }
 

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -21,12 +21,18 @@ const (
 // context is honored by the localization pre-processing phase so cancellation
 // or deadlines abort the pre-turn filesystem scan.
 func (s *Session) initConversation(ctx context.Context, userInput string) {
-	// tool_access enforcement (issue #258): when restricted, the assembled
-	// system prompt must contain no tool-naming text. The default basePrompt
+	// tool_access enforcement (issue #258): when restricted, swap the
+	// built-in basePrompt for a tool-free variant. The default basePrompt
 	// names read/write/edit/glob/grep_search/bash explicitly to disambiguate
 	// path semantics — under tool_access restriction the agent has no tools
 	// so the disambiguation is irrelevant and the prompt would only tell the
 	// LLM what tools to ask for.
+	//
+	// Note: this scrub applies ONLY to the built-in prefix. If the caller
+	// also supplies SessionConfig.SystemPrompt that names tools, those names
+	// are still appended verbatim below. The registry-empty + ToolChoice=none
+	// + dispatch-shortcircuit defenses do NOT depend on the prompt scrub;
+	// the scrub is defense-in-depth, not the load-bearing check.
 	basePrompt := "File tool arguments (read, write, edit, glob, grep_search) MUST use paths relative to the working directory. " +
 		"For example, use \"src/main.go\" instead of \"/home/user/project/src/main.go\". " +
 		"Bash commands may use absolute paths when needed."
@@ -140,9 +146,14 @@ func (s *Session) doLLMCall(ctx context.Context, turn int) (*llm.Response, error
 	// tool_access enforcement (issue #258): zero out the tool surface in
 	// the outbound request and signal ToolChoice=none. The registry is
 	// already empty under restriction (cleared in NewSession), so Tools is
-	// nil already; setting it explicitly is defensive. ToolChoice=none
-	// translates to the Anthropic `tool_choice: none` and equivalent
-	// signals on other providers.
+	// nil already; setting it explicitly is defensive.
+	//
+	// Wire encoding of ToolChoice=none varies by provider:
+	//   - Anthropic: translator omits `tool_choice` entirely (an empty
+	//     tool surface alone tells the API not to call any tool).
+	//   - OpenAI:    `tool_choice: "none"`.
+	//   - Gemini:    no tool-config field → no tool calls.
+	// All three converge on the same observable behavior (no tool calls).
 	if s.config.IsToolAccessRestricted() {
 		req.Tools = nil
 		none := llm.ToolChoiceNone()

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -21,9 +21,19 @@ const (
 // context is honored by the localization pre-processing phase so cancellation
 // or deadlines abort the pre-turn filesystem scan.
 func (s *Session) initConversation(ctx context.Context, userInput string) {
+	// tool_access enforcement (issue #258): when restricted, the assembled
+	// system prompt must contain no tool-naming text. The default basePrompt
+	// names read/write/edit/glob/grep_search/bash explicitly to disambiguate
+	// path semantics — under tool_access restriction the agent has no tools
+	// so the disambiguation is irrelevant and the prompt would only tell the
+	// LLM what tools to ask for.
 	basePrompt := "File tool arguments (read, write, edit, glob, grep_search) MUST use paths relative to the working directory. " +
 		"For example, use \"src/main.go\" instead of \"/home/user/project/src/main.go\". " +
 		"Bash commands may use absolute paths when needed."
+	if s.config.IsToolAccessRestricted() {
+		basePrompt = "Respond to the user with plain text only; do not attempt to invoke any tool. " +
+			"No tools are available for this session."
+	}
 	if s.config.SystemPrompt != "" {
 		s.messages = append(s.messages, llm.SystemMessage(basePrompt+"\n\n"+s.config.SystemPrompt))
 	} else {
@@ -125,6 +135,18 @@ func (s *Session) doLLMCall(ctx context.Context, turn int) (*llm.Response, error
 				s.emitLLMTraceEvent(turn, traceEvt)
 			}),
 		},
+	}
+
+	// tool_access enforcement (issue #258): zero out the tool surface in
+	// the outbound request and signal ToolChoice=none. The registry is
+	// already empty under restriction (cleared in NewSession), so Tools is
+	// nil already; setting it explicitly is defensive. ToolChoice=none
+	// translates to the Anthropic `tool_choice: none` and equivalent
+	// signals on other providers.
+	if s.config.IsToolAccessRestricted() {
+		req.Tools = nil
+		none := llm.ToolChoiceNone()
+		req.ToolChoice = &none
 	}
 
 	s.emit(Event{
@@ -274,6 +296,20 @@ func (s *Session) computeToolSignature(toolCalls []llm.ToolCallData) string {
 // step" (e.g., a model emitting `[dispatch_sprints, write_summary_doc]`
 // shouldn't run write_summary_doc once dispatch_sprints succeeded).
 func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult) (hadErrors, terminate bool) {
+	// tool_access enforcement (issue #258): when restricted, the LLM was
+	// instructed via ToolChoice=none not to emit tool calls. If it did
+	// anyway (mock, retry of stale state, provider that ignored the
+	// signal), skip dispatch entirely — zero executions, zero counts. The
+	// session loop continues without appending tool-result messages, and
+	// the next LLM turn proceeds without prior tool context.
+	if s.config.IsToolAccessRestricted() {
+		s.emit(Event{
+			Type:      EventError,
+			SessionID: s.id,
+			Err:       fmt.Errorf("tool_access restricted: dropped %d tool call(s) emitted by the LLM despite ToolChoice=none", len(toolCalls)),
+		})
+		return false, false
+	}
 	var toolResults []llm.ContentPart
 	for _, call := range toolCalls {
 		toolResult, toolDuration := s.executeSingleTool(ctx, call)

--- a/agent/tool_access_test.go
+++ b/agent/tool_access_test.go
@@ -1,0 +1,257 @@
+// ABOUTME: Tests for tool_access enforcement on agent sessions (issue #258).
+// ABOUTME: Bounds the v0.28.2 single-agent multi-tool-call vector — when
+// ABOUTME: ToolAccess is set, an LLM emitting multiple tool calls in one
+// ABOUTME: response must execute zero of them. Covers the red-team scenario,
+// ABOUTME: WithTools bypass, case/typo fail-closed, and system-prompt scrub.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// recordingTool tracks how many times Execute is invoked. The red-team test
+// uses this instead of stubTool so we can assert zero invocations.
+type recordingTool struct {
+	name      string
+	output    string
+	calls     int
+	lastInput string
+}
+
+func (r *recordingTool) Name() string        { return r.name }
+func (r *recordingTool) Description() string { return "recording tool for tool_access tests" }
+func (r *recordingTool) Parameters() json.RawMessage {
+	return json.RawMessage(`{"type":"object","properties":{}}`)
+}
+func (r *recordingTool) Execute(_ context.Context, args json.RawMessage) (string, error) {
+	r.calls++
+	r.lastInput = string(args)
+	return r.output, nil
+}
+
+// multiToolCallResponse builds the v0.28.2 red-team payload: a single
+// assistant message containing three tool calls. Payload contents are
+// inert sentinel strings — the test asserts zero invocations, so the
+// payload never runs; the strings only need to be parseable JSON.
+func multiToolCallResponse() *llm.Response {
+	return &llm.Response{
+		Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{
+				{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:        "call_1",
+						Name:      "bash",
+						Arguments: json.RawMessage(`{"command":"PAYLOAD_1"}`),
+					},
+				},
+				{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:        "call_2",
+						Name:      "write",
+						Arguments: json.RawMessage(`{"path":"payload.txt","content":"PAYLOAD_2"}`),
+					},
+				},
+				{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:        "call_3",
+						Name:      "bash",
+						Arguments: json.RawMessage(`{"command":"PAYLOAD_3"}`),
+					},
+				},
+			},
+		},
+		FinishReason: llm.FinishReason{Reason: "tool_calls"},
+		Usage:        llm.Usage{InputTokens: 30, OutputTokens: 30, TotalTokens: 60},
+	}
+}
+
+// TestSessionToolAccess_RedTeamMultiToolCall is the dispositive test for
+// issue #258: an LLM that emits multiple tool calls in a single response
+// must execute zero of them when ToolAccess is non-empty. This bounds the
+// v0.28.2 attack vector (LLM gets through `max_turns` because multiple
+// calls fit in one turn).
+func TestSessionToolAccess_RedTeamMultiToolCall(t *testing.T) {
+	bashTool := &recordingTool{name: "bash", output: "should-not-execute"}
+	writeTool := &recordingTool{name: "write", output: "should-not-execute"}
+
+	var capturedRequests []llm.Request
+	client := &mockCompleter{
+		responses: []*llm.Response{multiToolCallResponse()},
+		onComplete: func(req *llm.Request) {
+			copied := *req
+			copied.Messages = append([]llm.Message(nil), req.Messages...)
+			capturedRequests = append(capturedRequests, copied)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.ToolAccess = "none"
+	cfg.MaxTurns = 3
+
+	// Register tools via WithTools — the registry must still end up empty
+	// because ToolAccess gates registration at session construction.
+	sess := mustNewSession(t, client, cfg, WithTools(bashTool, writeTool))
+
+	result, err := sess.Run(context.Background(), "Do whatever it takes")
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	// Dispositive assertion: zero tool executions despite the LLM emitting
+	// three tool calls in one response.
+	if bashTool.calls != 0 {
+		t.Errorf("bash tool was invoked %d times; expected 0 under tool_access=none", bashTool.calls)
+	}
+	if writeTool.calls != 0 {
+		t.Errorf("write tool was invoked %d times; expected 0 under tool_access=none", writeTool.calls)
+	}
+	if result.TotalToolCalls() != 0 {
+		t.Errorf("result.TotalToolCalls() = %d; expected 0", result.TotalToolCalls())
+	}
+
+	// The outbound LLM request must carry no tool definitions and a
+	// ToolChoiceNone signal so the API itself blocks tool invocation.
+	if len(capturedRequests) == 0 {
+		t.Fatal("expected at least one LLM request captured")
+	}
+	first := capturedRequests[0]
+	if len(first.Tools) != 0 {
+		t.Errorf("request carried %d tool definitions; expected 0", len(first.Tools))
+	}
+	if first.ToolChoice == nil {
+		t.Error("request.ToolChoice was nil; expected ToolChoiceNone()")
+	} else if first.ToolChoice.Mode != "none" {
+		t.Errorf("request.ToolChoice.Mode = %q; expected \"none\"", first.ToolChoice.Mode)
+	}
+}
+
+// TestSessionToolAccess_RestrictedRegistry_EmptyAfterWithTools confirms the
+// defense-in-depth move: even when a caller registers tools via WithTools,
+// the registry ends up empty when ToolAccess is set.
+func TestSessionToolAccess_RestrictedRegistry_EmptyAfterWithTools(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ToolAccess = "none"
+
+	sess := mustNewSession(t, &mockCompleter{}, cfg, WithTools(
+		&recordingTool{name: "read"},
+		&recordingTool{name: "write"},
+		&recordingTool{name: "bash"},
+	))
+
+	if got := len(sess.registry.Definitions()); got != 0 {
+		t.Errorf("registry holds %d tools after ToolAccess=none + WithTools; expected 0", got)
+	}
+}
+
+// TestSessionToolAccess_FailClosedOnTypo confirms that a misspelled
+// directive (e.g. "noen") still disables tools — any non-empty value
+// triggers the restriction so a lint-skipped typo can't ship full tools.
+func TestSessionToolAccess_FailClosedOnTypo(t *testing.T) {
+	for _, val := range []string{"noen", "None", "  none  ", "NONE", "off", "x"} {
+		t.Run(val, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.ToolAccess = val
+
+			sess := mustNewSession(t, &mockCompleter{}, cfg, WithTools(
+				&recordingTool{name: "read"},
+			))
+
+			if got := len(sess.registry.Definitions()); got != 0 {
+				t.Errorf("ToolAccess=%q: registry holds %d tools; expected 0 (fail-closed)", val, got)
+			}
+		})
+	}
+}
+
+// TestSessionToolAccess_EmptyMeansUnrestricted confirms that the empty
+// string means no restriction — tools register normally.
+func TestSessionToolAccess_EmptyMeansUnrestricted(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ToolAccess = ""
+
+	sess := mustNewSession(t, &mockCompleter{}, cfg, WithTools(
+		&recordingTool{name: "read"},
+	))
+
+	if got := len(sess.registry.Definitions()); got != 1 {
+		t.Errorf("ToolAccess=\"\": registry holds %d tools; expected 1 (unrestricted)", got)
+	}
+}
+
+// TestSessionToolAccess_SystemPromptScrub confirms the assembled system
+// prompt contains no standalone case-insensitive tool names when ToolAccess
+// is restricted. Defends against the LLM noticing tool affordances even
+// though the API tool list is empty.
+func TestSessionToolAccess_SystemPromptScrub(t *testing.T) {
+	var captured []llm.Request
+	client := &mockCompleter{
+		responses: []*llm.Response{{
+			Message:      llm.AssistantMessage("acknowledged"),
+			FinishReason: llm.FinishReason{Reason: "stop"},
+		}},
+		onComplete: func(req *llm.Request) {
+			copied := *req
+			copied.Messages = append([]llm.Message(nil), req.Messages...)
+			captured = append(captured, copied)
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.ToolAccess = "none"
+	cfg.SystemPrompt = "You are an assistant."
+
+	sess := mustNewSession(t, client, cfg)
+	if _, err := sess.Run(context.Background(), "Hello"); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	if len(captured) == 0 {
+		t.Fatal("no LLM request captured")
+	}
+
+	var systemText string
+	for _, msg := range captured[0].Messages {
+		if msg.Role == llm.RoleSystem {
+			systemText = msg.Text()
+			break
+		}
+	}
+	if systemText == "" {
+		t.Fatal("no system message in request")
+	}
+
+	// The forbidden tokens per spec's system-prompt-audit rule.
+	forbidden := []string{"read", "write", "edit", "glob", "grep_search", "bash", "apply_patch"}
+	lower := strings.ToLower(systemText)
+	for _, tok := range forbidden {
+		// Match the token surrounded by non-word boundaries (start, end, or
+		// non-alphanumeric/underscore). Using simple substring + word-edge
+		// checks rather than regexp to stay literal about the contract.
+		for i := 0; i <= len(lower)-len(tok); i++ {
+			if lower[i:i+len(tok)] != tok {
+				continue
+			}
+			if i > 0 && isWordChar(lower[i-1]) {
+				continue
+			}
+			if i+len(tok) < len(lower) && isWordChar(lower[i+len(tok)]) {
+				continue
+			}
+			t.Errorf("system prompt contains forbidden standalone token %q at offset %d under tool_access=none\n  prompt: %s", tok, i, systemText)
+			break
+		}
+	}
+}
+
+func isWordChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}

--- a/agent/tool_access_test.go
+++ b/agent/tool_access_test.go
@@ -187,10 +187,17 @@ func TestSessionToolAccess_EmptyMeansUnrestricted(t *testing.T) {
 	}
 }
 
-// TestSessionToolAccess_SystemPromptScrub confirms the assembled system
-// prompt contains no standalone case-insensitive tool names when ToolAccess
-// is restricted. Defends against the LLM noticing tool affordances even
-// though the API tool list is empty.
+// TestSessionToolAccess_SystemPromptScrub confirms the BUILT-IN prefix of
+// the assembled system prompt contains no standalone case-insensitive tool
+// names when ToolAccess is restricted. Defends against the LLM noticing
+// tool affordances from tracker's own boilerplate.
+//
+// Scope: tracker only scrubs its own built-in prefix. A caller-supplied
+// SessionConfig.SystemPrompt is appended verbatim — if it names tools,
+// they survive into the assembled prompt. The registry-empty + ToolChoice
+// + dispatch-shortcircuit defenses do not depend on the prompt scrub; the
+// scrub is defense-in-depth. This test deliberately uses a SystemPrompt
+// that does NOT name tools so the assertion holds for the built-in path.
 func TestSessionToolAccess_SystemPromptScrub(t *testing.T) {
 	var captured []llm.Request
 	client := &mockCompleter{

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.29.0
+	github.com/2389-research/dippin-lang v0.31.1-0.20260526211025-53c24f13a4d0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/2389-research/dippin-lang v0.29.0 h1:E3SqzBtPxm4Q7PU2iOWto0hyySjIxK0+6P2gt0Onaoo=
-github.com/2389-research/dippin-lang v0.29.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.31.1-0.20260526211025-53c24f13a4d0 h1:PHx2EgwIaHC/FAEZjB555j5wcCX5ZZD8T/P5+ASRe8c=
+github.com/2389-research/dippin-lang v0.31.1-0.20260526211025-53c24f13a4d0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pipeline/backend.go
+++ b/pipeline/backend.go
@@ -26,6 +26,13 @@ type AgentRunConfig struct {
 	MaxTurns     int
 	Timeout      time.Duration
 	Extra        any // backend-specific: *ClaudeCodeConfig for claude-code backend
+
+	// ToolAccess restricts the agent's tool surface. When non-empty, every
+	// backend must enforce: native via agent.SessionConfig.IsToolAccessRestricted;
+	// claude-code via the DisallowedTools list set by applyClaudeCodeToolAccess;
+	// ACP refuses session creation (no verified deny-equivalent — see
+	// backend_acp.go for the refusal site). Issue: github.com/2389-research/tracker#258.
+	ToolAccess string
 }
 
 // ClaudeCodeConfig holds Claude-Code-specific settings.

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -371,8 +371,8 @@ func extractAgentOutputAttrs(cfg ir.AgentConfig, attrs map[string]string) {
 //   - max_budget_usd  → attrs["max_budget_usd"]    (float string, e.g. "1.50")
 //   - permission_mode → attrs["permission_mode"]   (plan|acceptEdits|bypassPermissions)
 //   - tool_access     → attrs["tool_access"]       ("none" to disable tools entirely;
-//                                                   any non-empty value is fail-closed —
-//                                                   see issue #258 and dippin-lang#41)
+//     any non-empty value is fail-closed —
+//     see issue #258 and dippin-lang#41)
 //
 // Unrecognized keys are silently ignored.
 // A nil or empty params map is a no-op.

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -370,6 +370,9 @@ func extractAgentOutputAttrs(cfg ir.AgentConfig, attrs map[string]string) {
 //   - disallowed_tools→ attrs["disallowed_tools"]  (comma-separated tool names)
 //   - max_budget_usd  → attrs["max_budget_usd"]    (float string, e.g. "1.50")
 //   - permission_mode → attrs["permission_mode"]   (plan|acceptEdits|bypassPermissions)
+//   - tool_access     → attrs["tool_access"]       ("none" to disable tools entirely;
+//                                                   any non-empty value is fail-closed —
+//                                                   see issue #258 and dippin-lang#41)
 //
 // Unrecognized keys are silently ignored.
 // A nil or empty params map is a no-op.
@@ -382,6 +385,7 @@ func extractAgentBackendAttrs(params map[string]string, attrs map[string]string)
 		"disallowed_tools",
 		"max_budget_usd",
 		"permission_mode",
+		"tool_access",
 	}
 	for _, k := range keys {
 		if v, ok := params[k]; ok && v != "" {

--- a/pipeline/handlers/backend_acp.go
+++ b/pipeline/handlers/backend_acp.go
@@ -135,6 +135,18 @@ func NewACPBackend() *ACPBackend {
 // prompt, and collects results. The agent binary is selected based on the
 // provider in cfg or the ACPConfig.Agent override.
 func (b *ACPBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig, emit func(agent.Event)) (agent.SessionResult, error) {
+	// tool_access enforcement (issue #258): the ACP backend has no verified
+	// deny-equivalent for the directive — the protocol exposes session
+	// permissions but tracker has not yet audited the spelling against the
+	// upstream ACP agents (claude-code-acp, codex-acp, gemini). Per the
+	// spec's "fallback unsupported → refuse" rule, refuse session creation
+	// with a clear error rather than ship a soft-no that silently allows
+	// tool execution. Lifting this requires a follow-up that pins ACP's
+	// session.permission_modes (or equivalent) against each known agent.
+	if strings.TrimSpace(cfg.ToolAccess) != "" {
+		return agent.SessionResult{}, fmt.Errorf("acp backend cannot enforce tool_access=%q yet — see github.com/2389-research/tracker#258 (use the native backend, or open a follow-up issue once the ACP deny-equivalent is verified for your agent)", cfg.ToolAccess)
+	}
+
 	agentName := b.resolveAgentName(cfg)
 
 	agentPath, err := b.ensureAgentPath(agentName)

--- a/pipeline/handlers/backend_claudecode.go
+++ b/pipeline/handlers/backend_claudecode.go
@@ -205,11 +205,49 @@ func buildArgs(cfg pipeline.AgentRunConfig) ([]string, error) {
 	}
 
 	ccCfg, _ := cfg.Extra.(*pipeline.ClaudeCodeConfig)
+
+	// tool_access enforcement (issue #258): if a direct caller constructed
+	// AgentRunConfig with cfg.ToolAccess set but no (or only partial)
+	// ClaudeCodeConfig in Extra, synthesize one with the canonical deny
+	// list so the CLI denies the surface. CodergenHandler already populates
+	// this via applyClaudeCodeToolAccess; this branch covers the direct-Run
+	// bypass Codex flagged on PR #259.
+	if strings.TrimSpace(cfg.ToolAccess) != "" {
+		if ccCfg == nil {
+			ccCfg = &pipeline.ClaudeCodeConfig{}
+		}
+		// Override AllowedTools (don't trust caller-provided allowlist when
+		// tool_access is set — that would be the Params-bypass shape).
+		ccCfg.AllowedTools = nil
+		ccCfg.DisallowedTools = canonicalClaudeCodeDenyListCopy()
+	}
+
 	if ccCfg == nil {
 		return args, nil
 	}
 
 	return appendClaudeCodeArgs(args, ccCfg)
+}
+
+// canonicalClaudeCodeDenyListCopy returns a fresh copy of the canonical
+// tool name list used to deny the CLI's tool surface when tool_access is
+// set. Mirrors the list in codergen.go's applyClaudeCodeToolAccess —
+// kept here to avoid exporting that list across the package boundary.
+// Issue: github.com/2389-research/tracker#258.
+func canonicalClaudeCodeDenyListCopy() []string {
+	return []string{
+		"Bash",
+		"Edit",
+		"Glob",
+		"Grep",
+		"NotebookEdit",
+		"Read",
+		"Task",
+		"TodoWrite",
+		"WebFetch",
+		"WebSearch",
+		"Write",
+	}
 }
 
 // appendClaudeCodeArgs appends ClaudeCode-specific flags to args.

--- a/pipeline/handlers/backend_claudecode.go
+++ b/pipeline/handlers/backend_claudecode.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -218,8 +219,10 @@ func buildArgs(cfg pipeline.AgentRunConfig) ([]string, error) {
 		}
 		// Override AllowedTools (don't trust caller-provided allowlist when
 		// tool_access is set — that would be the Params-bypass shape).
+		// Use slices.Clone so callers can't accidentally mutate the
+		// package-level canonical list via the assigned DisallowedTools.
 		ccCfg.AllowedTools = nil
-		ccCfg.DisallowedTools = canonicalClaudeCodeDenyListCopy()
+		ccCfg.DisallowedTools = slices.Clone(canonicalClaudeCodeToolDenyList)
 	}
 
 	if ccCfg == nil {
@@ -227,27 +230,6 @@ func buildArgs(cfg pipeline.AgentRunConfig) ([]string, error) {
 	}
 
 	return appendClaudeCodeArgs(args, ccCfg)
-}
-
-// canonicalClaudeCodeDenyListCopy returns a fresh copy of the canonical
-// tool name list used to deny the CLI's tool surface when tool_access is
-// set. Mirrors the list in codergen.go's applyClaudeCodeToolAccess —
-// kept here to avoid exporting that list across the package boundary.
-// Issue: github.com/2389-research/tracker#258.
-func canonicalClaudeCodeDenyListCopy() []string {
-	return []string{
-		"Bash",
-		"Edit",
-		"Glob",
-		"Grep",
-		"NotebookEdit",
-		"Read",
-		"Task",
-		"TodoWrite",
-		"WebFetch",
-		"WebSearch",
-		"Write",
-	}
 }
 
 // appendClaudeCodeArgs appends ClaudeCode-specific flags to args.

--- a/pipeline/handlers/backend_native.go
+++ b/pipeline/handlers/backend_native.go
@@ -98,9 +98,20 @@ func (b *NativeBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig, em
 // buildSessionConfig returns the SessionConfig to use for a run.
 // If cfg.Extra carries a pre-built *agent.SessionConfig it is used directly;
 // otherwise a default config is built from the AgentRunConfig fields.
+//
+// tool_access enforcement (issue #258): regardless of whether Extra carries
+// a pre-built SessionConfig or we build fresh, the directive on the
+// AgentRunConfig must end up on the SessionConfig — direct callers (tests,
+// integrators) that construct AgentRunConfig manually would otherwise
+// bypass enforcement because Extra is nil and applyRunConfigOverrides
+// previously dropped the field.
 func (b *NativeBackend) buildSessionConfig(cfg pipeline.AgentRunConfig) agent.SessionConfig {
 	if sc, ok := cfg.Extra.(*agent.SessionConfig); ok && sc != nil {
-		return *sc
+		out := *sc
+		if cfg.ToolAccess != "" && out.ToolAccess == "" {
+			out.ToolAccess = cfg.ToolAccess
+		}
+		return out
 	}
 	return applyRunConfigOverrides(agent.DefaultConfig(), cfg)
 }
@@ -121,6 +132,12 @@ func applyRunConfigOverrides(base agent.SessionConfig, cfg pipeline.AgentRunConf
 	}
 	if cfg.WorkingDir != "" {
 		base.WorkingDir = cfg.WorkingDir
+	}
+	// tool_access enforcement (issue #258): propagate the directive to the
+	// SessionConfig so direct AgentRunConfig callers (not just CodergenHandler)
+	// get the empty-registry / ToolChoice=none defenses.
+	if cfg.ToolAccess != "" {
+		base.ToolAccess = cfg.ToolAccess
 	}
 	return base
 }

--- a/pipeline/handlers/backend_native.go
+++ b/pipeline/handlers/backend_native.go
@@ -108,7 +108,13 @@ func (b *NativeBackend) Run(ctx context.Context, cfg pipeline.AgentRunConfig, em
 func (b *NativeBackend) buildSessionConfig(cfg pipeline.AgentRunConfig) agent.SessionConfig {
 	if sc, ok := cfg.Extra.(*agent.SessionConfig); ok && sc != nil {
 		out := *sc
-		if cfg.ToolAccess != "" && out.ToolAccess == "" {
+		// Inherit cfg.ToolAccess whenever the pre-built SessionConfig
+		// is not already restricted under the canonical (whitespace-
+		// trimmed) check. Using `out.ToolAccess == ""` alone would
+		// treat a whitespace-only value like " " as "set" — but
+		// IsToolAccessRestricted considers it unrestricted, so the
+		// AgentRunConfig directive should override.
+		if cfg.ToolAccess != "" && !out.IsToolAccessRestricted() {
 			out.ToolAccess = cfg.ToolAccess
 		}
 		return out

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -222,6 +222,7 @@ func (h *CodergenHandler) buildRunConfig(node *pipeline.Node, prompt string, bac
 		Provider:     sessionCfg.Provider,
 		WorkingDir:   sessionCfg.WorkingDir,
 		MaxTurns:     sessionCfg.MaxTurns,
+		ToolAccess:   sessionCfg.ToolAccess,
 	}
 
 	// Build backend-specific Extra config.
@@ -271,6 +272,7 @@ func parseClaudeCodeToolAttrs(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeCon
 		return err
 	}
 	applyToolLists(node, ccCfg)
+	applyClaudeCodeToolAccess(node, ccCfg)
 	if err := pipeline.ValidateToolLists(ccCfg.AllowedTools, ccCfg.DisallowedTools); err != nil {
 		return fmt.Errorf("node %q: %w", node.ID, err)
 	}
@@ -292,13 +294,68 @@ func applyMCPServers(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) erro
 }
 
 // applyToolLists sets AllowedTools and DisallowedTools from node attrs if present.
+//
+// tool_access enforcement (issue #258): when the node carries
+// `tool_access: <any>`, the Params bypass keys `allowed_tools` and
+// `disallowed_tools` are ignored — they could otherwise re-enable tools
+// the directive intends to deny. For the claude-code backend, the deny
+// list is set explicitly by applyClaudeCodeToolAccess (best-effort
+// enumeration of canonical tool names).
 func applyToolLists(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) {
+	if isNodeToolAccessRestricted(node) {
+		return
+	}
 	if raw := node.Attrs["allowed_tools"]; raw != "" {
 		ccCfg.AllowedTools = pipeline.ParseToolList(raw)
 	}
 	if raw := node.Attrs["disallowed_tools"]; raw != "" {
 		ccCfg.DisallowedTools = pipeline.ParseToolList(raw)
 	}
+}
+
+// isNodeToolAccessRestricted reports whether the node's `tool_access` attr
+// is set to any non-empty (canonical) value. Mirrors
+// agent.SessionConfig.IsToolAccessRestricted; defined here to avoid an
+// import cycle. Issue: github.com/2389-research/tracker#258.
+func isNodeToolAccessRestricted(node *pipeline.Node) bool {
+	return strings.TrimSpace(node.Attrs["tool_access"]) != ""
+}
+
+// canonicalClaudeCodeToolDenyList is the best-effort enumeration of
+// Claude Code tool names used to populate the CLI's --disallowed-tools
+// when `tool_access: <any>` is set on a node that targets the claude-code
+// backend. Kept in sync with the names the Claude Code CLI recognizes;
+// a stricter approach (fail backend creation) is taken for backends
+// where we cannot verify the deny spelling — see backend_acp.go.
+//
+// Issue: github.com/2389-research/tracker#258.
+var canonicalClaudeCodeToolDenyList = []string{
+	"Bash",
+	"Edit",
+	"Glob",
+	"Grep",
+	"NotebookEdit",
+	"Read",
+	"Task",
+	"TodoWrite",
+	"WebFetch",
+	"WebSearch",
+	"Write",
+}
+
+// applyClaudeCodeToolAccess applies the `tool_access` directive to the
+// claude-code backend by populating DisallowedTools with the canonical
+// tool name list. If the node also carried `allowed_tools` or
+// `disallowed_tools`, applyToolLists already short-circuited and the
+// caller-supplied lists are ignored — by design.
+func applyClaudeCodeToolAccess(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) {
+	if !isNodeToolAccessRestricted(node) {
+		return
+	}
+	ccCfg.AllowedTools = nil
+	denied := make([]string, len(canonicalClaudeCodeToolDenyList))
+	copy(denied, canonicalClaudeCodeToolDenyList)
+	ccCfg.DisallowedTools = denied
 }
 
 // parseClaudeCodeBudgetAttrs parses max_budget_usd and permission_mode.
@@ -326,7 +383,15 @@ func applyMaxBudget(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) error
 }
 
 // applyPermissionMode parses and applies the permission_mode attribute if present.
+//
+// tool_access enforcement (issue #258): when the node carries
+// `tool_access: <any>`, the Params bypass key `permission_mode` is
+// ignored — `permission_mode: bypassPermissions` or `acceptEdits` could
+// otherwise re-enable tool execution the directive intends to deny.
 func applyPermissionMode(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) error {
+	if isNodeToolAccessRestricted(node) {
+		return nil
+	}
 	raw, ok := node.Attrs["permission_mode"]
 	if !ok || raw == "" {
 		return nil
@@ -604,6 +669,14 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	}
 	if cfg.PlanBeforeExecuteSet {
 		config.PlanBeforeExecute = cfg.PlanBeforeExecute
+	}
+
+	// tool_access enforcement (issue #258): thread the directive from the
+	// node's AgentConfig into SessionConfig. The session's IsToolAccessRestricted
+	// helper does the canonical case-insensitive, whitespace-trimmed check.
+	// Any non-empty value disables tools (fail-closed for typos).
+	if cfg.ToolAccess != "" {
+		config.ToolAccess = cfg.ToolAccess
 	}
 
 	return config

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -322,8 +323,9 @@ func isNodeToolAccessRestricted(node *pipeline.Node) bool {
 }
 
 // canonicalClaudeCodeToolDenyList is the best-effort enumeration of
-// Claude Code tool names used to populate the CLI's --disallowed-tools
-// when `tool_access: <any>` is set on a node that targets the claude-code
+// Claude Code tool names used to populate the CLI's --disallowedTools
+// flag (see appendToolFlags / buildArgs for the actual invocation) when
+// `tool_access: <any>` is set on a node that targets the claude-code
 // backend. Kept in sync with the names the Claude Code CLI recognizes;
 // a stricter approach (fail backend creation) is taken for backends
 // where we cannot verify the deny spelling — see backend_acp.go.
@@ -353,9 +355,9 @@ func applyClaudeCodeToolAccess(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeCo
 		return
 	}
 	ccCfg.AllowedTools = nil
-	denied := make([]string, len(canonicalClaudeCodeToolDenyList))
-	copy(denied, canonicalClaudeCodeToolDenyList)
-	ccCfg.DisallowedTools = denied
+	// Clone so a downstream mutator on ccCfg.DisallowedTools can't drift
+	// the package-level canonical list.
+	ccCfg.DisallowedTools = slices.Clone(canonicalClaudeCodeToolDenyList)
 }
 
 // parseClaudeCodeBudgetAttrs parses max_budget_usd and permission_mode.

--- a/pipeline/handlers/tool_access_test.go
+++ b/pipeline/handlers/tool_access_test.go
@@ -198,3 +198,93 @@ func TestACPBackend_RefusesAnyNonEmptyToolAccess(t *testing.T) {
 		})
 	}
 }
+
+// TestNativeBackend_DirectRunBypass_AppliesToolAccess covers the bypass
+// path Codex flagged on PR #259: a direct AgentRunConfig caller (not via
+// CodergenHandler) sets cfg.ToolAccess but cfg.Extra is nil — the
+// SessionConfig that NativeBackend ultimately constructs must still
+// inherit the directive.
+func TestNativeBackend_DirectRunBypass_AppliesToolAccess(t *testing.T) {
+	b := &NativeBackend{}
+
+	// No Extra → applyRunConfigOverrides path.
+	cfg := pipeline.AgentRunConfig{ToolAccess: "none"}
+	sc := b.buildSessionConfig(cfg)
+	if !sc.IsToolAccessRestricted() {
+		t.Error("buildSessionConfig with cfg.ToolAccess=none and nil Extra did not set SessionConfig.ToolAccess")
+	}
+
+	// Pre-built Extra without ToolAccess → must inherit from cfg.ToolAccess.
+	cfg2 := pipeline.AgentRunConfig{
+		ToolAccess: "none",
+		Extra:      &agent.SessionConfig{Model: "claude-sonnet-4-6"}, // ToolAccess unset
+	}
+	sc2 := b.buildSessionConfig(cfg2)
+	if !sc2.IsToolAccessRestricted() {
+		t.Error("buildSessionConfig with cfg.ToolAccess=none and Extra missing ToolAccess did not inherit the directive")
+	}
+}
+
+// TestApplyRunConfigOverrides_PropagatesToolAccess confirms the field is
+// copied onto base when set. Without this, NativeBackend's direct-caller
+// path (no Extra) would silently drop the directive.
+func TestApplyRunConfigOverrides_PropagatesToolAccess(t *testing.T) {
+	base := agent.SessionConfig{}
+	cfg := pipeline.AgentRunConfig{ToolAccess: "none"}
+	out := applyRunConfigOverrides(base, cfg)
+	if out.ToolAccess != "none" {
+		t.Errorf("applyRunConfigOverrides dropped ToolAccess; got %q expected %q", out.ToolAccess, "none")
+	}
+}
+
+// TestClaudeCodeBuildArgs_DirectRunBypass_PopulatesDenyList covers the
+// claude-code equivalent of the Codex-flagged bypass: a direct
+// AgentRunConfig caller sets cfg.ToolAccess but cfg.Extra has no deny
+// list. The CLI args must still carry --disallowedTools with the
+// canonical names.
+func TestClaudeCodeBuildArgs_DirectRunBypass_PopulatesDenyList(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  pipeline.AgentRunConfig
+	}{
+		{
+			"no Extra",
+			pipeline.AgentRunConfig{ToolAccess: "none"},
+		},
+		{
+			"Extra with empty ClaudeCodeConfig",
+			pipeline.AgentRunConfig{
+				ToolAccess: "none",
+				Extra:      &pipeline.ClaudeCodeConfig{},
+			},
+		},
+		{
+			"Extra with caller-provided AllowedTools (must be cleared)",
+			pipeline.AgentRunConfig{
+				ToolAccess: "none",
+				Extra: &pipeline.ClaudeCodeConfig{
+					AllowedTools: []string{"Bash", "Read"}, // bypass attempt
+				},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			args, err := buildArgs(tc.cfg)
+			if err != nil {
+				t.Fatalf("buildArgs error: %v", err)
+			}
+			joined := strings.Join(args, " ")
+			if !strings.Contains(joined, "--disallowedTools") {
+				t.Errorf("--disallowedTools missing from args under tool_access=none: %v", args)
+			}
+			if !strings.Contains(joined, "Bash") || !strings.Contains(joined, "Write") {
+				t.Errorf("canonical tool names missing from --disallowedTools args: %v", args)
+			}
+			// AllowedTools must NOT be set even if a caller tried to bypass.
+			if strings.Contains(joined, "--allowedTools") {
+				t.Errorf("--allowedTools leaked into args under tool_access=none (bypass-defense regression): %v", args)
+			}
+		})
+	}
+}

--- a/pipeline/handlers/tool_access_test.go
+++ b/pipeline/handlers/tool_access_test.go
@@ -1,0 +1,200 @@
+// ABOUTME: Tests for tool_access enforcement at the pipeline/handlers layer
+// ABOUTME: (issue #258). Covers the Params-bypass defense in codergen
+// ABOUTME: (allowed_tools/disallowed_tools/permission_mode ignored when
+// ABOUTME: tool_access is set), the claude-code best-effort DisallowedTools
+// ABOUTME: enumeration, and the ACP backend refusal.
+package handlers
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// TestCodergenBuildConfig_ThreadsToolAccess confirms the directive flows from
+// node.Attrs["tool_access"] through to agent.SessionConfig.ToolAccess.
+func TestCodergenBuildConfig_ThreadsToolAccess(t *testing.T) {
+	h := NewCodergenHandler(nil, "/tmp")
+	node := &pipeline.Node{
+		ID:    "test",
+		Attrs: map[string]string{"tool_access": "none"},
+	}
+	cfg := h.buildConfig(node)
+	if cfg.ToolAccess != "none" {
+		t.Errorf("ToolAccess on SessionConfig = %q; expected %q", cfg.ToolAccess, "none")
+	}
+	if !cfg.IsToolAccessRestricted() {
+		t.Error("IsToolAccessRestricted() = false; expected true under tool_access=none")
+	}
+}
+
+// TestApplyToolLists_BypassDefense confirms that when tool_access is set,
+// the allowed_tools and disallowed_tools Params keys are ignored. This is
+// the v0.28.2 bypass defense — an LLM-authored .dip can't re-enable tools
+// via the existing Params keys.
+func TestApplyToolLists_BypassDefense(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolAccess string
+	}{
+		{"explicit none", "none"},
+		{"typo noen", "noen"},
+		{"uppercase NONE", "NONE"},
+		{"whitespace", "  none  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			node := &pipeline.Node{
+				ID: "test",
+				Attrs: map[string]string{
+					"tool_access":      tc.toolAccess,
+					"allowed_tools":    "Bash,Read",
+					"disallowed_tools": "Write",
+				},
+			}
+			ccCfg := &pipeline.ClaudeCodeConfig{}
+			applyToolLists(node, ccCfg)
+			if len(ccCfg.AllowedTools) != 0 {
+				t.Errorf("AllowedTools = %v; expected nil under tool_access=%q (bypass defense)", ccCfg.AllowedTools, tc.toolAccess)
+			}
+			if len(ccCfg.DisallowedTools) != 0 {
+				t.Errorf("DisallowedTools = %v; expected nil under tool_access=%q", ccCfg.DisallowedTools, tc.toolAccess)
+			}
+		})
+	}
+}
+
+// TestApplyToolLists_Unrestricted confirms the bypass defense doesn't fire
+// when tool_access is empty — the existing allowed_tools/disallowed_tools
+// passthrough still works.
+func TestApplyToolLists_Unrestricted(t *testing.T) {
+	node := &pipeline.Node{
+		ID: "test",
+		Attrs: map[string]string{
+			"allowed_tools":    "Bash,Read",
+			"disallowed_tools": "Write",
+		},
+	}
+	ccCfg := &pipeline.ClaudeCodeConfig{}
+	applyToolLists(node, ccCfg)
+	if len(ccCfg.AllowedTools) != 2 {
+		t.Errorf("AllowedTools length = %d; expected 2 when tool_access is empty", len(ccCfg.AllowedTools))
+	}
+	if len(ccCfg.DisallowedTools) != 1 {
+		t.Errorf("DisallowedTools length = %d; expected 1 when tool_access is empty", len(ccCfg.DisallowedTools))
+	}
+}
+
+// TestApplyPermissionMode_BypassDefense confirms that when tool_access is
+// set, the permission_mode Params key is ignored — a node author can't
+// set permission_mode=bypassPermissions to re-enable tool execution.
+func TestApplyPermissionMode_BypassDefense(t *testing.T) {
+	node := &pipeline.Node{
+		ID: "test",
+		Attrs: map[string]string{
+			"tool_access":     "none",
+			"permission_mode": "bypassPermissions",
+		},
+	}
+	ccCfg := &pipeline.ClaudeCodeConfig{}
+	if err := applyPermissionMode(node, ccCfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ccCfg.PermissionMode != "" {
+		t.Errorf("PermissionMode = %q; expected empty under tool_access=none (bypass defense)", ccCfg.PermissionMode)
+	}
+}
+
+// TestApplyClaudeCodeToolAccess populates DisallowedTools with the canonical
+// list when tool_access is set on a claude-code-backend node.
+func TestApplyClaudeCodeToolAccess(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "test",
+		Attrs: map[string]string{"tool_access": "none"},
+	}
+	ccCfg := &pipeline.ClaudeCodeConfig{}
+	applyClaudeCodeToolAccess(node, ccCfg)
+
+	if len(ccCfg.AllowedTools) != 0 {
+		t.Errorf("AllowedTools should be nil after applyClaudeCodeToolAccess; got %v", ccCfg.AllowedTools)
+	}
+	if len(ccCfg.DisallowedTools) == 0 {
+		t.Fatal("DisallowedTools is empty after applyClaudeCodeToolAccess; expected canonical deny list")
+	}
+	for _, expected := range []string{"Bash", "Read", "Write", "Edit", "Glob", "Grep"} {
+		found := false
+		for _, name := range ccCfg.DisallowedTools {
+			if name == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("canonical tool %q missing from DisallowedTools %v", expected, ccCfg.DisallowedTools)
+		}
+	}
+}
+
+// TestApplyClaudeCodeToolAccess_NoOpWhenUnrestricted confirms the deny list
+// isn't populated when tool_access is empty — existing claude-code configs
+// (with their own allowed_tools/disallowed_tools/permission_mode) are
+// unaffected.
+func TestApplyClaudeCodeToolAccess_NoOpWhenUnrestricted(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "test",
+		Attrs: map[string]string{},
+	}
+	ccCfg := &pipeline.ClaudeCodeConfig{
+		AllowedTools: []string{"PreviouslyAllowed"},
+	}
+	applyClaudeCodeToolAccess(node, ccCfg)
+	if len(ccCfg.AllowedTools) != 1 || ccCfg.AllowedTools[0] != "PreviouslyAllowed" {
+		t.Errorf("AllowedTools mutated under unrestricted tool_access: %v", ccCfg.AllowedTools)
+	}
+	if len(ccCfg.DisallowedTools) != 0 {
+		t.Errorf("DisallowedTools populated under unrestricted tool_access: %v", ccCfg.DisallowedTools)
+	}
+}
+
+// TestACPBackend_RefusesToolAccess confirms the ACP backend returns a clear
+// error when tool_access is non-empty — no verified deny-equivalent yet, so
+// per spec "fallback unsupported → refuse" the session is refused rather
+// than allowed through.
+func TestACPBackend_RefusesToolAccess(t *testing.T) {
+	b := &ACPBackend{}
+	cfg := pipeline.AgentRunConfig{
+		Prompt:     "test",
+		ToolAccess: "none",
+	}
+	_, err := b.Run(context.Background(), cfg, func(agent.Event) {})
+	if err == nil {
+		t.Fatal("expected error from ACP backend under tool_access=none; got nil")
+	}
+	if !strings.Contains(err.Error(), "tool_access") {
+		t.Errorf("error did not mention tool_access: %v", err)
+	}
+	if !strings.Contains(err.Error(), "#258") {
+		t.Errorf("error did not reference issue #258 for follow-up context: %v", err)
+	}
+}
+
+// TestACPBackend_RefusesAnyNonEmptyToolAccess confirms fail-closed behavior
+// — even a typo or unrecognized value triggers refusal.
+func TestACPBackend_RefusesAnyNonEmptyToolAccess(t *testing.T) {
+	b := &ACPBackend{}
+	for _, val := range []string{"noen", "off", "X", "  none  "} {
+		t.Run(val, func(t *testing.T) {
+			cfg := pipeline.AgentRunConfig{
+				Prompt:     "test",
+				ToolAccess: val,
+			}
+			_, err := b.Run(context.Background(), cfg, func(agent.Event) {})
+			if err == nil {
+				t.Fatalf("ToolAccess=%q: expected refusal; got nil error", val)
+			}
+		})
+	}
+}

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -33,6 +33,14 @@ type AgentNodeConfig struct {
 	PermissionMode  string
 	ACPAgent        string
 
+	// ToolAccess restricts the agent's tool surface. When non-empty (any
+	// value), the runtime registers zero tools, sets ToolChoice=none on
+	// LLM requests, scrubs tool-naming text from the system prompt, and
+	// rejects Params bypass keys. Canonical: case-insensitive, whitespace-
+	// trimmed. Fail-closed for typos. See agent.SessionConfig.ToolAccess.
+	// Issue: github.com/2389-research/tracker#258.
+	ToolAccess string
+
 	AutoStatus        bool
 	ReflectOnError    bool // initialized to true by AgentConfig; explicit "false" disables
 	ReflectOnErrorSet bool // true when the attr was present on the node
@@ -88,6 +96,7 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	cfg.AllowedTools = n.Attrs["allowed_tools"]
 	cfg.DisallowedTools = n.Attrs["disallowed_tools"]
 	cfg.PermissionMode = n.Attrs["permission_mode"]
+	cfg.ToolAccess = n.Attrs["tool_access"]
 	cfg.ACPAgent = n.Attrs["acp_agent"]
 	cfg.SystemPrompt = n.Attrs["system_prompt"]
 	cfg.ResponseFormat = n.Attrs["response_format"]

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -21,9 +21,14 @@ import (
 	"github.com/2389-research/tracker/pipeline"
 )
 
-// PinnedDippinVersion is the dippin-lang version from go.mod.
-// Keep in sync with the require line in go.mod.
-const PinnedDippinVersion = "v0.29.0"
+// PinnedDippinVersion is the dippin-lang version from go.mod. Kept in sync
+// with go.mod by TestPinnedDippinVersionMatchesGoMod.
+//
+// During the joint tracker #258 + dippin-lang #41 release window this is a
+// pseudo-version pinned to the dippin merge SHA. After dippin tags v0.32.0
+// this swaps to "v0.32.0" in a follow-up commit (see github.com/2389-research/tracker#258
+// for the coordination plan).
+const PinnedDippinVersion = "v0.31.1-0.20260526211025-53c24f13a4d0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
Closes [#258](https://github.com/2389-research/tracker/issues/258). Pairs with [dippin-lang#41](https://github.com/2389-research/dippin-lang/issues/41).

## Summary

Bounds the v0.28.2 single-agent multi-tool-call vector: an LLM that emits multiple tool calls in one response (e.g. `[bash("rm -rf"), write("payload"), bash("./payload")]`) would otherwise have all of them dispatched before `max_turns` checks the cap. With `tool_access: none` set on an agent node, tracker now hands the LLM **zero tools** so the response comes back as plain text.

Implementation follows the upstream spec at [dippin-lang/docs/superpowers/specs/2026-05-26-issue-41-design.md § Tracker-side design](https://github.com/2389-research/dippin-lang/blob/main/docs/superpowers/specs/2026-05-26-issue-41-design.md).

## Defense in depth — three independent gates

1. **Built-in registry gate** — `agent.builtInToolsForConfig` returns `nil` when `ToolAccess` is set.
2. **Post-WithTools clear** — `agent.NewSession` clears the registry after all options apply, catching `WithTools(...)` bypass.
3. **executeToolCalls early-exit** — if the LLM emits tool calls despite `ToolChoice=none` (mock, retry, provider that ignored the signal), zero of them execute.

Plus the API-side signal:
- `request.Tools = nil` and `request.ToolChoice = llm.ToolChoiceNone()` so the provider itself blocks invocation.
- System prompt scrubbed: no standalone case-insensitive `read`/`write`/`edit`/`glob`/`grep_search`/`bash`/`apply_patch`.

## Params-bypass defense

`pipeline/handlers/codergen.go` ignores `allowed_tools`/`disallowed_tools`/`permission_mode` Params keys when `tool_access` is set — a node author can't set `permission_mode=bypassPermissions` to re-enable tool execution.

## Fail-closed on typos

`tool_access: noen` / `None` / `  none  ` / `NONE` / `off` / `x` all trip the restriction. The only recognized spelling is `none`; any other non-empty value still disables tools so a lint-skipped misspelling can't ship full tools.

## Backend compatibility

| Backend | Behavior |
|---|---|
| **Native** | Full honor via `agent.SessionConfig.ToolAccess`. |
| **claude-code** | Best-effort: `applyClaudeCodeToolAccess` populates `DisallowedTools` with canonical Claude Code tool names (`Bash`, `Edit`, `Glob`, `Grep`, `NotebookEdit`, `Read`, `Task`, `TodoWrite`, `WebFetch`, `WebSearch`, `Write`) so the CLI denies the surface. |
| **ACP** | Refuses session creation with a clear error pointing to #258. ACP's deny-equivalent spelling hasn't been verified against each upstream agent (claude-code-acp, codex-acp, gemini); per the spec's "fallback unsupported → refuse" rule, refusing is safer than shipping a soft-no that silently allows execution. Follow-up issue can lift this once each ACP agent's deny mechanism is audited. |

## Joint-release coordination

Per the issue body:
- **This PR opens first and lands on `main` but is NOT tagged.**
- dippin-lang's PR opens in parallel (using `go.mod replace ../tracker` or commit pin during the PR window).
- After both PRs are approved: tag tracker → bump dippin go.mod → tag dippin v0.32.0 immediately after.

No advisory window — the dippin field does not ship in a tagged release until tracker enforcement is also tagged.

## Test Plan

- [x] `TestSessionToolAccess_RedTeamMultiToolCall` — the dispositive v0.28.2 test. Mock LLM returns single response with three tool calls; assert zero executions, `result.TotalToolCalls() == 0`, request had no tools, `ToolChoice.Mode == "none"`
- [x] `TestSessionToolAccess_RestrictedRegistry_EmptyAfterWithTools` — `WithTools` bypass defense
- [x] `TestSessionToolAccess_FailClosedOnTypo` — `noen`/`None`/`  none  `/`NONE`/`off`/`x` all disable
- [x] `TestSessionToolAccess_EmptyMeansUnrestricted` — empty string preserves existing behavior
- [x] `TestSessionToolAccess_SystemPromptScrub` — no standalone case-insensitive tool names in assembled prompt
- [x] `TestApplyToolLists_BypassDefense` + `TestApplyPermissionMode_BypassDefense` — Params keys ignored
- [x] `TestApplyClaudeCodeToolAccess` + `_NoOpWhenUnrestricted` — canonical deny list, no-op when unrestricted
- [x] `TestACPBackend_RefusesToolAccess` + `_RefusesAnyNonEmptyToolAccess` — ACP refusal
- [x] `go build ./...` clean
- [x] `go test ./... -short` — all 19 packages pass
- [x] `dippin doctor examples/build_product.dip` — A/100
- [x] `tracker validate examples/build_product.dip` — clean
- [x] `make check-workflows` — in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782423256&installation_id=131176874&pr_number=259&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F259&signature=ca5b0b3e9161b256659b55e1fd6970fd728a4c2a483c02109b141e2e3d3f8c26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a node-level tool_access option: any non-empty value (e.g., "none") fail-closes tool usage—removes tool surface and related prompt instructions, blocks tool dispatch/execution, short-circuits emitted tool calls, and enforces backend-specific handling (native/claude-code apply deny-lists; ACP refuses sessions).

* **Tests**
  * Added comprehensive tests covering multi-tool-call resistance, registry clearing, fail-closed parsing, system-prompt scrubbing, bypass defenses, backend deny-listing, and ACP refusal behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->