### PR TITLE
feat(build_product): commit-first / stop-when-green + commit-if-dirty checkpoint (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **build_product: commit-first / stop-when-green discipline + `CommitIfDirty`
+  checkpoint node** (closes #297, refs epic #308 Phase 1, builds on #296). Two
+  `.dip`-only changes guard against green-but-uncommitted work being lost. (1) A
+  terminal stop-when-green-and-committed rule appended to both the `Implement`
+  and `FixMilestone` prompts: the agent emits `DONE` and stops the instant the
+  milestone verify passes **and** it has committed — committing is the
+  precondition for stopping, so turns aren't burned on redundant re-verification
+  that ends with an uncommitted tree (the proximate cause of the `code-goblin`
+  run `7b6e08c9e2b2` failure). (2) A new `tool CommitIfDirty` node on the
+  `Implement` **success** path — the success edge changed from
+  `Implement -> TestMilestone` to `Implement -> CommitIfDirty`, with a new
+  `CommitIfDirty -> TestMilestone` edge — commits the working tree iff dirty so
+  a success-with-dirty-tree is persisted before `TestMilestone` runs. The commit
+  passes an explicit git identity and does **not** swallow failures (no
+  `|| true`, per CLAUDE.md "never silently swallow errors"). `CommitIfDirty` does
+  **not** run on the turn-**exhaustion** path: `Implement` failure routes
+  straight to `EscalateMilestone` via the #296 catch-all / `fallback_target`
+  (left unchanged), and persisting green work on the exhaustion path is the
+  engine's job, tracked in #302.
 - **Agent-tool jail threat model + jail-bypass lint** (closes #283, refs
   #275/#272). New doc `docs/architecture/agent-tool-jail-checklist.md`: a
   per-tool threat-model table (every `agent/tools/` tool — what it touches and

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -453,6 +453,31 @@ workflow BuildProduct
         Add a comment to the golden file naming the spec section it was
         verified against and the date.
 
+      STOP WHEN GREEN AND COMMITTED (issue #297):
+      - The instant the milestone verify passes AND you have committed, emit
+        DONE and STOP. Do NOT perform further verification, re-reading, or
+        polishing. Committing is the precondition for stopping — never end a
+        session with a green-but-uncommitted tree.
+
+  tool CommitIfDirty
+    label: "Commit working tree if dirty"
+    timeout: 30s
+    command:
+      set -eu
+      # Issue #297: persist green-but-uncommitted work on the Implement SUCCESS
+      # path so it survives a later node death. Explicit identity makes the
+      # commit independent of the tool subprocess's git config (unproven here —
+      # commits otherwise happen inside agent sessions). A genuine commit
+      # failure is NOT swallowed (no `|| true`); it surfaces per CLAUDE.md
+      # "never silently swallow errors". The marker is printed last so it
+      # survives output truncation (CLAUDE.md "Tool output capture").
+      if ! git diff --quiet || ! git diff --cached --quiet; then
+        git add -A
+        git -c user.name="build_product" -c user.email="build_product@tracker.local" \
+          commit -m "chore(milestone): checkpoint working tree (auto-commit by build_product)"
+      fi
+      printf 'commit-if-dirty-done'
+
   tool TestMilestone
     label: "Test Current Milestone"
     timeout: 300s
@@ -776,6 +801,11 @@ workflow BuildProduct
 
       Do NOT make superficial patches. If a test expects story events to NOT
       merge, understand WHY they're merging and fix the decision logic.
+
+      The instant verification passes AND you have committed, emit DONE and
+      STOP. Do NOT perform further verification, re-reading, or polishing.
+      Committing is the precondition for stopping — never end a session with a
+      green-but-uncommitted tree. (issue #297)
 
   # ─── Phase 3: Cross-Review ─────────────────────────────────
 
@@ -1322,8 +1352,9 @@ workflow BuildProduct
     PickNextMilestone -> Implement  when ctx.tool_stdout not contains all-done
     PickNextMilestone -> ReviewParallel  when ctx.tool_stdout contains all-done
     PickNextMilestone -> EscalateMilestone
-    Implement -> TestMilestone  when ctx.outcome = success
+    Implement -> CommitIfDirty  when ctx.outcome = success
     Implement -> EscalateMilestone
+    CommitIfDirty -> TestMilestone
     TestMilestone -> VerifyMilestone  when ctx.outcome = success
     TestMilestone -> EscalateMilestone  when ctx.tool_stdout contains escalate
     TestMilestone -> FixMilestone  when ctx.outcome = fail

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -471,7 +471,12 @@ workflow BuildProduct
       # failure is NOT swallowed (no `|| true`); it surfaces per CLAUDE.md
       # "never silently swallow errors". The marker is printed last so it
       # survives output truncation (CLAUDE.md "Tool output capture").
-      if ! git diff --quiet || ! git diff --cached --quiet; then
+      #
+      # `git status --porcelain` (not `git diff`) so UNTRACKED files count as
+      # dirty — a milestone that only adds new files would otherwise look clean
+      # to `git diff` and skip the commit, leaving exactly the green-but-
+      # uncommitted tree this node exists to prevent.
+      if [ -n "$(git status --porcelain)" ]; then
         git add -A
         git -c user.name="build_product" -c user.email="build_product@tracker.local" \
           commit -m "chore(milestone): checkpoint working tree (auto-commit by build_product)"

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -180,9 +180,11 @@ func TestBuildProductCommitIfDirtyCheckpoint(t *testing.T) {
 		t.Errorf("CommitIfDirty handler = %q, want \"tool\" (issue #297)", n.Handler)
 	}
 
-	// Success path: Implement --(success)--> CommitIfDirty --> TestMilestone.
-	if !hasConditionalEdgeTo(g, "Implement", "CommitIfDirty") {
-		t.Error("Implement has no conditional success edge to CommitIfDirty (issue #297)")
+	// Success path: Implement --(ctx.outcome = success)--> CommitIfDirty.
+	// Assert the SUCCESS condition specifically, not just "some condition" — a
+	// future edit routing `ctx.outcome = fail` to CommitIfDirty must fail here.
+	if !hasEdgeWithCondition(g, "Implement", "CommitIfDirty", "ctx.outcome = success") {
+		t.Error("Implement has no `ctx.outcome = success` edge to CommitIfDirty (issue #297)")
 	}
 	if hasEdgeTo(g, "Implement", "TestMilestone") {
 		t.Error("Implement still routes directly to TestMilestone; the success path must go through CommitIfDirty (issue #297)")
@@ -204,6 +206,17 @@ func TestBuildProductCommitIfDirtyCheckpoint(t *testing.T) {
 func hasEdgeTo(g *Graph, from, to string) bool {
 	for _, e := range g.OutgoingEdges(from) {
 		if e.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEdgeWithCondition reports whether the node has an outgoing edge to the
+// given target whose condition matches exactly.
+func hasEdgeWithCondition(g *Graph, from, to, cond string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && e.Condition == cond {
 			return true
 		}
 	}

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -154,6 +154,73 @@ func TestBuildProductIssue296FailureRoutes(t *testing.T) {
 	}
 }
 
+// TestBuildProductCommitIfDirtyCheckpoint pins issue #297: a CommitIfDirty tool
+// node sits on the Implement SUCCESS path so green-but-uncommitted work is
+// persisted before TestMilestone runs:
+//
+//	Implement --(ctx.outcome = success)--> CommitIfDirty --> TestMilestone
+//
+// while the #296 Implement FAILURE routing (unconditional catch-all edge +
+// fallback_target to EscalateMilestone) is left UNCHANGED. CommitIfDirty is
+// deliberately NOT on the failure path — turn-exhaustion routes straight to
+// EscalateMilestone, and persisting work on that path is engine issue #302.
+//
+// Negative control: removing the success edge through CommitIfDirty (so
+// Implement routes to TestMilestone again) fails this test on both the
+// "edge to CommitIfDirty" and "no direct edge to TestMilestone" assertions.
+func TestBuildProductCommitIfDirtyCheckpoint(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	// CommitIfDirty exists and is a tool node.
+	n, ok := g.Nodes["CommitIfDirty"]
+	if !ok {
+		t.Fatal("CommitIfDirty node missing from build_product.dip (issue #297)")
+	}
+	if n.Handler != "tool" {
+		t.Errorf("CommitIfDirty handler = %q, want \"tool\" (issue #297)", n.Handler)
+	}
+
+	// Success path: Implement --(success)--> CommitIfDirty --> TestMilestone.
+	if !hasConditionalEdgeTo(g, "Implement", "CommitIfDirty") {
+		t.Error("Implement has no conditional success edge to CommitIfDirty (issue #297)")
+	}
+	if hasEdgeTo(g, "Implement", "TestMilestone") {
+		t.Error("Implement still routes directly to TestMilestone; the success path must go through CommitIfDirty (issue #297)")
+	}
+	if !hasEdgeTo(g, "CommitIfDirty", "TestMilestone") {
+		t.Error("CommitIfDirty has no edge to TestMilestone (issue #297)")
+	}
+
+	// #296 failure routing must be intact: unconditional catch-all + fallback.
+	if !hasUnconditionalEdgeTo(g, "Implement", "EscalateMilestone") {
+		t.Error("Implement lost its unconditional catch-all to EscalateMilestone (issue #296 regression)")
+	}
+	if got := resolveFallback(g, g.Nodes["Implement"]); got != "EscalateMilestone" {
+		t.Errorf("Implement resolved fallback = %q, want EscalateMilestone (issue #296 regression)", got)
+	}
+}
+
+// hasEdgeTo reports whether the node has any outgoing edge to the given target.
+func hasEdgeTo(g *Graph, from, to string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+// hasUnconditionalEdgeTo reports whether the node has an outgoing edge to the
+// given target with no condition (the strict-failure catch-all).
+func hasUnconditionalEdgeTo(g *Graph, from, to string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && e.Condition == "" {
+			return true
+		}
+	}
+	return false
+}
+
 // hasConditionalEdgeTo reports whether the node has an outgoing conditional edge
 // to the given target.
 func hasConditionalEdgeTo(g *Graph, from, to string) bool {


### PR DESCRIPTION
## Summary

Closes #297. Refs epic #308 (Phase 1). Builds on merged #296 (PR #312).

`Implement` and `FixMilestone` had no instruction to STOP once the milestone is green **and committed** — the agent kept re-verifying and polishing, burning the turn budget, and work could be green-in-the-tree but uncommitted when turns ran out (the proximate cause of `code-goblin` run `7b6e08c9e2b2`: `go test ./...` + `go vet` passed at turn 48, turns 49–50 were redundant re-verification, the work was never persisted, total loss).

This is a **`.dip`-only** change (plus test + CHANGELOG).

## Changes

### 1. Stop-when-green-and-committed prompt rule (`Implement` + `FixMilestone`)

Terminal rule appended to both prompts: emit `DONE` and stop the instant the milestone verify passes **and** the work is committed. Committing is the precondition for stopping — never end a session with a green-but-uncommitted tree.

### 2. `CommitIfDirty` checkpoint node on the `Implement` SUCCESS path

| | Before (#296) | After (#297) |
|---|---|---|
| success | `Implement -> TestMilestone when ctx.outcome = success` | `Implement -> CommitIfDirty when ctx.outcome = success` + `CommitIfDirty -> TestMilestone` |
| failure | `Implement -> EscalateMilestone` (catch-all) + `fallback_target: EscalateMilestone` | **unchanged** |

`CommitIfDirty` commits the working tree iff dirty, so a *success-with-dirty-tree* is persisted before `TestMilestone` runs.

**Tool-node safety** (CLAUDE.md):
- Author-controlled command, no LLM-origin interpolation — safe by construction.
- The issue's draft ended the commit with `|| true`, which would silently swallow a real failure (e.g. missing git identity) — that violates "never silently swallow errors". Instead the node passes an **explicit git identity** (`git -c user.name=... -c user.email=...`) so the most likely failure mode can't occur, and lets any genuine commit failure **surface** (no `|| true`).
- The `commit-if-dirty-done` marker is printed **last** so it survives output truncation (CLAUDE.md "Tool output capture").
- `timeout: 30s`.

## Critical design subtlety (deliberate, in-scope tradeoff)

`CommitIfDirty` is on the **success** path only. It protects the *"Implement returned success but left a dirty tree"* case. It does **NOT** run on hard turn-**exhaustion** (`OutcomeFail`), because `Implement` failure routes straight to `EscalateMilestone` via the #296 catch-all / `fallback_target`.

Persisting green-but-uncommitted work on the **exhaustion** path is the **engine's** job — **issue #302** (commit-WIP before routing a failed node) — and is **out of scope** here. Forcing the failure path through a tool node between `Implement` and `EscalateMilestone` would clobber `Implement`'s outcome and risk a routing loop, so it is deliberately avoided. For #297 the prompt-discipline rule is the primary exhaustion mitigation; `CommitIfDirty` backstops the success-with-dirty case.

`FixMilestone` gets the **prompt rule only** (no own `CommitIfDirty` node), matching the issue's scope — `FixMilestone -> TestMilestone` is a restart edge and `FixMilestone` already commits in its steps.

A secondary tradeoff: because `CommitIfDirty`'s only outgoing edge is unconditional, a *genuine* commit failure (`set -eu`) dead-stops the pipeline rather than continuing. This is consistent with the engine's strict-failure philosophy (don't continue silently past a failed tool node) and is loud, not silent.

## Loop-safety

`CommitIfDirty` is a linear node: one inbound (`Implement` success), one outbound (`TestMilestone`, unconditional). No cycle is introduced. The #296 catch-all + `fallback_target` are preserved verbatim.

## Regression test

Extends `pipeline/build_product_failure_routing_test.go` with `TestBuildProductCommitIfDirtyCheckpoint`, asserting: `CommitIfDirty` exists and is a `tool` node; the success path is `Implement -> CommitIfDirty -> TestMilestone` (and Implement no longer routes directly to TestMilestone); and the #296 failure routing (unconditional catch-all + `fallback_target` to `EscalateMilestone`) is unchanged. Verified to **fail** on the pre-#297 graph (node absent) while the #296 tests still pass — negative control.

## Verification

- `dippin validate examples/build_product.dip` — passed
- `dippin doctor` — `build_product` **A 90/100** (unchanged from main), `ask_and_execute` A 95, `build_product_with_superspec` A 100
- `dippin simulate -all-paths examples/build_product.dip` — **100/100 paths terminate `success`**; success path is now `Implement -> CommitIfDirty -> TestMilestone`, failure path still reaches `EscalateMilestone`, no new cycle, no dead-stop
- `go build ./... && go test ./... -short` — green

## Scope

`examples/build_product.dip` (+ test + CHANGELOG) only. No engine Go changes. No engine commit-WIP (#302), turn-limit guard (#303), per-node build-context (#298), or parallel-branch routing (#313). `build_product_with_superspec.dip` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783218323&installation_id=131176874&pr_number=314&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F314&signature=df6784da877f716aa1e084c5c67acf94d99e816cc195da0b652b219d524dab71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build workflow now includes automatic commit checkpointing before milestone verification tests run. Changes are committed before tests execute, preventing loss of uncommitted work when test verification passes. The workflow stops immediately upon successful verification and commit completion.

* **Tests**
  * Added regression test to validate commit checkpoint functionality and verify correct edge routing in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->