### PR TITLE
docs(site): add v0.34.0 changelog entry

### DIFF
--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,8 +28,9 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
-    <a href="#v0-33-0">v0.33.0</a>
+    <a href="#v0-34-0">v0.34.0</a>
     <strong>Jump to:</strong>
+    <a href="#v0-33-0">v0.33.0</a>
     <a href="#v0-32-0">v0.32.0</a>
     <a href="#v0-31-0">v0.31.0</a>
     <a href="#v0-30-0">v0.30.0</a>
@@ -65,6 +66,20 @@ jsonld:
     <a href="#v0-9-x">v0.9.x</a>
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
+
+  <!-- ═══ v0.34.0 ═══ -->
+  <section class="glass" id="v0-34-0" style="border-left: 3px solid var(--orange-600);">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.34.0" style="color: inherit; text-decoration: none;">v0.34.0</a></h2>
+      <span class="badge">2026-05-27</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.34.0" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">The <code>workflows/</code> mirror is gone — built-in workflows are now embedded directly from <code>examples/</code> via explicit-file <code>//go:embed</code> lines (<a href="https://github.com/2389-research/tracker/issues/256">#256</a>). <strong>No functional change for CLI users.</strong> The library-API <code>WorkflowInfo.File</code> field now reports paths with the <code>examples/</code> prefix instead of <code>workflows/</code> — the only externally visible delta.</p>
+    <h4>Changed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong>Collapsed <code>workflows/</code> mirror into <code>examples/</code> via explicit-file <code>go:embed</code></strong> (<a href="https://github.com/2389-research/tracker/pull/267">#267</a>). The repo previously kept four byte-identical copies of the built-in workflow <code>.dip</code> files under <code>workflows/</code> and <code>examples/</code>, synchronized by a <code>make sync-workflows</code> / <code>make check-workflows</code> target, a pre-commit gate, and a CI step — guardrails that still let the two copies drift three times. The <code>//go:embed workflows/*.dip</code> glob is replaced with four explicit <code>//go:embed examples/&lt;name&gt;.dip</code> lines pointing directly at the canonical copies. The <code>workflows/</code> directory and all of the sync infrastructure (Makefile targets, pre-commit gate #9, CI <code>Embedded workflows in sync</code> step) are deleted. <code>WorkflowInfo.File</code> (library API) now reports paths with the <code>examples/</code> prefix instead of <code>workflows/</code>; that's the only externally visible delta. ~3,200 lines deleted net.</li>
+    </ul>
+  </section>
 
   <!-- ═══ v0.33.0 ═══ -->
   <section class="glass" id="v0-33-0" style="border-left: 3px solid var(--orange-600);">


### PR DESCRIPTION
Adds the v0.34.0 entry to the website changelog (mirrors how v0.30.0–v0.33.0 were handled).

- New TOC link to \`#v0-34-0\`
- New \`<section>\` above v0.33.0 covering #267 (the \`workflows/\` mirror collapsed into \`examples/\` via explicit-file \`go:embed\`)

No code changes. The Hugo workflow auto-rebuilds \`gh-pages\` on push to \`main\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782510377&installation_id=131176874&pr_number=269&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F269&signature=eb12ea4ef7e282c62f30c009b26e7b0c8638f975361c5ade33b8b18fb9dd172c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->