### PR TITLE
fix(pipeline): parseAutoStatus tolerates markdown emphasis on STATUS lines (#233 Gap 5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`parseAutoStatus` tolerates markdown-emphasis on STATUS lines** ([#233](https://github.com/2389-research/tracker/issues/233) Gap 5.1). The original `build_product` audit observed a `FinalSpecCheck` run where the agent emitted `**STATUS: fail**` (bold) and the parser silently fell back to the default `success` because `HasPrefix("**STATUS:", "STATUS:")` returns false. LLMs commonly bold/italicize STATUS lines when they want the verdict to draw the eye — the parser was treating these as no-STATUS-found and the inverted Gap 7 contract was the only thing preventing fail-open on a real bug. Fix: `parseStatusLine` now `strings.Trim`s the line and value with the `"*_"` cutset before the prefix check + switch, so `**STATUS: fail**` / `*STATUS: fail*` / `STATUS: **fail**` / `__STATUS: success__` / etc. all parse correctly. Locked semantics from `TestParseAutoStatus_V3FailFirstContract` are unchanged: last-line-wins + default-success-on-empty. New regression coverage in `TestParseAutoStatus_Gap5_1_AuditedShapes` (11 sub-tests) — six previously RED, now GREEN; five pin existing behavior (uppercase value, whitespace trimming, last-wins under emphasis, code-fence skip). Closes Gap 5.1 of the #233 audit recap. Gap 5.2 (`OutcomeHumanOverride`) and Gap 5.3 (re-run `FinalSpecCheck` after `ApplyReviewFixes`) remain as separate follow-ups.
+
 ## [0.32.0] - 2026-05-27
 
 ### Changed

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -732,11 +732,22 @@ func parseAutoStatus(text string) string {
 
 // parseStatusLine extracts the status value from a "STATUS: ..." line.
 // Returns "" if the line is not a valid STATUS directive.
+//
+// Markdown-emphasis tolerance (issue #233 Gap 5.1): LLMs commonly emit
+// `**STATUS: fail**` or `STATUS: **fail**` when they want the directive
+// to draw the eye. strings.Trim with the "*_" cutset strips any
+// combination of leading/trailing markdown emphasis markers (bold `**`,
+// italic `*`, underscore-bold `__`, underscore-italic `_`) from both
+// the full line and the value portion, so the prefix check and value
+// switch see the bare token.
 func parseStatusLine(trimmed string) string {
+	trimmed = strings.Trim(trimmed, "*_")
 	if !strings.HasPrefix(strings.ToUpper(trimmed), "STATUS:") {
 		return ""
 	}
-	switch strings.ToLower(strings.TrimSpace(trimmed[len("STATUS:"):])) {
+	value := strings.TrimSpace(trimmed[len("STATUS:"):])
+	value = strings.Trim(value, "*_")
+	switch strings.ToLower(value) {
 	case "success":
 		return pipeline.OutcomeSuccess
 	case "fail":

--- a/pipeline/handlers/codergen_test.go
+++ b/pipeline/handlers/codergen_test.go
@@ -1269,3 +1269,123 @@ func TestParseAutoStatus_V3FailFirstContract(t *testing.T) {
 		})
 	}
 }
+
+// TestParseAutoStatus_Gap5_1_AuditedShapes covers the LLM-emitted STATUS-line
+// variations the original #233 audit named as parser misses:
+// `**STATUS: fail**` (markdown bold) and `STATUS: FAIL` (uppercase value).
+// Plus adjacent shapes that exercise the same parsing seams: italic, value-
+// only bold, leading/trailing whitespace, mid-response position.
+//
+// Discipline: these tests MUST go RED before they go GREEN if the parser
+// is changing semantics. Tests that go GREEN on first run document existing
+// behavior — flagged inline.
+//
+// Locked semantics from TestParseAutoStatus_V3FailFirstContract that this
+// test must NOT break: (a) last-line-wins, (b) default success on no STATUS.
+//
+// Issue: github.com/2389-research/tracker#233 Gap 5.1.
+func TestParseAutoStatus_Gap5_1_AuditedShapes(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect string
+		note   string
+	}{
+		// --- The two shapes the audit named ---
+		{
+			name:   "bold full-line: **STATUS: fail**",
+			input:  "**STATUS: fail**",
+			expect: pipeline.OutcomeFail,
+			note:   "RED→GREEN: parser pre-Gap-5.1 rejects because HasPrefix('**STATUS:', 'STATUS:') is false. Audit-named regression.",
+		},
+		{
+			name:   "uppercase value: STATUS: FAIL",
+			input:  "STATUS: FAIL",
+			expect: pipeline.OutcomeFail,
+			note:   "GREEN-on-first-run: parser already lowercases the value via strings.ToLower — pin existing behavior. Audit's uppercase claim may have predated the lower-case normalization.",
+		},
+
+		// --- Variations on the bold shape (incidental coverage from same fix) ---
+		{
+			name:   "bold no space: **STATUS:fail**",
+			input:  "**STATUS:fail**",
+			expect: pipeline.OutcomeFail,
+			note:   "RED→GREEN: same surrounding-emphasis miss as audit-named case.",
+		},
+		{
+			name:   "italic full-line: *STATUS: fail*",
+			input:  "*STATUS: fail*",
+			expect: pipeline.OutcomeFail,
+			note:   "RED→GREEN: same shape as bold; LLMs sometimes italicize for emphasis instead.",
+		},
+		{
+			name:   "bold value only: STATUS: **fail**",
+			input:  "STATUS: **fail**",
+			expect: pipeline.OutcomeFail,
+			note:   "RED→GREEN: prefix matches, but value 'fail' is wrapped in '**' so the switch falls through.",
+		},
+		{
+			name:   "bold success: **STATUS: success**",
+			input:  "**STATUS: success**",
+			expect: pipeline.OutcomeSuccess,
+			note:   "RED→GREEN: success value via the same emphasis shape (verifies the fix isn't fail-specific).",
+		},
+
+		// --- Position + whitespace variants (mostly GREEN-on-first-run) ---
+		{
+			name: "mid-response bold STATUS line surrounded by prose",
+			input: "I have completed the enumeration.\n" +
+				"Several interface methods lack production callers.\n" +
+				"**STATUS: fail**\n" +
+				"Recommend escalating to human review.",
+			expect: pipeline.OutcomeFail,
+			note:   "RED→GREEN: parser scans every non-fenced line so position is fine, but bold formatting still trips the prefix check.",
+		},
+		{
+			name:   "trailing whitespace: STATUS:fail   ",
+			input:  "STATUS:fail   ",
+			expect: pipeline.OutcomeFail,
+			note:   "GREEN-on-first-run: parseStatusLine trims the value via strings.TrimSpace — pin existing behavior.",
+		},
+		{
+			name:   "leading whitespace on line: '   STATUS:fail'",
+			input:  "   STATUS:fail",
+			expect: pipeline.OutcomeFail,
+			note:   "GREEN-on-first-run: parseAutoStatus trims each line before parseStatusLine — pin existing behavior.",
+		},
+
+		// --- Last-wins invariant must survive the emphasis-handling change ---
+		{
+			name: "last-wins still holds with bold mid-response",
+			input: "**STATUS: fail**\n" +
+				"... agent recovers and continues ...\n" +
+				"STATUS:success",
+			expect: pipeline.OutcomeSuccess,
+			note:   "Locked semantics: last-line-wins. The bold fail mid-response must not override a clean terminal success.",
+		},
+		{
+			name: "last-wins with bold terminal",
+			input: "STATUS:fail\n" +
+				"... checks ran ...\n" +
+				"**STATUS: success**",
+			expect: pipeline.OutcomeSuccess,
+			note:   "RED→GREEN: terminal bold success must override the early plain fail (Gap 7 inverted-contract case wearing bold).",
+		},
+
+		// --- Edge cases that should stay misses (NOT a regression to fix) ---
+		{
+			name:   "code-fence-wrapped bold STATUS stays ignored",
+			input:  "```text\n**STATUS: success**\n```",
+			expect: pipeline.OutcomeSuccess,
+			note:   "Behavior pinned: lines inside ``` fences are skipped regardless of emphasis. The default-success on no-STATUS-found rule applies. Locked from TestParseAutoStatus_V3FailFirstContract.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseAutoStatus(tc.input)
+			if got != tc.expect {
+				t.Errorf("parseAutoStatus(%q) = %q; want %q\n  note: %s", tc.input, got, tc.expect, tc.note)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes Gap 5.1 of [#233](https://github.com/2389-research/tracker/issues/233). Two Gap 5 sub-tasks remain (5.2 `OutcomeHumanOverride`, 5.3 re-run `FinalSpecCheck` after `ApplyReviewFixes`) — those will be separate PRs.

## The audit-observed bug

The original `build_product` audit recorded a `FinalSpecCheck` run where the agent emitted `**STATUS: fail**` (markdown bold) and the parser silently fell back to default `success` because `HasPrefix("**STATUS:", "STATUS:")` returns false. The Gap 7 inverted-contract opening (PR #254) was the only thing preventing fail-open — without it, bold-formatted verdicts would have silently shipped wrong-shape audit signals.

The audit named two shapes the parser missed:
1. **`**STATUS: fail**`** (bold) — confirmed RED locally
2. **`STATUS: FAIL`** (uppercase value) — actually GREEN now; the parser lowercases the value via `strings.ToLower`. Audit's uppercase claim may have predated this normalization. Pinned via test either way.

## The fix

`parseStatusLine` (`pipeline/handlers/codergen.go:735`) now `strings.Trim`s the line and value with the `"*_"` cutset BEFORE the prefix check and value switch. `strings.Trim` with a cutset strips ALL consecutive occurrences of the listed characters from both ends, so `**STATUS: fail**` → `STATUS: fail`, `***STATUS***` → `STATUS`, `__STATUS: success__` → `STATUS: success`. Underscore-emphasis comes free from the same fix.

```go
func parseStatusLine(trimmed string) string {
	trimmed = strings.Trim(trimmed, "*_")
	if !strings.HasPrefix(strings.ToUpper(trimmed), "STATUS:") {
		return ""
	}
	value := strings.TrimSpace(trimmed[len("STATUS:"):])
	value = strings.Trim(value, "*_")
	switch strings.ToLower(value) {
	case "success": return pipeline.OutcomeSuccess
	case "fail":    return pipeline.OutcomeFail
	case "retry":   return pipeline.OutcomeRetry
	}
	return ""
}
```

## Locked semantics preserved

`TestParseAutoStatus_V3FailFirstContract` still passes — the inverted-contract semantics that PR #254 relies on are unchanged:
- **Last-line-wins** (bold mid-response no longer silently skipped; it now contributes to the last-wins computation)
- **Default success on no-STATUS-found** (legacy default)
- **Code-fence lines skipped** (verified in the new test suite)

## Tests added

`TestParseAutoStatus_Gap5_1_AuditedShapes` — 11 sub-tests in `pipeline/handlers/codergen_test.go`. Per CLAUDE.md discipline, each sub-test's `note` flags whether it's RED→GREEN (fix-driven) or GREEN-on-first-run (pinning existing behavior):

| Shape | Status before fix | After fix |
|---|---|---|
| `**STATUS: fail**` | ❌ RED (audit-named) | ✅ GREEN |
| `**STATUS:fail**` | ❌ RED | ✅ GREEN |
| `*STATUS: fail*` (italic) | ❌ RED | ✅ GREEN |
| `STATUS: **fail**` (value-only bold) | ❌ RED | ✅ GREEN |
| `**STATUS: success**` | ❌ RED | ✅ GREEN |
| mid-response bold | ❌ RED | ✅ GREEN |
| last-wins with bold terminal | ❌ RED | ✅ GREEN |
| `STATUS: FAIL` (uppercase) | ✅ GREEN (pin) | ✅ GREEN |
| trailing/leading whitespace | ✅ GREEN (pin) | ✅ GREEN |
| last-wins under bold mid-response | ✅ GREEN (pin) | ✅ GREEN |
| code-fence-wrapped bold | ✅ GREEN (pin) | ✅ GREEN |

## Test plan

- [x] `TestParseAutoStatus_Gap5_1_AuditedShapes` — 11/11 pass
- [x] `TestParseAutoStatus_V3FailFirstContract` — 3/3 pass (locked semantics intact)
- [x] `go build ./...` — clean
- [x] `go test ./... -short` — all 19 packages pass
- [x] `gofmt -l .` — clean
- [x] `dippin doctor examples/build_product.dip` — A / 100

## #233 status

| Gap | Status |
|---|---|
| 1, 2, 3, 4, 6, 7, 8 | ✅ closed (v0.31.0) |
| **5.1** | ✅ this PR |
| 5.2 (`OutcomeHumanOverride`) | follow-up — wide blast radius per #258 brief; will audit `pipeline.Outcome` consumers before changing the enum |
| 5.3 (re-run `FinalSpecCheck` after `ApplyReviewFixes`) | follow-up — workflow edge change, `dippin simulate -all-paths` validates loop-freeness |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782498900&installation_id=131176874&pr_number=263&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F263&signature=1395d4b45cdc715f1f60b3a385c20675be752c7e23d7910355b4ba2e5d346885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * STATUS verdict parsing now tolerates markdown emphasis formatting, including bold and italic variations (e.g., `**STATUS: fail**`, `*STATUS: success*`). Improves compatibility with various output formats.

* **Tests**
  * Added comprehensive test coverage for multiple STATUS formatting styles and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2389-research/tracker/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->