### PR TITLE
fix(engine): route unhandled agent failure to fallback_target instead of dead-stop (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `openai-compat` fail-closed). Linked from the architecture docs index and
   `llm.md`.
 
+### Fixed
+
+- **Unhandled agent failure no longer dead-stops the pipeline** (closes #295,
+  refs epic #308, pairs with #296). When an agent node returns `OutcomeFail`
+  (including turn-limit exhaustion) and has only unconditional outgoing edges,
+  the strict-failure guard now consults `findFallbackTarget` before halting:
+  if a node-level or graph-level `fallback_target`/`fallback_retry_target`
+  resolves, the run routes there (one-shot per node, guarded by
+  `Checkpoint.FallbackTaken` and persisted across resume) instead of skipping
+  every downstream safety node. A single graph-level `fallback_target` thus
+  becomes a catch-all escalation route for any unhandled failure. Behavior is
+  unchanged when no fallback is declared — same terminal `OutcomeFail` status
+  and the same error string as before.
+
 ## [0.35.1] - 2026-06-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every downstream safety node. A single graph-level `fallback_target` thus
   becomes a catch-all escalation route for any unhandled failure. Behavior is
   unchanged when no fallback is declared — same terminal `OutcomeFail` status
-  and the same error string as before.
+  and the same error string as before. The fallback advance applies the same
+  post-node `BudgetGuard` check as the normal edge-advance path, so a failed
+  node that already breached a hard token/cost ceiling halts on budget instead
+  of spending more on the fallback node.
 
 ## [0.35.1] - 2026-06-02
 

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -576,6 +576,15 @@ func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *Trac
 	if fb == "" {
 		return nil
 	}
+	traceEntry.EdgeTo = fb
+	s.trace.AddEntry(*traceEntry)
+	// Apply the same post-node budget check as advanceToNextNode before
+	// advancing, so a node that already breached a hard ceiling halts the run
+	// rather than spending more on the fallback node (#311 review).
+	e.emitCostUpdate(s)
+	if lr := e.checkBudgetAfterEmit(s); lr != nil {
+		return lr
+	}
 	if s.cp.FallbackTaken == nil {
 		s.cp.FallbackTaken = map[string]bool{}
 	}
@@ -587,8 +596,6 @@ func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *Trac
 		NodeID:    node.ID,
 		Message:   fmt.Sprintf("node %q failed with no failure edge, routing to fallback %q", node.ID, fb),
 	})
-	traceEntry.EdgeTo = fb
-	s.trace.AddEntry(*traceEntry)
 	e.clearDownstream(fb, s.cp)
 	s.cp.CurrentNode = fb
 	e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, node.ID)

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -529,6 +529,14 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 	if outcome != string(OutcomeFail) || hasAnyConditionalEdge(edges) {
 		return nil
 	}
+	// Before dead-stopping, consult the node/graph-level fallback_target so an
+	// unhandled failure (incl. turn-exhaustion) escalates to a safety node
+	// instead of skipping every downstream node (#295). One-shot per node.
+	if node := e.graph.Nodes[nodeID]; node != nil {
+		if lr := e.strictFailureFallback(s, node, traceEntry); lr != nil {
+			return lr
+		}
+	}
 	e.emit(PipelineEvent{
 		Type:      EventStageFailed,
 		Timestamp: time.Now(),
@@ -551,6 +559,40 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 		err: fmt.Errorf("node %q failed with no conditional edges to handle failure", nodeID),
 	}
 	return &lr
+}
+
+// strictFailureFallback attempts to route an unhandled strict failure to a
+// node- or graph-level fallback_target instead of halting. It mirrors
+// goalGateExhaustedPath (engine_checkpoint.go): the fallback is taken at most
+// once per node per run, guarded by cp.FallbackTaken (persisted in the
+// checkpoint) to prevent loop-backs from re-escalating forever. Returns an
+// advancing loopResult when a fallback resolves, or nil to let the caller
+// perform today's terminal halt.
+func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *TraceEntry) *loopResult {
+	if s.cp.FallbackTaken[node.ID] {
+		return nil
+	}
+	fb := e.findFallbackTarget(node)
+	if fb == "" {
+		return nil
+	}
+	if s.cp.FallbackTaken == nil {
+		s.cp.FallbackTaken = map[string]bool{}
+	}
+	s.cp.FallbackTaken[node.ID] = true
+	e.emit(PipelineEvent{
+		Type:      EventStageFailed,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    node.ID,
+		Message:   fmt.Sprintf("node %q failed with no failure edge, routing to fallback %q", node.ID, fb),
+	})
+	traceEntry.EdgeTo = fb
+	s.trace.AddEntry(*traceEntry)
+	e.clearDownstream(fb, s.cp)
+	s.cp.CurrentNode = fb
+	e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, node.ID)
+	return &loopResult{action: loopContinue, nextNodeID: fb}
 }
 
 // handleCompletedTarget handles the case where the selected next node was already completed.

