### PR TITLE
fix(build_product): route agent failure/turn-exhaustion to escalation on every node (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,16 +124,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uncommitted work halted the pipeline before the cross-review lanes and
   FinalSpecCheck ever ran) the engine's strict-failure rule halted the whole
   run. Mirroring the `FixMilestone` precedent: `Implement` gains
-  `fallback_target: EscalateMilestone`; `ReviewClaude`/`ReviewCodex`/
-  `ReviewGemini`/`ApplyReviewFixes`/`FinalCommit` gain
-  `fallback_target: EscalateReview`. For `Implement` and `ApplyReviewFixes` the
-  primary edge is now conditional on `ctx.outcome = success` with an
+  `fallback_target: EscalateMilestone`; `ApplyReviewFixes` and `FinalCommit`
+  gain `fallback_target: EscalateReview`. For `Implement` and `ApplyReviewFixes`
+  the primary edge is now conditional on `ctx.outcome = success` with an
   unconditional belt-and-suspenders catch-all to the escalation gate;
   `FinalCommit` relies on `fallback_target` alone because a catch-all edge there
   would close an unconditional `Cleanup → FinalCommit → EscalateReview` cycle
-  (DIP005). New `pipeline/build_product_failure_routing_test.go` pins the
+  (DIP005). The three cross-review reviewers run as **parallel branches**, which
+  execute via `ParallelHandler` and bypass the engine's strict-failure path — a
+  per-branch `fallback_target` would be inert — so their failure is routed on the
+  aggregating `ReviewParallel` node with a conditional fail edge to
+  `EscalateReview`. Because `aggregateStatus` is success-if-any, this fires when
+  **all three** reviewers fail (previously a silent dead-stop); a single
+  reviewer failing is still masked by `aggregateStatus` and is tracked as an
+  engine follow-up (#313). New `pipeline/build_product_failure_routing_test.go` pins the
   invariant — every codergen node has a conditional edge or a resolvable
-  fallback — as the in-repo counterpart to dippin-lang#93's author-time lint.
+  fallback, with parallel branches checked against their parent's route — as the
+  in-repo counterpart to dippin-lang#93's author-time lint.
 
 ## [0.35.1] - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   post-node `BudgetGuard` check as the normal edge-advance path, so a failed
   node that already breached a hard token/cost ceiling halts on budget instead
   of spending more on the fallback node.
+- **`build_product.dip`: every agent node now routes failure/turn-exhaustion to
+  an escalation gate instead of dead-stopping** (closes #296, refs epic #308,
+  pairs with the #295 engine catch-all). Six agent nodes had exactly one
+  unconditional outgoing edge and no fallback, so on `max_turns` exhaustion (the
+  proximate cause of the code-goblin run `7b6e08c9e2b2`, where GREEN-but-
+  uncommitted work halted the pipeline before the cross-review lanes and
+  FinalSpecCheck ever ran) the engine's strict-failure rule halted the whole
+  run. Mirroring the `FixMilestone` precedent: `Implement` gains
+  `fallback_target: EscalateMilestone`; `ReviewClaude`/`ReviewCodex`/
+  `ReviewGemini`/`ApplyReviewFixes`/`FinalCommit` gain
+  `fallback_target: EscalateReview`. For `Implement` and `ApplyReviewFixes` the
+  primary edge is now conditional on `ctx.outcome = success` with an
+  unconditional belt-and-suspenders catch-all to the escalation gate;
+  `FinalCommit` relies on `fallback_target` alone because a catch-all edge there
+  would close an unconditional `Cleanup → FinalCommit → EscalateReview` cycle
+  (DIP005). New `pipeline/build_product_failure_routing_test.go` pins the
+  invariant — every codergen node has a conditional edge or a resolvable
+  fallback — as the in-repo counterpart to dippin-lang#93's author-time lint.
 
 ## [0.35.1] - 2026-06-02
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -400,6 +400,7 @@ workflow BuildProduct
     reasoning_effort: high
     fidelity: full
     max_turns: 50
+    fallback_target: EscalateMilestone
     prompt:
       Read the current milestone spec at .ai/milestones/current.md.
       Read the full spec at SPEC.md for context.
@@ -797,6 +798,7 @@ workflow BuildProduct
     model: claude-opus-4-6
     provider: anthropic
     reasoning_effort: high
+    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -858,6 +860,7 @@ workflow BuildProduct
     model: gpt-5.4
     provider: openai
     reasoning_effort: high
+    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -919,6 +922,7 @@ workflow BuildProduct
     model: gemini-2.5-pro
     provider: gemini
     reasoning_effort: high
+    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -1035,6 +1039,7 @@ workflow BuildProduct
     provider: anthropic
     reasoning_effort: high
     fidelity: full
+    fallback_target: EscalateReview
     prompt:
       Read the review synthesis at .ai/decisions/review-synthesis.md.
       Apply ONLY the required fixes. Do NOT apply suggested improvements
@@ -1298,6 +1303,7 @@ workflow BuildProduct
     model: claude-sonnet-4-6
     provider: anthropic
     reasoning_effort: low
+    fallback_target: EscalateReview
     prompt:
       Ensure all changes are committed. If there are uncommitted changes from
       the cleanup or final fixes, commit them. Include the commit hash.
@@ -1319,7 +1325,8 @@ workflow BuildProduct
     PickNextMilestone -> Implement  when ctx.tool_stdout not contains all-done
     PickNextMilestone -> ReviewParallel  when ctx.tool_stdout contains all-done
     PickNextMilestone -> EscalateMilestone
-    Implement -> TestMilestone
+    Implement -> TestMilestone  when ctx.outcome = success
+    Implement -> EscalateMilestone
     TestMilestone -> VerifyMilestone  when ctx.outcome = success
     TestMilestone -> EscalateMilestone  when ctx.tool_stdout contains escalate
     TestMilestone -> FixMilestone  when ctx.outcome = fail
@@ -1354,7 +1361,8 @@ workflow BuildProduct
     # loop at MAX_ATTEMPTS=1 — a clean re-review proceeds to FinalBuild
     # via SynthesizeReviews's existing success edge; an exhausted budget
     # escalates to a human.
-    ApplyReviewFixes -> CheckReviewFixBudget
+    ApplyReviewFixes -> CheckReviewFixBudget  when ctx.outcome = success
+    ApplyReviewFixes -> EscalateReview
     CheckReviewFixBudget -> ReviewParallel  when ctx.outcome = success  restart: true
     CheckReviewFixBudget -> EscalateReview  when ctx.outcome = fail
 
@@ -1373,4 +1381,7 @@ workflow BuildProduct
     EscalateReview -> Done  label: "abandon"
 
     Cleanup -> FinalCommit
+    # FinalCommit failure routes via fallback_target: EscalateReview (node attr),
+    # not a catch-all edge — Cleanup is reachable from EscalateReview (accept), so a
+    # FinalCommit -> EscalateReview edge would close an unconditional cycle (DIP005).
     FinalCommit -> Done

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -798,7 +798,6 @@ workflow BuildProduct
     model: claude-opus-4-6
     provider: anthropic
     reasoning_effort: high
-    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -860,7 +859,6 @@ workflow BuildProduct
     model: gpt-5.4
     provider: openai
     reasoning_effort: high
-    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -922,7 +920,6 @@ workflow BuildProduct
     model: gemini-2.5-pro
     provider: gemini
     reasoning_effort: high
-    fallback_target: EscalateReview
     prompt:
       Review the COMPLETE implementation against SPEC.md. All milestones are done.
 
@@ -1344,6 +1341,15 @@ workflow BuildProduct
     EscalateMilestone -> Done  label: "abandon"
 
     # Cross-review
+    # The three reviewers run as parallel branches; a branch runs via
+    # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
+    # path, so a per-branch fallback_target would be inert. Route failure on the
+    # aggregating ReviewParallel node instead: aggregateStatus is success-if-any,
+    # so this fires only when ALL THREE reviewers fail (which would otherwise
+    # dead-stop the pipeline). On success the parallel handler's suggested-next
+    # routes to ReviewJoin. A single reviewer failing is masked by aggregateStatus
+    # and needs an engine fix (per-branch routing); tracked separately.
+    ReviewParallel -> EscalateReview  when ctx.outcome = fail
     ReviewClaude -> ReviewJoin
     ReviewCodex -> ReviewJoin
     ReviewGemini -> ReviewJoin

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -1,0 +1,106 @@
+// ABOUTME: Regression guard for issue #296 — every agent (codergen) node in the
+// ABOUTME: shipped build_product.dip must route failure/turn-exhaustion, never dead-stop.
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// loadBuildProduct loads the embedded-on-disk examples/build_product.dip the
+// same way the binary embeds it. Relative to the pipeline package dir.
+func loadBuildProduct(t *testing.T) *Graph {
+	t.Helper()
+	path := filepath.Join("..", "examples", "build_product.dip")
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	g, _, err := LoadDippinWorkflow(string(source), "build_product.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	return g
+}
+
+// TestBuildProductAgentNodesHaveFailureRouting pins the issue #296 invariant:
+// no agent node in build_product.dip can silently halt the pipeline on an
+// unhandled failure (e.g. max_turns exhaustion). This is the in-repo
+// counterpart to dippin-lang#93's author-time lint.
+//
+// It mirrors the engine's strict-failure rule exactly (checkStrictFailure /
+// findFallbackTarget): a failed node dead-stops only when it has NO conditional
+// outgoing edge AND no node/graph-level fallback_target resolves. So every
+// codergen node must satisfy hasAnyConditionalEdge(out) || a resolvable
+// fallback_target. If a future edit reintroduces a single-unconditional-edge
+// agent node with no fallback, this fails — the regression that caused the
+// code-goblin run (7b6e08c9e2b2) to halt before review + FinalSpecCheck.
+func TestBuildProductAgentNodesHaveFailureRouting(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	checked := 0
+	for _, n := range g.Nodes {
+		// Only agent/codergen nodes run a session that can exhaust turns.
+		// Passthrough start/exit carry no agent work.
+		if n.Handler != "codergen" || n.ID == g.StartNode || n.ID == g.ExitNode {
+			continue
+		}
+		checked++
+		if hasAnyConditionalEdge(g.OutgoingEdges(n.ID)) || resolveFallback(g, n) != "" {
+			continue
+		}
+		t.Errorf("agent node %q can dead-stop on failure: no conditional fail edge and no fallback_target (issue #296)", n.ID)
+	}
+	if checked == 0 {
+		t.Fatal("no codergen nodes found — loader or fixture changed; invariant not actually exercised")
+	}
+}
+
+// resolveFallback returns the node's effective fallback target using the same
+// candidate order as Engine.findFallbackTarget, or "" if none resolves. The
+// .dip `fallback_target:` keyword lands in node.Attrs["fallback_retry_target"]
+// after the IR→Graph adapter (extractRetryAttrs), so a direct read of
+// "fallback_target" would miss it — resolve the way the engine does.
+func resolveFallback(g *Graph, n *Node) string {
+	for _, fb := range []string{
+		n.Attrs["fallback_target"],
+		n.Attrs["fallback_retry_target"],
+		g.Attrs["fallback_target"],
+		g.Attrs["fallback_retry_target"],
+	} {
+		if fb != "" {
+			if _, ok := g.Nodes[fb]; ok {
+				return fb
+			}
+		}
+	}
+	return ""
+}
+
+// TestBuildProductIssue296FallbackTargets pins the specific escalation targets
+// for the six nodes #296 hardened. The general invariant above proves "has a
+// route"; this proves the route goes to the *correct* escalation gate, so a
+// future edit can't satisfy the invariant by pointing failure somewhere unsafe
+// (e.g. a Fix node or loop target).
+func TestBuildProductIssue296FallbackTargets(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	want := map[string]string{
+		"Implement":        "EscalateMilestone",
+		"ReviewClaude":     "EscalateReview",
+		"ReviewCodex":      "EscalateReview",
+		"ReviewGemini":     "EscalateReview",
+		"ApplyReviewFixes": "EscalateReview",
+		"FinalCommit":      "EscalateReview",
+	}
+	for id, target := range want {
+		if _, ok := g.Nodes[id]; !ok {
+			t.Errorf("node %q missing from build_product.dip", id)
+			continue
+		}
+		if got := resolveFallback(g, g.Nodes[id]); got != target {
+			t.Errorf("node %q: resolved fallback = %q, want %q (issue #296)", id, got, target)
+		}
+	}
+}

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -24,39 +24,6 @@ func loadBuildProduct(t *testing.T) *Graph {
 	return g
 }
 
-// TestBuildProductAgentNodesHaveFailureRouting pins the issue #296 invariant:
-// no agent node in build_product.dip can silently halt the pipeline on an
-// unhandled failure (e.g. max_turns exhaustion). This is the in-repo
-// counterpart to dippin-lang#93's author-time lint.
-//
-// It mirrors the engine's strict-failure rule exactly (checkStrictFailure /
-// findFallbackTarget): a failed node dead-stops only when it has NO conditional
-// outgoing edge AND no node/graph-level fallback_target resolves. So every
-// codergen node must satisfy hasAnyConditionalEdge(out) || a resolvable
-// fallback_target. If a future edit reintroduces a single-unconditional-edge
-// agent node with no fallback, this fails — the regression that caused the
-// code-goblin run (7b6e08c9e2b2) to halt before review + FinalSpecCheck.
-func TestBuildProductAgentNodesHaveFailureRouting(t *testing.T) {
-	g := loadBuildProduct(t)
-
-	checked := 0
-	for _, n := range g.Nodes {
-		// Only agent/codergen nodes run a session that can exhaust turns.
-		// Passthrough start/exit carry no agent work.
-		if n.Handler != "codergen" || n.ID == g.StartNode || n.ID == g.ExitNode {
-			continue
-		}
-		checked++
-		if hasAnyConditionalEdge(g.OutgoingEdges(n.ID)) || resolveFallback(g, n) != "" {
-			continue
-		}
-		t.Errorf("agent node %q can dead-stop on failure: no conditional fail edge and no fallback_target (issue #296)", n.ID)
-	}
-	if checked == 0 {
-		t.Fatal("no codergen nodes found — loader or fixture changed; invariant not actually exercised")
-	}
-}
-
 // resolveFallback returns the node's effective fallback target using the same
 // candidate order as Engine.findFallbackTarget, or "" if none resolves. The
 // .dip `fallback_target:` keyword lands in node.Attrs["fallback_retry_target"]
@@ -78,23 +45,87 @@ func resolveFallback(g *Graph, n *Node) string {
 	return ""
 }
 
-// TestBuildProductIssue296FallbackTargets pins the specific escalation targets
-// for the six nodes #296 hardened. The general invariant above proves "has a
-// route"; this proves the route goes to the *correct* escalation gate, so a
-// future edit can't satisfy the invariant by pointing failure somewhere unsafe
-// (e.g. a Fix node or loop target).
-func TestBuildProductIssue296FallbackTargets(t *testing.T) {
+// routesFailure reports whether the engine's strict-failure rule
+// (checkStrictFailure → findFallbackTarget) can NOT dead-stop this node: it has
+// a conditional outgoing edge (intentional routing) or a resolvable
+// fallback_target. This is the exact predicate the engine uses on the main loop.
+func routesFailure(g *Graph, nodeID string) bool {
+	return hasAnyConditionalEdge(g.OutgoingEdges(nodeID)) || resolveFallback(g, g.Nodes[nodeID]) != ""
+}
+
+// parallelBranchParents maps each parallel-branch node ID to the ID of the
+// parallel node that dispatches it. A branch node executes via ParallelHandler
+// (registry.Execute), bypassing the engine run loop — so checkStrictFailure /
+// findFallbackTarget NEVER apply to it and a per-branch fallback_target is
+// runtime-inert. A branch node's only real failure route is its parent parallel
+// node's aggregate-failure route, so the invariant below must check the parent,
+// not the branch (crediting a branch's own fallback would be a false positive).
+func parallelBranchParents(g *Graph) map[string]string {
+	parents := map[string]string{}
+	for _, e := range g.Edges {
+		if from := g.Nodes[e.From]; from != nil && from.Handler == "parallel" {
+			parents[e.To] = e.From
+		}
+	}
+	return parents
+}
+
+// TestBuildProductAgentNodesHaveFailureRouting pins the issue #296 invariant:
+// no agent node in build_product.dip can silently halt the pipeline on an
+// unhandled failure (e.g. max_turns exhaustion). This is the in-repo
+// counterpart to dippin-lang#93's author-time lint.
+//
+// It mirrors the engine's strict-failure rule exactly (checkStrictFailure /
+// findFallbackTarget): a failed node dead-stops only when it has NO conditional
+// outgoing edge AND no fallback_target resolves. For a normal (main-loop) agent
+// node, that route must be on the node itself. For a parallel-branch agent node
+// (the three reviewers), the route must be on its PARENT parallel node — the
+// branch itself runs via ParallelHandler and never reaches the strict-failure
+// path, so its own fallback would be inert (the Codex finding on PR #312).
+func TestBuildProductAgentNodesHaveFailureRouting(t *testing.T) {
+	g := loadBuildProduct(t)
+	branchParent := parallelBranchParents(g)
+
+	checked := 0
+	for _, n := range g.Nodes {
+		// Only agent/codergen nodes run a session that can exhaust turns.
+		// Passthrough start/exit carry no agent work.
+		if n.Handler != "codergen" || n.ID == g.StartNode || n.ID == g.ExitNode {
+			continue
+		}
+		checked++
+		// A parallel branch is protected by its parent's aggregate-failure
+		// route, not by anything on the branch node itself.
+		if parent, isBranch := branchParent[n.ID]; isBranch {
+			if !routesFailure(g, parent) {
+				t.Errorf("reviewer branch %q can dead-stop on failure: parent parallel node %q has no conditional fail edge and no fallback_target (issue #296)", n.ID, parent)
+			}
+			continue
+		}
+		if !routesFailure(g, n.ID) {
+			t.Errorf("agent node %q can dead-stop on failure: no conditional fail edge and no fallback_target (issue #296)", n.ID)
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no codergen nodes found — loader or fixture changed; invariant not actually exercised")
+	}
+}
+
+// TestBuildProductIssue296FailureRoutes pins the specific escalation targets so
+// a future edit can't satisfy the invariant by routing failure somewhere unsafe
+// (a Fix node or a loop target). Main-loop nodes resolve a fallback_target; the
+// reviewers' failure is handled on the aggregating ReviewParallel node via a
+// conditional fail edge (their own fallback would be inert — see above).
+func TestBuildProductIssue296FailureRoutes(t *testing.T) {
 	g := loadBuildProduct(t)
 
-	want := map[string]string{
+	// Main-loop agent nodes: resolvable fallback_target to the right gate.
+	wantFallback := map[string]string{
 		"Implement":        "EscalateMilestone",
-		"ReviewClaude":     "EscalateReview",
-		"ReviewCodex":      "EscalateReview",
-		"ReviewGemini":     "EscalateReview",
 		"ApplyReviewFixes": "EscalateReview",
 		"FinalCommit":      "EscalateReview",
 	}
-	for id, target := range want {
+	for id, target := range wantFallback {
 		if _, ok := g.Nodes[id]; !ok {
 			t.Errorf("node %q missing from build_product.dip", id)
 			continue
@@ -103,4 +134,43 @@ func TestBuildProductIssue296FallbackTargets(t *testing.T) {
 			t.Errorf("node %q: resolved fallback = %q, want %q (issue #296)", id, got, target)
 		}
 	}
+
+	// Reviewer branches: failure is routed on ReviewParallel (a conditional fail
+	// edge to EscalateReview), since a per-branch fallback_target is inert.
+	if !hasConditionalEdgeTo(g, "ReviewParallel", "EscalateReview") {
+		t.Errorf("ReviewParallel has no conditional fail edge to EscalateReview — an all-reviewers-fail outcome would dead-stop (issue #296)")
+	}
+
+	// The three reviewer branches must carry NO fallback_target: it would be
+	// runtime-inert and is intentionally removed so the routing isn't a lie.
+	branchParent := parallelBranchParents(g)
+	for _, id := range []string{"ReviewClaude", "ReviewCodex", "ReviewGemini"} {
+		if branchParent[id] != "ReviewParallel" {
+			t.Errorf("expected %q to be a parallel branch of ReviewParallel, got parent %q", id, branchParent[id])
+		}
+		if fb := resolveNodeFallbackAttr(g.Nodes[id]); fb != "" {
+			t.Errorf("reviewer branch %q carries an inert fallback_target=%q; route failure on ReviewParallel instead (issue #296)", id, fb)
+		}
+	}
+}
+
+// hasConditionalEdgeTo reports whether the node has an outgoing conditional edge
+// to the given target.
+func hasConditionalEdgeTo(g *Graph, from, to string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && e.Condition != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveNodeFallbackAttr returns the node's own fallback_target attr (either
+// spelling), ignoring graph-level defaults — used to assert a branch node
+// carries no node-level fallback of its own.
+func resolveNodeFallbackAttr(n *Node) string {
+	if v := n.Attrs["fallback_target"]; v != "" {
+		return v
+	}
+	return n.Attrs["fallback_retry_target"]
 }


### PR DESCRIPTION
## Summary

Closes #296. Refs epic #308 (Phase 0). Pairs with the merged engine catch-all #295.

Several agent nodes in `examples/build_product.dip` had **no failure route**, so on `max_turns` exhaustion (or any unexpected `ctx.outcome`) the engine's strict-failure rule **halted the whole pipeline** — silently skipping the cross-review lanes (incl. adversarial ReviewGemini) and FinalSpecCheck. This was the proximate cause of the `code-goblin` run `7b6e08c9e2b2`: GREEN-but-uncommitted work was lost and the safety net that exists to catch what shipped (a `Retry-After: 0` panic, an off-by-one retry) never ran.

Now that #295 makes the engine consult `fallback_target` on the bare strict-failure path, these `.dip`-side routes take effect at runtime.

## Changes (`.dip` edits, mirroring the `FixMilestone` precedent)

| Node | Fix |
|------|-----|
| `Implement` | `fallback_target: EscalateMilestone`; primary edge now `when ctx.outcome = success` + unconditional catch-all `Implement -> EscalateMilestone` |
| `ApplyReviewFixes` | `fallback_target: EscalateReview`; `when ctx.outcome = success` + catch-all `-> EscalateReview` |
| `FinalCommit` | `fallback_target: EscalateReview` **only** (a catch-all edge would close a DIP005 cycle — see below) |
| `ReviewClaude` / `ReviewCodex` / `ReviewGemini` | **No per-branch fallback.** They run as parallel branches, where a per-branch fallback is runtime-inert (see below) |
| `ReviewParallel` | `ReviewParallel -> EscalateReview when ctx.outcome = fail` — routes the **all-three-reviewers-fail** outcome (previously a silent dead-stop) |

### Why the reviewers route on `ReviewParallel`, not per-branch (Codex P1)

The three reviewers execute as **parallel branches**: `ParallelHandler.runBranch` calls `registry.Execute` directly (`pipeline/handlers/parallel.go:270`), bypassing the engine's `checkStrictFailure`/`findFallbackTarget`. So a `fallback_target` on a branch node is **runtime-inert** — the first commit's per-branch attrs were removed rather than ship a no-op. Failure is instead routed on the aggregating `ReviewParallel` node (a main-loop node). Because `aggregateStatus` is **success-if-any** (`parallel.go:324`), this fires only when **all three** reviewers fail. The **single-branch-masked** case (one reviewer fails, the other two mask it) can't be fixed in `.dip` — it needs per-branch routing / a configurable fan-in quorum in the engine — and is filed as **#313** under epic #308.

A `fallback_target` attr on a `parallel` node is rejected by the dippin parser, so a conditional fail edge is the mechanism.

### Why `FinalCommit` gets no catch-all edge

`Cleanup` is reachable from `EscalateReview` (the `accept` label), so a `FinalCommit -> EscalateReview` edge would close an unconditional `Cleanup -> FinalCommit -> EscalateReview` cycle that `dippin validate` rejects (DIP005). The runtime `fallback_target` path (a node attr, not counted by cycle detection — same as `FinalSpecCheck`) carries the failure route instead.

## Loop-safety

Every escalation target is a **human gate** (`EscalateMilestone`/`EscalateReview`), never a Fix node or conditional-edge target. Each escalation return path is human-gated and `restart: true`, so no new automated cycle is introduced. `selectByCondition` runs before `selectByWeight`, so the success path can never be hijacked by the lexical tiebreaker between unconditional edges.

## Regression test

`pipeline/build_product_failure_routing_test.go` pins the invariant — **every codergen node has a conditional edge or a resolvable `fallback_target`** — mirroring `checkStrictFailure`/`findFallbackTarget`. Parallel-branch nodes are checked against their **parent** parallel node's route (never credited for their own inert fallback), and the reviewer branches are asserted to carry **no** `fallback_target`. Verified to fail when the `ReviewParallel` fail edge is removed (flags all three reviewer branches), and to fail on the pre-#296 `.dip` (flags the six offenders).

## Verification

- `dippin validate examples/build_product.dip` — passed
- `dippin doctor` — `build_product` A (90/100, unchanged from main), `ask_and_execute` A (95), `build_product_with_superspec` A (100)
- `dippin simulate -all-paths examples/build_product.dip` — 100/100 paths terminate `success`; `Implement` failure -> `EscalateMilestone`, `ApplyReviewFixes` failure -> `EscalateReview`, `ReviewParallel` all-fail -> `EscalateReview`, no dead-stop
- `go build ./... && go test ./... -short` — green

## Scope

`examples/build_product.dip` (+ test + CHANGELOG) only. No engine Go changes (#295 is done; the engine-level parallel-branch fix is #313). No commit-if-dirty node (#297), engine WIP-commit (#302), or turn-limit redesign (#303). `build_product_with_superspec.dip` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)