### PR TITLE
release: v0.35.1 — joint-release closeout for dippin v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-06-02
+
+### Changed
+
+- **Joint-release closeout for v0.35.0 ↔ dippin v0.35.0.** `go.mod` swaps the
+  joint-release-window pseudo-version
+  (`v0.34.1-0.20260601154018-792e6e644e9f`) for the published
+  `github.com/2389-research/dippin-lang v0.35.0` tag. `PinnedDippinVersion`
+  in `tracker_doctor.go` updated in lockstep. **No functional changes vs
+  v0.35.0** — the underlying dippin code is byte-identical (`792e6e6` is
+  the commit dippin v0.35.0 tagged). Joint-release loop closed: tracker
+  v0.35.0 ships against dippin's `main` HEAD, dippin v0.35.0 tags pinning
+  tracker v0.35.0, tracker v0.35.1 swaps the SHA for the tag. Same shape
+  as the v0.31.0 → v0.32.0 closeout.
+
 ## [0.35.0] - 2026-06-02
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.34.1-0.20260601154018-792e6e644e9f
+	github.com/2389-research/dippin-lang v0.35.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/2389-research/dippin-lang v0.34.1-0.20260601154018-792e6e644e9f h1:XRzarwSJCC2Ys2IWG+VQ3heQG3pL+uhIOlx/2sKVDPw=
-github.com/2389-research/dippin-lang v0.34.1-0.20260601154018-792e6e644e9f/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.35.0 h1:7pAfzZmU+D/Du2pbF/W1/NOljvCSIaoJxSKsfefvQy4=
+github.com/2389-research/dippin-lang v0.35.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/site/content/_index.html
+++ b/site/content/_index.html
@@ -48,7 +48,7 @@ jsonld:
       Three agent backends &mdash; <strong>native</strong> (Anthropic / OpenAI / Gemini / OpenAI-compat),
       <strong>Claude&nbsp;Code</strong> (subscription auth, file editing, terminal),
       and <strong>ACP</strong> (claude-agent-acp&nbsp;/ codex-acp&nbsp;/ gemini --acp). Mix per node.
-      &middot; Latest: <a href="changelog.html#v0-35-0">v0.35.0</a>
+      &middot; Latest: <a href="changelog.html#v0-35-1">v0.35.1</a>
     </p>
   </section>
 

--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,6 +28,7 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
+    <a href="#v0-35-1">v0.35.1</a>
     <a href="#v0-35-0">v0.35.0</a>
     <a href="#v0-34-0">v0.34.0</a>
     <strong>Jump to:</strong>
@@ -67,6 +68,20 @@ jsonld:
     <a href="#v0-9-x">v0.9.x</a>
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
+
+  <!-- ═══ v0.35.1 ═══ -->
+  <section class="glass" id="v0-35-1" style="border-left: 3px solid var(--orange-600);">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.35.1" style="color: inherit; text-decoration: none;">v0.35.1</a></h2>
+      <span class="badge">2026-06-02</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.35.1" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">Joint-release closeout for <a href="https://github.com/2389-research/tracker/releases/tag/v0.35.0">tracker v0.35.0</a> &harr; <a href="https://github.com/2389-research/dippin-lang/releases/tag/v0.35.0">dippin v0.35.0</a>. <code>go.mod</code> swaps the joint-release-window pseudo-version (<code>v0.34.1-0.20260601154018-792e6e644e9f</code>) for the published <code>dippin v0.35.0</code> tag. <code>PinnedDippinVersion</code> in <code>tracker_doctor.go</code> updated in lockstep. <strong>No functional changes vs v0.35.0</strong> &mdash; the underlying dippin code is byte-identical (<code>792e6e6</code> is the commit dippin v0.35.0 tagged). Same shape as the v0.31.0 &rarr; v0.32.0 closeout.</p>
+    <h4>Changed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong>dippin-lang dependency bumped to v0.35.0 tag.</strong> <code>go.mod</code> swaps the joint-release-window pseudo-version (<code>v0.34.1-0.20260601154018-792e6e644e9f</code>) for the published <code>v0.35.0</code> tag. <code>PinnedDippinVersion</code> in <code>tracker_doctor.go</code> updated in lockstep.</li>
+    </ul>
+  </section>
 
   <!-- ═══ v0.35.0 ═══ -->
   <section class="glass" id="v0-35-0" style="border-left: 3px solid var(--orange-600);">

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -23,12 +23,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod. Kept in sync
 // with go.mod by TestPinnedDippinVersionMatchesGoMod.
