### PR TITLE
test: property/invariant tests for writable_paths jail surface (#282)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Property/invariant tests for the `writable_paths` jail public surface**
+  (closes #282, refs #275/#272). New `agent/exec/jail_property_test.go` and
+  `pipeline/handlers/codergen_jail_property_test.go`, plus property additions to
+  `agent/exec/jail_linux_test.go` and `agent/exec/jail_other_test.go`, all using
+  the existing `pgregory.net/rapid` dev dep (no new deps). These pin the
+  first-principles properties the #275 review surfaced round-by-round (~30
+  findings over 13 rounds) so a regression fails fast with a shrunk
+  counter-example: the escape-vs-malformed sentinel partition of
+  `ValidateWritablePaths`/`validateGlobEntry`; the supported doublestar shapes
+  of `matchOneGlob`/`matchWritablePath` and the matcher↔`landlockDirForGlob`
+  never-escapes-anchor invariant; `OpenForWrite`/`SafeMkdirAll`/`SafeRemove`
+  containment (absolute/parent/symlink-at-any-depth refusal, EACCES-vs-escape
+  classification, EEXIST/ENOENT tolerance); `relPathForJail` containment incl.
+  the bare-`..name` allow case; the `configureJail` G1/G2 refuse-to-start gates
+  and the `WriteOpener`/`Remover` closures (glob accept/`ErrPathNotAllowed`/
+  `ErrPathEscape` classes, mkdir-after-glob ordering); and the non-Linux stubs'
+  input-independent fail-closed contract. Test-only — no product code changed.
 - **`TRACKER_GATEWAY_KIND` routing dispatch** (refs #274, closes #276). New env
   var, `--gateway-kind` CLI flag, and `Config.GatewayKind` library option select
   the per-provider URL suffix convention used with `TRACKER_GATEWAY_URL`:

--- a/agent/exec/jail_linux_test.go
+++ b/agent/exec/jail_linux_test.go
@@ -10,7 +10,10 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+
+	"pgregory.net/rapid"
 )
 
 // TestMain dispatches to the jail-exec helper when the test binary is invoked
@@ -216,5 +219,322 @@ func TestRunJailExec_DeniesSymlinkEscape(t *testing.T) {
 	escapePath := filepath.Join(outsideDir, "escape.txt")
 	if _, err := os.Stat(escapePath); err == nil {
 		t.Errorf("file %q exists; symlink-escape was not blocked", escapePath)
+	}
+}
+
+// --- Property/invariant tests (issue #282) ---
+//
+// These generalize the example-based tests above. The literal-segment/path
+// generators (genLiteralSegment / genLiteralPath / genLiteralSegments) live in
+// jail_property_test.go (no build constraint) and are shared across the
+// package's Linux and non-Linux test files.
+
+// TestOpenForWrite_AllowsLiteralLeaf_Rapid: any single literal filename under a
+// fresh anchor opens and writes successfully. openat2's RESOLVE_BENEATH binds
+// resolution to the anchor fd, so a benign relative name always lands inside.
+func TestOpenForWrite_AllowsLiteralLeaf_Rapid(t *testing.T) {
+	anchor := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		leaf := genLiteralSegment(rt, "leaf") + ".txt"
+		f, err := OpenForWrite(anchor, leaf, 0o644)
+		if err != nil {
+			rt.Fatalf("OpenForWrite(%q) = %v, want success", leaf, err)
+		}
+		if _, err := f.Write([]byte("ok")); err != nil {
+			rt.Errorf("Write: %v", err)
+		}
+		_ = f.Close()
+		if _, err := os.Stat(filepath.Join(anchor, leaf)); err != nil {
+			rt.Fatalf("file %q not created under anchor: %v", leaf, err)
+		}
+	})
+}
+
+// TestOpenForWrite_RejectsAbsolute_Rapid: any absolute path is refused with
+// ErrPathEscape, regardless of where it points. RESOLVE_BENEATH only constrains
+// relative resolution after the anchor fd, so OpenForWrite must reject absolute
+// inputs defensively before the syscall.
+func TestOpenForWrite_RejectsAbsolute_Rapid(t *testing.T) {
+	anchor := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		abs := "/" + genLiteralPath(rt, "abs")
+		_, err := OpenForWrite(anchor, abs, 0o644)
+		if !errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("OpenForWrite(absolute %q) = %v, want errors.Is ErrPathEscape", abs, err)
+		}
+	})
+}
+
+// TestOpenForWrite_RejectsParentEscape_Rapid: any number of leading `../`
+// segments escapes the anchor and the kernel returns EXDEV, which OpenForWrite
+// maps to ErrPathEscape.
+func TestOpenForWrite_RejectsParentEscape_Rapid(t *testing.T) {
+	anchor := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		n := rapid.IntRange(1, 5).Draw(rt, "depth")
+		rel := strings.Repeat("../", n) + genLiteralSegment(rt, "leaf")
+		_, err := OpenForWrite(anchor, rel, 0o644)
+		if !errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("OpenForWrite(parent-escape %q) = %v, want errors.Is ErrPathEscape", rel, err)
+		}
+	})
+}
+
+// TestOpenForWrite_RejectsSymlinkEscape_Rapid: a symlink component pointing
+// outside the anchor is rejected (ELOOP → ErrPathEscape) no matter what the
+// leaf written through it is named.
+func TestOpenForWrite_RejectsSymlinkEscape_Rapid(t *testing.T) {
+	base := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor, err := os.MkdirTemp(base, "anchor")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		outside, err := os.MkdirTemp(base, "outside")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(anchor, "lnk")); err != nil {
+			rt.Skipf("symlink unsupported: %v", err)
+		}
+		rel := "lnk/" + genLiteralSegment(rt, "leaf") + ".txt"
+		_, err = OpenForWrite(anchor, rel, 0o644)
+		if !errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("OpenForWrite through symlink %q = %v, want errors.Is ErrPathEscape", rel, err)
+		}
+	})
+}
+
+// TestOpenForWrite_PermissionDenied_NotEscape pins the EACCES-vs-escape
+// classification (#275 review): a plain permission failure must NOT be reported
+// as ErrPathEscape, because EACCES also fires for ordinary mode/ownership
+// reasons and over-claiming "escape" would mislead operators.
+func TestOpenForWrite_PermissionDenied_NotEscape(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses mode bits; cannot provoke EACCES")
+	}
+	anchor := t.TempDir()
+	noWrite := filepath.Join(anchor, "ro")
+	if err := os.Mkdir(noWrite, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	_, err := OpenForWrite(anchor, "ro/denied.txt", 0o644)
+	if err == nil {
+		t.Fatal("OpenForWrite into a 0500 dir succeeded; expected permission error")
+	}
+	// It must read as a permission error (EACCES → os.ErrPermission) ...
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("err = %v, want errors.Is(err, os.ErrPermission)", err)
+	}
+	// ... and must NOT be over-claimed as a path-escape (the #275 distinction).
+	if errors.Is(err, ErrPathEscape) {
+		t.Errorf("EACCES misclassified as ErrPathEscape: %v", err)
+	}
+}
+
+// TestSafeMkdirAll_CreatesTree_Rapid: any literal relative directory path is
+// created in full, and a second call over the same path is a no-op (the EEXIST
+// tolerance — re-running over already-present components must not error).
+func TestSafeMkdirAll_CreatesTree_Rapid(t *testing.T) {
+	anchor := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		relDir := genLiteralPath(rt, "dir")
+		if err := SafeMkdirAll(anchor, relDir, 0o755); err != nil {
+			rt.Fatalf("SafeMkdirAll(%q) = %v, want nil", relDir, err)
+		}
+		fi, err := os.Stat(filepath.Join(anchor, relDir))
+		if err != nil || !fi.IsDir() {
+			rt.Fatalf("dir %q not created (stat err=%v)", relDir, err)
+		}
+		// Idempotent: existing components take the openat2-success branch.
+		if err := SafeMkdirAll(anchor, relDir, 0o755); err != nil {
+			rt.Fatalf("second SafeMkdirAll(%q) = %v, want nil (idempotent)", relDir, err)
+		}
+	})
+}
+
+// TestSafeMkdirAll_ConcurrentSamePath_Rapid exercises the EEXIST race branch:
+// many goroutines create the same deep path at once. Each must return nil; the
+// loser of the ENOENT-openat2 / mkdirat race re-opens the winner's directory
+// (still under RESOLVE_NO_SYMLINKS). Run with -race for the data-race check.
+func TestSafeMkdirAll_ConcurrentSamePath_Rapid(t *testing.T) {
+	base := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor, err := os.MkdirTemp(base, "anchor")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		relDir := genLiteralPath(rt, "dir")
+		const workers = 8
+		var wg sync.WaitGroup
+		errs := make([]error, workers)
+		wg.Add(workers)
+		for i := range workers {
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = SafeMkdirAll(anchor, relDir, 0o755)
+			}(i)
+		}
+		wg.Wait()
+		for i, e := range errs {
+			if e != nil {
+				rt.Fatalf("worker %d: SafeMkdirAll(%q) = %v, want nil under concurrency", i, relDir, e)
+			}
+		}
+		if fi, err := os.Stat(filepath.Join(anchor, relDir)); err != nil || !fi.IsDir() {
+			rt.Fatalf("dir %q missing after concurrent creation (err=%v)", relDir, err)
+		}
+	})
+}
+
+// TestSafeMkdirAll_RejectsSymlinkAtAnyDepth_Rapid: a symlink planted at any
+// depth in the path chain causes resolution to fail with EXDEV/ELOOP →
+// ErrPathEscape. depth==0 puts the symlink directly under the anchor.
+func TestSafeMkdirAll_RejectsSymlinkAtAnyDepth_Rapid(t *testing.T) {
+	base := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor, err := os.MkdirTemp(base, "anchor")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		outside, err := os.MkdirTemp(base, "outside")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		depth := rapid.IntRange(0, 3).Draw(rt, "depth")
+		comps := make([]string, depth)
+		cur := anchor
+		for i := range depth {
+			comps[i] = genLiteralSegment(rt, fmt.Sprintf("c%d", i))
+			cur = filepath.Join(cur, comps[i])
+		}
+		if depth > 0 {
+			if err := os.MkdirAll(cur, 0o755); err != nil {
+				rt.Fatal(err)
+			}
+		}
+		if err := os.Symlink(outside, filepath.Join(cur, "lnk")); err != nil {
+			rt.Skipf("symlink unsupported: %v", err)
+		}
+		parts := append(append([]string{}, comps...), "lnk", "child")
+		relDir := filepath.Join(parts...)
+		err = SafeMkdirAll(anchor, relDir, 0o755)
+		if !errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("SafeMkdirAll through symlink at depth %d (%q) = %v, want errors.Is ErrPathEscape", depth, relDir, err)
+		}
+	})
+}
+
+// TestSafeRemove_RemovesFile_Rapid: a file created under the anchor is removed,
+// and removing it again returns an error that is NOT ErrPathEscape (a missing
+// file is ENOENT, not an escape attempt).
+func TestSafeRemove_RemovesFile_Rapid(t *testing.T) {
+	anchor := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		leaf := genLiteralSegment(rt, "leaf") + ".txt"
+		f, err := OpenForWrite(anchor, leaf, 0o644)
+		if err != nil {
+			rt.Fatalf("setup OpenForWrite(%q): %v", leaf, err)
+		}
+		_ = f.Close()
+		if err := SafeRemove(anchor, leaf); err != nil {
+			rt.Fatalf("SafeRemove(%q) = %v, want nil", leaf, err)
+		}
+		if _, err := os.Stat(filepath.Join(anchor, leaf)); !os.IsNotExist(err) {
+			rt.Fatalf("file %q still present after SafeRemove (stat err=%v)", leaf, err)
+		}
+		// Second remove: error, but not an escape misclassification.
+		err = SafeRemove(anchor, leaf)
+		if err == nil {
+			rt.Fatalf("second SafeRemove(%q) = nil, want ENOENT error", leaf)
+		}
+		if errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("ENOENT misclassified as ErrPathEscape: %v", err)
+		}
+	})
+}
+
+// TestSafeRemove_RejectsSymlinkParent_Rapid: when any parent component is a
+// symlink pointing outside the anchor, SafeRemove refuses with ErrPathEscape
+// before unlinking — even if the named leaf doesn't exist.
+func TestSafeRemove_RejectsSymlinkParent_Rapid(t *testing.T) {
+	base := t.TempDir()
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor, err := os.MkdirTemp(base, "anchor")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		outside, err := os.MkdirTemp(base, "outside")
+		if err != nil {
+			rt.Fatal(err)
+		}
+		if err := os.Symlink(outside, filepath.Join(anchor, "lnk")); err != nil {
+			rt.Skipf("symlink unsupported: %v", err)
+		}
+		rel := "lnk/" + genLiteralSegment(rt, "leaf") + ".txt"
+		err = SafeRemove(anchor, rel)
+		if !errors.Is(err, ErrPathEscape) {
+			rt.Fatalf("SafeRemove through symlink parent %q = %v, want errors.Is ErrPathEscape", rel, err)
+		}
+	})
+}
+
+// TestSafeRemove_EmptyLeaf rejects degenerate leaf names that have no file to
+// unlink (the guard that prevents unlinkat from acting on the parent dir).
+func TestSafeRemove_EmptyLeaf(t *testing.T) {
+	anchor := t.TempDir()
+	for _, leaf := range []string{"", ".", "/"} {
+		if err := SafeRemove(anchor, leaf); !errors.Is(err, ErrPathEscape) {
+			t.Errorf("SafeRemove(%q) = %v, want errors.Is ErrPathEscape", leaf, err)
+		}
+	}
+}
+
+// TestLandlockDirForGlob_Rapid pins the static-prefix-ancestor mapping and the
+// security-critical invariant that the derived Landlock RW directory is always
+// the anchor itself or a descendant — never broader/outside. A regression here
+// would grant the Bash tier write access outside the authored subtree.
+func TestLandlockDirForGlob_Rapid(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor := "/" + strings.Join(genLiteralSegments(rt, "anchor", 1, 3), "/")
+		g := genValidGlobForLandlock(rt, "g")
+
+		got := landlockDirForGlob(anchor, g)
+
+		// Invariant: result never escapes the anchor.
+		if got != anchor && !strings.HasPrefix(got, anchor+"/") {
+			rt.Fatalf("landlockDirForGlob(%q, %q) = %q, escapes anchor", anchor, g, got)
+		}
+
+		// Shape: result is anchor joined with the directory of the glob's
+		// static prefix (the part before the first metachar), matching the
+		// documented examples in jail_linux.go.
+		idx := strings.IndexAny(g, "*?[{")
+		prefix := g
+		if idx >= 0 {
+			prefix = g[:idx]
+		}
+		want := anchor
+		if d := filepath.Dir(prefix); d != "." {
+			want = filepath.Join(anchor, d)
+		}
+		if got != want {
+			rt.Fatalf("landlockDirForGlob(%q, %q) = %q, want %q", anchor, g, got, want)
+		}
+	})
+}
+
+// genValidGlobForLandlock draws a glob in one of the shapes that pass
+// validateGlobEntry and reach landlockDirForGlob at runtime.
+func genValidGlobForLandlock(t *rapid.T, label string) string {
+	switch rapid.IntRange(0, 3).Draw(t, label+"_shape") {
+	case 0:
+		return "**"
+	case 1:
+		return genLiteralPath(t, label+"_p") + "/**"
+	case 2:
+		return genLiteralPath(t, label+"_lit") // static literal path
+	default:
+		return genLiteralSegment(t, label+"_top") // single top-level name
 	}
 }