--- a/pipeline/engine_strict_fallback_test.go
+++ b/pipeline/engine_strict_fallback_test.go
@@ -175,6 +175,54 @@ func TestStrictFailureFallbackTakenAtMostOnce(t *testing.T) {
 	}
 }
 
+// TestStrictFailureFallbackRespectsBudget verifies that when the failed node's
+// own usage already breaches a hard budget ceiling, the run halts on budget
+// instead of spending more by running the fallback node. The strict-failure
+// fallback advance must apply the same post-node budget check as the normal
+// advanceToNextNode path (#311 review, Codex).
+func TestStrictFailureFallbackRespectsBudget(t *testing.T) {
+	g := NewGraph("strict-fallback-budget")
+	g.Attrs["fallback_target"] = "escalate"
+
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "agentFail", Shape: "box"})
+	g.AddNode(&Node{ID: "escalate", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "agentFail"})
+	g.AddEdge(&Edge{From: "agentFail", To: "done"})
+	g.AddEdge(&Edge{From: "escalate", To: "done"})
+
+	reg := newTestRegistry()
+	escalateVisited := false
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "agentFail":
+				// Spend past the 1000-token ceiling before failing.
+				return Outcome{Status: string(OutcomeFail), Stats: &SessionStats{TotalTokens: 5000}}, nil
+			case "escalate":
+				escalateVisited = true
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	guard := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 1000})
+	engine := NewEngine(g, reg, WithBudgetGuard(guard))
+	result, _ := engine.Run(context.Background())
+
+	if escalateVisited {
+		t.Fatal("escalate must NOT run: the failed node already breached the token budget")
+	}
+	if result.Status != OutcomeBudgetExceeded {
+		t.Fatalf("status = %q, want %q", result.Status, OutcomeBudgetExceeded)
+	}
+}
+
 // TestStrictFailureNoFallbackPreservesHalt pins the unchanged behavior when no
 // node/graph fallback_target is declared: same status and same error string.
 func TestStrictFailureNoFallbackPreservesHalt(t *testing.T) {

--- a/pipeline/engine_strict_fallback_test.go
+++ b/pipeline/engine_strict_fallback_test.go
@@ -1,0 +1,211 @@
+// ABOUTME: Tests for strict-failure fallback catch-all (issue #295).
+// ABOUTME: An unhandled agent OutcomeFail (only unconditional edges) routes to a
+// node/graph-level fallback_target instead of dead-stopping the pipeline.
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// traceEdgeTo returns the EdgeTo of the first trace entry for nodeID.
+func traceEdgeTo(tr *Trace, nodeID string) (string, bool) {
+	for _, e := range tr.Entries {
+		if e.NodeID == nodeID {
+			return e.EdgeTo, true
+		}
+	}
+	return "", false
+}
+
+// TestStrictFailureRoutesToGraphFallbackTarget verifies that a bare agent
+// OutcomeFail with only unconditional edges routes to the graph-level
+// fallback_target and the run actually reaches that node, rather than halting.
+func TestStrictFailureRoutesToGraphFallbackTarget(t *testing.T) {
+	g := NewGraph("strict-fallback-graph")
+	g.Attrs["fallback_target"] = "escalate"
+
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "agentFail", Shape: "box"})
+	g.AddNode(&Node{ID: "escalate", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "agentFail"})
+	g.AddEdge(&Edge{From: "agentFail", To: "done"}) // only edge: unconditional
+	g.AddEdge(&Edge{From: "escalate", To: "done"})
+
+	reg := newTestRegistry()
+	escalateVisited := false
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "agentFail":
+				return Outcome{Status: string(OutcomeFail)}, nil
+			case "escalate":
+				escalateVisited = true
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+	if !escalateVisited {
+		t.Fatal("expected escalate node to be reached via fallback_target")
+	}
+	if edgeTo, ok := traceEdgeTo(result.Trace, "agentFail"); !ok || edgeTo != "escalate" {
+		t.Fatalf("agentFail trace EdgeTo = %q (found=%v), want %q", edgeTo, ok, "escalate")
+	}
+}
+
+// TestStrictFailureNodeFallbackPrecedesGraph verifies node-level fallback_target
+// wins over the graph-level one on the strict-failure path.
+func TestStrictFailureNodeFallbackPrecedesGraph(t *testing.T) {
+	g := NewGraph("strict-fallback-precedence")
+	g.Attrs["fallback_target"] = "graphEscalate"
+
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "agentFail", Shape: "box", Attrs: map[string]string{
+		"fallback_target": "nodeEscalate",
+	}})
+	g.AddNode(&Node{ID: "nodeEscalate", Shape: "box"})
+	g.AddNode(&Node{ID: "graphEscalate", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "agentFail"})
+	g.AddEdge(&Edge{From: "agentFail", To: "done"})
+	g.AddEdge(&Edge{From: "nodeEscalate", To: "done"})
+	g.AddEdge(&Edge{From: "graphEscalate", To: "done"})
+
+	reg := newTestRegistry()
+	var visited string
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "agentFail":
+				return Outcome{Status: string(OutcomeFail)}, nil
+			case "nodeEscalate", "graphEscalate":
+				visited = node.ID
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+	if visited != "nodeEscalate" {
+		t.Fatalf("visited = %q, want node-level fallback %q", visited, "nodeEscalate")
+	}
+	if edgeTo, _ := traceEdgeTo(result.Trace, "agentFail"); edgeTo != "nodeEscalate" {
+		t.Fatalf("agentFail trace EdgeTo = %q, want %q", edgeTo, "nodeEscalate")
+	}
+}
+
+// TestStrictFailureFallbackTakenAtMostOnce verifies the FallbackTaken guard: a
+// node that re-enters after the fallback target loops back to it does NOT take
+// the fallback a second time — it halts as today.
+func TestStrictFailureFallbackTakenAtMostOnce(t *testing.T) {
+	g := NewGraph("strict-fallback-once")
+	g.Attrs["fallback_target"] = "rescue"
+
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "agentFail", Shape: "box"})
+	g.AddNode(&Node{ID: "rescue", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "agentFail"})
+	g.AddEdge(&Edge{From: "agentFail", To: "done"})
+	g.AddEdge(&Edge{From: "rescue", To: "agentFail"}) // loop back into the failing node
+
+	reg := newTestRegistry()
+	agentFailCalls := 0
+	rescueCalls := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "agentFail":
+				agentFailCalls++
+				return Outcome{Status: string(OutcomeFail)}, nil
+			case "rescue":
+				rescueCalls++
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+
+	if rescueCalls != 1 {
+		t.Fatalf("rescue ran %d times, want exactly 1 (fallback taken at most once)", rescueCalls)
+	}
+	if agentFailCalls != 2 {
+		t.Fatalf("agentFail ran %d times, want 2 (initial + one loop-back)", agentFailCalls)
+	}
+	if result.Status != OutcomeFail {
+		t.Fatalf("status = %q, want %q (halt on second unhandled failure)", result.Status, OutcomeFail)
+	}
+	if err == nil {
+		t.Fatal("expected terminal error on the second unhandled failure")
+	}
+}
+
+// TestStrictFailureNoFallbackPreservesHalt pins the unchanged behavior when no
+// node/graph fallback_target is declared: same status and same error string.
+func TestStrictFailureNoFallbackPreservesHalt(t *testing.T) {
+	g := NewGraph("strict-fallback-none")
+
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "agentFail", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "agentFail"})
+	g.AddEdge(&Edge{From: "agentFail", To: "done"})
+
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "agentFail" {
+				return Outcome{Status: string(OutcomeFail)}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(context.Background())
+
+	if result.Status != OutcomeFail {
+		t.Fatalf("status = %q, want %q", result.Status, OutcomeFail)
+	}
+	const wantErr = `node "agentFail" failed with no conditional edges to handle failure`
+	if err == nil || err.Error() != wantErr {
+		t.Fatalf("err = %v, want %q", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Summary

A plain agent `OutcomeFail` — **including turn-limit exhaustion** — on a node whose only outgoing edges are unconditional would HALT the entire pipeline via `checkStrictFailure`, silently skipping every downstream safety node (cross-review, `FinalSpecCheck`). The strict-failure rule is right in spirit but was a guillotine with no escalation path.

A `findFallbackTarget` mechanism already existed and reads node- **and** graph-level `fallback_target`/`fallback_retry_target`, but only the goal-gate and retry-exhaustion paths consulted it. The bare strict-failure path never did.

## Change (engine-only, surgical)

`pipeline/engine.go` `checkStrictFailure` now consults a new `strictFailureFallback` helper **before** building the terminal result:

- If a node- or graph-level fallback resolves → route there and advance the run loop (returns a `loopContinue` `loopResult`, matching how the other advance branches signal "next node"). Mirrors `goalGateExhaustedPath` + the `handleExitNode` escalation sequence: emit `EventStageFailed`, set `traceEntry.EdgeTo`, `clearDownstream`, set `cp.CurrentNode`, checkpoint.
- **One-shot per node**, guarded by `Checkpoint.FallbackTaken` (already persisted in checkpoint JSON → survives resume), preventing loop-backs from re-escalating forever.
- If no fallback resolves (or already taken) → today's terminal halt is preserved **byte-for-byte**: same `OutcomeFail` status, same error string.

A single graph-level `fallback_target` thus becomes a one-declaration catch-all escalation route for any unhandled failure across all nodes.

### Design note
`checkStrictFailure` already returned `*loopResult` consumed by `advanceToNextNode` via `if lr := …; lr != nil { return *lr }`, so producing the advance `loopResult` inside it (via the extracted helper) was the smallest diff — no change to `advanceToNextNode`'s body. Both functions stay under the ≤8 cyclomatic/cognitive gate.

## Tests (TDD — written first, watched fail, then implemented)

`pipeline/engine_strict_fallback_test.go`:
- Graph-level `fallback_target` → agent `OutcomeFail` with only unconditional edges routes to the fallback and the run **reaches** it (asserts trace `EdgeTo`).
- Node-level `fallback_target` precedes graph-level.
- Fallback taken **at most once** per node per run (fallback loops back into the failing node; second unhandled failure halts).
- No node/graph fallback → unchanged halt, pinned to the exact prior error string (regression).

## Verification
- `go build ./...` + `GOOS=darwin GOARCH=amd64 go build ./...` ✓
- `go test ./... -short` ✓ · `go test -race -short ./pipeline/...` ✓ · `go vet ./...` ✓
- `dippin doctor` on the three core pipelines — all Grade A (unchanged; engine-only)
- New funcs verified under `gocyclo`/`gocognit -over 8`

## Scope
Engine-only. The `build_product.dip` author-side fix is **#296** (separate P0). Reuses the existing `fallback_target` graph attr — no dippin-lang change.

Closes #295. Refs epic #308. Pairs with #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783199780&installation_id=131176874&pr_number=311&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F311&signature=443c128c4ab615e16cd019fe45efd9f4c78e13542d682d7bff4551f78f2d5961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Unhandled agent failures now route to fallback targets when available instead of halting the pipeline. Pipelines without configured fallbacks preserve the existing halt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->