### PR TITLE
feat(doctor): surface bedrock-gateway routing caveats (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matches the prior hard-coded suffix map. Operator-facing docs + doctor
   preflight notes ship in follow-up PRs (#277, #278).
 
+- **`tracker doctor` gateway routing notes** (refs #274, closes #277). When a
+  gateway is configured (`TRACKER_GATEWAY_URL` or `TRACKER_GATEWAY_KIND` set),
+  doctor adds a "Gateway Routing" check that surfaces two setup-time caveats
+  as informational notes (never warnings or errors):
+  - **Bedrock masquerade** — under `TRACKER_GATEWAY_KIND=bedrock` with
+    `OPENAI_API_KEY` set, `gpt-*` / `o*-*` model strings route to Claude
+    Sonnet 4.6 today (AWS Bedrock has no OpenAI models yet); the gateway
+    re-routes automatically with no tracker change once AWS adds them.
+  - **Per-provider precedence** — when `TRACKER_GATEWAY_URL` and one or more
+    `<PROVIDER>_BASE_URL` are both set, the per-provider overrides that win
+    over the gateway are listed by name. The check is omitted entirely when
+    no gateway is configured, so default runs are unchanged.
+
 ## [0.35.1] - 2026-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,10 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gateway is configured (`TRACKER_GATEWAY_URL` or `TRACKER_GATEWAY_KIND` set),
   doctor adds a "Gateway Routing" check that surfaces two setup-time caveats
   as informational notes (never warnings or errors):
-  - **Bedrock masquerade** — under `TRACKER_GATEWAY_KIND=bedrock` with
-    `OPENAI_API_KEY` set, `gpt-*` / `o*-*` model strings route to Claude
-    Sonnet 4.6 today (AWS Bedrock has no OpenAI models yet); the gateway
-    re-routes automatically with no tracker change once AWS adds them.
+  - **Bedrock masquerade** — when OpenAI traffic actually traverses the
+    bedrock gateway (`TRACKER_GATEWAY_KIND=bedrock` + a gateway URL +
+    `OPENAI_API_KEY`, with no `OPENAI_BASE_URL` override), `gpt-*` / `o*-*`
+    model strings route to Claude Sonnet 4.6 today (AWS Bedrock has no
+    OpenAI models yet); the gateway re-routes automatically with no tracker
+    change once AWS adds them.
   - **Per-provider precedence** — when `TRACKER_GATEWAY_URL` and one or more
     `<PROVIDER>_BASE_URL` are both set, the per-provider overrides that win
     over the gateway are listed by name. The check is omitted entirely when

--- a/cmd/tracker/doctor.go
+++ b/cmd/tracker/doctor.go
@@ -174,7 +174,8 @@ func printCheckResult(c tracker.CheckResult) {
 func needsCompositeResultLine(checkName string) bool {
 	switch checkName {
 	case "LLM Providers", "Version Compatibility", "Optional Binaries",
-		"Artifact Directories", "Working Directory", "Pipeline File":
+		"Artifact Directories", "Working Directory", "Pipeline File",
+		"Gateway Routing":
 		return false
 	}
 	return true

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -167,6 +167,12 @@ func Doctor(ctx context.Context, cfg DoctorConfig, opts ...DoctorOption) (*Docto
 		checkArtifactDirs(cfg.WorkDir),
 		checkDiskSpace(cfg.WorkDir),
 	)
+	// Gateway routing caveats only matter when a gateway is actually
+	// configured (#277). Appending unconditionally would add noise to the
+	// common no-gateway run, so gate on the env presence here.
+	if os.Getenv("TRACKER_GATEWAY_URL") != "" || os.Getenv("TRACKER_GATEWAY_KIND") != "" {
+		r.Checks = append(r.Checks, checkGatewayRouting())
+	}
 	if cfg.PipelineFile != "" {
 		r.Checks = append(r.Checks,
 			checkPipelineFile(cfg.PipelineFile),
@@ -208,6 +214,91 @@ func checkEnvWarnings() CheckResult {
 		Message: fmt.Sprintf("dangerous variables set: %s", strings.Join(found, "; ")),
 		Hint:    "unset TRACKER_PASS_ENV and TRACKER_PASS_API_KEYS to restore default security posture",
 	}
+}
+
+// gatewayBaseURLEnvVars maps a provider label to its per-provider *_BASE_URL
+// override env var. The Gateway Routing check uses this to report which
+// overrides win over TRACKER_GATEWAY_URL. Order mirrors knownProviders.
+var gatewayBaseURLEnvVars = []struct {
+	provider string
+	envVar   string
+}{
+	{"anthropic", "ANTHROPIC_BASE_URL"},
+	{"openai", "OPENAI_BASE_URL"},
+	{"gemini", "GEMINI_BASE_URL"},
+	{"openai-compat", "OPENAI_COMPAT_BASE_URL"},
+}
+
+// checkGatewayRouting surfaces non-fatal gateway routing caveats (#277). It
+// runs only when TRACKER_GATEWAY_URL or TRACKER_GATEWAY_KIND is set (see
+// Doctor) and emits informational notes — never warnings or errors, since
+// every condition it reports is an intentional configuration:
+//
+//   - B.1 bedrock masquerade: under KIND=bedrock, gpt-* / o*-* model strings
+//     route to Claude today because AWS Bedrock has no OpenAI models yet.
+//     Triggered by KIND=bedrock + OPENAI_API_KEY present, so it surfaces once
+//     at setup time rather than as a per-session runtime warning.
+//   - B.2 per-provider precedence: a *_BASE_URL override silently wins over
+//     TRACKER_GATEWAY_URL for that provider.
+func checkGatewayRouting() CheckResult {
+	out := CheckResult{Name: "Gateway Routing", Status: CheckStatusOK}
+
+	gatewayURL := strings.TrimRight(os.Getenv("TRACKER_GATEWAY_URL"), "/")
+	kind := os.Getenv("TRACKER_GATEWAY_KIND")
+	kindLabel := kind
+	if kindLabel == "" {
+		kindLabel = string(GatewayKindCFAIG) + " (default)"
+	}
+
+	// Context line: describe what routing is in effect.
+	if gatewayURL != "" {
+		out.Details = append(out.Details, CheckDetail{
+			Status:  CheckStatusOK,
+			Message: fmt.Sprintf("TRACKER_GATEWAY_URL=%s (kind=%s)", gatewayURL, kindLabel),
+		})
+	} else {
+		out.Details = append(out.Details, CheckDetail{
+			Status:  CheckStatusOK,
+			Message: fmt.Sprintf("TRACKER_GATEWAY_KIND=%s (no TRACKER_GATEWAY_URL — per-provider *_BASE_URL or SDK defaults in effect)", kindLabel),
+		})
+	}
+
+	notes := 0
+
+	// B.1 — OpenAI→Claude masquerade under the bedrock gateway.
+	if kind == string(GatewayKindBedrock) {
+		if key, _ := findProviderKey([]string{"OPENAI_API_KEY"}); key != "" {
+			out.Details = append(out.Details, CheckDetail{
+				Status:  CheckStatusHint,
+				Message: "TRACKER_GATEWAY_KIND=bedrock: gpt-* / o*-* model strings route to Claude Sonnet 4.6 today (the bedrock gateway translates because AWS hasn't added OpenAI to Bedrock yet). When AWS adds it, the gateway updates its mapping without tracker changes.",
+			})
+			notes++
+		}
+	}
+
+	// B.2 — per-provider *_BASE_URL overrides win over the gateway URL.
+	if gatewayURL != "" {
+		var overridden []string
+		for _, p := range gatewayBaseURLEnvVars {
+			if os.Getenv(p.envVar) != "" {
+				overridden = append(overridden, fmt.Sprintf("%s (%s)", p.provider, p.envVar))
+			}
+		}
+		if len(overridden) > 0 {
+			out.Details = append(out.Details, CheckDetail{
+				Status:  CheckStatusHint,
+				Message: fmt.Sprintf("per-provider overrides win over TRACKER_GATEWAY_URL: %s", strings.Join(overridden, ", ")),
+			})
+			notes++
+		}
+	}
+
+	if notes > 0 {
+		out.Message = fmt.Sprintf("gateway configured (%d routing note(s))", notes)
+	} else {
+		out.Message = "gateway configured (no routing caveats)"
+	}
+	return out
 }
 
 type providerDef struct {

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -234,10 +234,11 @@ var gatewayBaseURLEnvVars = []struct {
 // Doctor) and emits informational notes — never warnings or errors, since
 // every condition it reports is an intentional configuration:
 //
-//   - B.1 bedrock masquerade: under KIND=bedrock, gpt-* / o*-* model strings
-//     route to Claude today because AWS Bedrock has no OpenAI models yet.
-//     Triggered by KIND=bedrock + OPENAI_API_KEY present, so it surfaces once
-//     at setup time rather than as a per-session runtime warning.
+//   - B.1 bedrock masquerade: when OpenAI traffic actually routes through the
+//     bedrock gateway (KIND=bedrock + a gateway URL + OPENAI_API_KEY, with no
+//     OPENAI_BASE_URL override), gpt-* / o*-* model strings route to Claude
+//     today because AWS Bedrock has no OpenAI models yet. Surfaced once at
+//     setup time rather than as a per-session runtime warning.
 //   - B.2 per-provider precedence: a *_BASE_URL override silently wins over
 //     TRACKER_GATEWAY_URL for that provider.
 func checkGatewayRouting() CheckResult {
@@ -306,9 +307,14 @@ func checkGatewayRouting() CheckResult {
 		}
 	}
 
-	if notes > 0 {
+	switch {
+	case gatewayURL == "":
+		// Only the kind is set; without a URL the resolver never routes via a
+		// gateway, so don't imply one is in use.
+		out.Message = fmt.Sprintf("TRACKER_GATEWAY_KIND=%s set without TRACKER_GATEWAY_URL — no gateway routing in effect", kindLabel)
+	case notes > 0:
 		out.Message = fmt.Sprintf("gateway configured (%d routing note(s))", notes)
-	} else {
+	default:
 		out.Message = "gateway configured (no routing caveats)"
 	}
 	return out

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -225,8 +225,8 @@ var gatewayBaseURLEnvVars = []struct {
 }{
 	{"anthropic", "ANTHROPIC_BASE_URL"},
 	{"openai", "OPENAI_BASE_URL"},
-	{"gemini", "GEMINI_BASE_URL"},
 	{"openai-compat", "OPENAI_COMPAT_BASE_URL"},
+	{"gemini", "GEMINI_BASE_URL"},
 }
 
 // checkGatewayRouting surfaces non-fatal gateway routing caveats (#277). It
@@ -265,8 +265,11 @@ func checkGatewayRouting() CheckResult {
 
 	notes := 0
 
-	// B.1 — OpenAI→Claude masquerade under the bedrock gateway.
-	if kind == string(GatewayKindBedrock) {
+	// B.1 — OpenAI→Claude masquerade under the bedrock gateway. Skip the note
+	// when OPENAI_BASE_URL is set: that override wins over the gateway in the
+	// resolver, so OpenAI traffic never traverses the bedrock gateway and is
+	// not masqueraded. The B.2 precedence note below covers that case instead.
+	if kind == string(GatewayKindBedrock) && os.Getenv("OPENAI_BASE_URL") == "" {
 		if key, _ := findProviderKey([]string{"OPENAI_API_KEY"}); key != "" {
 			out.Details = append(out.Details, CheckDetail{
 				Status:  CheckStatusHint,

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -265,11 +265,21 @@ func checkGatewayRouting() CheckResult {
 
 	notes := 0
 
-	// B.1 — OpenAI→Claude masquerade under the bedrock gateway. Skip the note
-	// when OPENAI_BASE_URL is set: that override wins over the gateway in the
-	// resolver, so OpenAI traffic never traverses the bedrock gateway and is
-	// not masqueraded. The B.2 precedence note below covers that case instead.
-	if kind == string(GatewayKindBedrock) && os.Getenv("OPENAI_BASE_URL") == "" {
+	// B.1 — OpenAI→Claude masquerade under the bedrock gateway. The note fires
+	// only when OpenAI traffic actually traverses the bedrock gateway:
+	//   - kind must be bedrock;
+	//   - a gateway URL must be configured — without one, openai resolves to
+	//     the SDK default (api.openai.com), so there is no gateway and no
+	//     masquerade;
+	//   - OPENAI_BASE_URL must be unset — it wins over the gateway in the
+	//     resolver, so when set, openai bypasses the gateway. The B.2
+	//     precedence note covers that case instead.
+	//
+	// Residual gap: an OPENAI_BASE_URL pointed explicitly at the bedrock
+	// gateway (e.g. <gateway>/v1) would still masquerade, but an arbitrary
+	// URL can't be reliably recognized as a gateway endpoint, so we defer to
+	// the B.2 note rather than guess.
+	if kind == string(GatewayKindBedrock) && gatewayURL != "" && os.Getenv("OPENAI_BASE_URL") == "" {
 		if key, _ := findProviderKey([]string{"OPENAI_API_KEY"}); key != "" {
 			out.Details = append(out.Details, CheckDetail{
 				Status:  CheckStatusHint,

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -991,6 +991,10 @@ func TestCheckGatewayRouting_NoPrecedenceNoteWithoutGatewayURL(t *testing.T) {
 	if gatewayDetailContains(c, "per-provider overrides win") {
 		t.Errorf("precedence note requires TRACKER_GATEWAY_URL; details = %+v", c.Details)
 	}
+	// The summary must not imply gateway routing is in effect without a URL.
+	if !strings.Contains(c.Message, "no gateway routing in effect") {
+		t.Errorf("summary should note no routing without a URL; got %q", c.Message)
+	}
 }
 
 func TestDoctor_GatewayRoutingCheckGatedOnEnv(t *testing.T) {

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -927,6 +927,25 @@ func TestCheckGatewayRouting_NoMasqueradeUnderCFAIG(t *testing.T) {
 	}
 }
 
+func TestCheckGatewayRouting_NoMasqueradeWhenOpenAIBaseURLOverridden(t *testing.T) {
+	clearGatewayEnv(t)
+	// OPENAI_BASE_URL wins over the gateway in the resolver, so OpenAI
+	// traffic bypasses the bedrock gateway entirely — no masquerade.
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
+	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
+	t.Setenv("OPENAI_BASE_URL", "https://direct.openai.example.com")
+
+	c := checkGatewayRouting()
+	if gatewayDetailContains(c, "route to Claude") {
+		t.Errorf("masquerade note should be suppressed when OPENAI_BASE_URL overrides routing; details = %+v", c.Details)
+	}
+	// The precedence note should still cover the OpenAI override.
+	if !gatewayDetailContains(c, "openai (OPENAI_BASE_URL)") {
+		t.Errorf("expected precedence note for the OpenAI override; details = %+v", c.Details)
+	}
+}
+
 func TestCheckGatewayRouting_PerProviderPrecedenceNote(t *testing.T) {
 	clearGatewayEnv(t)
 	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
@@ -967,7 +986,7 @@ func TestDoctor_GatewayRoutingCheckGatedOnEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Doctor: %v", err)
 	}
-	if findCheckByName(r, "Gateway Routing") != nil {
+	if findCheck(r, "Gateway Routing") != nil {
 		t.Error("Gateway Routing check should be absent when no gateway env is set")
 	}
 
@@ -977,16 +996,7 @@ func TestDoctor_GatewayRoutingCheckGatedOnEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Doctor: %v", err)
 	}
-	if findCheckByName(r, "Gateway Routing") == nil {
+	if findCheck(r, "Gateway Routing") == nil {
 		t.Error("Gateway Routing check should appear when TRACKER_GATEWAY_KIND is set")
 	}
-}
-
-func findCheckByName(r *DoctorReport, name string) *CheckResult {
-	for i := range r.Checks {
-		if r.Checks[i].Name == name {
-			return &r.Checks[i]
-		}
-	}
-	return nil
 }

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -866,3 +866,127 @@ func mustGitInitForDoctor(t *testing.T, dir string) {
 		t.Fatalf("git commit --allow-empty in %s: %v: %s", dir, err, out)
 	}
 }
+
+// clearGatewayEnv unsets every env var the Gateway Routing check consults so
+// each test starts from a known-empty baseline regardless of the developer's
+// shell environment.
+func clearGatewayEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"TRACKER_GATEWAY_URL", "TRACKER_GATEWAY_KIND",
+		"OPENAI_API_KEY",
+		"ANTHROPIC_BASE_URL", "OPENAI_BASE_URL", "GEMINI_BASE_URL", "OPENAI_COMPAT_BASE_URL",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+// gatewayDetailContains reports whether any detail message in the check
+// contains substr.
+func gatewayDetailContains(c CheckResult, substr string) bool {
+	for _, d := range c.Details {
+		if strings.Contains(d.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCheckGatewayRouting_BedrockMasqueradeNote(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
+
+	c := checkGatewayRouting()
+	if c.Status != CheckStatusOK {
+		t.Fatalf("status = %q, want ok (informational only)", c.Status)
+	}
+	if !gatewayDetailContains(c, "route to Claude Sonnet 4.6") {
+		t.Errorf("expected bedrock masquerade note; details = %+v", c.Details)
+	}
+}
+
+func TestCheckGatewayRouting_NoMasqueradeWithoutOpenAIKey(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+
+	c := checkGatewayRouting()
+	if gatewayDetailContains(c, "route to Claude") {
+		t.Errorf("masquerade note should not fire without OPENAI_API_KEY; details = %+v", c.Details)
+	}
+}
+
+func TestCheckGatewayRouting_NoMasqueradeUnderCFAIG(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("TRACKER_GATEWAY_KIND", "cf-aig")
+	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
+
+	c := checkGatewayRouting()
+	if gatewayDetailContains(c, "route to Claude") {
+		t.Errorf("masquerade note is bedrock-only; details = %+v", c.Details)
+	}
+}
+
+func TestCheckGatewayRouting_PerProviderPrecedenceNote(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://direct.anthropic.example.com")
+
+	c := checkGatewayRouting()
+	if c.Status != CheckStatusOK {
+		t.Fatalf("status = %q, want ok (informational only)", c.Status)
+	}
+	if !gatewayDetailContains(c, "per-provider overrides win over TRACKER_GATEWAY_URL") {
+		t.Errorf("expected precedence note; details = %+v", c.Details)
+	}
+	if !gatewayDetailContains(c, "anthropic (ANTHROPIC_BASE_URL)") {
+		t.Errorf("expected the overriding provider named; details = %+v", c.Details)
+	}
+}
+
+func TestCheckGatewayRouting_NoPrecedenceNoteWithoutGatewayURL(t *testing.T) {
+	clearGatewayEnv(t)
+	// Kind set but no gateway URL: a *_BASE_URL is a direct override, not a
+	// conflict with any gateway, so no precedence note.
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("ANTHROPIC_BASE_URL", "https://direct.anthropic.example.com")
+
+	c := checkGatewayRouting()
+	if gatewayDetailContains(c, "per-provider overrides win") {
+		t.Errorf("precedence note requires TRACKER_GATEWAY_URL; details = %+v", c.Details)
+	}
+}
+
+func TestDoctor_GatewayRoutingCheckGatedOnEnv(t *testing.T) {
+	clearGatewayEnv(t)
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-12345678901234567890")
+	workdir := t.TempDir()
+
+	// No gateway env → check absent.
+	r, err := Doctor(context.Background(), DoctorConfig{WorkDir: workdir})
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if findCheckByName(r, "Gateway Routing") != nil {
+		t.Error("Gateway Routing check should be absent when no gateway env is set")
+	}
+
+	// Gateway env present → check appears.
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	r, err = Doctor(context.Background(), DoctorConfig{WorkDir: workdir})
+	if err != nil {
+		t.Fatalf("Doctor: %v", err)
+	}
+	if findCheckByName(r, "Gateway Routing") == nil {
+		t.Error("Gateway Routing check should appear when TRACKER_GATEWAY_KIND is set")
+	}
+}
+
+func findCheckByName(r *DoctorReport, name string) *CheckResult {
+	for i := range r.Checks {
+		if r.Checks[i].Name == name {
+			return &r.Checks[i]
+		}
+	}
+	return nil
+}

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -895,6 +895,7 @@ func gatewayDetailContains(c CheckResult, substr string) bool {
 func TestCheckGatewayRouting_BedrockMasqueradeNote(t *testing.T) {
 	clearGatewayEnv(t)
 	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
 	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
 
 	c := checkGatewayRouting()
@@ -906,9 +907,24 @@ func TestCheckGatewayRouting_BedrockMasqueradeNote(t *testing.T) {
 	}
 }
 
+func TestCheckGatewayRouting_NoMasqueradeWithoutGatewayURL(t *testing.T) {
+	clearGatewayEnv(t)
+	// kind=bedrock + OPENAI_API_KEY but no gateway URL: openai resolves to
+	// the SDK default (api.openai.com), so traffic never traverses a gateway
+	// and is not masqueraded.
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
+
+	c := checkGatewayRouting()
+	if gatewayDetailContains(c, "route to Claude") {
+		t.Errorf("masquerade note should not fire without a gateway URL; details = %+v", c.Details)
+	}
+}
+
 func TestCheckGatewayRouting_NoMasqueradeWithoutOpenAIKey(t *testing.T) {
 	clearGatewayEnv(t)
 	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
 
 	c := checkGatewayRouting()
 	if gatewayDetailContains(c, "route to Claude") {
@@ -919,6 +935,7 @@ func TestCheckGatewayRouting_NoMasqueradeWithoutOpenAIKey(t *testing.T) {
 func TestCheckGatewayRouting_NoMasqueradeUnderCFAIG(t *testing.T) {
 	clearGatewayEnv(t)
 	t.Setenv("TRACKER_GATEWAY_KIND", "cf-aig")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
 	t.Setenv("OPENAI_API_KEY", "sk-test-12345678901234567890")
 
 	c := checkGatewayRouting()


### PR DESCRIPTION
Closes #277. Refs #274. Depends on #276 (merged in `4eb7714`).

## What

Adds a **Gateway Routing** check to `tracker doctor` that fires only when a
gateway is configured (`TRACKER_GATEWAY_URL` or `TRACKER_GATEWAY_KIND` set) and
surfaces two setup-time caveats as informational notes. Both are **hint-level
only** — never warnings or errors — because each reports an intentional config:

- **B.1 — Bedrock masquerade (spec D4):** under `TRACKER_GATEWAY_KIND=bedrock`
  with `OPENAI_API_KEY` set, `gpt-*` / `o*-*` model strings route to Claude
  Sonnet 4.6 today (AWS Bedrock has no OpenAI models yet). Surfaced once at
  setup instead of as a noisy per-session runtime warning.
- **B.2 — Per-provider precedence (spec D5):** when `TRACKER_GATEWAY_URL` and
  one or more `<PROVIDER>_BASE_URL` are both set, the overrides that win over
  the gateway are listed by name.

The check is gated on env presence, so default (no-gateway) doctor runs are
completely unchanged — no new line, no new check.

## Sample output

```
  Gateway Routing
    ✓ TRACKER_GATEWAY_URL=https://bedrock-gw.example.com (kind=bedrock)
    → TRACKER_GATEWAY_KIND=bedrock: gpt-* / o*-* model strings route to Claude Sonnet 4.6 today ...
    → per-provider overrides win over TRACKER_GATEWAY_URL: anthropic (ANTHROPIC_BASE_URL)
```

## Note on divergence from the design spec

Spec **D4** ties masquerade detection to *pipeline nodes* (`provider: openai` +
`model ^(gpt-|o\d-)`). Issue #277's B.1 specifies **env-var** triggers
(`KIND=bedrock` + `OPENAI_API_KEY`). I followed the issue: doctor commonly runs
without a pipeline file, and the env-based trigger catches the confusion at
setup time regardless. Happy to switch to node-based detection if preferred.

## Tests

- `checkGatewayRouting` unit tests: masquerade fires/suppresses correctly
  (bedrock+key vs no-key vs cf-aig), precedence note fires only with a gateway
  URL, status is always `ok`.
- `Doctor()` gating test: check absent without gateway env, present with it.
- Full `go test ./... -short` green (18 packages); `go build ./...`, `gofmt`,
  `go vet` clean.

## Scope

+230 / -1 across 4 files. No IR/product-routing changes (those landed in #276),
so `dippin doctor` output is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783102850&installation_id=131176874&pr_number=291&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F291&signature=908e34c2eb310362ead034d47b8ebe4120f6ddd01062e837995df16f41444ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Gateway Routing preflight check to tracker doctor that reports active gateway configuration, lists informational caveats (e.g., Bedrock masquerade and per-provider override precedence), and is shown only when gateway config is present. The check output avoids duplicate summary lines.

* **Documentation**
  * Updated changelog with Gateway Routing configuration notes for operators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->