### PR TITLE
docs+ci: agent-tool jail threat model + os.* bypass lint (#283)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Dippin doctor
         run: make doctor
 
+      - name: Agent-tool jail lint
+        run: make tools-jail-check
+
       - name: Verify tracker binary
         run: ./bin/tracker --help
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ bin/
 /tracker
 /tracker-conformance
 /generate
+/jailcheck
 .DS_Store
 .tracker/
 .scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,21 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Agent-tool jail threat model + `os.*` bypass lint** (closes #283, refs
+- **Agent-tool jail threat model + jail-bypass lint** (closes #283, refs
   #275/#272). New doc `docs/architecture/agent-tool-jail-checklist.md`: a
   per-tool threat-model table (every `agent/tools/` tool — what it touches and
   which `ExecutionEnvironment` seam it routes through, each row verified against
-  the code), the rule that any filesystem mutation MUST route through
-  `exec.ExecutionEnvironment` (direct `os.WriteFile`/`MkdirAll`/`Remove`/… is a
-  review-blocker), a new-tool checklist, and the documented env==nil-fallback
-  invariant. New CI gate `make tools-jail-check` (a `go/ast` analyzer under
-  `tools/jailcheck/`) flags any mutating `os.*` call in `agent/tools/*.go`
-  (excluding `_test.go`); the one legal exception — a fallback reachable only
-  when `env == nil`, where no jail can be active — is whitelisted by a
-  `//jail:allow-unjailed-fallback` marker on the function. Wired into the `ci:`
-  target and the CI "Quality Gates" job. The two existing audited fallbacks
-  (`generate_code`, `write_enriched_sprint`) carry the marker; no other product
-  code changed.
+  the code), the rule that any filesystem mutation **or subprocess** MUST route
+  through `exec.ExecutionEnvironment`, a new-tool checklist, and the documented
+  env==nil-fallback invariant. New CI gate `make tools-jail-check` (a `go/ast`
+  analyzer under `tools/jailcheck/`) flags any reference to a watched mutating
+  function in `agent/tools/*.go` (excluding `_test.go`) across **`os`,
+  `os/exec`, `io/ioutil`, and `syscall`** — covering both jail seams (filesystem
+  writes and subprocess spawn). It resolves aliased imports, matches selector
+  references (so function-value capture / callback passes can't dodge it), and
+  flags dot-imports of watched packages. The one legal exception — a fallback
+  reachable only when `env == nil`, where no jail can be active — is whitelisted
+  by a `//jail:allow-unjailed-fallback` marker on the function. Wired into the
+  `ci:` target and the CI "Quality Gates" job. The two existing audited
+  fallbacks (`generate_code`, `write_enriched_sprint`) carry the marker; no
+  other product code changed.
 - **Property/invariant tests for the `writable_paths` jail public surface**
   (closes #282, refs #275/#272). New `agent/exec/jail_property_test.go` and
   `pipeline/handlers/codergen_jail_property_test.go`, plus property additions to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent-tool jail threat model + `os.*` bypass lint** (closes #283, refs
+  #275/#272). New doc `docs/architecture/agent-tool-jail-checklist.md`: a
+  per-tool threat-model table (every `agent/tools/` tool — what it touches and
+  which `ExecutionEnvironment` seam it routes through, each row verified against
+  the code), the rule that any filesystem mutation MUST route through
+  `exec.ExecutionEnvironment` (direct `os.WriteFile`/`MkdirAll`/`Remove`/… is a
+  review-blocker), a new-tool checklist, and the documented env==nil-fallback
+  invariant. New CI gate `make tools-jail-check` (a `go/ast` analyzer under
+  `tools/jailcheck/`) flags any mutating `os.*` call in `agent/tools/*.go`
+  (excluding `_test.go`); the one legal exception — a fallback reachable only
+  when `env == nil`, where no jail can be active — is whitelisted by a
+  `//jail:allow-unjailed-fallback` marker on the function. Wired into the `ci:`
+  target and the CI "Quality Gates" job. The two existing audited fallbacks
+  (`generate_code`, `write_enriched_sprint`) carry the marker; no other product
+  code changed.
 - **Property/invariant tests for the `writable_paths` jail public surface**
   (closes #282, refs #275/#272). New `agent/exec/jail_property_test.go` and
   `pipeline/handlers/codergen_jail_property_test.go`, plus property additions to

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # ABOUTME: Provides build targets, quality enforcement, and release helpers.
 
 .PHONY: build test test-race test-short lint fmt fmt-check vet coverage \
-        doctor complexity complexity-report ci install clean setup-hooks
+        doctor complexity complexity-report ci install clean setup-hooks \
+        tools-jail-check
 
 GOCACHE ?= $(CURDIR)/.gocache
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -159,9 +160,19 @@ doctor:
 	if [ "$$FAIL" -gt 0 ]; then echo "FAIL: core pipelines must be grade A"; exit 1; fi
 	@echo "All core pipelines grade A (via $(DIPPIN_VERSION))"
 
+# ─── Agent-tool jail lint ────────────────────────────────
+
+# tools-jail-check flags direct os.* filesystem mutations in agent/tools/ that
+# bypass the ExecutionEnvironment seam guarding the writable_paths jail (#283,
+# refs #275/#272). The single legal exception — an env==nil fallback — must
+# carry a //jail:allow-unjailed-fallback marker on its function. See
+# docs/architecture/agent-tool-jail-checklist.md.
+tools-jail-check:
+	@GOCACHE=$(GOCACHE) go run ./tools/jailcheck agent/tools
+
 # ─── CI (all gates in sequence) ──────────────────────────
 
-ci: fmt-check vet build test-short test-race coverage lint doctor complexity
+ci: fmt-check vet build test-short test-race coverage lint doctor complexity tools-jail-check
 	@echo ""
 	@echo "═══ All CI gates passed ═══"
 

--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,11 @@ doctor:
 
 # ─── Agent-tool jail lint ────────────────────────────────
 
-# tools-jail-check flags direct os.* filesystem mutations in agent/tools/ that
-# bypass the ExecutionEnvironment seam guarding the writable_paths jail (#283,
-# refs #275/#272). The single legal exception — an env==nil fallback — must
-# carry a //jail:allow-unjailed-fallback marker on its function. See
+# tools-jail-check flags direct filesystem-mutation / subprocess calls in
+# agent/tools/ that bypass the ExecutionEnvironment seam guarding the
+# writable_paths jail (#283, refs #275/#272). It watches os, os/exec, io/ioutil,
+# and syscall. The single legal exception — an env==nil fallback — must carry a
+# //jail:allow-unjailed-fallback marker on its function. See
 # docs/architecture/agent-tool-jail-checklist.md.
 tools-jail-check:
 	@GOCACHE=$(GOCACHE) go run ./tools/jailcheck agent/tools

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -332,8 +332,11 @@ func stripMarkdownFences(code string) string {
 // The os.* fallback below is reachable ONLY when t.env == nil. backend_native
 // wires the JAILED *LocalEnvironment into t.env whenever writable_paths is set
 // (it refuses-to-start otherwise), so env==nil implies no active jail and the
-// fallback has nothing to bypass. The jailcheck linter (#283) enforces this
-// invariant; this marker records that the exception is intentional and audited.
+// fallback has nothing to bypass. That env==nil invariant is enforced by
+// backend_native's refuse-to-start, not by the linter: the jailcheck linter
+// (#283) only requires this direct-os.* fallback to carry the marker below, so
+// no UNannotated bypass can be added. The marker records that this exception
+// is intentional and audited.
 //
 //jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md
 func (t *GenerateCodeTool) writeFile(ctx context.Context, path string, content string) error {

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -335,7 +335,7 @@ func stripMarkdownFences(code string) string {
 // fallback has nothing to bypass. That env==nil invariant is enforced by
 // backend_native's refuse-to-start, not by the linter: the jailcheck linter
 // (#283) only requires this direct-os.* fallback to carry the marker below, so
-// no UNannotated bypass can be added. The marker records that this exception
+// no unannotated bypass can be added. The marker records that this exception
 // is intentional and audited.
 //
 //jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md

--- a/agent/tools/generate_code.go
+++ b/agent/tools/generate_code.go
@@ -328,6 +328,14 @@ func stripMarkdownFences(code string) string {
 // files are bounded just like apply_patch/edit/write. Falls back to direct
 // os.WriteFile for unjailed sessions (no env wired) and for the test-only
 // path where workDir is empty. #275 audit pass.
+//
+// The os.* fallback below is reachable ONLY when t.env == nil. backend_native
+// wires the JAILED *LocalEnvironment into t.env whenever writable_paths is set
+// (it refuses-to-start otherwise), so env==nil implies no active jail and the
+// fallback has nothing to bypass. The jailcheck linter (#283) enforces this
+// invariant; this marker records that the exception is intentional and audited.
+//
+//jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md
 func (t *GenerateCodeTool) writeFile(ctx context.Context, path string, content string) error {
 	if t.env != nil {
 		rel, err := filepath.Rel(t.env.WorkingDir(), path)

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -1230,7 +1230,7 @@ func trimEnclosingMarkdownFence(s string) string {
 // fallback has nothing to bypass. That env==nil invariant is enforced by
 // backend_native's refuse-to-start, not by the linter: the jailcheck linter
 // (#283) only requires this direct-os.* fallback to carry the marker below, so
-// no UNannotated bypass can be added. The marker records that this exception
+// no unannotated bypass can be added. The marker records that this exception
 // is intentional and audited.
 //
 //jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -1223,6 +1223,14 @@ func trimEnclosingMarkdownFence(s string) string {
 // that routes through the writable_paths fs-jail (#272) WriteOpener so
 // generated sprint files are bounded just like apply_patch/edit/write.
 // Falls back to direct os.WriteFile for unjailed sessions. #275 audit pass.
+//
+// The os.* fallback below is reachable ONLY when t.env == nil. backend_native
+// wires the JAILED *LocalEnvironment into t.env whenever writable_paths is set
+// (it refuses-to-start otherwise), so env==nil implies no active jail and the
+// fallback has nothing to bypass. The jailcheck linter (#283) enforces this
+// invariant; this marker records that the exception is intentional and audited.
+//
+//jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md
 func (t *WriteEnrichedSprintTool) writeSprintFile(ctx context.Context, path string, content string) error {
 	if t.env != nil {
 		rel, err := filepath.Rel(t.env.WorkingDir(), path)

--- a/agent/tools/write_enriched_sprint.go
+++ b/agent/tools/write_enriched_sprint.go
@@ -1227,8 +1227,11 @@ func trimEnclosingMarkdownFence(s string) string {
 // The os.* fallback below is reachable ONLY when t.env == nil. backend_native
 // wires the JAILED *LocalEnvironment into t.env whenever writable_paths is set
 // (it refuses-to-start otherwise), so env==nil implies no active jail and the
-// fallback has nothing to bypass. The jailcheck linter (#283) enforces this
-// invariant; this marker records that the exception is intentional and audited.
+// fallback has nothing to bypass. That env==nil invariant is enforced by
+// backend_native's refuse-to-start, not by the linter: the jailcheck linter
+// (#283) only requires this direct-os.* fallback to carry the marker below, so
+// no UNannotated bypass can be added. The marker records that this exception
+// is intentional and audited.
 //
 //jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md
 func (t *WriteEnrichedSprintTool) writeSprintFile(ctx context.Context, path string, content string) error {

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -47,8 +47,8 @@ read-only calls.
 
 One row per LLM-callable tool in `agent/tools/` (the 11 types that implement a
 `Name()` method and are registered for the model to call). Verified against the
-code at the cited lines — re-verify with `grep -nE 'os\.[A-Z]|env\.'
-agent/tools/<file>.go` before trusting a row after a refactor.
+code at the cited lines — re-verify with `grep -nE 'os\.[A-Z]|env\.' agent/tools/<file>.go`
+before trusting a row after a refactor.
 
 | Tool (`Name()`)        | File                       | Reads                          | Writes                              | Deletes            | Subprocess                       | Routes through `ExecutionEnvironment`? |
 | ---------------------- | -------------------------- | ------------------------------ | ----------------------------------- | ------------------ | -------------------------------- | -------------------------------------- |
@@ -79,13 +79,18 @@ fallback for the unjailed path:
 func (t *GenerateCodeTool) writeFile(ctx context.Context, path, content string) error {
 	if t.env != nil {
 		// jailed path: env.WriteFile → WriteOpener → openat2 glob check
+		rel, _ := filepath.Rel(t.env.WorkingDir(), path)
 		return t.env.WriteFile(ctx, rel, content)
 	}
-	// fallback: only reachable when env == nil
+	// fallback: only reachable when env == nil (no jail can be active)
+	dir := filepath.Dir(path)
 	os.MkdirAll(dir, 0o755)
 	return os.WriteFile(path, []byte(content), 0o644)
 }
 ```
+
+(Abbreviated; the real `writeFile` in `generate_code.go` propagates the
+`filepath.Rel` error rather than discarding it.)
 
 **This fallback is not a bypass.** The invariant, traced end-to-end:
 
@@ -148,19 +153,22 @@ parses every non-`_test.go` file in `agent/tools/` and reports any call to a
 mutating `os.*` function (`WriteFile`, `MkdirAll`, `Mkdir`, `MkdirTemp`,
 `Remove`, `RemoveAll`, `Rename`, `Create`, `CreateTemp`, `OpenFile`,
 `Truncate`, `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`),
-exiting non-zero with `file:line: os.X called directly in <func>` for each.
-AST (not grep) so a mention of `os.WriteFile` inside a doc comment or string
-does not false-positive. It matches the **selector reference**, not just the
-call, so hoisting the symbol into a variable (`wf := os.WriteFile; wf(...)`) or
-passing it as a callback (`f(os.Remove)`) is flagged just like a direct call.
-Package qualifiers are resolved against the file's imports, so an aliased import
+exiting non-zero with `file:line: os.X in <func> — …` for each. AST (not grep)
+so a mention of `os.WriteFile` inside a doc comment or string does not
+false-positive. It matches the **selector reference**, not just the call, so
+hoisting the symbol into a variable (`wf := os.WriteFile; wf(...)`) or passing
+it as a callback (`f(os.Remove)`) is flagged just like a direct call. Package
+qualifiers are resolved against the file's imports, so an aliased import
 (`import stdos "os"` → `stdos.WriteFile`) is still caught, while a non-stdlib
-package that happens to be named `os` is not. The single exemption is the
-`//jail:allow-unjailed-fallback` marker described above.
+package that happens to be named `os` is not. A **dot-import** of `os`
+(`import . "os"`) — which would hide every mutating call behind a bare
+identifier — is itself flagged as a violation so it can't be used to slip past
+the gate. The single exemption is the `//jail:allow-unjailed-fallback` marker
+described above.
 
 It is wired into the `ci:` Makefile target and the CI "Quality Gates" job, and
-is unit-tested against `clean` / `violation` fixtures under
-`tools/jailcheck/testdata/`.
+is unit-tested against `clean` / `violation` / `aliased` / `funcvalue` /
+`dotimport` fixtures under `tools/jailcheck/testdata/`.
 
 ## Residual risks (not covered by this lint)
 
@@ -168,12 +176,6 @@ is unit-tested against `clean` / `violation` fixtures under
   reads outside the workspace (or `grep_search`/`dispatch_sprints` reading an
   attacker-chosen path within it) is not flagged.
 - **Network egress.** Out of scope for the filesystem jail entirely.
-- **Dot-imported `os`.** The lint resolves aliased imports (`import stdos "os"`
-  is caught) and selector references (function-value capture / callback pass are
-  caught), but a dot-import (`import . "os"`) makes `WriteFile(...)` a bare
-  identifier with no package selector, which this selector-based analyzer cannot
-  attribute to `os`. Dot-importing `os` is its own red flag; reject it in
-  review.
 - **Reflective / indirect dispatch.** Reaching a mutating syscall via
   `reflect`, `plugin`, `//go:linkname`, or a syscall wrapper that doesn't name
   `os.*` is out of scope — the lint is a static guardrail against the easy

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -1,0 +1,180 @@
+# Agent-tool jail checklist & threat model
+
+Follow-up to [#275](https://github.com/2389-research/tracker/pull/275) /
+[#272](https://github.com/2389-research/tracker/issues/272). This doc pins the
+invariant the `writable_paths` filesystem jail depends on — **every agent tool
+routes its filesystem mutations through `exec.ExecutionEnvironment`** — and the
+CI lint (`make tools-jail-check`) that keeps it from rotting.
+
+## Why this exists
+
+When an agent node sets `writable_paths`, tracker wires a Landlock + `openat2`
+sandbox into a single seam: the `ExecutionEnvironment` interface
+(`agent/exec/env.go`). `pipeline/handlers/codergen_jail.go` populates
+`LocalEnvironment.WriteOpener` / `Remover` / `CommandWrapper`, so any write,
+delete, or subprocess that flows through `env.WriteFile` / `env.RemoveFile` /
+`env.ExecCommand` is bounded to the declared globs. A tool that instead calls
+`os.WriteFile` / `os.Remove` / `os.MkdirAll` directly **bypasses the jail
+entirely** — the write lands wherever the path points, with no glob check and
+no Landlock.
+
+That is not hypothetical. The #275 round-8 audit found exactly this bug in two
+tools (`generate_code`, `write_enriched_sprint`) that called `os.WriteFile`
+directly. They had been in the tree for months; the only reason they were
+caught is a manual grep for `os.WriteFile` in `agent/tools/`. This lint
+replaces that luck with a gate.
+
+## The rule
+
+> Any `agent/tools/` tool that mutates the filesystem **MUST** route through
+> `exec.ExecutionEnvironment`. A direct `os.WriteFile` / `os.MkdirAll` /
+> `os.Mkdir` / `os.Remove` / `os.RemoveAll` / `os.Rename` / `os.Create` /
+> `os.OpenFile` / `os.Truncate` / `os.Symlink` / `os.Link` / `os.Chmod` /
+> `os.Chown` call in `agent/tools/*.go` is a **review-blocker**.
+
+The one legal exception is an **unjailed fallback** — see
+[The env==nil-fallback invariant](#the-envnil-fallback-invariant).
+
+Read-only `os.*` (`os.ReadFile`, `os.Open`, `os.Stat`, `os.ReadDir`) is **not**
+covered by this rule. The jail bounds *writes*, not reads; read/exfil is an
+accepted residual risk of the design (see the activity-log threat model in
+`CLAUDE.md` and the `writable_paths` spec). The lint deliberately ignores
+read-only calls.
+
+## Threat-model table
+
+One row per LLM-callable tool in `agent/tools/` (the 11 types that implement a
+`Name()` method and are registered for the model to call). Verified against the
+code at the cited lines — re-verify with `grep -nE 'os\.[A-Z]|env\.'
+agent/tools/<file>.go` before trusting a row after a refactor.
+
+| Tool (`Name()`)        | File                       | Reads                          | Writes                              | Deletes            | Subprocess                       | Routes through `ExecutionEnvironment`? |
+| ---------------------- | -------------------------- | ------------------------------ | ----------------------------------- | ------------------ | -------------------------------- | -------------------------------------- |
+| `read`                 | `read.go`                  | `env.ReadFile`                 | —                                   | —                  | —                                | ✅ yes                                  |
+| `write`                | `write.go`                 | —                              | `env.WriteFile`                     | —                  | —                                | ✅ yes                                  |
+| `edit`                 | `edit.go`                  | `env.ReadFile`                 | `env.WriteFile`                     | —                  | —                                | ✅ yes                                  |
+| `apply_patch`          | `apply_patch.go`           | `env.ReadFile`                 | `env.WriteFile`                     | `env.RemoveFile`   | —                                | ✅ yes (add/update/delete + move)       |
+| `glob`                 | `glob.go`                  | `env.Glob`                     | —                                   | —                  | —                                | ✅ yes                                  |
+| `grep_search`          | `grep.go`                  | `os.Stat` / `os.Open` (read-only, scoped under `env.WorkingDir()`) | — | — | — | ➖ read-only (no mutation; reads bypass jail by design) |
+| `bash`                 | `bash.go`                  | —                              | (subprocess)                        | (subprocess)       | `env.ExecCommand` (→ `CommandWrapper` → `__jail-exec`) | ✅ yes |
+| `generate_code`        | `generate_code.go`         | —                              | `env.WriteFile` **+ annotated `os.*` fallback when `env==nil`** | — | — | ✅ yes (guarded fallback) |
+| `write_enriched_sprint`| `write_enriched_sprint.go` | —                              | `env.WriteFile` **+ annotated `os.*` fallback when `env==nil`** | — | — | ✅ yes (guarded fallback) |
+| `dispatch_sprints`     | `dispatch_sprints.go`      | `os.Open` (reads the JSONL plan, read-only) | (delegated)            | —                  | —                                | ✅ yes (writes delegated to the jailed `write_enriched_sprint` tool) |
+| `spawn_agent`          | `spawn.go`                 | —                              | (child session)                     | (child session)    | child via `SessionRunner`        | ✅ inherited (child session carries its own `env`; no direct `os.*`) |
+
+Infrastructure files in `agent/tools/` that are **not** LLM-callable tools and
+hold no filesystem-mutation surface: `completer.go` (the `Completer` LLM-client
+interface + a read-only symlink-resolution helper using `os.Stat`),
+`registry.go` (the tool dispatch registry), `truncate.go` (in-memory output
+truncation). The lint still scans them; they contain no mutating `os.*` calls.
+
+## The env==nil-fallback invariant
+
+`generate_code` and `write_enriched_sprint` keep a deliberate direct-`os.*`
+fallback for the unjailed path:
+
+```go
+func (t *GenerateCodeTool) writeFile(ctx context.Context, path, content string) error {
+	if t.env != nil {
+		// jailed path: env.WriteFile → WriteOpener → openat2 glob check
+		return t.env.WriteFile(ctx, rel, content)
+	}
+	// fallback: only reachable when env == nil
+	os.MkdirAll(dir, 0o755)
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+```
+
+**This fallback is not a bypass.** The invariant, traced end-to-end:
+
+1. `pipeline/handlers/backend_native.go` builds `env`. When
+   `sessionCfg.WritablePathsSet` is **true**, it requires `b.env` to be a
+   `*LocalEnvironment` (else it **refuses to start** — `backend_native.go:45-48`),
+   builds a fresh jailed env via `configureJail`, and assigns it to `env`.
+2. That same `env` is then passed into **both** tools via
+   `tools.WithGenerateEnv(env)` / `tools.WithSprintWriterEnv(env)`
+   (`backend_native.go:114,137`).
+3. So whenever a jail is active, `t.env` is the **jailed** `*LocalEnvironment`,
+   non-nil, and the tool takes the `env.WriteFile` branch.
+4. The `os.*` fallback is therefore reachable **only** when `t.env == nil`,
+   which can happen only when `b.env` is nil — and that state cannot coexist
+   with `WritablePathsSet == true` (step 1 refuses it). **`env == nil` ⟹ no
+   active jail ⟹ nothing to bypass.**
+
+Because the invariant is real but invisible to a grep, each fallback function
+carries a marker comment:
+
+```go
+//jail:allow-unjailed-fallback env==nil ⟹ no active jail; see agent-tool-jail-checklist.md
+```
+
+The lint whitelists mutating `os.*` calls inside any function whose doc comment
+or body contains that marker. A new tool that adds an `os.WriteFile` **without**
+the marker fails the gate.
+
+> If you ever find a path where a writing tool can reach its `os.*` fallback
+> **while `writable_paths` is active** (i.e. `env` should have been wired but
+> wasn't), that is a real jail bypass — **stop and file it**, don't add a
+> marker. The marker asserts the env==nil invariant above; it is not a mute
+> button.
+
+## Checklist for adding a new tool
+
+When you add a tool to `agent/tools/` that touches the filesystem:
+
+- [ ] If the tool **writes** files, it takes an `exec.ExecutionEnvironment`
+      (not a bare `workDir string`) and writes via `env.WriteFile`.
+- [ ] If the tool **deletes** files, it uses `env.RemoveFile`, not `os.Remove`.
+- [ ] If the tool **renames/moves** files, it composes `env.ReadFile` +
+      `env.WriteFile` + `env.RemoveFile` (see `apply_patch.go`'s move path) —
+      there is no `env.Rename`.
+- [ ] If the tool **spawns subprocesses**, it uses `env.ExecCommand`, not
+      `os/exec.Cmd` directly, so the jail's `CommandWrapper` can re-exec through
+      `__jail-exec` with Landlock applied.
+- [ ] The tool's writes work when `env` is a jailed `*LocalEnvironment` — add a
+      `writable_paths` e2e fixture exercising the new tool.
+- [ ] If the tool genuinely needs a direct-`os.*` unjailed fallback, gate it on
+      `env == nil`, prove the [env==nil invariant](#the-envnil-fallback-invariant)
+      holds for it, and annotate the function with
+      `//jail:allow-unjailed-fallback`.
+- [ ] `make tools-jail-check` passes.
+
+## The lint
+
+`make tools-jail-check` runs the `go/ast` analyzer at `tools/jailcheck/`. It
+parses every non-`_test.go` file in `agent/tools/` and reports any call to a
+mutating `os.*` function (`WriteFile`, `MkdirAll`, `Mkdir`, `MkdirTemp`,
+`Remove`, `RemoveAll`, `Rename`, `Create`, `CreateTemp`, `OpenFile`,
+`Truncate`, `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`),
+exiting non-zero with `file:line: os.X called directly in <func>` for each.
+AST (not grep) so a mention of `os.WriteFile` inside a doc comment or string
+does not false-positive. The single exemption is the
+`//jail:allow-unjailed-fallback` marker described above.
+
+It is wired into the `ci:` Makefile target and the CI "Quality Gates" job, and
+is unit-tested against `clean` / `violation` fixtures under
+`tools/jailcheck/testdata/`.
+
+## Residual risks (not covered by this lint)
+
+- **Reads / exfil-by-read.** The jail bounds writes, not reads. A tool that
+  reads outside the workspace (or `grep_search`/`dispatch_sprints` reading an
+  attacker-chosen path within it) is not flagged.
+- **Network egress.** Out of scope for the filesystem jail entirely.
+- **Aliased `os` imports.** The lint matches the `os.X(...)` selector on an
+  unaliased `os` import (the convention everywhere in this package). An
+  `import ospkg "os"` alias would slip past — flagged here so a reviewer knows
+  to reject aliasing the `os` import in `agent/tools/`.
+- **Out-of-process backends.** `claude-code` and `acp` run the agent in a
+  separate process tracker cannot Landlock; `writable_paths` refuses them at
+  start (see `CLAUDE.md` → Agent backends). This lint only governs the
+  in-process `native` tool surface.
+
+## See also
+
+- `CLAUDE.md` → "Tool node safety", "writable_paths"/`__jail-exec`, "Agent
+  backends".
+- `docs/superpowers/specs/2026-06-01-issue-272-writable-paths-enforcement-design.md`
+  — full jail design and threat model.
+- `agent/exec/env.go`, `agent/exec/local.go` — the `ExecutionEnvironment` seam.
+- `pipeline/handlers/codergen_jail.go` — where the jail is wired into `env`.

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -148,8 +148,10 @@ mutating `os.*` function (`WriteFile`, `MkdirAll`, `Mkdir`, `MkdirTemp`,
 `Truncate`, `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`),
 exiting non-zero with `file:line: os.X called directly in <func>` for each.
 AST (not grep) so a mention of `os.WriteFile` inside a doc comment or string
-does not false-positive. The single exemption is the
-`//jail:allow-unjailed-fallback` marker described above.
+does not false-positive. Package qualifiers are resolved against the file's
+imports, so an aliased import (`import stdos "os"` → `stdos.WriteFile`) is still
+caught, while a non-stdlib package that happens to be named `os` is not. The
+single exemption is the `//jail:allow-unjailed-fallback` marker described above.
 
 It is wired into the `ci:` Makefile target and the CI "Quality Gates" job, and
 is unit-tested against `clean` / `violation` fixtures under
@@ -161,10 +163,11 @@ is unit-tested against `clean` / `violation` fixtures under
   reads outside the workspace (or `grep_search`/`dispatch_sprints` reading an
   attacker-chosen path within it) is not flagged.
 - **Network egress.** Out of scope for the filesystem jail entirely.
-- **Aliased `os` imports.** The lint matches the `os.X(...)` selector on an
-  unaliased `os` import (the convention everywhere in this package). An
-  `import ospkg "os"` alias would slip past — flagged here so a reviewer knows
-  to reject aliasing the `os` import in `agent/tools/`.
+- **Dot-imported `os`.** The lint resolves aliased imports (`import stdos "os"`
+  is caught), but a dot-import (`import . "os"`) makes `WriteFile(...)` a bare
+  call with no package selector, which this selector-based analyzer cannot
+  attribute to `os`. Dot-importing `os` is its own red flag; reject it in
+  review.
 - **Out-of-process backends.** `claude-code` and `acp` run the agent in a
   separate process tracker cannot Landlock; `writable_paths` refuses them at
   start (see `CLAUDE.md` → Agent backends). This lint only governs the

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -27,10 +27,12 @@ replaces that luck with a gate.
 ## The rule
 
 > Any `agent/tools/` tool that mutates the filesystem **MUST** route through
-> `exec.ExecutionEnvironment`. A direct `os.WriteFile` / `os.MkdirAll` /
-> `os.Mkdir` / `os.Remove` / `os.RemoveAll` / `os.Rename` / `os.Create` /
-> `os.OpenFile` / `os.Truncate` / `os.Symlink` / `os.Link` / `os.Chmod` /
-> `os.Chown` call in `agent/tools/*.go` is a **review-blocker**.
+> `exec.ExecutionEnvironment`. **Any** direct mutating `os.*` call in
+> `agent/tools/*.go` is a **review-blocker** — `os.WriteFile`, `os.MkdirAll`,
+> `os.Mkdir`, `os.MkdirTemp`, `os.Remove`, `os.RemoveAll`, `os.Rename`,
+> `os.Create`, `os.CreateTemp`, `os.OpenFile`, `os.Truncate`, `os.Symlink`,
+> `os.Link`, `os.Chmod`, `os.Chown`, `os.Lchown`, `os.Chtimes` (the exact set
+> the analyzer flags; see `mutatingOSFuncs` in `tools/jailcheck/jailcheck.go`).
 
 The one legal exception is an **unjailed fallback** — see
 [The env==nil-fallback invariant](#the-envnil-fallback-invariant).

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -150,10 +150,13 @@ mutating `os.*` function (`WriteFile`, `MkdirAll`, `Mkdir`, `MkdirTemp`,
 `Truncate`, `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`),
 exiting non-zero with `file:line: os.X called directly in <func>` for each.
 AST (not grep) so a mention of `os.WriteFile` inside a doc comment or string
-does not false-positive. Package qualifiers are resolved against the file's
-imports, so an aliased import (`import stdos "os"` → `stdos.WriteFile`) is still
-caught, while a non-stdlib package that happens to be named `os` is not. The
-single exemption is the `//jail:allow-unjailed-fallback` marker described above.
+does not false-positive. It matches the **selector reference**, not just the
+call, so hoisting the symbol into a variable (`wf := os.WriteFile; wf(...)`) or
+passing it as a callback (`f(os.Remove)`) is flagged just like a direct call.
+Package qualifiers are resolved against the file's imports, so an aliased import
+(`import stdos "os"` → `stdos.WriteFile`) is still caught, while a non-stdlib
+package that happens to be named `os` is not. The single exemption is the
+`//jail:allow-unjailed-fallback` marker described above.
 
 It is wired into the `ci:` Makefile target and the CI "Quality Gates" job, and
 is unit-tested against `clean` / `violation` fixtures under
@@ -166,10 +169,16 @@ is unit-tested against `clean` / `violation` fixtures under
   attacker-chosen path within it) is not flagged.
 - **Network egress.** Out of scope for the filesystem jail entirely.
 - **Dot-imported `os`.** The lint resolves aliased imports (`import stdos "os"`
-  is caught), but a dot-import (`import . "os"`) makes `WriteFile(...)` a bare
-  call with no package selector, which this selector-based analyzer cannot
+  is caught) and selector references (function-value capture / callback pass are
+  caught), but a dot-import (`import . "os"`) makes `WriteFile(...)` a bare
+  identifier with no package selector, which this selector-based analyzer cannot
   attribute to `os`. Dot-importing `os` is its own red flag; reject it in
   review.
+- **Reflective / indirect dispatch.** Reaching a mutating syscall via
+  `reflect`, `plugin`, `//go:linkname`, or a syscall wrapper that doesn't name
+  `os.*` is out of scope — the lint is a static guardrail against the easy
+  mistake (a direct `os.*` write), not a sandbox. The jail itself (Landlock +
+  `openat2`) is the actual enforcement boundary.
 - **Out-of-process backends.** `claude-code` and `acp` run the agent in a
   separate process tracker cannot Landlock; `writable_paths` refuses them at
   start (see `CLAUDE.md` → Agent backends). This lint only governs the

--- a/docs/architecture/agent-tool-jail-checklist.md
+++ b/docs/architecture/agent-tool-jail-checklist.md
@@ -2,9 +2,9 @@
 
 Follow-up to [#275](https://github.com/2389-research/tracker/pull/275) /
 [#272](https://github.com/2389-research/tracker/issues/272). This doc pins the
-invariant the `writable_paths` filesystem jail depends on — **every agent tool
-routes its filesystem mutations through `exec.ExecutionEnvironment`** — and the
-CI lint (`make tools-jail-check`) that keeps it from rotting.
+invariant the `writable_paths` jail depends on — **every agent tool routes its
+filesystem mutations and subprocesses through `exec.ExecutionEnvironment`** —
+and the CI lint (`make tools-jail-check`) that keeps it from rotting.
 
 ## Why this exists
 
@@ -26,22 +26,34 @@ replaces that luck with a gate.
 
 ## The rule
 
-> Any `agent/tools/` tool that mutates the filesystem **MUST** route through
-> `exec.ExecutionEnvironment`. **Any** direct mutating `os.*` call in
-> `agent/tools/*.go` is a **review-blocker** — `os.WriteFile`, `os.MkdirAll`,
-> `os.Mkdir`, `os.MkdirTemp`, `os.Remove`, `os.RemoveAll`, `os.Rename`,
-> `os.Create`, `os.CreateTemp`, `os.OpenFile`, `os.Truncate`, `os.Symlink`,
-> `os.Link`, `os.Chmod`, `os.Chown`, `os.Lchown`, `os.Chtimes` (the exact set
-> the analyzer flags; see `mutatingOSFuncs` in `tools/jailcheck/jailcheck.go`).
+> Any `agent/tools/` tool that mutates the filesystem **or spawns a
+> subprocess** MUST route through `exec.ExecutionEnvironment`. **Any** direct
+> mutating call in `agent/tools/*.go` is a **review-blocker**, across all of:
+>
+> - **`os`** — `WriteFile`, `Create`, `CreateTemp`, `OpenFile`, `Mkdir`,
+>   `MkdirAll`, `MkdirTemp`, `Remove`, `RemoveAll`, `Rename`, `Truncate`,
+>   `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`, `StartProcess`,
+>   `OpenRoot`, `NewRoot`.
+> - **`os/exec`** — `Command`, `CommandContext` (every `*exec.Cmd` starts here;
+>   use `env.ExecCommand`).
+> - **`io/ioutil`** — `WriteFile`, `TempFile`, `TempDir` (deprecated, but still
+>   bypass `env`).
+> - **`syscall`** — the mutating/spawning surface (`Unlink`, `Rmdir`, `Rename`,
+>   `Mkdir`, `Link`, `Symlink`, `Truncate`, `Chmod`, `Chown`, `Creat`, `Open`,
+>   `Exec`, `ForkExec`, …).
+>
+> The exact set the analyzer flags is `mutatingFuncs` in
+> `tools/jailcheck/jailcheck.go` — that map is the source of truth; this list is
+> a summary.
 
 The one legal exception is an **unjailed fallback** — see
 [The env==nil-fallback invariant](#the-envnil-fallback-invariant).
 
-Read-only `os.*` (`os.ReadFile`, `os.Open`, `os.Stat`, `os.ReadDir`) is **not**
-covered by this rule. The jail bounds *writes*, not reads; read/exfil is an
-accepted residual risk of the design (see the activity-log threat model in
-`CLAUDE.md` and the `writable_paths` spec). The lint deliberately ignores
-read-only calls.
+Read-only entry points (`os.ReadFile`/`Open`/`Stat`/`ReadDir`, `exec.LookPath`,
+`ioutil.ReadFile`, `syscall.Read`/`Stat`) are **not** covered by this rule. The
+jail bounds *writes and subprocesses*, not reads; read/exfil is an accepted
+residual risk of the design (see the activity-log threat model in `CLAUDE.md`
+and the `writable_paths` spec). The lint deliberately ignores read-only calls.
 
 ## Threat-model table
 
@@ -149,26 +161,29 @@ When you add a tool to `agent/tools/` that touches the filesystem:
 ## The lint
 
 `make tools-jail-check` runs the `go/ast` analyzer at `tools/jailcheck/`. It
-parses every non-`_test.go` file in `agent/tools/` and reports any call to a
-mutating `os.*` function (`WriteFile`, `MkdirAll`, `Mkdir`, `MkdirTemp`,
-`Remove`, `RemoveAll`, `Rename`, `Create`, `CreateTemp`, `OpenFile`,
-`Truncate`, `Symlink`, `Link`, `Chmod`, `Chown`, `Lchown`, `Chtimes`),
-exiting non-zero with `file:line: os.X in <func> — …` for each. AST (not grep)
-so a mention of `os.WriteFile` inside a doc comment or string does not
-false-positive. It matches the **selector reference**, not just the call, so
-hoisting the symbol into a variable (`wf := os.WriteFile; wf(...)`) or passing
-it as a callback (`f(os.Remove)`) is flagged just like a direct call. Package
-qualifiers are resolved against the file's imports, so an aliased import
-(`import stdos "os"` → `stdos.WriteFile`) is still caught, while a non-stdlib
-package that happens to be named `os` is not. A **dot-import** of `os`
-(`import . "os"`) — which would hide every mutating call behind a bare
-identifier — is itself flagged as a violation so it can't be used to slip past
-the gate. The single exemption is the `//jail:allow-unjailed-fallback` marker
-described above.
+parses every non-`_test.go` file in `agent/tools/` and reports any reference to
+a watched mutating function across **`os`, `os/exec`, `io/ioutil`, and
+`syscall`** (the `mutatingFuncs` map), exiting non-zero with
+`file:line: pkg.Func in <func> — …` for each. Its robustness properties:
+
+- **AST, not grep** — a mention of `os.WriteFile` inside a doc comment or string
+  does not false-positive.
+- **Selector reference, not just calls** — hoisting the symbol into a variable
+  (`wf := os.WriteFile; wf(...)`) or passing it as a callback (`f(os.Remove)`)
+  is flagged just like a direct call.
+- **Import-resolved** — qualifiers are matched against the file's imports, so an
+  aliased import (`import stdos "os"` → `stdos.WriteFile`) is caught while a
+  non-stdlib package that happens to share a name is not.
+- **Dot-import flagged** — `import . "os"` (or any watched package) would hide
+  every mutating call behind a bare identifier, so the dot-import itself is a
+  violation.
+
+The single exemption is the `//jail:allow-unjailed-fallback` marker described
+above.
 
 It is wired into the `ci:` Makefile target and the CI "Quality Gates" job, and
 is unit-tested against `clean` / `violation` / `aliased` / `funcvalue` /
-`dotimport` fixtures under `tools/jailcheck/testdata/`.
+`subprocess` / `dotimport` fixtures under `tools/jailcheck/testdata/`.
 
 ## Residual risks (not covered by this lint)
 
@@ -176,11 +191,12 @@ is unit-tested against `clean` / `violation` / `aliased` / `funcvalue` /
   reads outside the workspace (or `grep_search`/`dispatch_sprints` reading an
   attacker-chosen path within it) is not flagged.
 - **Network egress.** Out of scope for the filesystem jail entirely.
-- **Reflective / indirect dispatch.** Reaching a mutating syscall via
-  `reflect`, `plugin`, `//go:linkname`, or a syscall wrapper that doesn't name
-  `os.*` is out of scope — the lint is a static guardrail against the easy
-  mistake (a direct `os.*` write), not a sandbox. The jail itself (Landlock +
-  `openat2`) is the actual enforcement boundary.
+- **Reflective / indirect dispatch.** Reaching a mutating call via `reflect`,
+  `plugin`, `//go:linkname`, `golang.org/x/sys/unix`, or a wrapper that names
+  none of the watched packages is out of scope — the lint is a static guardrail
+  against the easy mistake (a direct `os.*` / `exec.Command` / raw `syscall.*`),
+  not a sandbox. The jail itself (Landlock + `openat2` + the `__jail-exec`
+  CommandWrapper) is the actual enforcement boundary.
 - **Out-of-process backends.** `claude-code` and `acp` run the agent in a
   separate process tracker cannot Landlock; `writable_paths` refuses them at
   start (see `CLAUDE.md` → Agent backends). This lint only governs the

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -1,0 +1,259 @@
+// ABOUTME: jailcheck flags direct os.* filesystem mutations in agent/tools that
+// ABOUTME: bypass the ExecutionEnvironment seam guarding the writable_paths jail (#272/#275/#283).
+//
+// Background: agent tools must route every filesystem mutation through the
+// exec.ExecutionEnvironment interface (env.WriteFile / env.RemoveFile /
+// env.ExecCommand). When a node sets writable_paths, that seam is the single
+// choke point where Landlock + openat2 enforcement is wired (see
+// pipeline/handlers/codergen_jail.go). A tool that calls os.WriteFile /
+// os.Remove / os.MkdirAll directly bypasses the jail entirely — exactly the
+// bug the #275 audit caught in generate_code and write_enriched_sprint.
+//
+// This analyzer parses every non-test .go file in the target directory
+// (default agent/tools) and reports any call to a mutating os.* function.
+// The single legal exception is an env==nil fallback path, which can only run
+// when no jail is active and therefore has nothing to bypass; such a function
+// must carry the //jail:allow-unjailed-fallback marker comment.
+//
+// Usage: go run ./tools/jailcheck [dir]   (exit 1 on any violation)
+//
+// Full rationale and the per-tool threat model:
+// docs/architecture/agent-tool-jail-checklist.md
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// mutatingOSFuncs are os-package functions that mutate the filesystem. A call
+// to any of these from agent/tools/ bypasses ExecutionEnvironment and so the
+// writable_paths jail. Read-only os funcs (ReadFile, Open, Stat, ReadDir, ...)
+// are intentionally absent: reads/exfil are an accepted residual risk of the
+// jail design (the jail bounds writes, not reads), not a bypass.
+var mutatingOSFuncs = map[string]bool{
+	"WriteFile":  true,
+	"MkdirAll":   true,
+	"Mkdir":      true,
+	"MkdirTemp":  true,
+	"Remove":     true,
+	"RemoveAll":  true,
+	"Rename":     true,
+	"Create":     true,
+	"CreateTemp": true,
+	"OpenFile":   true,
+	"Truncate":   true,
+	"Symlink":    true,
+	"Link":       true,
+	"Chmod":      true,
+	"Chown":      true,
+	"Lchown":     true,
+	"Chtimes":    true,
+}
+
+// allowMarker, when present in a comment inside (or on the doc comment of) the
+// enclosing function, permits that function's os.* mutations. It documents the
+// one legal exception: a fallback that runs only when env == nil, where no jail
+// can be active. See docs/architecture/agent-tool-jail-checklist.md.
+const allowMarker = "jail:allow-unjailed-fallback"
+
+// Violation is a single unguarded os.* mutation call.
+type Violation struct {
+	File string
+	Line int
+	Func string // enclosing function name, or "<file scope>"
+	Call string // e.g. "os.WriteFile"
+}
+
+func main() {
+	dir := "agent/tools"
+	if len(os.Args) > 1 {
+		dir = os.Args[1]
+	}
+
+	violations, err := checkDir(dir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "jailcheck: %v\n", err)
+		os.Exit(2)
+	}
+
+	if len(violations) == 0 {
+		fmt.Printf("jailcheck: ok — no unguarded os.* filesystem mutations in %s\n", dir)
+		return
+	}
+
+	for _, v := range violations {
+		fmt.Fprintf(os.Stderr,
+			"%s:%d: %s called directly in %s — route filesystem mutations through "+
+				"exec.ExecutionEnvironment (env.WriteFile/RemoveFile/ExecCommand), or, for an "+
+				"env==nil fallback, annotate the function with //%s. "+
+				"See docs/architecture/agent-tool-jail-checklist.md\n",
+			v.File, v.Line, v.Call, v.Func, allowMarker)
+	}
+	fmt.Fprintf(os.Stderr, "jailcheck: FAIL — %d unguarded os.* filesystem mutation(s) in %s\n", len(violations), dir)
+	os.Exit(1)
+}
+
+// checkDir parses every non-test .go file in dir and returns all violations,
+// sorted by file then line.
+func checkDir(dir string) ([]Violation, error) {
+	files, err := goFiles(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	var violations []Violation
+	for _, path := range files {
+		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		violations = append(violations, checkFile(fset, f)...)
+	}
+	return violations, nil
+}
+
+// goFiles lists non-test .go files directly under dir, sorted.
+func goFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		files = append(files, filepath.Join(dir, name))
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// funcRange records a function's source span and name.
+type funcRange struct {
+	start, end token.Pos
+	name       string
+	allowed    bool
+}
+
+// checkFile reports every unguarded mutating os.* call in a parsed file.
+func checkFile(fset *token.FileSet, f *ast.File) []Violation {
+	funcs := funcRanges(f)
+
+	var violations []Violation
+	ast.Inspect(f, func(n ast.Node) bool {
+		name, ok := mutatingOSCall(n)
+		if !ok {
+			return true
+		}
+		pos := n.Pos()
+		fr := enclosingFunc(pos, funcs)
+		if fr != nil && fr.allowed {
+			return true
+		}
+		p := fset.Position(pos)
+		violations = append(violations, Violation{
+			File: p.Filename,
+			Line: p.Line,
+			Func: funcLabel(fr),
+			Call: "os." + name,
+		})
+		return true
+	})
+	return violations
+}
+
+// funcRanges collects every top-level function/method span in the file, marking
+// which carry the allow marker (in their doc comment or body).
+func funcRanges(f *ast.File) []funcRange {
+	var ranges []funcRange
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		ranges = append(ranges, funcRange{
+			start:   fn.Pos(),
+			end:     fn.End(),
+			name:    fn.Name.Name,
+			allowed: funcHasMarker(fn, f),
+		})
+	}
+	return ranges
+}
+
+// mutatingOSCall reports whether n is a call to a mutating os.* function and,
+// if so, the bare function name (e.g. "WriteFile").
+func mutatingOSCall(n ast.Node) (string, bool) {
+	call, ok := n.(*ast.CallExpr)
+	if !ok {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return "", false
+	}
+	if !mutatingOSFuncs[sel.Sel.Name] {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+// enclosingFunc returns the function span containing pos, or nil for file scope.
+func enclosingFunc(pos token.Pos, funcs []funcRange) *funcRange {
+	for i := range funcs {
+		if pos >= funcs[i].start && pos < funcs[i].end {
+			return &funcs[i]
+		}
+	}
+	return nil
+}
+
+func funcLabel(fr *funcRange) string {
+	if fr == nil {
+		return "<file scope>"
+	}
+	return fr.name
+}
+
+// funcHasMarker reports whether the allow marker appears in the function's doc
+// comment or anywhere inside its body.
+func funcHasMarker(fn *ast.FuncDecl, f *ast.File) bool {
+	if commentGroupHasMarker(fn.Doc) {
+		return true
+	}
+	if fn.Body == nil {
+		return false
+	}
+	for _, cg := range f.Comments {
+		if cg.Pos() >= fn.Body.Lbrace && cg.End() <= fn.Body.Rbrace && commentGroupHasMarker(cg) {
+			return true
+		}
+	}
+	return false
+}
+
+func commentGroupHasMarker(cg *ast.CommentGroup) bool {
+	if cg == nil {
+		return false
+	}
+	for _, c := range cg.List {
+		if strings.Contains(c.Text, allowMarker) {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -64,12 +64,27 @@ var mutatingOSFuncs = map[string]bool{
 // can be active. See docs/architecture/agent-tool-jail-checklist.md.
 const allowMarker = "jail:allow-unjailed-fallback"
 
-// Violation is a single unguarded os.* mutation call.
+// Violation is a single unguarded os.* mutation reference (or a dot-import of
+// "os", which defeats selector attribution wholesale).
 type Violation struct {
 	File string
 	Line int
-	Func string // enclosing function name, or "<file scope>"
-	Call string // e.g. "os.WriteFile"
+	Func string // enclosing function name, or a "<...>" pseudo-scope
+	Call string // e.g. "os.WriteFile", or `dot-import of "os"`
+	Hint string // remediation hint; empty → the default ExecutionEnvironment hint
+}
+
+// report renders the one-line CI message for a violation.
+func (v Violation) report() string {
+	hint := v.Hint
+	if hint == "" {
+		hint = "route filesystem mutations through exec.ExecutionEnvironment " +
+			"(env.WriteFile/RemoveFile/ExecCommand), or, for an env==nil fallback, " +
+			"annotate the function with //" + allowMarker
+	}
+	return fmt.Sprintf("%s:%d: %s in %s — %s. "+
+		"See docs/architecture/agent-tool-jail-checklist.md",
+		v.File, v.Line, v.Call, v.Func, hint)
 }
 
 func main() {
@@ -90,12 +105,7 @@ func main() {
 	}
 
 	for _, v := range violations {
-		fmt.Fprintf(os.Stderr,
-			"%s:%d: %s used directly in %s — route filesystem mutations through "+
-				"exec.ExecutionEnvironment (env.WriteFile/RemoveFile/ExecCommand), or, for an "+
-				"env==nil fallback, annotate the function with //%s. "+
-				"See docs/architecture/agent-tool-jail-checklist.md\n",
-			v.File, v.Line, v.Call, v.Func, allowMarker)
+		fmt.Fprintln(os.Stderr, v.report())
 	}
 	fmt.Fprintf(os.Stderr, "jailcheck: FAIL — %d unguarded os.* filesystem mutation(s) in %s\n", len(violations), dir)
 	os.Exit(1)
@@ -156,6 +166,12 @@ type funcRange struct {
 
 // checkFile reports every unguarded mutating os.* reference in a parsed file.
 func checkFile(fset *token.FileSet, f *ast.File) []Violation {
+	if v, ok := dotImportViolation(fset, f); ok {
+		// A dot-import of "os" turns every WriteFile(...) into a bare ident the
+		// selector matcher can't attribute — a wholesale bypass. Flag the import
+		// itself and stop: per-call results for this file would be misleading.
+		return []Violation{v}
+	}
 	osNames := osLocalNames(f)
 	if len(osNames) == 0 {
 		return nil // file does not import "os" — no os.* reference can resolve here.
@@ -230,8 +246,9 @@ func mutatingOSRef(n ast.Node, osNames map[string]bool) (string, bool) {
 
 // osLocalNames returns the set of local identifiers bound to the standard
 // library "os" package in f. Handles the default name (`import "os"` → "os")
-// and aliases (`import stdos "os"` → "stdos"). Dot- and blank-imports are
-// recorded but cannot form a flaggable `pkg.Sel` selector, so they are inert.
+// and aliases (`import stdos "os"` → "stdos"). Dot-imports are handled earlier
+// by dotImportViolation; a blank import (`_ "os"`) is recorded but can never
+// form a `pkg.Sel` selector, so it is inert.
 func osLocalNames(f *ast.File) map[string]bool {
 	names := map[string]bool{}
 	for _, imp := range f.Imports {
@@ -246,6 +263,29 @@ func osLocalNames(f *ast.File) map[string]bool {
 		}
 	}
 	return names
+}
+
+// dotImportViolation reports a dot-import of the standard library "os"
+// (`import . "os"`). Such an import makes every os function a bare identifier
+// (`WriteFile(...)`), which the selector-based matcher cannot attribute to os —
+// a wholesale bypass of this gate. Flag it explicitly so CI fails fast rather
+// than silently passing a file that has hidden the entire os surface.
+func dotImportViolation(fset *token.FileSet, f *ast.File) (Violation, bool) {
+	for _, imp := range f.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != "os" || imp.Name == nil || imp.Name.Name != "." {
+			continue
+		}
+		p := fset.Position(imp.Pos())
+		return Violation{
+			File: p.Filename,
+			Line: p.Line,
+			Func: "<imports>",
+			Call: `dot-import of "os"`,
+			Hint: `import "os" under its normal name (no "." dot-import) so mutating os.* calls stay attributable to this lint`,
+		}, true
+	}
+	return Violation{}, false
 }
 
 // enclosingFunc returns the function span containing pos, or nil for file scope.

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -169,22 +169,37 @@ func checkDir(dir string) ([]Violation, error) {
 	return violations, nil
 }
 
-// goFiles lists non-test .go files directly under dir, sorted.
+// goFiles lists non-test .go files under dir recursively (so a tool added in a
+// future subpackage is covered too), skipping testdata directories, sorted.
 func goFiles(dir string) ([]string, error) {
-	entries, err := os.ReadDir(dir)
+	var files []string
+	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		return collectGoFile(&files, path, d, err)
+	})
 	if err != nil {
 		return nil, err
 	}
-	var files []string
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		files = append(files, filepath.Join(dir, name))
-	}
 	sort.Strings(files)
 	return files, nil
+}
+
+// collectGoFile is the WalkDir visitor for goFiles: it skips testdata trees and
+// _test.go files, appending every other .go file to *files.
+func collectGoFile(files *[]string, path string, d os.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		if d.Name() == "testdata" {
+			return filepath.SkipDir
+		}
+		return nil
+	}
+	name := d.Name()
+	if strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
+		*files = append(*files, path)
+	}
+	return nil
 }
 
 // funcRange records a function's source span and name.

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -118,6 +118,14 @@ func checkDir(dir string) ([]Violation, error) {
 		}
 		violations = append(violations, checkFile(fset, f)...)
 	}
+	// Honor the documented contract explicitly rather than relying on
+	// file-list order + AST-walk order happening to coincide with it.
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].File != violations[j].File {
+			return violations[i].File < violations[j].File
+		}
+		return violations[i].Line < violations[j].Line
+	})
 	return violations, nil
 }
 

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -1,19 +1,23 @@
-// ABOUTME: jailcheck flags direct os.* filesystem mutations in agent/tools that
-// ABOUTME: bypass the ExecutionEnvironment seam guarding the writable_paths jail (#272/#275/#283).
+// ABOUTME: jailcheck flags direct filesystem-mutation / subprocess calls in
+// ABOUTME: agent/tools that bypass the ExecutionEnvironment seam guarding the writable_paths jail (#272/#275/#283).
 //
-// Background: agent tools must route every filesystem mutation through the
-// exec.ExecutionEnvironment interface (env.WriteFile / env.RemoveFile /
-// env.ExecCommand). When a node sets writable_paths, that seam is the single
-// choke point where Landlock + openat2 enforcement is wired (see
+// Background: agent tools must route every filesystem mutation and subprocess
+// through the exec.ExecutionEnvironment interface (env.WriteFile /
+// env.RemoveFile / env.ExecCommand). When a node sets writable_paths, that seam
+// is the single choke point where Landlock + openat2 (writes) and the
+// __jail-exec CommandWrapper (subprocesses) are wired (see
 // pipeline/handlers/codergen_jail.go). A tool that calls os.WriteFile /
-// os.Remove / os.MkdirAll directly bypasses the jail entirely — exactly the
-// bug the #275 audit caught in generate_code and write_enriched_sprint.
+// os.Remove / os.MkdirAll — or exec.Command, ioutil.WriteFile, a mutating
+// syscall.* — directly bypasses the jail entirely. That is exactly the bug the
+// #275 audit caught in generate_code and write_enriched_sprint.
 //
 // This analyzer parses every non-test .go file in the target directory
-// (default agent/tools) and reports any call to a mutating os.* function.
-// The single legal exception is an env==nil fallback path, which can only run
-// when no jail is active and therefore has nothing to bypass; such a function
-// must carry the //jail:allow-unjailed-fallback marker comment.
+// (default agent/tools) and reports any reference to a watched mutating
+// function (filesystem write/delete or subprocess spawn) across the os,
+// os/exec, io/ioutil, and syscall packages — resolving aliased imports and
+// flagging dot-imports. The single legal exception is an env==nil fallback
+// path, which can only run when no jail is active and therefore has nothing to
+// bypass; such a function must carry the //jail:allow-unjailed-fallback marker.
 //
 // Usage: go run ./tools/jailcheck [dir]   (exit 1 on any violation)
 //
@@ -33,44 +37,70 @@ import (
 	"strings"
 )
 
-// mutatingOSFuncs are os-package functions that mutate the filesystem. A call
-// to any of these from agent/tools/ bypasses ExecutionEnvironment and so the
-// writable_paths jail. Read-only os funcs (ReadFile, Open, Stat, ReadDir, ...)
-// are intentionally absent: reads/exfil are an accepted residual risk of the
-// jail design (the jail bounds writes, not reads), not a bypass.
-var mutatingOSFuncs = map[string]bool{
-	"WriteFile":  true,
-	"MkdirAll":   true,
-	"Mkdir":      true,
-	"MkdirTemp":  true,
-	"Remove":     true,
-	"RemoveAll":  true,
-	"Rename":     true,
-	"Create":     true,
-	"CreateTemp": true,
-	"OpenFile":   true,
-	"Truncate":   true,
-	"Symlink":    true,
-	"Link":       true,
-	"Chmod":      true,
-	"Chown":      true,
-	"Lchown":     true,
-	"Chtimes":    true,
+// mutatingFuncs maps a watched import path to the set of its functions that
+// mutate the filesystem or spawn a subprocess OUTSIDE the ExecutionEnvironment
+// seam. A reference to any of these from agent/tools/ bypasses the
+// writable_paths jail (Landlock+openat2 for writes, CommandWrapper for
+// subprocesses). Read-only entry points (os.ReadFile/Open/Stat, exec.LookPath,
+// ioutil.ReadFile/ReadDir, syscall.Read/Stat) are intentionally absent: reads
+// are an accepted residual risk of the jail design (it bounds writes, not
+// reads), not a bypass.
+var mutatingFuncs = map[string]map[string]bool{
+	"os": {
+		// filesystem writes / deletes / metadata
+		"WriteFile": true, "Create": true, "CreateTemp": true, "OpenFile": true,
+		"Mkdir": true, "MkdirAll": true, "MkdirTemp": true,
+		"Remove": true, "RemoveAll": true, "Rename": true, "Truncate": true,
+		"Symlink": true, "Link": true,
+		"Chmod": true, "Chown": true, "Lchown": true, "Chtimes": true,
+		// process spawn; and the os.Root handle whose methods escape selector
+		// detection on later calls, so flag the entry points.
+		"StartProcess": true, "OpenRoot": true, "NewRoot": true,
+	},
+	"os/exec": {
+		// every *exec.Cmd starts here; Run/Start/Output are methods on the
+		// returned value, so flagging the constructors covers them all.
+		"Command": true, "CommandContext": true,
+	},
+	"io/ioutil": {
+		// deprecated, but still compiles and bypasses env just like os.*.
+		"WriteFile": true, "TempFile": true, "TempDir": true,
+	},
+	"syscall": {
+		// low-level mutators that sidestep the os.* surface entirely.
+		"Unlink": true, "Unlinkat": true, "Rmdir": true,
+		"Rename": true, "Renameat": true,
+		"Mkdir": true, "Mkdirat": true, "Link": true, "Linkat": true,
+		"Symlink": true, "Symlinkat": true, "Truncate": true, "Ftruncate": true,
+		"Chmod": true, "Fchmodat": true, "Chown": true, "Fchownat": true,
+		"Creat": true, "Open": true, "Openat": true, "Mkfifo": true, "Mknod": true,
+		"Exec": true, "ForkExec": true, "StartProcess": true,
+	},
 }
 
 // allowMarker, when present in a comment inside (or on the doc comment of) the
-// enclosing function, permits that function's os.* mutations. It documents the
-// one legal exception: a fallback that runs only when env == nil, where no jail
-// can be active. See docs/architecture/agent-tool-jail-checklist.md.
+// enclosing function, permits that function's watched mutating calls. It
+// documents the one legal exception: a fallback that runs only when env == nil,
+// where no jail can be active. See docs/architecture/agent-tool-jail-checklist.md.
 const allowMarker = "jail:allow-unjailed-fallback"
 
-// Violation is a single unguarded os.* mutation reference (or a dot-import of
-// "os", which defeats selector attribution wholesale).
+// pkgBase returns the import path's final segment (the default package name):
+// "os/exec" → "exec", "io/ioutil" → "ioutil", "os" → "os". Import paths always
+// use "/" so this is OS-independent.
+func pkgBase(importPath string) string {
+	if i := strings.LastIndex(importPath, "/"); i >= 0 {
+		return importPath[i+1:]
+	}
+	return importPath
+}
+
+// Violation is a single unguarded mutating reference (or a dot-import of a
+// watched package, which defeats selector attribution wholesale).
 type Violation struct {
 	File string
 	Line int
 	Func string // enclosing function name, or a "<...>" pseudo-scope
-	Call string // e.g. "os.WriteFile", or `dot-import of "os"`
+	Call string // e.g. "os.WriteFile", "exec.Command", or `dot-import of "os"`
 	Hint string // remediation hint; empty → the default ExecutionEnvironment hint
 }
 
@@ -78,9 +108,9 @@ type Violation struct {
 func (v Violation) report() string {
 	hint := v.Hint
 	if hint == "" {
-		hint = "route filesystem mutations through exec.ExecutionEnvironment " +
-			"(env.WriteFile/RemoveFile/ExecCommand), or, for an env==nil fallback, " +
-			"annotate the function with //" + allowMarker
+		hint = "route filesystem mutations and subprocesses through " +
+			"exec.ExecutionEnvironment (env.WriteFile/RemoveFile/ExecCommand), or, " +
+			"for an env==nil fallback, annotate the function with //" + allowMarker
 	}
 	return fmt.Sprintf("%s:%d: %s in %s — %s. "+
 		"See docs/architecture/agent-tool-jail-checklist.md",
@@ -100,14 +130,14 @@ func main() {
 	}
 
 	if len(violations) == 0 {
-		fmt.Printf("jailcheck: ok — no unguarded os.* filesystem mutations in %s\n", dir)
+		fmt.Printf("jailcheck: ok — no unguarded filesystem-mutation/subprocess calls in %s\n", dir)
 		return
 	}
 
 	for _, v := range violations {
 		fmt.Fprintln(os.Stderr, v.report())
 	}
-	fmt.Fprintf(os.Stderr, "jailcheck: FAIL — %d unguarded os.* filesystem mutation(s) in %s\n", len(violations), dir)
+	fmt.Fprintf(os.Stderr, "jailcheck: FAIL — %d unguarded jail-bypassing call(s) in %s\n", len(violations), dir)
 	os.Exit(1)
 }
 
@@ -164,23 +194,23 @@ type funcRange struct {
 	allowed    bool
 }
 
-// checkFile reports every unguarded mutating os.* reference in a parsed file.
+// checkFile reports every unguarded mutating reference in a parsed file.
 func checkFile(fset *token.FileSet, f *ast.File) []Violation {
 	if v, ok := dotImportViolation(fset, f); ok {
-		// A dot-import of "os" turns every WriteFile(...) into a bare ident the
-		// selector matcher can't attribute — a wholesale bypass. Flag the import
-		// itself and stop: per-call results for this file would be misleading.
+		// A dot-import of a watched package turns every WriteFile(...) into a
+		// bare ident the selector matcher can't attribute — a wholesale bypass.
+		// Flag the import itself and stop: per-call results would be misleading.
 		return []Violation{v}
 	}
-	osNames := osLocalNames(f)
-	if len(osNames) == 0 {
-		return nil // file does not import "os" — no os.* reference can resolve here.
+	named := watchedLocalNames(f)
+	if len(named) == 0 {
+		return nil // no watched package imported — nothing can resolve here.
 	}
 	funcs := funcRanges(f)
 
 	var violations []Violation
 	ast.Inspect(f, func(n ast.Node) bool {
-		name, ok := mutatingOSRef(n, osNames)
+		call, ok := mutatingRef(n, named)
 		if !ok {
 			return true
 		}
@@ -194,7 +224,7 @@ func checkFile(fset *token.FileSet, f *ast.File) []Violation {
 			File: p.Filename,
 			Line: p.Line,
 			Func: funcLabel(fr),
-			Call: "os." + name,
+			Call: call,
 		})
 		return true
 	})
@@ -220,60 +250,61 @@ func funcRanges(f *ast.File) []funcRange {
 	return ranges
 }
 
-// mutatingOSRef reports whether n is a *reference* to a mutating os.* function
-// (e.g. "WriteFile") and, if so, the bare function name. It matches the
-// selector itself rather than the enclosing call, so a function-value capture
-// (`wf := os.WriteFile; wf(...)`) or callback pass (`f(os.Remove)`) is flagged
-// just like a direct `os.WriteFile(...)` call — a CI gate must not be bypassable
-// by hoisting the symbol into a variable. osNames is the set of local
-// identifiers bound to the standard-library "os" package in the file, so an
-// aliased import (`stdos "os"` → `stdos.WriteFile`) is matched while a
-// non-stdlib package happening to be named "os" is not.
-func mutatingOSRef(n ast.Node, osNames map[string]bool) (string, bool) {
+// mutatingRef reports whether n is a *reference* to a watched mutating function
+// and, if so, the canonical "pkg.Func" display string (e.g. "os.WriteFile",
+// "exec.Command", "syscall.Unlink"). It matches the selector itself rather than
+// the enclosing call, so a function-value capture (`wf := os.WriteFile;
+// wf(...)`) or callback pass (`f(os.Remove)`) is flagged just like a direct
+// call — a CI gate must not be bypassable by hoisting the symbol into a
+// variable. named maps each local identifier to the watched import path it is
+// bound to, so an aliased import (`stdos "os"` → `stdos.WriteFile`) is matched
+// while a non-stdlib package happening to share a name is not.
+func mutatingRef(n ast.Node, named map[string]string) (string, bool) {
 	sel, ok := n.(*ast.SelectorExpr)
 	if !ok {
 		return "", false
 	}
 	pkg, ok := sel.X.(*ast.Ident)
-	if !ok || !osNames[pkg.Name] {
+	if !ok {
 		return "", false
 	}
-	if !mutatingOSFuncs[sel.Sel.Name] {
+	importPath, watched := named[pkg.Name]
+	if !watched || !mutatingFuncs[importPath][sel.Sel.Name] {
 		return "", false
 	}
-	return sel.Sel.Name, true
+	return pkgBase(importPath) + "." + sel.Sel.Name, true
 }
 
-// osLocalNames returns the set of local identifiers bound to the standard
-// library "os" package in f. Handles the default name (`import "os"` → "os")
-// and aliases (`import stdos "os"` → "stdos"). Dot-imports are handled earlier
-// by dotImportViolation; a blank import (`_ "os"`) is recorded but can never
-// form a `pkg.Sel` selector, so it is inert.
-func osLocalNames(f *ast.File) map[string]bool {
-	names := map[string]bool{}
+// watchedLocalNames maps each local identifier bound to a watched package
+// (mutatingFuncs keys) to that package's import path. Handles the default name
+// (`import "os"` → "os":"os") and aliases (`import stdos "os"` → "stdos":"os").
+// Dot-imports are handled earlier by dotImportViolation; a blank import
+// (`_ "os"`) maps "_", which can never form a `pkg.Sel` selector, so it is inert.
+func watchedLocalNames(f *ast.File) map[string]string {
+	named := map[string]string{}
 	for _, imp := range f.Imports {
 		path, err := strconv.Unquote(imp.Path.Value)
-		if err != nil || path != "os" {
+		if err != nil || mutatingFuncs[path] == nil {
 			continue
 		}
 		if imp.Name != nil {
-			names[imp.Name.Name] = true
+			named[imp.Name.Name] = path
 		} else {
-			names["os"] = true
+			named[pkgBase(path)] = path
 		}
 	}
-	return names
+	return named
 }
 
-// dotImportViolation reports a dot-import of the standard library "os"
-// (`import . "os"`). Such an import makes every os function a bare identifier
-// (`WriteFile(...)`), which the selector-based matcher cannot attribute to os —
-// a wholesale bypass of this gate. Flag it explicitly so CI fails fast rather
-// than silently passing a file that has hidden the entire os surface.
+// dotImportViolation reports a dot-import of any watched package (e.g.
+// `import . "os"`). Such an import makes every function a bare identifier
+// (`WriteFile(...)`), which the selector-based matcher cannot attribute — a
+// wholesale bypass. Flag it explicitly so CI fails fast rather than silently
+// passing a file that has hidden a watched package's surface.
 func dotImportViolation(fset *token.FileSet, f *ast.File) (Violation, bool) {
 	for _, imp := range f.Imports {
 		path, err := strconv.Unquote(imp.Path.Value)
-		if err != nil || path != "os" || imp.Name == nil || imp.Name.Name != "." {
+		if err != nil || mutatingFuncs[path] == nil || imp.Name == nil || imp.Name.Name != "." {
 			continue
 		}
 		p := fset.Position(imp.Pos())
@@ -281,8 +312,8 @@ func dotImportViolation(fset *token.FileSet, f *ast.File) (Violation, bool) {
 			File: p.Filename,
 			Line: p.Line,
 			Func: "<imports>",
-			Call: `dot-import of "os"`,
-			Hint: `import "os" under its normal name (no "." dot-import) so mutating os.* calls stay attributable to this lint`,
+			Call: fmt.Sprintf("dot-import of %q", path),
+			Hint: fmt.Sprintf("import %q under its normal name (no %q dot-import) so its mutating calls stay attributable to this lint", path, "."),
 		}, true
 	}
 	return Violation{}, false

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -147,11 +148,15 @@ type funcRange struct {
 
 // checkFile reports every unguarded mutating os.* call in a parsed file.
 func checkFile(fset *token.FileSet, f *ast.File) []Violation {
+	osNames := osLocalNames(f)
+	if len(osNames) == 0 {
+		return nil // file does not import "os" — no os.* call can resolve here.
+	}
 	funcs := funcRanges(f)
 
 	var violations []Violation
 	ast.Inspect(f, func(n ast.Node) bool {
-		name, ok := mutatingOSCall(n)
+		name, ok := mutatingOSCall(n, osNames)
 		if !ok {
 			return true
 		}
@@ -192,8 +197,11 @@ func funcRanges(f *ast.File) []funcRange {
 }
 
 // mutatingOSCall reports whether n is a call to a mutating os.* function and,
-// if so, the bare function name (e.g. "WriteFile").
-func mutatingOSCall(n ast.Node) (string, bool) {
+// if so, the bare function name (e.g. "WriteFile"). osNames is the set of local
+// identifiers bound to the standard-library "os" package in the file, so an
+// aliased import (`stdos "os"` → `stdos.WriteFile`) is matched while a
+// non-stdlib package happening to be named "os" is not.
+func mutatingOSCall(n ast.Node, osNames map[string]bool) (string, bool) {
 	call, ok := n.(*ast.CallExpr)
 	if !ok {
 		return "", false
@@ -203,13 +211,33 @@ func mutatingOSCall(n ast.Node) (string, bool) {
 		return "", false
 	}
 	pkg, ok := sel.X.(*ast.Ident)
-	if !ok || pkg.Name != "os" {
+	if !ok || !osNames[pkg.Name] {
 		return "", false
 	}
 	if !mutatingOSFuncs[sel.Sel.Name] {
 		return "", false
 	}
 	return sel.Sel.Name, true
+}
+
+// osLocalNames returns the set of local identifiers bound to the standard
+// library "os" package in f. Handles the default name (`import "os"` → "os")
+// and aliases (`import stdos "os"` → "stdos"). Dot- and blank-imports are
+// recorded but cannot form a flaggable `pkg.Sel` selector, so they are inert.
+func osLocalNames(f *ast.File) map[string]bool {
+	names := map[string]bool{}
+	for _, imp := range f.Imports {
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil || path != "os" {
+			continue
+		}
+		if imp.Name != nil {
+			names[imp.Name.Name] = true
+		} else {
+			names["os"] = true
+		}
+	}
+	return names
 }
 
 // enclosingFunc returns the function span containing pos, or nil for file scope.

--- a/tools/jailcheck/jailcheck.go
+++ b/tools/jailcheck/jailcheck.go
@@ -91,7 +91,7 @@ func main() {
 
 	for _, v := range violations {
 		fmt.Fprintf(os.Stderr,
-			"%s:%d: %s called directly in %s — route filesystem mutations through "+
+			"%s:%d: %s used directly in %s — route filesystem mutations through "+
 				"exec.ExecutionEnvironment (env.WriteFile/RemoveFile/ExecCommand), or, for an "+
 				"env==nil fallback, annotate the function with //%s. "+
 				"See docs/architecture/agent-tool-jail-checklist.md\n",
@@ -154,17 +154,17 @@ type funcRange struct {
 	allowed    bool
 }
 
-// checkFile reports every unguarded mutating os.* call in a parsed file.
+// checkFile reports every unguarded mutating os.* reference in a parsed file.
 func checkFile(fset *token.FileSet, f *ast.File) []Violation {
 	osNames := osLocalNames(f)
 	if len(osNames) == 0 {
-		return nil // file does not import "os" — no os.* call can resolve here.
+		return nil // file does not import "os" — no os.* reference can resolve here.
 	}
 	funcs := funcRanges(f)
 
 	var violations []Violation
 	ast.Inspect(f, func(n ast.Node) bool {
-		name, ok := mutatingOSCall(n, osNames)
+		name, ok := mutatingOSRef(n, osNames)
 		if !ok {
 			return true
 		}
@@ -204,17 +204,17 @@ func funcRanges(f *ast.File) []funcRange {
 	return ranges
 }
 
-// mutatingOSCall reports whether n is a call to a mutating os.* function and,
-// if so, the bare function name (e.g. "WriteFile"). osNames is the set of local
+// mutatingOSRef reports whether n is a *reference* to a mutating os.* function
+// (e.g. "WriteFile") and, if so, the bare function name. It matches the
+// selector itself rather than the enclosing call, so a function-value capture
+// (`wf := os.WriteFile; wf(...)`) or callback pass (`f(os.Remove)`) is flagged
+// just like a direct `os.WriteFile(...)` call — a CI gate must not be bypassable
+// by hoisting the symbol into a variable. osNames is the set of local
 // identifiers bound to the standard-library "os" package in the file, so an
 // aliased import (`stdos "os"` → `stdos.WriteFile`) is matched while a
 // non-stdlib package happening to be named "os" is not.
-func mutatingOSCall(n ast.Node, osNames map[string]bool) (string, bool) {
-	call, ok := n.(*ast.CallExpr)
-	if !ok {
-		return "", false
-	}
-	sel, ok := call.Fun.(*ast.SelectorExpr)
+func mutatingOSRef(n ast.Node, osNames map[string]bool) (string, bool) {
+	sel, ok := n.(*ast.SelectorExpr)
 	if !ok {
 		return "", false
 	}

--- a/tools/jailcheck/jailcheck_test.go
+++ b/tools/jailcheck/jailcheck_test.go
@@ -79,6 +79,21 @@ func TestCheckDir_FuncValueCapture(t *testing.T) {
 	}
 }
 
+func TestCheckDir_DotImport(t *testing.T) {
+	// A dot-import of os hides every mutating call behind a bare identifier;
+	// the import itself must be flagged so CI fails fast.
+	violations, err := checkDir("testdata/dotimport")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation in dotimport fixture, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Call != `dot-import of "os"` {
+		t.Fatalf("expected dot-import violation, got %+v", violations[0])
+	}
+}
+
 func TestCheckDir_ReadOnlyNotFlagged(t *testing.T) {
 	// The violation fixture's readOnly func uses os.ReadFile; it must not appear.
 	violations, err := checkDir("testdata/violation")

--- a/tools/jailcheck/jailcheck_test.go
+++ b/tools/jailcheck/jailcheck_test.go
@@ -48,6 +48,21 @@ func TestCheckDir_Violation(t *testing.T) {
 	}
 }
 
+func TestCheckDir_AliasedImport(t *testing.T) {
+	// An aliased os import (`stdos "os"`) must still be caught via import
+	// resolution; the aliased read-only call must not be flagged.
+	violations, err := checkDir("testdata/aliased")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation in aliased fixture, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Call != "os.WriteFile" || violations[0].Func != "rawWriteAliased" {
+		t.Fatalf("expected os.WriteFile in rawWriteAliased, got %+v", violations[0])
+	}
+}
+
 func TestCheckDir_ReadOnlyNotFlagged(t *testing.T) {
 	// The violation fixture's readOnly func uses os.ReadFile; it must not appear.
 	violations, err := checkDir("testdata/violation")

--- a/tools/jailcheck/jailcheck_test.go
+++ b/tools/jailcheck/jailcheck_test.go
@@ -79,6 +79,31 @@ func TestCheckDir_FuncValueCapture(t *testing.T) {
 	}
 }
 
+func TestCheckDir_NonOSPackages(t *testing.T) {
+	// The jail has two seams: filesystem writes and subprocesses. A tool can
+	// bypass either without touching os.* — via os/exec, io/ioutil, or a raw
+	// syscall. All must be flagged; read-only entry points must not.
+	violations, err := checkDir("testdata/subprocess")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	got := make([]string, 0, len(violations))
+	for _, v := range violations {
+		got = append(got, v.Call)
+	}
+	sort.Strings(got)
+
+	want := []string{"exec.Command", "exec.CommandContext", "ioutil.WriteFile", "syscall.Unlink"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v (full: %+v)", want, got, violations)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
 func TestCheckDir_DotImport(t *testing.T) {
 	// A dot-import of os hides every mutating call behind a bare identifier;
 	// the import itself must be flagged so CI fails fast.

--- a/tools/jailcheck/jailcheck_test.go
+++ b/tools/jailcheck/jailcheck_test.go
@@ -63,6 +63,22 @@ func TestCheckDir_AliasedImport(t *testing.T) {
 	}
 }
 
+func TestCheckDir_FuncValueCapture(t *testing.T) {
+	// Hoisting os.WriteFile into a variable (`wf := os.WriteFile; wf(...)`)
+	// must still be caught: the lint matches the selector reference, not just
+	// the call. The read-only capture must not be flagged.
+	violations, err := checkDir("testdata/funcvalue")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	if len(violations) != 1 {
+		t.Fatalf("expected 1 violation in funcvalue fixture, got %d: %+v", len(violations), violations)
+	}
+	if violations[0].Call != "os.WriteFile" || violations[0].Func != "captureWrite" {
+		t.Fatalf("expected os.WriteFile in captureWrite, got %+v", violations[0])
+	}
+}
+
 func TestCheckDir_ReadOnlyNotFlagged(t *testing.T) {
 	// The violation fixture's readOnly func uses os.ReadFile; it must not appear.
 	violations, err := checkDir("testdata/violation")

--- a/tools/jailcheck/jailcheck_test.go
+++ b/tools/jailcheck/jailcheck_test.go
@@ -1,0 +1,62 @@
+// ABOUTME: Tests for the jailcheck analyzer against clean and violating fixtures.
+// ABOUTME: Pins the env-routed/read-only/annotated-fallback exemptions and the bypass detection.
+package main
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestCheckDir_Clean(t *testing.T) {
+	violations, err := checkDir("testdata/clean")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected 0 violations in clean fixture, got %d: %+v", len(violations), violations)
+	}
+}
+
+func TestCheckDir_Violation(t *testing.T) {
+	violations, err := checkDir("testdata/violation")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+
+	got := make([]string, 0, len(violations))
+	for _, v := range violations {
+		got = append(got, v.Call)
+	}
+	sort.Strings(got)
+
+	want := []string{"os.MkdirAll", "os.Remove", "os.WriteFile"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v, got %v (full: %+v)", want, got, violations)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+
+	// Every violation must carry a real file/line and the enclosing func name,
+	// so the CI failure message points the contributor at the exact site.
+	for _, v := range violations {
+		if v.Line == 0 || v.File == "" || v.Func == "" {
+			t.Errorf("violation missing location/func: %+v", v)
+		}
+	}
+}
+
+func TestCheckDir_ReadOnlyNotFlagged(t *testing.T) {
+	// The violation fixture's readOnly func uses os.ReadFile; it must not appear.
+	violations, err := checkDir("testdata/violation")
+	if err != nil {
+		t.Fatalf("checkDir: %v", err)
+	}
+	for _, v := range violations {
+		if v.Func == "readOnly" {
+			t.Errorf("read-only os.* must not be flagged, got %+v", v)
+		}
+	}
+}

--- a/tools/jailcheck/testdata/aliased/aliased.go
+++ b/tools/jailcheck/testdata/aliased/aliased.go
@@ -1,0 +1,15 @@
+// ABOUTME: jailcheck fixture — aliased os import still bypasses the jail.
+// ABOUTME: Must produce exactly one violation (stdos.WriteFile) via import resolution.
+package aliased
+
+import stdos "os"
+
+// rawWriteAliased bypasses the seam through an aliased os import.
+func rawWriteAliased(path, content string) error {
+	return stdos.WriteFile(path, []byte(content), 0o644)
+}
+
+// readOnlyAliased uses a read-only aliased os.* call — must NOT be flagged.
+func readOnlyAliased(path string) ([]byte, error) {
+	return stdos.ReadFile(path)
+}

--- a/tools/jailcheck/testdata/clean/clean.go
+++ b/tools/jailcheck/testdata/clean/clean.go
@@ -1,0 +1,40 @@
+// ABOUTME: jailcheck fixture — a clean tool that routes all mutations through env.
+// ABOUTME: Must produce zero violations.
+package clean
+
+import (
+	"context"
+	"os"
+)
+
+type env interface {
+	WriteFile(ctx context.Context, path, content string) error
+	RemoveFile(ctx context.Context, path string) error
+}
+
+// writeViaEnv routes through the ExecutionEnvironment seam — no os.* mutation.
+func writeViaEnv(ctx context.Context, e env, path, content string) error {
+	return e.WriteFile(ctx, path, content)
+}
+
+// readOnly uses read-only os.* funcs, which are not jail bypasses.
+func readOnly(path string) ([]byte, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, err
+	}
+	return os.ReadFile(path)
+}
+
+// guardedFallback mutates os.* only on the env==nil path and is annotated, so
+// it is allowed.
+//
+//jail:allow-unjailed-fallback env==nil path can never coexist with an active jail
+func guardedFallback(ctx context.Context, e env, path, content string) error {
+	if e != nil {
+		return e.WriteFile(ctx, path, content)
+	}
+	if err := os.MkdirAll("dir", 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/tools/jailcheck/testdata/dotimport/dotimport.go
+++ b/tools/jailcheck/testdata/dotimport/dotimport.go
@@ -1,0 +1,11 @@
+// ABOUTME: jailcheck fixture — dot-importing os hides every mutating call.
+// ABOUTME: Must produce exactly one violation flagging the dot-import itself.
+package dotimport
+
+import . "os"
+
+// rawWrite calls WriteFile as a bare identifier (no os. selector) thanks to the
+// dot-import — the import itself must be flagged.
+func rawWrite(path string, data []byte) error {
+	return WriteFile(path, data, 0o644)
+}

--- a/tools/jailcheck/testdata/funcvalue/funcvalue.go
+++ b/tools/jailcheck/testdata/funcvalue/funcvalue.go
@@ -1,0 +1,17 @@
+// ABOUTME: jailcheck fixture — capturing a mutating os.* function value bypasses
+// ABOUTME: a call-only lint. Must produce exactly one violation (os.WriteFile).
+package funcvalue
+
+import "os"
+
+// captureWrite hoists os.WriteFile into a variable then calls it — a call-only
+// analyzer would miss this; the selector reference must still be flagged.
+func captureWrite(path string, data []byte) error {
+	wf := os.WriteFile
+	return wf(path, data, 0o644)
+}
+
+// captureRead does the same with a read-only func — must NOT be flagged.
+func captureRead() func(string) ([]byte, error) {
+	return os.ReadFile
+}

--- a/tools/jailcheck/testdata/subprocess/subprocess.go
+++ b/tools/jailcheck/testdata/subprocess/subprocess.go
@@ -1,0 +1,38 @@
+// ABOUTME: jailcheck fixture — non-os jail bypasses across watched packages.
+// ABOUTME: Must flag exec.Command, exec.CommandContext, ioutil.WriteFile, syscall.Unlink (4).
+package subprocess
+
+import (
+	"context"
+	"io/ioutil"
+	"os/exec"
+	"syscall"
+)
+
+// spawnDirect bypasses env.ExecCommand (and so the jail's CommandWrapper).
+func spawnDirect() error {
+	return exec.Command("true").Run()
+}
+
+// spawnCtx is the context variant — also a subprocess bypass.
+func spawnCtx(ctx context.Context) error {
+	return exec.CommandContext(ctx, "sh", "-c", "echo hi").Run()
+}
+
+// deprecatedWrite bypasses env.WriteFile via the deprecated ioutil alias.
+func deprecatedWrite(path string, data []byte) error {
+	return ioutil.WriteFile(path, data, 0o644)
+}
+
+// lowLevelDelete bypasses env.RemoveFile via a raw syscall.
+func lowLevelDelete(path string) error {
+	return syscall.Unlink(path)
+}
+
+// readOnlyNotFlagged uses read-only entry points — must NOT be flagged.
+func readOnlyNotFlagged(path string) ([]byte, error) {
+	if _, err := exec.LookPath("sh"); err != nil {
+		return nil, err
+	}
+	return ioutil.ReadFile(path)
+}

--- a/tools/jailcheck/testdata/violation/violation.go
+++ b/tools/jailcheck/testdata/violation/violation.go
@@ -1,0 +1,23 @@
+// ABOUTME: jailcheck fixture — a tool with unguarded os.* mutations (jail bypass).
+// ABOUTME: Must produce exactly three violations: os.WriteFile, os.Remove, os.MkdirAll.
+package violation
+
+import "os"
+
+// rawWrite bypasses the ExecutionEnvironment seam — a jail bypass.
+func rawWrite(path, content string) error {
+	if err := os.MkdirAll("dir", 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// rawDelete bypasses the seam for a destructive op.
+func rawDelete(path string) error {
+	return os.Remove(path)
+}
+
+// readOnly is fine — read-only os.* is not a bypass and must NOT be flagged.
+func readOnly(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}


### PR DESCRIPTION
Closes #283. Refs #275, #272.

Follow-up to the merged `writable_paths`/Landlock-jail work. The #275 round-8 audit caught `generate_code` and `write_enriched_sprint` calling `os.WriteFile` directly — bypassing the jail entirely — and the only reason it was caught was a manual grep for `os.WriteFile` in `agent/tools/`. This PR replaces that luck with a doc + a CI gate.

## Central design decision (resolved: option a)

The two tools keep a deliberate direct-`os.*` fallback for the unjailed path. **These are guarded fallbacks, not bypasses** — traced end-to-end through `pipeline/handlers/backend_native.go`:

1. When `writable_paths` is set, the backend requires `b.env` to be a `*LocalEnvironment` (else **refuse-to-start**), builds a jailed env via `configureJail`, and assigns it to `env`.
2. That same jailed `env` is passed into **both** tools (`WithGenerateEnv` / `WithSprintWriterEnv`).
3. So whenever a jail is active, `t.env` is the jailed env (non-nil) and the tool takes the `env.WriteFile` branch.
4. The `os.*` fallback is reachable **only** when `env == nil`, which cannot coexist with an active jail. **`env == nil` ⟹ no jail ⟹ nothing to bypass.**

No fallback refactor; the only product-code change is comment-only (the invariant + a `//jail:allow-unjailed-fallback` marker on each fallback function).

## Deliverable 1 — `docs/architecture/agent-tool-jail-checklist.md`

- Per-tool threat-model **table** (11 LLM-callable tools), each row verified against the code: what it touches (read/write/delete/exec) and which `ExecutionEnvironment` seam it routes through.
- **The rule**: any `agent/tools/` filesystem mutation MUST route through `exec.ExecutionEnvironment`; direct `os.WriteFile`/`MkdirAll`/`Remove`/… is a review-blocker.
- New-tool checklist; the documented env==nil-fallback invariant; residual risks (reads/exfil, aliased `os` imports, out-of-process backends).

## Deliverable 2 — the lint

- `go/ast` analyzer at `tools/jailcheck/`, run via `make tools-jail-check`. Flags any mutating `os.*` call in `agent/tools/*.go` (excl. `_test.go`). AST, not grep, so `os.WriteFile` mentions in doc-comments/strings don't false-positive.
- Read-only `os.*` (`ReadFile`/`Open`/`Stat`) intentionally ignored — the jail bounds writes, not reads.
- The one legal exception (env==nil fallback) is whitelisted by the `//jail:allow-unjailed-fallback` marker. The two existing audited fallbacks carry it.
- Wired into the `ci:` Makefile target and the CI "Quality Gates" job. Unit-tested against `clean`/`violation` fixtures under `tools/jailcheck/testdata/`.

## Teeth (evidence, not assertion)

```
$ make tools-jail-check
jailcheck: ok — no unguarded os.* filesystem mutations in agent/tools

# inject `os.Remove(params.Path)` into read.go's (unannotated) Execute:
$ go run ./tools/jailcheck agent/tools
agent/tools/read.go:64: os.Remove called directly in Execute — route filesystem
  mutations through exec.ExecutionEnvironment ... See docs/architecture/agent-tool-jail-checklist.md
jailcheck: FAIL — 1 unguarded os.* filesystem mutation(s) in agent/tools
exit status 1
# reverted; clean again.
```

Plus unit tests: `clean` fixture → 0 violations (env-routed + read-only + annotated-fallback all exempt); `violation` fixture → exactly `os.MkdirAll`/`os.Remove`/`os.WriteFile`, read-only not flagged.

## Verification

`gofmt`/`goimports` clean · `go vet ./...` · `go build ./...` (linux + `GOOS=darwin`) · `go test ./... -short` (no FAIL) · `make tools-jail-check` (clean + proven-failing) · analyzer max cyclomatic 7 (< 8 gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783115733&installation_id=131176874&pr_number=294&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F294&signature=7308d4a66c8ae2d331fae7a1b86489d0e56f62c19c69293c645b711a68a3f142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New architecture doc formalizing filesystem-safety rules, per-tool threat models, checklist, and residual risks.

* **Chores**
  * Added a CI quality gate and Makefile target to enforce agent-tool filesystem constraints; updated .gitignore and annotated audited env==nil fallback paths.

* **Tests**
  * Added lint fixtures and unit tests covering aliased imports, dot-imports, function-value captures, subprocess cases, clean/no-violation cases, and expected violations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->