--- a/agent/exec/jail_other_test.go
+++ b/agent/exec/jail_other_test.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"os/exec"
 	"testing"
+
+	"pgregory.net/rapid"
 )
 
 func TestProbeLandlock_NonLinux(t *testing.T) {
@@ -36,4 +38,50 @@ func TestOpenForWrite_NonLinux_FailsClosed(t *testing.T) {
 	if !errors.Is(err, ErrLandlockUnavailable) {
 		t.Errorf("OpenForWrite on non-Linux = %v, want ErrLandlockUnavailable", err)
 	}
+}
+
+func TestRunJailExec_NonLinux_HardError(t *testing.T) {
+	// The __jail-exec subcommand is unreachable in production on non-Linux
+	// (the handler refuses to install the wrap). A stray invocation must exit
+	// non-zero rather than silently no-op into an unjailed exec.
+	if code := RunJailExec([]string{"--", "/tmp/anchor", "workspace/**", "--", "true"}); code == 0 {
+		t.Errorf("RunJailExec on non-Linux = 0, want non-zero exit")
+	}
+}
+
+func TestSafeMkdirAll_NonLinux_FailsClosed(t *testing.T) {
+	if err := SafeMkdirAll("/tmp/anchor", "workspace/sub", 0o755); !errors.Is(err, ErrLandlockUnavailable) {
+		t.Errorf("SafeMkdirAll on non-Linux = %v, want ErrLandlockUnavailable", err)
+	}
+}
+
+func TestSafeRemove_NonLinux_FailsClosed(t *testing.T) {
+	if err := SafeRemove("/tmp/anchor", "workspace/out.txt"); !errors.Is(err, ErrLandlockUnavailable) {
+		t.Errorf("SafeRemove on non-Linux = %v, want ErrLandlockUnavailable", err)
+	}
+}
+
+// TestNonLinuxStubs_RefuseForAnyInput_Rapid pins the contract that the
+// non-Linux fail-closed behavior is input-independent: no anchor/path
+// combination can coax a write/mkdir/remove past the stub. (genLiteralSegment /
+// genLiteralPath are defined in jail_property_test.go, which has no build
+// constraint, so they are available in this !linux file too.)
+func TestNonLinuxStubs_RefuseForAnyInput_Rapid(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		anchor := "/" + genLiteralPath(rt, "anchor")
+		rel := genLiteralPath(rt, "rel")
+
+		if f, err := OpenForWrite(anchor, rel, 0o644); !errors.Is(err, ErrLandlockUnavailable) {
+			if f != nil {
+				_ = f.Close()
+			}
+			rt.Fatalf("OpenForWrite(%q, %q) = %v, want ErrLandlockUnavailable", anchor, rel, err)
+		}
+		if err := SafeMkdirAll(anchor, rel, 0o755); !errors.Is(err, ErrLandlockUnavailable) {
+			rt.Fatalf("SafeMkdirAll(%q, %q) = %v, want ErrLandlockUnavailable", anchor, rel, err)
+		}
+		if err := SafeRemove(anchor, rel); !errors.Is(err, ErrLandlockUnavailable) {
+			rt.Fatalf("SafeRemove(%q, %q) = %v, want ErrLandlockUnavailable", anchor, rel, err)
+		}
+	})
 }

