### PR TITLE
feat(engine): commit-WIP to a recoverable ref before routing a failed/exhausted node (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   green-but-uncommitted work is no longer silently discarded (the loss in the
   `code-goblin` run `7b6e08c9e2b2`, where `Implement` was green at turn 48 but
   uncommitted when the turn budget breached). A new `gitArtifactRepo.CommitWIP`
-  method commits the dirty tree (including newly created/untracked files via
-  `git add .`) and points the lightweight tag `tracker/wip/<runID>/<nodeID>` at
+  method commits the dirty tree (additions, modifications, **and** removals via
+  `git add -A`) and points the lightweight tag `tracker/wip/<runID>/<nodeID>` at
   it, mirroring the existing `TagCheckpoint` precedent; the ref is recorded in
   both the checkpoint (`Checkpoint.WIPRefs`, additive/backward-compatible) and
   the trace (`TraceEntry.WIPRef`). A single engine helper
-  (`commitWIPBeforeRouting`) is wired into all three fail/exhaust routing paths
-  — the strict-failure path (`checkStrictFailure`, covering both the
-  `fallback_target` escalation and the terminal halt), the retry-exhausted path
-  (`handleRetryExhausted`), and the exit-node fail path (`handleExitNode`) — and
-  always runs **before** the routing decision. A clean tree is a no-op (no empty
+  (`commitWIPBeforeRouting`) is wired into every fail/exhaust routing path — the
+  strict-failure path (`checkStrictFailure`, covering both the `fallback_target`
+  escalation and the terminal halt), the retry-exhausted path
+  (`handleRetryExhausted`), the exit-node fail path (`handleExitNode`), and the
+  terminal handler-error path (`processActiveNode`, e.g. a node that wrote files
+  then returned an error or was cancelled mid-write) — and always runs
+  **before** the routing/halt decision. A clean tree is a no-op (no empty
   commit, no ref); when git artifacts are disabled it logs an `EventWarning` and
   skips (it never touches the user's real working repo); a WIP-commit failure is
   surfaced as a warning and never masks the original failure or changes routing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **engine: commit-WIP to a recoverable ref before routing a failed/exhausted
+  node** (closes #302, refs epic #308 Phase 1). The engine now preserves an
+  agent node's dirty (possibly green) working tree to a named, recoverable git
+  ref **before** it routes away from — or halts at — a failure/exhaustion, so
+  green-but-uncommitted work is no longer silently discarded (the loss in the
+  `code-goblin` run `7b6e08c9e2b2`, where `Implement` was green at turn 48 but
+  uncommitted when the turn budget breached). A new `gitArtifactRepo.CommitWIP`
+  method commits the dirty tree (including newly created/untracked files via
+  `git add .`) and points the lightweight tag `tracker/wip/<runID>/<nodeID>` at
+  it, mirroring the existing `TagCheckpoint` precedent; the ref is recorded in
+  both the checkpoint (`Checkpoint.WIPRefs`, additive/backward-compatible) and
+  the trace (`TraceEntry.WIPRef`). A single engine helper
+  (`commitWIPBeforeRouting`) is wired into all three fail/exhaust routing paths
+  — the strict-failure path (`checkStrictFailure`, covering both the
+  `fallback_target` escalation and the terminal halt), the retry-exhausted path
+  (`handleRetryExhausted`), and the exit-node fail path (`handleExitNode`) — and
+  always runs **before** the routing decision. A clean tree is a no-op (no empty
+  commit, no ref); when git artifacts are disabled it logs an `EventWarning` and
+  skips (it never touches the user's real working repo); a WIP-commit failure is
+  surfaced as a warning and never masks the original failure or changes routing.
+  This completes #297's deferred exhaustion-path persistence (`CommitIfDirty`
+  covered only the success path) and is the persistence layer that #303's
+  verify-then-commit-on-breach builds on.
 - **build_product: commit-first / stop-when-green discipline + `CommitIfDirty`
   checkpoint node** (closes #297, refs epic #308 Phase 1, builds on #296). Two
   `.dip`-only changes guard against green-but-uncommitted work being lost. (1) A

--- a/pipeline/checkpoint.go
+++ b/pipeline/checkpoint.go
@@ -30,6 +30,12 @@ type Checkpoint struct {
 	// the guard survives checkpoint save/restore cycles.
 	FallbackTaken map[string]bool `json:"fallback_taken,omitempty"`
 
+	// WIPRefs maps a failed/exhausted node ID to the recoverable git ref
+	// (a tag tracker/wip/<runID>/<nodeID>) where its uncommitted work was
+	// preserved before the engine routed away from it (#302). Additive;
+	// omitempty keeps older checkpoints without the field loading cleanly.
+	WIPRefs map[string]string `json:"wip_refs,omitempty"`
+
 	// BundleIdentity is the content-addressed identity of the .dipx bundle
 	// the run was started against ("sha256:<hex>"). Empty for runs started
 	// from a plain .dip file. Used for strict resume verification.
@@ -97,6 +103,15 @@ func (cp *Checkpoint) SetEdgeSelection(nodeID, edgeTo string) {
 		cp.EdgeSelections = make(map[string]string)
 	}
 	cp.EdgeSelections[nodeID] = edgeTo
+}
+
+// RecordWIPRef records the recoverable git ref where a failed/exhausted node's
+// uncommitted work was preserved (#302).
+func (cp *Checkpoint) RecordWIPRef(nodeID, ref string) {
+	if cp.WIPRefs == nil {
+		cp.WIPRefs = make(map[string]string)
+	}
+	cp.WIPRefs[nodeID] = ref
 }
 
 // GetEdgeSelection returns the stored edge selection for a node, if any.

--- a/pipeline/checkpoint_test.go
+++ b/pipeline/checkpoint_test.go
@@ -218,3 +218,38 @@ func TestCheckpoint_BundleIdentity_BackwardCompat(t *testing.T) {
 		t.Errorf("expected empty BundleIdentity on old checkpoint, got %q", loaded.BundleIdentity)
 	}
 }
+
+// TestCheckpoint_WIPRefsRoundTrip verifies that recorded WIP refs (#302)
+// survive a checkpoint save/load round-trip and that older checkpoints without
+// the field still load (backward-compatible, additive).
+func TestCheckpoint_WIPRefsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint.json")
+
+	cp := &Checkpoint{RunID: "r1", CurrentNode: "Implement"}
+	cp.RecordWIPRef("Implement", "tracker/wip/r1/Implement")
+	if err := SaveCheckpoint(cp, path); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	loaded, err := LoadCheckpoint(path)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if got := loaded.WIPRefs["Implement"]; got != "tracker/wip/r1/Implement" {
+		t.Errorf("WIPRefs[Implement]: got %q want %q", got, "tracker/wip/r1/Implement")
+	}
+
+	// Backward compat: a checkpoint JSON without wip_refs loads with a nil map.
+	legacy := filepath.Join(dir, "legacy.json")
+	if err := os.WriteFile(legacy, []byte(`{"run_id":"old","current_node":"a","completed_nodes":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	old, err := LoadCheckpoint(legacy)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint(legacy): %v", err)
+	}
+	if len(old.WIPRefs) != 0 {
+		t.Errorf("expected empty WIPRefs on legacy checkpoint, got %v", old.WIPRefs)
+	}
+}

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -316,6 +316,15 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 
 	outcome, traceEntry, err := e.executeNode(ctx, s, currentNodeID, execNode)
 	if err != nil {
+		// Preserve any dirty (possibly green) tree before this terminal handler
+		// error halts the run (#302) — e.g. a tool/agent that wrote files then
+		// died, or a cancellation mid-write. No-op on a clean tree. executeNode
+		// already appended this node's trace entry, so mirror the recorded ref
+		// onto it after the helper sets it on our local copy.
+		e.commitWIPBeforeRouting(s, currentNodeID, &traceEntry)
+		if traceEntry.WIPRef != "" && len(s.trace.Entries) > 0 {
+			s.trace.Entries[len(s.trace.Entries)-1].WIPRef = traceEntry.WIPRef
+		}
 		// Scope any keys written before the error so checkpoints and downstream
 		// nodes can still access this node's partial output via the scoped namespace.
 		s.pctx.ScopeToNode(currentNodeID)

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -529,6 +529,11 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 	if outcome != string(OutcomeFail) || hasAnyConditionalEdge(edges) {
 		return nil
 	}
+	// Preserve any dirty (possibly green) working tree to a recoverable ref
+	// BEFORE deciding to halt or route to a fallback, so green-but-uncommitted
+	// work is never discarded by the routing decision (#302). No-op on a clean
+	// tree; warns and skips when no git adapter is configured.
+	e.commitWIPBeforeRouting(s, nodeID, traceEntry)
 	// Before dead-stopping, consult the node/graph-level fallback_target so an
 	// unhandled failure (incl. turn-exhaustion) escalates to a safety node
 	// instead of skipping every downstream node (#295). One-shot per node.

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -48,12 +48,15 @@ func (e *Engine) emitGitCommit(s *runState, nodeID string, traceEntry *TraceEntr
 // the routing outcome (CLAUDE.md: never silently swallow errors).
 func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *TraceEntry) {
 	if s.gitRepo == nil {
+		// gitRepo is nil when git artifacts are disabled, when enabled but no
+		// artifact dir was configured, or when repo init failed (initRunState
+		// already warned about that case) — so don't claim a single cause.
 		e.emit(PipelineEvent{
 			Type:      EventWarning,
 			Timestamp: time.Now(),
 			RunID:     s.runID,
 			NodeID:    nodeID,
-			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: git artifacts not enabled (run with --git-artifacts)", nodeID),
+			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: git artifact repository unavailable (enable with --git-artifacts and an artifact dir, or see the earlier init-failure warning)", nodeID),
 		})
 		return
 	}

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -35,6 +35,60 @@ func (e *Engine) emitGitCommit(s *runState, nodeID string, traceEntry *TraceEntr
 	}
 }
 
+// commitWIPBeforeRouting preserves a failed/exhausted node's uncommitted work
+// to a recoverable git ref BEFORE the engine routes away from (or halts at) the
+// node, so green-but-uncommitted work is never silently discarded (#302). It
+// records the ref on the trace entry and durably in the checkpoint (cp.WIPRefs)
+// so the work is retrievable after the run.
+//
+// It is a no-op when the working tree is clean (no empty commit, no ref). When
+// no git artifact adapter is configured it emits an EventWarning and skips —
+// it never reaches into the user's real working repo. A WIP-commit failure is
+// surfaced as a warning and never masks the original node failure or changes
+// the routing outcome (CLAUDE.md: never silently swallow errors).
+func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *TraceEntry) {
+	if s.gitRepo == nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    nodeID,
+			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: git artifacts not enabled (run with --git-artifacts)", nodeID),
+		})
+		return
+	}
+	ref, err := s.gitRepo.CommitWIP(nodeID)
+	if err != nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    nodeID,
+			Message:   fmt.Sprintf("WIP commit failed for node %q (work may be unpreserved): %v", nodeID, err),
+		})
+		return
+	}
+	if ref == "" {
+		return // clean tree — nothing to preserve
+	}
+	s.cp.RecordWIPRef(nodeID, ref)
+	if traceEntry != nil {
+		traceEntry.WIPRef = ref
+	}
+	// Persist immediately so the recoverable ref survives even on terminal-halt
+	// paths that do not otherwise save the checkpoint.
+	e.saveCheckpoint(s.cp, s.pctx, s.runID)
+	// Surface the recovery handle on the out-of-band warning channel so the
+	// preserved work is discoverable at runtime, not just in the trace.
+	e.emit(PipelineEvent{
+		Type:      EventWarning,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    nodeID,
+		Message:   fmt.Sprintf("preserved uncommitted work for failed node %q to recoverable ref %s", nodeID, ref),
+	})
+}
+
 // saveCheckpointWithTag saves the checkpoint and creates a lightweight git tag
 // checkpoint/<runID>/<nodeID> pointing at HEAD (the most recent node-outcome
 // commit). Because checkpoint.json is in .gitignore it is never committed, so
@@ -759,6 +813,9 @@ func (e *Engine) handleRetryWithinBudget(ctx context.Context, s *runState, curre
 // handleRetryExhausted handles the case when retry budget is depleted.
 // Routes to fallback target if available, otherwise fails the pipeline.
 func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNode *Node, traceEntry *TraceEntry) (string, bool, *EngineResult, error) {
+	// Preserve any dirty (possibly green) tree to a recoverable ref before
+	// routing away from the exhausted node (#302). No-op on a clean tree.
+	e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 	if fallback, ok := execNode.Attrs["fallback_retry_target"]; ok {
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
@@ -880,6 +937,9 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 		return false, "", result
 	}
 	if outcomeStatus == string(OutcomeFail) {
+		// Preserve any dirty (possibly green) tree to a recoverable ref before
+		// the failing exit node halts the run (#302). No-op on a clean tree.
+		e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
 		s.trace.EndTime = time.Now()

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -177,6 +177,52 @@ func (r *gitArtifactRepo) TagCheckpoint(nodeID string) error {
 	return nil
 }
 
+// CommitWIP preserves a dirty working tree to a recoverable, named git ref
+// before the engine routes away from a failed/exhausted node (#302), so
+// green-but-uncommitted work is never silently discarded.
+//
+// Behavior:
+//   - Clean tree (nothing to preserve) → no-op: no commit, no ref, returns "".
+//   - Dirty tree → `git add .` (captures newly created/untracked files too),
+//     commits, then points the lightweight tag tracker/wip/<runID>/<nodeID> at
+//     the commit and returns that ref name. The commit lands on HEAD, so a
+//     subsequent CommitNode records the node outcome as an empty marker on top
+//     while the named tag remains the stable handle to the work.
+//   - Failed repo → no-op, returns "".
+//
+// Mirrors TagCheckpoint's lightweight-tag precedent. Errors are returned (not
+// swallowed) for the caller to surface as a warning; they never change routing.
+func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
+	if r.failed {
+		return "", nil
+	}
+
+	// Dirty check (includes untracked files; respects .gitignore). A clean
+	// tree must not produce an empty WIP commit or ref.
+	status, err := r.git("status", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("git status for WIP of node %q: %w\n%s", nodeID, err, status)
+	}
+	if strings.TrimSpace(status) == "" {
+		return "", nil
+	}
+
+	if out, err := r.git("add", "."); err != nil {
+		return "", fmt.Errorf("git add for WIP of node %q: %w\n%s", nodeID, err, out)
+	}
+	msg := fmt.Sprintf("wip(%s): preserved uncommitted work before routing failure", nodeID)
+	if out, err := r.git("commit", "-m", msg); err != nil {
+		return "", fmt.Errorf("git commit for WIP of node %q: %w\n%s", nodeID, err, out)
+	}
+
+	ref := fmt.Sprintf("tracker/wip/%s/%s", r.runID, nodeID)
+	// -f to overwrite a prior WIP ref for the same node (e.g. retry then fail).
+	if out, err := r.git("tag", "-f", ref); err != nil {
+		return "", fmt.Errorf("git tag %q for WIP: %w\n%s", ref, err, out)
+	}
+	return ref, nil
+}
+
 // git runs a git command in r.dir with a sanitized environment.
 // Returns combined output and any error.
 func (r *gitArtifactRepo) git(args ...string) (string, error) {

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -183,8 +183,10 @@ func (r *gitArtifactRepo) TagCheckpoint(nodeID string) error {
 //
 // Behavior:
 //   - Clean tree (nothing to preserve) → no-op: no commit, no ref, returns "".
-//   - Dirty tree → `git add .` (captures newly created/untracked files too),
-//     commits, then points the lightweight tag tracker/wip/<runID>/<nodeID> at
+//   - Dirty tree → `git add -A` (captures additions, modifications, and
+//     removals so the snapshot faithfully mirrors the tree state — unambiguous
+//     regardless of cwd or git version), commits, then points the lightweight
+//     tag tracker/wip/<runID>/<nodeID> at
 //     the commit and returns that ref name. The commit lands on HEAD, so a
 //     subsequent CommitNode records the node outcome as an empty marker on top
 //     while the named tag remains the stable handle to the work.
@@ -207,7 +209,10 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 		return "", nil
 	}
 
-	if out, err := r.git("add", "."); err != nil {
+	// -A stages additions, modifications, AND removals across the whole repo so
+	// a deletion-only dirty tree is preserved too (the porcelain gate above can
+	// be satisfied purely by removals).
+	if out, err := r.git("add", "-A"); err != nil {
 		return "", fmt.Errorf("git add for WIP of node %q: %w\n%s", nodeID, err, out)
 	}
 	msg := fmt.Sprintf("wip(%s): preserved uncommitted work before routing failure", nodeID)

--- a/pipeline/git_artifacts_test.go
+++ b/pipeline/git_artifacts_test.go
@@ -4,6 +4,7 @@ package pipeline
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -732,5 +733,109 @@ func TestEngine_CommitWIP_NoGitAdapterWarns(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected EventWarning about git artifacts not enabled when preserving failed work")
+	}
+}
+
+// TestGitArtifactRepo_CommitWIP_CapturesDeletion verifies that a deletion-only
+// dirty tree is fully captured in the WIP commit (#302 review, Copilot): the
+// snapshot must reflect removals, not just additions/modifications.
+func TestGitArtifactRepo_CommitWIP_CapturesDeletion(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	runID := "delrun"
+	repo := newGitArtifactRepo(dir, runID)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Seed a tracked file, commit it, then delete it so the ONLY dirty change
+	// is a deletion.
+	if err := os.WriteFile(filepath.Join(dir, "doomed.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitOutput(t, dir, "add", "-A")
+	gitOutput(t, dir, "commit", "-m", "seed doomed.go")
+	if err := os.Remove(filepath.Join(dir, "doomed.go")); err != nil {
+		t.Fatal(err)
+	}
+
+	ref, err := repo.CommitWIP("Implement")
+	if err != nil {
+		t.Fatalf("CommitWIP after delete: %v", err)
+	}
+	want := "tracker/wip/" + runID + "/Implement"
+	if ref != want {
+		t.Fatalf("ref: got %q want %q", ref, want)
+	}
+	// The deletion must be recorded at the tagged commit.
+	show := gitOutput(t, dir, "show", "--stat", want)
+	if !strings.Contains(show, "doomed.go") {
+		t.Errorf("WIP ref did not capture deletion of doomed.go:\n%s", show)
+	}
+	if st := gitOutput(t, dir, "status", "--porcelain"); st != "" {
+		t.Errorf("expected clean tree after CommitWIP, got:\n%s", st)
+	}
+}
+
+// TestEngine_CommitWIP_HandlerErrorPreservesWork verifies that when a handler
+// writes artifacts and then returns a Go error (terminal node death, e.g. a
+// tool/agent dying mid-write or a cancellation), the dirty tree is still
+// preserved to a recoverable ref recorded in the checkpoint and trace (#302
+// review, Codex) — not just on the status-based fail/exhaust paths.
+func TestEngine_CommitWIP_HandlerErrorPreservesWork(t *testing.T) {
+	requireGit(t)
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_handler_error_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "Implement" {
+				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
+				if err := os.WriteFile(filepath.Join(dir, "Implement.go"), []byte("package x\n"), 0o644); err != nil {
+					return Outcome{}, err
+				}
+				return Outcome{}, fmt.Errorf("boom: handler died after writing files")
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		}})
+	}
+
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true))
+	result, err := engine.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected handler error to propagate")
+	}
+	if result == nil || result.Status != OutcomeFail {
+		t.Fatalf("expected fail result, got %+v", result)
+	}
+
+	repoDir := filepath.Join(artifactBase, result.RunID)
+	wantRef := "tracker/wip/" + result.RunID + "/Implement"
+
+	if tags := gitOutput(t, repoDir, "tag", "-l", "tracker/wip/*"); !strings.Contains(tags, wantRef) {
+		t.Errorf("expected WIP tag %q on handler-error path, got:\n%s", wantRef, tags)
+	}
+	cp, e := LoadCheckpoint(filepath.Join(repoDir, "checkpoint.json"))
+	if e != nil {
+		t.Fatalf("LoadCheckpoint: %v", e)
+	}
+	if cp.WIPRefs["Implement"] != wantRef {
+		t.Errorf("checkpoint WIPRefs[Implement]: got %q want %q", cp.WIPRefs["Implement"], wantRef)
+	}
+	var traceRef string
+	for _, en := range result.Trace.Entries {
+		if en.NodeID == "Implement" {
+			traceRef = en.WIPRef
+		}
+	}
+	if traceRef != wantRef {
+		t.Errorf("trace WIPRef for Implement: got %q want %q", traceRef, wantRef)
 	}
 }

--- a/pipeline/git_artifacts_test.go
+++ b/pipeline/git_artifacts_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -441,5 +442,295 @@ func TestEngine_WithGitArtifacts_CommitsFailOutcome(t *testing.T) {
 	}
 	if !strings.Contains(log, "outcome=fail") {
 		t.Errorf("git log missing outcome=fail:\n%s", log)
+	}
+}
+
+// --- #302: CommitWIP recoverable-ref tests ---
+
+// TestGitArtifactRepo_CommitWIP_DirtyTree verifies that CommitWIP commits a
+// dirty working tree (including newly created/untracked files) to a named,
+// recoverable tag tracker/wip/<runID>/<nodeID> and leaves the tree clean.
+func TestGitArtifactRepo_CommitWIP_DirtyTree(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	runID := "wiprun1"
+	repo := newGitArtifactRepo(dir, runID)
+	if err := repo.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Simulate green-but-uncommitted agent work: a brand-new (untracked) file.
+	if err := os.WriteFile(filepath.Join(dir, "feature.go"), []byte("package x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ref, err := repo.CommitWIP("Implement")
+	if err != nil {
+		t.Fatalf("CommitWIP: %v", err)
+	}
+	want := "tracker/wip/" + runID + "/Implement"
+	if ref != want {
+		t.Fatalf("ref: got %q want %q", ref, want)
+	}
+
+	tags := gitOutput(t, dir, "tag", "-l", "tracker/wip/*")
+	if !strings.Contains(tags, want) {
+		t.Errorf("expected tag %q in:\n%s", want, tags)
+	}
+
+	// The untracked file must be captured at the tagged commit.
+	show := gitOutput(t, dir, "show", "--stat", want)
+	if !strings.Contains(show, "feature.go") {
+		t.Errorf("WIP commit missing feature.go:\n%s", show)
+	}
+
+	// Tree is clean after WIP commit — the work was persisted.
+	if st := gitOutput(t, dir, "status", "--porcelain"); st != "" {
+		t.Errorf("expected clean tree after CommitWIP, got:\n%s", st)
+	}
+}
+
+// TestGitArtifactRepo_CommitWIP_CleanTree verifies that CommitWIP is a no-op on
+// a clean tree: no empty commit, no ref, empty return.
+func TestGitArtifactRepo_CommitWIP_CleanTree(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	repo := newGitArtifactRepo(dir, "cleanrun")
+	if err := repo.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	headBefore := gitOutput(t, dir, "rev-parse", "HEAD")
+
+	ref, err := repo.CommitWIP("Implement")
+	if err != nil {
+		t.Fatalf("CommitWIP: %v", err)
+	}
+	if ref != "" {
+		t.Errorf("expected empty ref on clean tree, got %q", ref)
+	}
+	if tags := gitOutput(t, dir, "tag", "-l", "tracker/wip/*"); tags != "" {
+		t.Errorf("expected no WIP tag on clean tree, got:\n%s", tags)
+	}
+	if headAfter := gitOutput(t, dir, "rev-parse", "HEAD"); headAfter != headBefore {
+		t.Errorf("clean-tree CommitWIP moved HEAD: %s -> %s", headBefore, headAfter)
+	}
+}
+
+// TestGitArtifactRepo_CommitWIP_FailedRepoNoOp verifies that a repo marked
+// failed no-ops without creating a ref.
+func TestGitArtifactRepo_CommitWIP_FailedRepoNoOp(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	repo := newGitArtifactRepo(dir, "failrun")
+	if err := repo.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	repo.failed = true
+
+	ref, err := repo.CommitWIP("Implement")
+	if err != nil {
+		t.Fatalf("CommitWIP on failed repo: %v", err)
+	}
+	if ref != "" {
+		t.Errorf("expected empty ref on failed repo, got %q", ref)
+	}
+}
+
+// makeWIPRegistry returns a registry whose codergen handler dirties the
+// artifact tree and/or fails based on per-node behavior, for #302 engine
+// integration tests. failNodes return OutcomeFail after writing
+// <nodeID>.go; other nodes write <nodeID>.go and succeed.
+func makeWIPRegistry(failNodes map[string]bool, dirtyNodes map[string]bool) *HandlerRegistry {
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if dirtyNodes[node.ID] {
+				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
+				if err := os.WriteFile(filepath.Join(dir, node.ID+".go"), []byte("package x\n"), 0o644); err != nil {
+					return Outcome{}, err
+				}
+			}
+			if failNodes[node.ID] {
+				return Outcome{Status: string(OutcomeFail)}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		}})
+	}
+	return reg
+}
+
+// TestEngine_CommitWIP_StrictFailureHaltPreservesWork drives an agent node to
+// OutcomeFail with a dirty tree on the strict-failure HALT path (#302). The
+// uncommitted work must be preserved to a recoverable ref recorded in both the
+// trace and the checkpoint, even though the pipeline halts.
+func TestEngine_CommitWIP_StrictFailureHaltPreservesWork(t *testing.T) {
+	requireGit(t)
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_halt_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	reg := makeWIPRegistry(map[string]bool{"Implement": true}, map[string]bool{"Implement": true})
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true))
+	result, _ := engine.Run(context.Background())
+	if result == nil || result.Status != OutcomeFail {
+		t.Fatalf("expected fail result, got %+v", result)
+	}
+
+	repoDir := filepath.Join(artifactBase, result.RunID)
+	wantRef := "tracker/wip/" + result.RunID + "/Implement"
+
+	// 1. recoverable ref exists and captured the work.
+	if tags := gitOutput(t, repoDir, "tag", "-l", "tracker/wip/*"); !strings.Contains(tags, wantRef) {
+		t.Errorf("expected WIP tag %q, got:\n%s", wantRef, tags)
+	}
+	if show := gitOutput(t, repoDir, "show", "--stat", wantRef); !strings.Contains(show, "Implement.go") {
+		t.Errorf("WIP ref missing Implement.go:\n%s", show)
+	}
+
+	// 2. trace records the ref on the failed node.
+	var traceRef string
+	for _, e := range result.Trace.Entries {
+		if e.NodeID == "Implement" {
+			traceRef = e.WIPRef
+		}
+	}
+	if traceRef != wantRef {
+		t.Errorf("trace WIPRef for Implement: got %q want %q", traceRef, wantRef)
+	}
+
+	// 3. checkpoint records the ref (durably persisted).
+	cp, err := LoadCheckpoint(filepath.Join(repoDir, "checkpoint.json"))
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if cp.WIPRefs["Implement"] != wantRef {
+		t.Errorf("checkpoint WIPRefs[Implement]: got %q want %q", cp.WIPRefs["Implement"], wantRef)
+	}
+}
+
+// TestEngine_CommitWIP_FallbackPreservesWorkBeforeRouting proves the WIP ref is
+// created BEFORE the fallback routing decision (#302): the failing node's work
+// is captured in the ref, but the fallback (escalation) node's later changes
+// are NOT — establishing the ordering.
+func TestEngine_CommitWIP_FallbackPreservesWorkBeforeRouting(t *testing.T) {
+	requireGit(t)
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_fallback_test")
+	g.Attrs["fallback_target"] = "Escalate" // graph-level catch-all (#295)
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "Escalate", Shape: "box", Label: "Escalate"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"}) // unconditional → strict failure → fallback
+	g.AddEdge(&Edge{From: "Escalate", To: "end"})
+
+	reg := makeWIPRegistry(
+		map[string]bool{"Implement": true},
+		map[string]bool{"Implement": true, "Escalate": true},
+	)
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true))
+	result, _ := engine.Run(context.Background())
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	repoDir := filepath.Join(artifactBase, result.RunID)
+	wantRef := "tracker/wip/" + result.RunID + "/Implement"
+
+	show := gitOutput(t, repoDir, "show", "--stat", wantRef)
+	if !strings.Contains(show, "Implement.go") {
+		t.Errorf("WIP ref missing Implement.go:\n%s", show)
+	}
+	// Ordering proof: the WIP ref was captured before Escalate ran, so it must
+	// NOT contain Escalate's file.
+	if strings.Contains(show, "Escalate.go") {
+		t.Errorf("WIP ref captured after fallback ran (contains Escalate.go):\n%s", show)
+	}
+
+	cp, err := LoadCheckpoint(filepath.Join(repoDir, "checkpoint.json"))
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if cp.WIPRefs["Implement"] != wantRef {
+		t.Errorf("checkpoint WIPRefs[Implement]: got %q want %q", cp.WIPRefs["Implement"], wantRef)
+	}
+}
+
+// TestEngine_CommitWIP_CleanTreeFailureNoRef verifies that a failed node with a
+// CLEAN tree creates no WIP ref and records none in the trace (#302 no-op).
+func TestEngine_CommitWIP_CleanTreeFailureNoRef(t *testing.T) {
+	requireGit(t)
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_clean_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	// fail but DO NOT dirty the tree.
+	reg := makeWIPRegistry(map[string]bool{"Implement": true}, map[string]bool{})
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true))
+	result, _ := engine.Run(context.Background())
+	if result == nil || result.Status != OutcomeFail {
+		t.Fatalf("expected fail result, got %+v", result)
+	}
+
+	repoDir := filepath.Join(artifactBase, result.RunID)
+	if tags := gitOutput(t, repoDir, "tag", "-l", "tracker/wip/*"); tags != "" {
+		t.Errorf("expected no WIP tag on clean-tree failure, got:\n%s", tags)
+	}
+	for _, e := range result.Trace.Entries {
+		if e.NodeID == "Implement" && e.WIPRef != "" {
+			t.Errorf("expected empty WIPRef on clean-tree failure, got %q", e.WIPRef)
+		}
+	}
+}
+
+// TestEngine_CommitWIP_NoGitAdapterWarns verifies that when git artifacts are
+// disabled (no adapter), a failed node routes without panic and emits a warning
+// that work could not be preserved (#302 graceful skip).
+func TestEngine_CommitWIP_NoGitAdapterWarns(t *testing.T) {
+	g := NewGraph("wip_noadapter_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := makeWIPRegistry(map[string]bool{"Implement": true}, map[string]bool{})
+	engine := NewEngine(g, reg, WithPipelineEventHandler(handler)) // no artifact dir, no git artifacts
+	result, _ := engine.Run(context.Background())
+	if result == nil || result.Status != OutcomeFail {
+		t.Fatalf("expected fail result, got %+v", result)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, e := range events {
+		if e.Type == EventWarning && strings.Contains(e.Message, "git artifacts") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected EventWarning about git artifacts not enabled when preserving failed work")
 	}
 }

--- a/pipeline/git_artifacts_test.go
+++ b/pipeline/git_artifacts_test.go
@@ -727,12 +727,12 @@ func TestEngine_CommitWIP_NoGitAdapterWarns(t *testing.T) {
 	defer mu.Unlock()
 	found := false
 	for _, e := range events {
-		if e.Type == EventWarning && strings.Contains(e.Message, "git artifacts") {
+		if e.Type == EventWarning && strings.Contains(e.Message, "cannot preserve uncommitted work") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected EventWarning about git artifacts not enabled when preserving failed work")
+		t.Error("expected EventWarning that uncommitted work could not be preserved when no git adapter is configured")
 	}
 }
 

--- a/pipeline/trace.go
+++ b/pipeline/trace.go
@@ -55,6 +55,11 @@ type TraceEntry struct {
 	// Outcome carries child-run totals so AggregateUsage can include them
 	// in the parent's rollup. Omitted from JSON when nil.
 	ChildUsage *UsageSummary `json:"child_usage,omitempty"`
+	// WIPRef is the recoverable git ref (tag tracker/wip/<runID>/<nodeID>)
+	// where this node's uncommitted work was preserved before the engine
+	// routed away from a failure/exhaustion (#302). Empty when the tree was
+	// clean or no git artifact adapter was configured.
+	WIPRef string `json:"wip_ref,omitempty"`
 }
 
 // Trace captures the full execution history of a pipeline run.


### PR DESCRIPTION
## Summary

Closes #302. Refs epic #308 (Phase 1). Completes merged #297 (PR #314)'s deferred exhaustion-path persistence; enables #303.

When an agent node fails or exhausts its turn budget, the engine routes to a fallback (or halts) — and today any dirty working tree is orphaned. A green-but-uncommitted milestone is silently lost (the proximate loss in `code-goblin` run `7b6e08c9e2b2`: `Implement` was green at turn 48 but uncommitted; the breach discarded it).

This change makes the engine preserve that work to a **named, recoverable git ref BEFORE** the routing/halt decision, recorded in both the checkpoint and the trace so it's retrievable after the run.

#297 covered only the **success-with-dirty-tree** case (the `.dip` `CommitIfDirty` node on the `Implement` success path); it explicitly deferred the **exhaustion path** to this engine-layer issue. This PR is that engine layer.

## Changes (engine + adapter Go only — no `.dip` edits)

### `gitArtifactRepo.CommitWIP(nodeID)` (`pipeline/git_artifacts.go`)
- `git status --porcelain` dirty check (includes **untracked/newly-created** files; respects `.gitignore`). **Clean tree → no-op**: no commit, no ref, returns `""`.
- Dirty tree → `git add -A` (captures additions, modifications, **and removals** so the snapshot faithfully mirrors the tree) + `git commit`, then points the lightweight tag `tracker/wip/<runID>/<nodeID>` at it (mirrors the existing `TagCheckpoint` precedent) and returns the ref name.
- Failed repo → no-op. Errors are **returned, not swallowed**, for the caller to surface.

### Engine helper `commitWIPBeforeRouting` (`pipeline/engine_run.go`)
Wired into **every** fail/exhaust path, always **before** the routing decision:
- `checkStrictFailure` (`engine.go`) — at the top, so it covers **both** the `fallback_target` escalation (#295) **and** the terminal halt.
- `handleRetryExhausted` (`engine_run.go`) — covers both the `fallback_retry_target` and no-fallback sub-branches.
- `handleExitNode` exit-node `OutcomeFail` path (`engine_run.go`).
- `processActiveNode` terminal **handler-error** path (`engine.go`) — a node that wrote files then returned a Go error, or was cancelled mid-write (added in review, per Codex). `executeNode` already records that node's trace entry, so the ref is mirrored onto it.

It records the ref in `Checkpoint.WIPRefs` (and persists the checkpoint immediately, so the ref survives even on terminal-halt paths that don't otherwise save) and on `TraceEntry.WIPRef`.

### Schema (additive, backward-compatible)
- `Checkpoint.WIPRefs map[string]string` (`json:"wip_refs,omitempty"`) + `RecordWIPRef`. Older checkpoints without the field load cleanly.
- `TraceEntry.WIPRef string` (`json:"wip_ref,omitempty"`).

## Acceptance criteria → tests

- **fail/exhaustion + dirty tree → recoverable ref created & recorded** → `TestEngine_CommitWIP_StrictFailureHaltPreservesWork` (asserts the `tracker/wip/...` tag exists and captured the work, `TraceEntry.WIPRef` is set, and `checkpoint.json` `wip_refs` records it).
- **clean tree → no-op (no empty commit/ref)** → `TestGitArtifactRepo_CommitWIP_CleanTree` (HEAD unmoved) + `TestEngine_CommitWIP_CleanTreeFailureNoRef`.
- **no git adapter → graceful skip + logged warning, no panic** → `TestEngine_CommitWIP_NoGitAdapterWarns`.
- **ref created BEFORE routing (ordering)** → `TestEngine_CommitWIP_FallbackPreservesWorkBeforeRouting`: the WIP ref contains the failing node's file but **not** the fallback node's later file, proving capture happened before the fallback ran.
- **handler-error path (review)** → `TestEngine_CommitWIP_HandlerErrorPreservesWork`.
- **deletion capture (review)** → `TestGitArtifactRepo_CommitWIP_CapturesDeletion`.
- adapter unit coverage incl. untracked-file capture & failed-repo no-op → `TestGitArtifactRepo_CommitWIP_DirtyTree` / `_FailedRepoNoOp`; schema round-trip + legacy load → `TestCheckpoint_WIPRefsRoundTrip`.

**Negative control:** with the `commitWIPBeforeRouting` wiring removed, the strict-failure / fallback / handler-error engine tests **fail** (no `tracker/wip/...` ref) — confirmed, then restored (as #296/#297 did).

## Design subtleties (deliberate)

1. **Scoped to the git-adapter path.** The recoverable ref lives in the engine-managed artifact-dir repo (`gitArtifactRepo`). When git artifacts are OFF there is no engine-managed repo, so the contract is an explicit **graceful skip + warning** — it never reaches into the user's real working repo.
2. **Relationship to `CommitNode`.** `CommitWIP` runs **first** and commits the dirty tree (moving HEAD), so the named tag is the stable handle to the work; the subsequent `emitGitCommit`/`CommitNode` records the node outcome as an empty (`--allow-empty`) marker on top. On the strict-halt/fallback paths `emitGitCommit` isn't called, so the WIP commit + tag is the sole capture.
3. **Checkpoint schema is additive + backward-compatible** (`omitempty`, lazy-init map).
4. **Never swallow errors** (CLAUDE.md). A WIP-commit failure is surfaced as an `EventWarning` and never masks the original node failure or changes the routing outcome.

## Review follow-ups (addressed)
- **Codex (P2):** WIP now also preserved on the terminal handler-error path (`processActiveNode`), not just the status-based fail/exhaust paths.
- **Copilot:** `CommitWIP` uses `git add -A` so deletion-only dirty trees are preserved (premise that `git add .` skips deletions is outdated for git 2.x and a no-op here since git runs at the repo root, but `-A` is unambiguous + robust on old git); doc/inline comments updated to match.

## Out of scope
- #303 turn-limit guard / verify-on-breach / operator-decision redesign — this PR only **persists** work on the existing fail/exhaust paths; it does not change `OutcomeFail` classification.
- #298 build-context, #299 quality-gate, #300/#301 spec coherence. No `.dip` edits, no dippin-lang grammar changes.

## Verification
- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓ · `go test -race -short ./pipeline/...` ✓ · `go vet ./pipeline/` ✓
- New + existing git-artifact tests (`go test ./pipeline/ -run Git`) ✓ — `TestEngine_WithGitArtifacts_CommitsRetryExhausted` / `_CommitsFailOutcome` unchanged.
- New funcs verified ≤8 under `gocyclo`/`gocognit -over 8`.
- `dippin doctor` on the three core pipelines — `build_product` A 90/100, `ask_and_execute` A 95, `build_product_with_superspec` A 100 (unchanged; no `.dip` touched).
- CHANGELOG.md updated under [Unreleased].

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic WIP preservation: when a pipeline node fails or exhausts retries, uncommitted work is committed to a recoverable WIP ref before routing or termination.
  * WIP refs are recorded in checkpoints and surfaced in execution traces for resume/recovery; clean trees no-op and warnings emitted if artifact tracking is unavailable or commit fails.

* **Tests**
  * Added unit and integration tests covering WIP commit behavior across dirty/clean/failed-repo scenarios and trace/checkpoint persistence.

* **Documentation**
  * CHANGELOG updated with the new engine persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->