-//
-// Currently a pseudo-version pointing at dippin's `main` HEAD because
-// the WritablePaths IR field (issue #272 / dippin-lang #75) is merged
-// but not yet tagged. The release PR will swap this for the tagged
-// v0.35.0 in lockstep with the go.mod bump.
-const PinnedDippinVersion = "v0.34.1-0.20260601154018-792e6e644e9f"
+const PinnedDippinVersion = "v0.35.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
## Summary

Cuts **v0.35.1**, closing the joint-release loop now that dippin has tagged **[v0.35.0](https://github.com/2389-research/dippin-lang/releases/tag/v0.35.0)** (commit `997964d`):

```diff
 go.mod
-github.com/2389-research/dippin-lang v0.34.1-0.20260601154018-792e6e644e9f
+github.com/2389-research/dippin-lang v0.35.0
```

```diff
 tracker_doctor.go
-const PinnedDippinVersion = "v0.34.1-0.20260601154018-792e6e644e9f"
+const PinnedDippinVersion = "v0.35.0"
```

**No functional changes vs [v0.35.0](https://github.com/2389-research/tracker/releases/tag/v0.35.0).** The underlying dippin code is byte-identical (commit `792e6e6` was already what we pinned to via pseudo-version, and that's the commit dippin v0.35.0 tagged).

Same shape as the **v0.31.0 → v0.32.0** closeout: tracker tags first against dippin's main HEAD pseudo-version, dippin then tags pinning tracker's tag, tracker publishes a patch swapping the SHA for the tag. Joint-release loop closed: tracker v0.35.0 ↔ dippin v0.35.0 mutually pinned.

## Verification

- `dippin doctor` on all four example pipelines — A grade preserved:
  - `ask_and_execute.dip` — **A 95/100**
  - `build_product.dip` — **A 90/100**
  - `build_product_with_superspec.dip` — **A 100/100**
  - `deep_review.dip` — **A 90/100**
- `go build ./...` clean
- `go test ./... -short` → all 18 packages pass (including `TestPinnedDippinVersionMatchesGoMod` which proves `go.mod` and the constant are in sync)

## Reminder: merging this PR does NOT cut the release

Per CLAUDE.md § Releases — merging only ships the dependency bump + CHANGELOG/site doc updates. The actual release requires:

```bash
git tag -a v0.35.1 <merge-commit-sha> -m "release: v0.35.1"
git push origin v0.35.1
```

The tag push triggers `.github/workflows/release.yml` → GoReleaser, which builds darwin/linux amd64/arm64 binaries for `tracker` and `tracker-conformance` and publishes the GitHub release. Don't consider the release done until `gh release view v0.35.1` shows the published entry with assets.

## Test plan

- [x] dippin v0.35.0 published on dippin-lang (verified at <https://github.com/2389-research/dippin-lang/releases/tag/v0.35.0>)
- [x] All four examples grade A on `dippin doctor`
- [x] `go build ./...` clean
- [x] `go test ./... -short` all 18 packages pass
- [x] `TestPinnedDippinVersionMatchesGoMod` green
- [ ] After merge: tag `v0.35.1` + push, then verify `gh release view v0.35.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783026202&installation_id=131176874&pr_number=288&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F288&signature=85fdc0966c9130c1875d295492e5f088ca60c93ef19d9c60c9b347110418ed34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released v0.35.1 as a joint-release closeout with dippin-lang v0.35.0 alignment.
  * No functional changes from v0.35.0.

* **Documentation**
  * Updated changelog and website to reflect v0.35.1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->