--- a/agent/exec/jail_property_test.go
+++ b/agent/exec/jail_property_test.go
@@ -236,20 +236,28 @@ func TestIsWindowsAbsolute_MatchesSpec_Rapid(t *testing.T) {
 // literal descendant is contained, and a sibling sharing a string prefix but
 // not a path-component boundary is NOT contained (the bug class isSubpathOf's
 // separator guard exists to prevent).
+//
+// isSubpathOf compares using string(filepath.Separator) and operates on cleaned
+// OS paths, so the test builds native-separator paths via filepath.Join rather
+// than hard-coded "/" — otherwise the descendant case would mismatch on Windows
+// (`/a/b/c` vs prefix `/a/b\`). (Globs elsewhere are forward-slash by spec, so
+// those generators legitimately keep "/".)
 func TestIsSubpathOf_Rapid(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
-		parent := "/" + strings.Join(genLiteralSegments(t, "p", 1, 4), "/")
+		sep := string(filepath.Separator)
+		parent := filepath.Join(append([]string{sep}, genLiteralSegments(t, "p", 1, 4)...)...)
 
 		if !isSubpathOf(parent, parent) {
 			t.Fatalf("isSubpathOf(%q, %q) = false, want true (reflexive)", parent, parent)
 		}
 
-		child := parent + "/" + genLiteralPath(t, "sub")
+		child := filepath.Join(parent, genLiteralPath(t, "sub"))
 		if !isSubpathOf(child, parent) {
 			t.Fatalf("isSubpathOf(%q, %q) = false, want true (descendant)", child, parent)
 		}
 
-		// "/a/b" vs sibling "/a/bx": string-prefix match, but NOT a path child.
+		// Sibling sharing a string prefix but NOT a path-component boundary
+		// (e.g. "/a/b" vs "/a/bx") — appended WITHOUT a separator on purpose.
 		sibling := parent + genLiteralSegment(t, "suffix")
 		if isSubpathOf(sibling, parent) {
 			t.Fatalf("isSubpathOf(%q, %q) = true, want false (prefix-but-not-child)", sibling, parent)

--- a/agent/exec/jail_property_test.go
+++ b/agent/exec/jail_property_test.go
@@ -1,0 +1,258 @@
+// ABOUTME: Cross-platform property/invariant tests for the writable_paths jail
+// ABOUTME: validation surface (issue #282, follow-up to #275/#272) using pgregory.net/rapid.
+package exec
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"pgregory.net/rapid"
+)
+
+// These tests pin first-principles properties of the cross-platform jail
+// validation surface (ValidateWritablePaths / validateGlobEntry and their
+// helpers) so a regression in any documented contract fails fast with a
+// shrunk counter-example rather than being rediscovered in review (the #275
+// review took 13 rounds / ~30 findings on exactly these properties).
+//
+// The example-based table in jail_test.go stays as-is; these generalize it.
+
+// genLiteralSegment draws a single path segment that is a pure literal: no
+// glob metachars (*?[]{}), no separators, no `.`/`..`, no `~`/`:`/`\`. Starts
+// with a letter so it can never be empty or collide with a Windows drive or a
+// dot-special. Shared by every property in package exec (this file has no
+// build constraint, so jail_linux_test.go and jail_other_test.go see it too).
+func genLiteralSegment(t *rapid.T, label string) string {
+	return rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`).Draw(t, label)
+}
+
+// genLiteralSegments draws between min and max literal segments.
+func genLiteralSegments(t *rapid.T, label string, min, max int) []string {
+	return rapid.SliceOfN(rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`), min, max).Draw(t, label)
+}
+
+// genLiteralPath draws a workspace-relative literal path of 1-4 segments joined
+// by `/` (e.g. "workspace/sub/out"). Always valid input to validateGlobEntry.
+func genLiteralPath(t *rapid.T, label string) string {
+	return strings.Join(genLiteralSegments(t, label, 1, 4), "/")
+}
+
+// genHappyGlob draws a writable_paths entry that validateGlobEntry MUST accept:
+// every documented supported shape.
+func genHappyGlob(t *rapid.T, label string) string {
+	switch rapid.IntRange(0, 5).Draw(t, label+"_shape") {
+	case 0:
+		return "**"
+	case 1:
+		return genLiteralPath(t, label+"_p") + "/**"
+	case 2:
+		return "**/" + genLiteralPath(t, label+"_s")
+	case 3:
+		return genLiteralPath(t, label+"_p") + "/**/" + genLiteralPath(t, label+"_s")
+	case 4:
+		// Plain literal path (static glob → literal match at runtime).
+		return genLiteralPath(t, label+"_lit")
+	default:
+		// Single-segment `*` glob (path.Match territory, not `**`).
+		return genLiteralPath(t, label+"_dir") + "/*"
+	}
+}
+
+// genEscapeGlob draws a writable_paths entry that MUST be refused with the
+// ErrPathEscape sentinel ("tried to point the jail outside the session root").
+func genEscapeGlob(t *rapid.T, label string) string {
+	base := genLiteralPath(t, label+"_base")
+	switch rapid.IntRange(0, 5).Draw(t, label+"_kind") {
+	case 0:
+		return "/" + base // absolute
+	case 1:
+		return "~/" + base // home-relative
+	case 2:
+		return "~" + base // bare tilde prefix
+	case 3:
+		// Windows drive-absolute, build-OS-independent.
+		drive := rapid.StringMatching(`^[A-Za-z]$`).Draw(t, label+"_drive")
+		return drive + `:\` + base
+	case 4:
+		return `\\` + base // Windows UNC
+	default:
+		// A `..` segment anywhere — rejected fail-closed because path.Clean
+		// would collapse it into a broader glob than authored.
+		pre := genLiteralSegments(t, label+"_pre", 0, 3)
+		post := genLiteralSegments(t, label+"_post", 0, 3)
+		all := append(append(append([]string{}, pre...), ".."), post...)
+		return strings.Join(all, "/")
+	}
+}
+
+// genMalformedGlob draws a writable_paths entry that MUST be refused with a
+// PLAIN (non-sentinel) error: a bad glob shape rather than an escape attempt.
+func genMalformedGlob(t *rapid.T, label string) string {
+	switch rapid.IntRange(0, 4).Draw(t, label+"_kind") {
+	case 0:
+		// Brace usage (balanced or not) — the matcher never expands it.
+		return genLiteralPath(t, label+"_brace") + "{"
+	case 1:
+		// `**` glued to other chars in the same segment.
+		return genLiteralPath(t, label+"_glue") + "/**" + genLiteralSegment(t, label+"_glueleaf")
+	case 2:
+		// More than one `**` segment.
+		return genLiteralSegment(t, label+"_a") + "/**/" + genLiteralSegment(t, label+"_b") + "/**/" + genLiteralSegment(t, label+"_c")
+	case 3:
+		// Glob metachars in the literal prefix before `**`.
+		return genLiteralSegment(t, label+"_meta") + "*/**"
+	default:
+		// Unbalanced character class — path.Match rejects it.
+		return genLiteralPath(t, label+"_cc") + "["
+	}
+}
+
+func TestValidateGlobEntry_HappyShapes_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		g := genHappyGlob(t, "g")
+		if err := validateGlobEntry(g); err != nil {
+			t.Fatalf("validateGlobEntry(%q) = %v, want nil (documented supported shape)", g, err)
+		}
+	})
+}
+
+func TestValidateGlobEntry_EscapeClass_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		g := genEscapeGlob(t, "g")
+		err := validateGlobEntry(g)
+		if !errors.Is(err, ErrPathEscape) {
+			t.Fatalf("validateGlobEntry(%q) = %v, want errors.Is(err, ErrPathEscape)", g, err)
+		}
+	})
+}
+
+func TestValidateGlobEntry_MalformedClass_NotEscape_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		g := genMalformedGlob(t, "g")
+		err := validateGlobEntry(g)
+		if err == nil {
+			t.Fatalf("validateGlobEntry(%q) = nil, want a malformed-shape error", g)
+		}
+		// The class invariant: malformed shapes are PLAIN errors, never the
+		// escape sentinel. Upstream consumers distinguish "bad shape" from
+		// "escape attempt" via errors.Is — that distinction must hold.
+		if errors.Is(err, ErrPathEscape) {
+			t.Fatalf("validateGlobEntry(%q) = %v, must NOT be classified as ErrPathEscape (malformed != escape)", g, err)
+		}
+	})
+}
+
+// TestValidateWritablePaths_PreservesGlobClass_Rapid pins that the PUBLIC entry
+// point (not just the lowercase helper) preserves the escape-vs-malformed
+// sentinel partition for whichever bad glob appears in the list.
+func TestValidateWritablePaths_PreservesGlobClass_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	rapid.Check(t, func(t *rapid.T) {
+		// Valid contained working_dir so only the glob class is under test.
+		const wd = "work"
+		if rapid.Bool().Draw(t, "escape") {
+			g := genEscapeGlob(t, "g")
+			if err := ValidateWritablePaths(wd, []string{g}, cwd); !errors.Is(err, ErrPathEscape) {
+				t.Fatalf("ValidateWritablePaths(glob=%q) = %v, want errors.Is ErrPathEscape", g, err)
+			}
+		} else {
+			g := genMalformedGlob(t, "g")
+			err := ValidateWritablePaths(wd, []string{g}, cwd)
+			if err == nil {
+				t.Fatalf("ValidateWritablePaths(glob=%q) = nil, want malformed error", g)
+			}
+			if errors.Is(err, ErrPathEscape) {
+				t.Fatalf("ValidateWritablePaths(glob=%q) = %v, malformed must not be ErrPathEscape", g, err)
+			}
+		}
+	})
+}
+
+// TestValidateWritablePaths_HappyGlobs_Rapid: a contained working_dir plus any
+// list of supported glob shapes validates clean.
+func TestValidateWritablePaths_HappyGlobs_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(1, 4).Draw(t, "n")
+		globs := make([]string, n)
+		for i := range globs {
+			globs[i] = genHappyGlob(t, "g")
+		}
+		if err := ValidateWritablePaths("work", globs, cwd); err != nil {
+			t.Fatalf("ValidateWritablePaths(work, %v) = %v, want nil", globs, err)
+		}
+	})
+}
+
+// TestValidateWorkingDir_ContainedRelative_Rapid: any relative working_dir
+// built from literal segments resolves under the process cwd → accepted. The
+// path need not exist; EvalSymlinks returning ErrNotExist is the safe case.
+func TestValidateWorkingDir_ContainedRelative_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	rapid.Check(t, func(t *rapid.T) {
+		rel := genLiteralPath(t, "rel")
+		if err := ValidateWritablePaths(rel, []string{"**"}, cwd); err != nil {
+			t.Fatalf("ValidateWritablePaths(workingDir=%q) = %v, want nil (contained relative path)", rel, err)
+		}
+	})
+}
+
+// TestValidateWorkingDir_AbsoluteEscape_Rapid: an absolute working_dir that is
+// not under the process cwd is refused with ErrPathEscape.
+func TestValidateWorkingDir_AbsoluteEscape_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	cleanCwd := filepath.Clean(cwd)
+	rapid.Check(t, func(t *rapid.T) {
+		abs := "/" + genLiteralPath(t, "abs")
+		// Guard against the astronomically unlikely case the random absolute
+		// path lands inside the temp cwd; that case is not an escape.
+		if isSubpathOf(filepath.Clean(abs), cleanCwd) {
+			t.Skip("generated absolute path happens to be under cwd")
+		}
+		err := ValidateWritablePaths(abs, []string{"**"}, cwd)
+		if !errors.Is(err, ErrPathEscape) {
+			t.Fatalf("ValidateWritablePaths(workingDir=%q, cwd=%q) = %v, want errors.Is ErrPathEscape", abs, cwd, err)
+		}
+	})
+}
+
+// TestIsWindowsAbsolute_MatchesSpec_Rapid pins isWindowsAbsolute against its
+// documented predicate over arbitrary input, so dropping either the
+// drive-letter or UNC branch diverges immediately.
+func TestIsWindowsAbsolute_MatchesSpec_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		s := rapid.StringN(0, 12, 12).Draw(t, "s")
+		want := (len(s) >= 2 && s[1] == ':' && ((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z'))) ||
+			strings.HasPrefix(s, `\\`)
+		if got := isWindowsAbsolute(s); got != want {
+			t.Fatalf("isWindowsAbsolute(%q) = %v, want %v", s, got, want)
+		}
+	})
+}
+
+// TestIsSubpathOf_Rapid pins the three containment invariants: reflexivity, any
+// literal descendant is contained, and a sibling sharing a string prefix but
+// not a path-component boundary is NOT contained (the bug class isSubpathOf's
+// separator guard exists to prevent).
+func TestIsSubpathOf_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		parent := "/" + strings.Join(genLiteralSegments(t, "p", 1, 4), "/")
+
+		if !isSubpathOf(parent, parent) {
+			t.Fatalf("isSubpathOf(%q, %q) = false, want true (reflexive)", parent, parent)
+		}
+
+		child := parent + "/" + genLiteralPath(t, "sub")
+		if !isSubpathOf(child, parent) {
+			t.Fatalf("isSubpathOf(%q, %q) = false, want true (descendant)", child, parent)
+		}
+
+		// "/a/b" vs sibling "/a/bx": string-prefix match, but NOT a path child.
+		sibling := parent + genLiteralSegment(t, "suffix")
+		if isSubpathOf(sibling, parent) {
+			t.Fatalf("isSubpathOf(%q, %q) = true, want false (prefix-but-not-child)", sibling, parent)
+		}
+	})
+}

--- a/pipeline/handlers/codergen_jail_property_test.go
+++ b/pipeline/handlers/codergen_jail_property_test.go
@@ -167,7 +167,12 @@ func TestMatchWritablePath_IsUnion_Rapid(t *testing.T) {
 // --- relPathForJail ---
 
 // TestRelPathForJail_ContainedRoundTrips_Rapid: for any literal relative path,
-// relPathForJail(anchor, anchor/rel) returns rel with no error.
+// relPathForJail(anchor, anchor/rel) round-trips to rel with no error.
+//
+// relPathForJail returns filepath.Rel's output, which uses OS separators, so the
+// comparison normalizes with filepath.ToSlash before checking against the
+// forward-slash-generated rel — otherwise the multi-segment case would mismatch
+// on Windows (`a\b` vs `a/b`).
 func TestRelPathForJail_ContainedRoundTrips_Rapid(t *testing.T) {
 	rapid.Check(t, func(t *rapid.T) {
 		anchor := "/" + drawPath(t, "anchor")
@@ -177,7 +182,7 @@ func TestRelPathForJail_ContainedRoundTrips_Rapid(t *testing.T) {
 		if err != nil {
 			t.Fatalf("relPathForJail(%q, %q) = err %v, want nil", anchor, abs, err)
 		}
-		if got != rel {
+		if filepath.ToSlash(got) != rel {
 			t.Fatalf("relPathForJail(%q, %q) = %q, want %q", anchor, abs, got, rel)
 		}
 	})

--- a/pipeline/handlers/codergen_jail_property_test.go
+++ b/pipeline/handlers/codergen_jail_property_test.go
@@ -1,0 +1,413 @@
+// ABOUTME: Property/invariant tests for the writable_paths jail wiring in
+// ABOUTME: codergen_jail.go (issue #282, follow-up to #275/#272) using pgregory.net/rapid.
+package handlers
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	execpkg "github.com/2389-research/tracker/agent/exec"
+	"github.com/2389-research/tracker/pipeline"
+
+	"pgregory.net/rapid"
+)
+
+// These tests pin the matcher, path-relativization, refuse-to-start gates, and
+// the WriteOpener/Remover closures that configureJail installs. They generalize
+// the example-based tables in codergen_jail_test.go (which stay as-is).
+//
+// fakeBackendForGate and NativeBackend are defined in codergen_jail_test.go;
+// this file shares them (same package).
+
+// drawSeg / drawPath generate literal (metachar-free) path segments and paths.
+func drawSeg(t *rapid.T, label string) string {
+	return rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`).Draw(t, label)
+}
+
+func drawPath(t *rapid.T, label string) string {
+	return strings.Join(rapid.SliceOfN(rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`), 1, 4).Draw(t, label), "/")
+}
+
+// drawValidGlob draws an entry in one of the documented supported shapes.
+func drawValidGlob(t *rapid.T, label string) string {
+	switch rapid.IntRange(0, 4).Draw(t, label+"_shape") {
+	case 0:
+		return "**"
+	case 1:
+		return drawPath(t, label+"_p") + "/**"
+	case 2:
+		return "**/" + drawPath(t, label+"_s")
+	case 3:
+		return drawPath(t, label+"_lit") // static literal path
+	default:
+		return drawPath(t, label+"_dir") + "/*" // single-segment star
+	}
+}
+
+// --- matchOneGlob / matchWritablePath ---
+
+// TestMatchOneGlob_PrefixDoublestar_Rapid: `prefix/**` matches the prefix
+// directory itself and every descendant (the headline example in issue #282).
+func TestMatchOneGlob_PrefixDoublestar_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := drawPath(t, "prefix")
+		g := prefix + "/**"
+		if !matchOneGlob(prefix, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = false, want true (prefix dir itself)", prefix, g)
+		}
+		full := prefix + "/" + drawPath(t, "leaf")
+		if !matchOneGlob(full, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = false, want true (descendant)", full, g)
+		}
+	})
+}
+
+// TestMatchOneGlob_BareDoublestar_Rapid: bare `**` matches any relative path.
+func TestMatchOneGlob_BareDoublestar_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		p := drawPath(t, "p")
+		if !matchOneGlob(p, "**") {
+			t.Fatalf("matchOneGlob(%q, \"**\") = false, want true", p)
+		}
+	})
+}
+
+// TestMatchOneGlob_SuffixDoublestar_Rapid: `**/suffix` matches any path that
+// ends in the suffix component(s) at any depth, including the top level.
+func TestMatchOneGlob_SuffixDoublestar_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		sufSegs := rapid.SliceOfN(rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`), 1, 3).Draw(t, "suf")
+		suffix := strings.Join(sufSegs, "/")
+		g := "**/" + suffix
+		preSegs := rapid.SliceOfN(rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`), 0, 3).Draw(t, "pre")
+		full := strings.Join(append(append([]string{}, preSegs...), sufSegs...), "/")
+		if !matchOneGlob(full, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = false, want true (suffix at any depth)", full, g)
+		}
+	})
+}
+
+// TestMatchOneGlob_PrefixSuffixDoublestar_Rapid: `prefix/**/suffix` matches
+// `prefix/<any-intermediate>/suffix`.
+func TestMatchOneGlob_PrefixSuffixDoublestar_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := drawPath(t, "prefix")
+		suf := drawSeg(t, "suf")
+		mid := rapid.SliceOfN(rapid.StringMatching(`^[a-z][a-z0-9_-]{0,7}$`), 0, 3).Draw(t, "mid")
+		g := prefix + "/**/" + suf
+		parts := append([]string{prefix}, mid...)
+		parts = append(parts, suf)
+		full := strings.Join(parts, "/")
+		if !matchOneGlob(full, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = false, want true (prefix/**/suffix)", full, g)
+		}
+	})
+}
+
+// TestMatchOneGlob_PrefixDoublestar_RejectsOtherTop_Rapid: a path under a
+// different top-level directory does NOT match `prefix/**`. Distinct "pre"/"oth"
+// tags guarantee the two top dirs differ without needing rejection sampling.
+func TestMatchOneGlob_PrefixDoublestar_RejectsOtherTop_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := "pre" + drawSeg(t, "prefix")
+		g := prefix + "/**"
+		other := "oth" + drawSeg(t, "other")
+		full := other + "/" + drawPath(t, "leaf")
+		if matchOneGlob(full, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = true, want false (different top dir)", full, g)
+		}
+		if matchOneGlob(other, g) {
+			t.Fatalf("matchOneGlob(%q, %q) = true, want false (sibling top dir)", other, g)
+		}
+	})
+}
+
+// TestMatchOneGlob_LiteralExact_Rapid: a static (metachar-free) glob matches
+// only the exact path equal to it.
+func TestMatchOneGlob_LiteralExact_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		lit := drawPath(t, "lit")
+		if !matchOneGlob(lit, lit) {
+			t.Fatalf("matchOneGlob(%q, %q) = false, want true (literal self-match)", lit, lit)
+		}
+		other := lit + drawSeg(t, "extra") // strictly longer, so != lit
+		if matchOneGlob(other, lit) {
+			t.Fatalf("matchOneGlob(%q, %q) = true, want false (literal matches only itself)", other, lit)
+		}
+	})
+}
+
+// TestMatchWritablePath_IsUnion_Rapid: matchWritablePath is exactly the OR of
+// matchOneGlob over the list. Pins the union contract against refactors.
+func TestMatchWritablePath_IsUnion_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		n := rapid.IntRange(1, 4).Draw(t, "n")
+		globs := make([]string, n)
+		for i := range globs {
+			globs[i] = drawValidGlob(t, "g")
+		}
+		p := drawPath(t, "p")
+		want := false
+		for _, g := range globs {
+			if matchOneGlob(p, g) {
+				want = true
+				break
+			}
+		}
+		if got := matchWritablePath(p, globs); got != want {
+			t.Fatalf("matchWritablePath(%q, %v) = %v, want %v (union of matchOneGlob)", p, globs, got, want)
+		}
+	})
+}
+
+// --- relPathForJail ---
+
+// TestRelPathForJail_ContainedRoundTrips_Rapid: for any literal relative path,
+// relPathForJail(anchor, anchor/rel) returns rel with no error.
+func TestRelPathForJail_ContainedRoundTrips_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		anchor := "/" + drawPath(t, "anchor")
+		rel := drawPath(t, "rel")
+		abs := filepath.Join(anchor, rel)
+		got, err := relPathForJail(anchor, abs)
+		if err != nil {
+			t.Fatalf("relPathForJail(%q, %q) = err %v, want nil", anchor, abs, err)
+		}
+		if got != rel {
+			t.Fatalf("relPathForJail(%q, %q) = %q, want %q", anchor, abs, got, rel)
+		}
+	})
+}
+
+// TestRelPathForJail_RejectsParentEscape_Rapid: the anchor's own parent
+// directory relativizes to ".." and must be refused with ErrPathEscape.
+func TestRelPathForJail_RejectsParentEscape_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		anchor := "/" + drawPath(t, "anchor")
+		parent := filepath.Dir(anchor) // Rel(anchor, parent) == ".."
+		_, err := relPathForJail(anchor, parent)
+		if !errors.Is(err, execpkg.ErrPathEscape) {
+			t.Fatalf("relPathForJail(%q, %q) = %v, want errors.Is ErrPathEscape", anchor, parent, err)
+		}
+	})
+}
+
+// TestRelPathForJail_AllowsDotDotPrefixName_Rapid: a bare leaf name that merely
+// STARTS with ".." (e.g. "..cache") stays below the anchor and must be allowed
+// — only a true ".."/"../" traversal escapes (#272 review nuance).
+func TestRelPathForJail_AllowsDotDotPrefixName_Rapid(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		anchor := "/" + drawPath(t, "anchor")
+		name := ".." + drawSeg(t, "name") // "..foo", never exactly ".."
+		abs := filepath.Join(anchor, name)
+		got, err := relPathForJail(anchor, abs)
+		if err != nil {
+			t.Fatalf("relPathForJail(%q, %q) = err %v, want nil (bare ..name is below anchor)", anchor, abs, err)
+		}
+		if got != name {
+			t.Fatalf("relPathForJail(%q, %q) = %q, want %q", anchor, abs, got, name)
+		}
+	})
+}
+
+// --- configureJail refusal gates ---
+
+// TestConfigureJail_G1_RefusesInvalidGlobs_Rapid: any invalid glob causes
+// configureJail to refuse (G1) without wiring any env hooks. Cross-platform —
+// G1 runs before the Landlock probe.
+func TestConfigureJail_G1_RefusesInvalidGlobs_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	rapid.Check(t, func(t *rapid.T) {
+		env := execpkg.NewLocalEnvironment(cwd)
+		cfg := agent.SessionConfig{
+			WorkingDir:       "work",
+			WritablePaths:    []string{drawInvalidGlob(t, "g")},
+			WritablePathsSet: true,
+			Backend:          "native",
+		}
+		enabled, err := configureJail(&cfg, env, cwd)
+		if err == nil {
+			t.Fatalf("configureJail accepted invalid glob %v, want refuse", cfg.WritablePaths)
+		}
+		if enabled {
+			t.Fatalf("configureJail enabled=true on G1 refusal")
+		}
+		if env.CommandWrapper != nil || env.WriteOpener != nil || env.Remover != nil {
+			t.Fatalf("env hooks wired despite G1 refusal")
+		}
+	})
+}
+
+// TestConfigureJail_G2_RefusesNonNativeBackend_Rapid: with valid paths, any
+// non-native backend is refused by name (G2) before any hooks are wired. G2
+// runs before the Landlock probe, so this holds on every OS.
+func TestConfigureJail_G2_RefusesNonNativeBackend_Rapid(t *testing.T) {
+	cwd := t.TempDir()
+	rapid.Check(t, func(t *rapid.T) {
+		backend := drawNonNativeBackend(t)
+		env := execpkg.NewLocalEnvironment(cwd)
+		cfg := agent.SessionConfig{
+			WorkingDir:       "work",
+			WritablePaths:    []string{drawValidGlob(t, "g")},
+			WritablePathsSet: true,
+			Backend:          backend,
+		}
+		enabled, err := configureJail(&cfg, env, cwd)
+		if err == nil {
+			t.Fatalf("configureJail accepted backend %q, want refuse", backend)
+		}
+		if enabled {
+			t.Fatalf("configureJail enabled=true on G2 refusal for %q", backend)
+		}
+		if !strings.Contains(err.Error(), backend) {
+			t.Fatalf("configureJail err %v does not name backend %q", err, backend)
+		}
+		if env.CommandWrapper != nil || env.WriteOpener != nil {
+			t.Fatalf("env hooks wired despite G2 refusal")
+		}
+	})
+}
+
+// drawInvalidGlob draws a glob that ValidateWritablePaths must reject (mix of
+// escape-class and malformed-class).
+func drawInvalidGlob(t *rapid.T, label string) string {
+	switch rapid.IntRange(0, 3).Draw(t, label+"_kind") {
+	case 0:
+		return "/" + drawPath(t, label+"_abs") // absolute → escape
+	case 1:
+		return "~/" + drawPath(t, label+"_tilde") // tilde → escape
+	case 2:
+		return drawPath(t, label+"_brace") + "/*.{md" // brace → malformed
+	default:
+		return drawSeg(t, label+"_meta") + "*/**" // metachar before ** → malformed
+	}
+}
+
+// drawNonNativeBackend draws a backend name configureJail's G2 must refuse:
+// the two known out-of-process backends plus an arbitrary unknown name.
+func drawNonNativeBackend(t *rapid.T) string {
+	switch rapid.IntRange(0, 2).Draw(t, "backend_kind") {
+	case 0:
+		return "claude-code"
+	case 1:
+		return "acp"
+	default:
+		return "xb" + drawSeg(t, "unknown") // never "", "native", "claude-code", "acp"
+	}
+}
+
+// TestRefuseWritablePathsOnUnsupportedBackend_Matrix is the exhaustive
+// dispatcher-layer table: {nil, unset, writable} × {native, non-native}. The
+// gate keys ONLY on the concrete *NativeBackend type, so acp / claude-code /
+// unknown all collapse to the single "non-native" column here; their distinct
+// refusal *messages* are exercised by TestConfigureJail_G2_RefusesNonNativeBackend_Rapid.
+func TestRefuseWritablePathsOnUnsupportedBackend_Matrix(t *testing.T) {
+	nodeWritable := &pipeline.Node{Attrs: map[string]string{"writable_paths": "workspace/**"}}
+	nodeUnset := &pipeline.Node{Attrs: map[string]string{}}
+	native := &NativeBackend{}
+	nonNative := fakeBackendForGate{}
+
+	cases := []struct {
+		name    string
+		node    *pipeline.Node
+		backend pipeline.AgentBackend
+		wantErr bool
+	}{
+		{"nil node + native", nil, native, false},
+		{"nil node + non-native", nil, nonNative, false},
+		{"unset + native", nodeUnset, native, false},
+		{"unset + non-native", nodeUnset, nonNative, false},
+		{"writable + native", nodeWritable, native, false},
+		{"writable + non-native", nodeWritable, nonNative, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := refuseWritablePathsOnUnsupportedBackend(tc.node, tc.backend)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("refuseWritablePathsOnUnsupportedBackend = %v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// --- WriteOpener / Remover closures (Landlock-gated) ---
+
+// TestConfigureJail_Closures_Rapid exercises the installed WriteOpener/Remover
+// over random paths in three classes:
+//   - allowed (matches the glob): write+remove succeed, file really created;
+//   - denied by glob (under anchor, no glob match): ErrPathNotAllowed, and the
+//     parent dir is NOT created (mkdir runs AFTER the glob check — a rejected
+//     write must leave no empty directories);
+//   - escaping the anchor: ErrPathEscape.
+//
+// Requires a working Landlock (the closures call the real Linux openat2 seam);
+// skips otherwise.
+func TestConfigureJail_Closures_Rapid(t *testing.T) {
+	if err := execpkg.ProbeLandlock(); err != nil {
+		t.Skipf("Landlock unavailable: %v", err)
+	}
+	anchor := t.TempDir()
+	env := execpkg.NewLocalEnvironment(anchor)
+	cfg := agent.SessionConfig{
+		WorkingDir:       ".",
+		WritablePaths:    []string{"workspace/**"},
+		WritablePathsSet: true,
+		Backend:          "native",
+	}
+	enabled, err := configureJail(&cfg, env, anchor)
+	if err != nil || !enabled {
+		t.Fatalf("configureJail setup: enabled=%v err=%v", enabled, err)
+	}
+	if env.WriteOpener == nil || env.Remover == nil {
+		t.Fatal("configureJail did not wire WriteOpener/Remover")
+	}
+
+	rapid.Check(t, func(rt *rapid.T) {
+		leaf := drawSeg(rt, "leaf") + ".txt"
+		switch rapid.IntRange(0, 2).Draw(rt, "case") {
+		case 0: // allowed
+			abs := filepath.Join(anchor, "workspace", leaf)
+			f, err := env.WriteOpener(abs, 0o644)
+			if err != nil {
+				rt.Fatalf("allowed write %q rejected: %v", abs, err)
+			}
+			_ = f.Close()
+			if _, e := os.Stat(abs); e != nil {
+				rt.Fatalf("allowed file %q not created: %v", abs, e)
+			}
+			if err := env.Remover(abs); err != nil {
+				rt.Fatalf("allowed remove %q failed: %v", abs, err)
+			}
+			if _, e := os.Stat(abs); !os.IsNotExist(e) {
+				rt.Fatalf("file %q persisted after Remover (stat err=%v)", abs, e)
+			}
+		case 1: // denied by glob
+			topDir := "deny" + drawSeg(rt, "top") // never "workspace"
+			abs := filepath.Join(anchor, topDir, leaf)
+			_, err := env.WriteOpener(abs, 0o644)
+			if !errors.Is(err, execpkg.ErrPathNotAllowed) {
+				rt.Fatalf("denied write %q = %v, want errors.Is ErrPathNotAllowed", abs, err)
+			}
+			// mkdir ordering: the rejected write must not have created the dir.
+			if _, e := os.Stat(filepath.Join(anchor, topDir)); e == nil {
+				rt.Fatalf("rejected write created parent dir %q (mkdir ran before glob check)", topDir)
+			}
+			if err := env.Remover(abs); !errors.Is(err, execpkg.ErrPathNotAllowed) {
+				rt.Fatalf("denied remove %q = %v, want errors.Is ErrPathNotAllowed", abs, err)
+			}
+		default: // escapes anchor
+			abs := filepath.Join(filepath.Dir(anchor), "escape"+drawSeg(rt, "e"), leaf)
+			_, err := env.WriteOpener(abs, 0o644)
+			if !errors.Is(err, execpkg.ErrPathEscape) {
+				rt.Fatalf("escape write %q = %v, want errors.Is ErrPathEscape", abs, err)
+			}
+			if err := env.Remover(abs); !errors.Is(err, execpkg.ErrPathEscape) {
+				rt.Fatalf("escape remove %q = %v, want errors.Is ErrPathEscape", abs, err)
+			}
+		}
+	})
+}

--- a/pipeline/handlers/codergen_jail_property_test.go
+++ b/pipeline/handlers/codergen_jail_property_test.go
@@ -266,7 +266,7 @@ func TestConfigureJail_G2_RefusesNonNativeBackend_Rapid(t *testing.T) {
 		if !strings.Contains(err.Error(), backend) {
 			t.Fatalf("configureJail err %v does not name backend %q", err, backend)
 		}
-		if env.CommandWrapper != nil || env.WriteOpener != nil {
+		if env.CommandWrapper != nil || env.WriteOpener != nil || env.Remover != nil {
 			t.Fatalf("env hooks wired despite G2 refusal")
 		}
 	})


### PR DESCRIPTION
## Summary

Closes #282 (follow-up to #275, refs #272). The #275 `writable_paths`/Landlock-jail review took **13 rounds / ~30 findings** — most on first-principles properties of the jail's public surface (path containment, glob matching, error-sentinel classes, syscall flag combos) that weren't pinned by tests at implementation time. This PR closes that gap with **property-based tests** so each documented invariant fails fast with a shrunk counter-example when regressed.

**Test-only.** No product code changed. Uses the `pgregory.net/rapid` dev dep that's already in `go.mod` (same library as `tail_buffer_property_test.go`) — **no new dependencies**. Generalizes the example-based table that landed in `88463c6`.

## What's covered

- **`agent/exec/jail_property_test.go`** (cross-platform): escape-vs-malformed sentinel partition of `ValidateWritablePaths`/`validateGlobEntry` (`errors.Is(…, ErrPathEscape)`); every supported doublestar/literal shape validates; `isWindowsAbsolute` vs its spec; `isSubpathOf` containment (reflexive / descendant / prefix-but-not-child); contained-relative vs absolute-escape `working_dir` resolution.
- **`agent/exec/jail_linux_test.go`** (`//go:build linux`): `OpenForWrite` (literal-leaf allow; absolute / parent-escape / symlink-escape refusal; **EACCES-vs-escape** classification); `SafeMkdirAll` (tree creation, idempotent **EEXIST** tolerance, concurrent same-path under `-race`, **symlink-at-any-depth** refusal); `SafeRemove` (remove, **ENOENT-not-escape**, empty-leaf guard, symlink-parent refusal); `landlockDirForGlob` shape + **never-escapes-anchor** invariant.
- **`agent/exec/jail_other_test.go`** (`//go:build !linux`): `RunJailExec` hard-error and `SafeMkdirAll`/`SafeRemove` fail-closed, plus an input-independent refusal property. (Verified via `GOOS=darwin GOARCH=amd64 go test -c`.)
- **`pipeline/handlers/codergen_jail_property_test.go`** (cross-platform): `matchOneGlob`/`matchWritablePath` semantics + union contract; `relPathForJail` containment incl. the bare-`..name` allow case; `configureJail` **G1/G2** refuse-to-start gates (no env hooks wired on refusal); the refuse-backend matrix; and the `WriteOpener`/`Remover` closures (allow / `ErrPathNotAllowed` / `ErrPathEscape` classes, **mkdir-after-glob ordering**) gated on Landlock availability.

## Verification

- `go build ./...` ✓ · `GOOS=darwin GOARCH=amd64 go build ./...` ✓ · `go vet` ✓ · `gofmt` clean
- `go test ./agent/exec/ ./pipeline/handlers/ -race` ✓ · `go test ./... -short` ✓
- `dippin doctor` on the three core pipelines: **Grade A** (unchanged — no engine/.dip edits)
- **Teeth proven:** deliberately mutating the brace-error sentinel and `matchOneGlob`'s descendant branch each fail the corresponding property (rapid shrank to `"a{"` and `matchOneGlob("a/a","a/**")`); both reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783113315&installation_id=131176874&pr_number=293&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F293&signature=c4501720f9a2f6901f2cf0e4928ff7a85f881fe23ff251c0172b4451d558a468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage with property-based testing across all platforms (Linux and non-Linux) to ensure system reliability and robustness.
  * Added comprehensive invariant tests for path validation and jail escape prevention logic to catch edge cases.
  * Implemented randomized input testing strategies to strengthen coverage of boundary conditions and degenerate scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->