### PR TITLE
release: v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-06-02
+
+### Joint-release coordination
+
+`go.mod` pins `github.com/2389-research/dippin-lang` to the pseudo-version
+`v0.34.1-0.20260601154018-792e6e644e9f` — dippin's `main` HEAD commit
+`792e6e6`, which contains the matching `WritablePaths` and `Override` IR
+fields. dippin v0.35.0 is not yet tagged; the joint-release loop closes
+when dippin tags v0.35.0 pinning tracker v0.35.0 and tracker then publishes
+v0.35.1 swapping the pseudo-version for the tagged dippin (zero functional
+change). Same pattern as the v0.31.0 → v0.32.0 closeout.
+
 ### Added
 
 - **`writable_paths` fs-jail enforcement** (closes #272, paired with dippin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.35.0] - 2026-06-02
 
-### Joint-release coordination
-
-`go.mod` pins `github.com/2389-research/dippin-lang` to the pseudo-version
-`v0.34.1-0.20260601154018-792e6e644e9f` — dippin's `main` HEAD commit
-`792e6e6`, which contains the matching `WritablePaths` and `Override` IR
-fields. dippin v0.35.0 is not yet tagged; the joint-release loop closes
-when dippin tags v0.35.0 pinning tracker v0.35.0 and tracker then publishes
-v0.35.1 swapping the pseudo-version for the tagged dippin (zero functional
-change). Same pattern as the v0.31.0 → v0.32.0 closeout.
-
 ### Added
 
 - **`writable_paths` fs-jail enforcement** (closes #272, paired with dippin
@@ -63,6 +53,7 @@ change). Same pattern as the v0.31.0 → v0.32.0 closeout.
 
 ### Changed
 
+- **Joint-release coordination**: `go.mod` pins `github.com/2389-research/dippin-lang` to the pseudo-version `v0.34.1-0.20260601154018-792e6e644e9f` (dippin's `main` commit `792e6e6`), which contains the matching `WritablePaths` and `Override` IR fields. dippin v0.35.0 is not yet tagged; the loop closes when dippin tags v0.35.0 pinning tracker v0.35.0 and tracker then publishes v0.35.1 swapping to the tagged dippin version (zero functional change). Same pattern as the v0.31.0 → v0.32.0 closeout.
 - **Library-API delta**: `EngineResult.Status`, `tracker.Result.Status`, `tracker.AuditReport.Status`, `tracker.RunSummary.Status` are re-typed from `string` to `pipeline.TerminalStatus` (a named string type). Existing literal-string comparisons (`result.Status == "success"`) continue to compile and produce the same answer. Assignments from a `string` variable into a `Status` field require an explicit cast — this is the one breaking change in the re-typing. Embedded library callers should migrate to the new `TerminalStatus.IsSuccess()` helper for forward-compat across future status additions.
 - **New exported symbols** (additive): `pipeline.TerminalStatus` (type), `pipeline.OutcomeValidationOverridden`, `pipeline.OverrideDetail`, `pipeline.Actor` (type), `pipeline.ActorHuman` / `ActorAutopilot` / `ActorWebhook` / `ActorUnknown`, `pipeline.Edge.Override`, `pipeline.Outcome.ChildOverride`, `pipeline.Outcome.OverrideActor`, `pipeline.EngineResult.ValidationOverrides`, `pipeline.Checkpoint.ValidationOverrides`, `pipeline.EventValidationOverridden`, `pipeline.PipelineEvent.Override`, `pipeline.ErrValidationOverridden`. Plus mirrored fields on `tracker.Result`, `tracker.AuditReport`, `tracker.RunSummary`, `tracker.DiagnoseReport`.
 - `tracker_audit.AuditReport.Recommendations` is no longer alphabetically sorted — entries appear in priority order (override notes first, then per-override entries chronologically, then retry/budget notes). Downstream tools that sort on receipt are unaffected; tools that displayed in receive-order will see a different order.

--- a/site/content/_index.html
+++ b/site/content/_index.html
@@ -48,7 +48,7 @@ jsonld:
       Three agent backends &mdash; <strong>native</strong> (Anthropic / OpenAI / Gemini / OpenAI-compat),
       <strong>Claude&nbsp;Code</strong> (subscription auth, file editing, terminal),
       and <strong>ACP</strong> (claude-agent-acp&nbsp;/ codex-acp&nbsp;/ gemini --acp). Mix per node.
-      &middot; Latest: <a href="changelog.html#v0-29-2">v0.29.2</a>
+      &middot; Latest: <a href="changelog.html#v0-35-0">v0.35.0</a>
     </p>
   </section>
 

--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,7 +28,7 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
-    <a href="#unreleased">[Unreleased]</a>
+    <a href="#v0-35-0">v0.35.0</a>
     <a href="#v0-34-0">v0.34.0</a>
     <strong>Jump to:</strong>
     <a href="#v0-33-0">v0.33.0</a>
@@ -68,11 +68,12 @@ jsonld:
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
 
-  <!-- ═══ [Unreleased] ═══ -->
-  <section class="glass" id="unreleased" style="border-left: 3px solid var(--orange-600);">
+  <!-- ═══ v0.35.0 ═══ -->
+  <section class="glass" id="v0-35-0" style="border-left: 3px solid var(--orange-600);">
     <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
-      <h2 style="margin: 0;">[Unreleased]</h2>
-      <span class="badge">tracking next minor</span>
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.35.0" style="color: inherit; text-decoration: none;">v0.35.0</a></h2>
+      <span class="badge">2026-06-02</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.35.0" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
     </div>
     <p style="color: var(--text-secondary); margin-bottom: 1rem;">
       <strong>Closes Gap 5.2 of <a href="https://github.com/2389-research/tracker/issues/233">#233</a></strong>


### PR DESCRIPTION
## Summary

Cuts **v0.35.0**, shipping the two unreleased features from main:

- **`validation_overridden` terminal status** (Gap 5.2, [#271](https://github.com/2389-research/tracker/issues/271) / [#273](https://github.com/2389-research/tracker/pull/273)) — runs that traverse a `wait.human` edge marked `override: true` now terminate with `Status=validation_overridden` instead of being silently bucketed as `success`. Audit trail, JSON output, TUI completion row, and exit code all distinguish operator-accepted overrides from clean successes.

- **`writable_paths` fs-jail enforcement** ([#272](https://github.com/2389-research/tracker/issues/272) / [#275](https://github.com/2389-research/tracker/pull/275)) — agents with `writable_paths` declared now have a runtime write jail bounding Write/Edit/ApplyPatch + Bash + descendants to declared globs via Linux Landlock ABI v3 + `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS | RESOLVE_NO_MAGICLINKS)`. **Linux-only** (kernel 6.7+); macOS/Windows/older Linux refuse-to-start. `claude-code` and `acp` backends also refuse-to-start (out-of-process; tracker cannot sandbox).

This PR only stamps doc updates (CHANGELOG date-stamp the `[0.35.0]` section over the Unreleased bullets + add the same section + TOC entry to `site/content/changelog.html`). No code changes vs main.

## Joint-release coordination

`go.mod` pins `github.com/2389-research/dippin-lang` to the pseudo-version `v0.34.1-0.20260601154018-792e6e644e9f` — dippin's `main` HEAD commit `792e6e6` with the matching `WritablePaths` and `Override` IR fields. dippin v0.35.0 is not yet tagged (the dippin maintainers prefer to wait until tracker tags first); the joint-release loop closes when dippin tags v0.35.0 pinning tracker v0.35.0 and tracker then ships v0.35.1 swapping the pseudo-version for the tagged dippin (zero functional change). Same pattern as the v0.31.0 → v0.32.0 closeout.

`PinnedDippinVersion` in `tracker_doctor.go` matches `go.mod` exactly; `TestPinnedDippinVersionMatchesGoMod` is green.

## Verification

- `dippin doctor` on all four example pipelines (same scores as v0.34.0):
  - `ask_and_execute.dip` — **A 95/100**
  - `build_product.dip` — **A 90/100**
  - `build_product_with_superspec.dip` — **A 100/100**
  - `deep_review.dip` — **A 90/100**
- `go build ./...` clean
- `go test ./... -short` → all 18 packages pass

## Reminder: merging this PR does NOT cut the release

Per CLAUDE.md § Releases — merging only ships the CHANGELOG/site doc updates. The actual release requires:

```bash
git tag -a v0.35.0 <merge-commit-sha> -m "release: v0.35.0"
git push origin v0.35.0
```

The tag push triggers `.github/workflows/release.yml` → GoReleaser, which builds darwin/linux amd64/arm64 binaries for `tracker` and `tracker-conformance` and publishes the GitHub release. Don't consider the release done until `gh release view v0.35.0` shows the published entry with assets.

## Test plan

- [x] All four examples grade A on `dippin doctor`
- [x] `go build ./...` clean
- [x] `go test ./... -short` all 18 packages pass
- [ ] After merge: tag `v0.35.0` + push, then verify `gh release view v0.35.0`
- [ ] After dippin v0.35.0 tags: open `release: v0.35.1` PR bumping `go.mod` from the pseudo-version to dippin v0.35.0 + `PinnedDippinVersion` in lockstep. Closes the joint-release loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783023179&installation_id=131176874&pr_number=287&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F287&signature=e739aed74f5c17a0161ad2a0486efed20837fe5badd395bd2e6b27fc9e8fa261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Released v0.35.0 release notes dated 2026-06-02 including joint-release coordination notes about dependency version pinning and subsequent tag swap.
  * Updated the website changelog and versions page to list v0.35.0 and replace the previous Unreleased entry.
  * Updated the homepage “Latest” changelog link to point to v0.35.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->