### PR TITLE
feat(engine): turn-limit breach = guard not guillotine — verify → classify (#303 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **engine: turn-limit breach = guard, not guillotine** (closes #303 PR1, refs
+  epic #308 Phase 1; builds on #302/#295/#297, completes the Phase-1 turn-limit
+  track). On a **native-backend** turn-limit breach the engine no longer fails
+  unconditionally. It runs one verify pass (an author-specified `verify_command`
+  only — never auto-detection, so a coarse/empty suite can't grant a pass) and
+  classifies the breach: a **verified-green** tree returns `OutcomeSuccess` and
+  advances through the pipeline's own commit-on-success node (e.g.
+  `build_product`'s `CommitIfDirty`, #297) — this alone would have saved the
+  `code-goblin` run `7b6e08c9e2b2` (green at turn 48 but discarded); a detected
+  **loop** is classified pathological and stops; anything else fails with
+  `ctx.turn_breach_class = operator_decision` for routing. `auto_status` can no
+  longer manufacture success on a breach (a stale/early `STATUS:` line is
+  ignored when turns are exhausted). A new `turn_breach_policy: fail` node
+  attribute (declare it under a `params:` block) opts back into the previous
+  always-fail behavior. The verify result is recorded on the trace
+  (`SessionStats.BreachVerify`). Non-native backends (claude-code/acp) are
+  unchanged.
 - **engine: commit-WIP to a recoverable ref before routing a failed/exhausted
   node** (closes #302, refs epic #308 Phase 1). The engine now preserves an
   agent node's dirty (possibly green) working tree to a named, recoverable git

--- a/agent/config.go
+++ b/agent/config.go
@@ -54,6 +54,13 @@ type SessionConfig struct {
 	// turn before giving up and proceeding. Default: 2.
 	MaxVerifyRetries int
 
+	// VerifyOnBreach, when true, makes the session run one verify pass after
+	// the turn loop exhausts (MaxTurns reached without a detected loop), using
+	// VerifyCommand only (never auto-detection — see resolveBreachVerifier).
+	// The pipeline layer sets this to (turn_breach_policy != "fail") so the
+	// opt-out path pays no verify cost. Independent of VerifyAfterEdit. (#303)
+	VerifyOnBreach bool
+
 	// Checkpoints are messages injected at specific turn-budget fractions.
 	// Each checkpoint fires exactly once, on the turn where the fraction is
 	// first reached. Fraction is in [0, 1] — e.g. 0.6 means "at 60% of MaxTurns".

--- a/agent/result.go
+++ b/agent/result.go
@@ -11,6 +11,17 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
+// BreachVerifyState records the result of the verify-on-breach pass (#303).
+// The zero value is BreachVerifyNotRun, so an unset field is always the safe
+// "could not verify" state — never mistaken for a pass.
+type BreachVerifyState int
+
+const (
+	BreachVerifyNotRun BreachVerifyState = iota // no verify ran (not a breach, no explicit command, or loop detected)
+	BreachVerifyPassed                          // verify command exited 0
+	BreachVerifyFailed                          // verify failed (non-zero exit) or errored
+)
+
 // SessionResult holds summary statistics and metadata from a completed session.
 type SessionResult struct {
 	SessionID          string
@@ -19,6 +30,7 @@ type SessionResult struct {
 	Turns              int
 	MaxTurnsUsed       bool
 	LoopDetected       bool
+	BreachVerify       BreachVerifyState // #303: result of the verify-on-breach pass
 	ToolCalls          map[string]int
 	FilesModified      []string
 	FilesCreated       []string

--- a/agent/result_test.go
+++ b/agent/result_test.go
@@ -10,6 +10,19 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
+func TestBreachVerifyState_ZeroValueIsNotRun(t *testing.T) {
+	var r SessionResult
+	if r.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("zero-value BreachVerify = %v, want BreachVerifyNotRun", r.BreachVerify)
+	}
+	if BreachVerifyNotRun != 0 {
+		t.Errorf("BreachVerifyNotRun = %d, want 0 (safe default)", BreachVerifyNotRun)
+	}
+	if BreachVerifyPassed == BreachVerifyFailed {
+		t.Error("BreachVerifyPassed and BreachVerifyFailed must be distinct")
+	}
+}
+
 func TestResultString(t *testing.T) {
 	r := SessionResult{
 		SessionID:     "a3f2",

--- a/agent/session.go
+++ b/agent/session.go
@@ -209,6 +209,13 @@ func (s *Session) Run(ctx context.Context, userInput string) (SessionResult, err
 
 	if !stoppedNaturally {
 		result.MaxTurnsUsed = true
+		// #303 verify-on-breach: only on plain exhaustion (not a detected
+		// loop), only when the pipeline asked for it via VerifyOnBreach, and
+		// only against an explicit command. Reached only when runTurnLoop
+		// returned err==nil above, so a provider error is never masked.
+		if s.config.VerifyOnBreach && !result.LoopDetected {
+			result.BreachVerify = s.runBreachVerify(ctx)
+		}
 	}
 
 	result.ToolTimings = s.toolTimings
@@ -401,6 +408,29 @@ func (s *Session) turnHasEdits(toolCalls []llm.ToolCallData) bool {
 		}
 	}
 	return false
+}
+
+// runBreachVerify runs a single verify pass after turn exhaustion and maps the
+// result to a BreachVerifyState. A real execution error (binary missing, bad
+// workdir — NOT a test failure) is surfaced via EventVerify and treated as
+// Failed (non-green): per CLAUDE.md we never swallow it, and a breach must never
+// advance on an unverifiable tree.
+func (s *Session) runBreachVerify(ctx context.Context) BreachVerifyState {
+	v := resolveBreachVerifier(s.config)
+	if v == nil {
+		return BreachVerifyNotRun
+	}
+	res, err := v.run(ctx)
+	if err != nil {
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: execution error: %v", err)})
+		return BreachVerifyFailed
+	}
+	if res.Passed {
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: passed (%s)", res.Command)})
+		return BreachVerifyPassed
+	}
+	s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: failed (exit %d, %s)", res.ExitCode, res.Command)})
+	return BreachVerifyFailed
 }
 
 // runVerifyLoop runs the verify-after-edit inner loop. It resolves the verify

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -2078,3 +2078,140 @@ exit 0
 	}
 	return scriptPath
 }
+
+// --- #303: verify-on-breach tests ---
+
+// exhaustingResponses returns n tool-call responses with VARYING names so the
+// loop-detector never fires (each turn's signature differs), forcing the loop
+// to run to MaxTurns → plain exhaustion (MaxTurnsUsed=true, LoopDetected=false).
+func exhaustingResponses(n int) []*llm.Response {
+	resps := make([]*llm.Response, n)
+	for i := range resps {
+		resps[i] = makeToolCallResponse(fmt.Sprintf("tool_%d", i))
+	}
+	return resps
+}
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestSession_VerifyOnBreach_Green_RecordsPassed(t *testing.T) {
+	dir := t.TempDir()
+	pass := writeScript(t, dir, "pass.sh", "#!/bin/sh\nexit 0\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = pass
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.MaxTurnsUsed || res.LoopDetected {
+		t.Fatalf("want plain exhaustion, got MaxTurnsUsed=%v LoopDetected=%v", res.MaxTurnsUsed, res.LoopDetected)
+	}
+	if res.BreachVerify != BreachVerifyPassed {
+		t.Errorf("BreachVerify = %v, want BreachVerifyPassed", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_Red_RecordsFailed(t *testing.T) {
+	dir := t.TempDir()
+	fail := writeScript(t, dir, "fail.sh", "#!/bin/sh\nexit 1\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = fail
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyFailed {
+		t.Errorf("BreachVerify = %v, want BreachVerifyFailed", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_NoExplicitCommand_NotRun(t *testing.T) {
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = t.TempDir()
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = "" // no explicit command → no breach verify
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want BreachVerifyNotRun", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_DisabledFlag_NoRun(t *testing.T) {
+	dir := t.TempDir()
+	pass := writeScript(t, dir, "pass.sh", "#!/bin/sh\nexit 0\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = false // flag off → mechanism never runs
+	cfg.VerifyCommand = pass
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want BreachVerifyNotRun (flag off)", res.BreachVerify)
+	}
+}
+
+func TestSession_LoopDetected_SkipsBreachVerify(t *testing.T) {
+	dir := t.TempDir()
+	// A verify that would create a sentinel file IF it ran. Loop detection must
+	// skip verify, so the sentinel must be absent.
+	sentinel := filepath.Join(dir, "verify_ran")
+	script := writeScript(t, dir, "touch.sh", "#!/bin/sh\ntouch "+sentinel+"\nexit 0\n")
+	// Identical tool-call names every turn → loop detector fires.
+	resps := make([]*llm.Response, 10)
+	for i := range resps {
+		resps[i] = makeToolCallResponse("read")
+	}
+	client := &mockCompleter{responses: resps}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 10
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = script
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.LoopDetected {
+		t.Fatalf("expected LoopDetected=true")
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want NotRun (verify must skip on loop)", res.BreachVerify)
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("verify ran on a detected loop (sentinel exists) — must be skipped")
+	}
+}

--- a/agent/verify.go
+++ b/agent/verify.go
@@ -140,6 +140,22 @@ func newVerifier(cfg SessionConfig) *verifier {
 	}
 }
 
+// resolveBreachVerifier returns a verifier for the verify-on-breach pass (#303),
+// or nil when no EXPLICIT verify command is configured. Unlike newVerifier it
+// ignores the VerifyAfterEdit gate (a breach should be able to rescue green work
+// even when in-loop verification was off) but it deliberately does NOT fall back
+// to detectVerifyCommand: only an author-specified command may grant a breach
+// success, so a coarse/auto-detected suite can never silently advance incomplete
+// work. broadCmd is intentionally empty — the breach check is a single focused
+// pass.
+func resolveBreachVerifier(cfg SessionConfig) *verifier {
+	cmd := strings.TrimSpace(cfg.VerifyCommand)
+	if cmd == "" {
+		return nil
+	}
+	return &verifier{cmd: cmd, workDir: cfg.WorkingDir}
+}
+
 // verifyResult holds the result of a verification run, including which command
 // was executed so callers can attribute failures correctly.
 type verifyResult struct {

--- a/agent/verify_test.go
+++ b/agent/verify_test.go
@@ -9,6 +9,30 @@ import (
 	"testing"
 )
 
+func TestResolveBreachVerifier_ExplicitCommandOnly(t *testing.T) {
+	// Explicit command → a verifier is returned regardless of VerifyAfterEdit.
+	v := resolveBreachVerifier(SessionConfig{
+		VerifyAfterEdit: false,
+		VerifyCommand:   "true",
+		WorkingDir:      t.TempDir(),
+	})
+	if v == nil {
+		t.Fatal("expected a verifier when VerifyCommand is set, got nil")
+	}
+	if v.cmd != "true" {
+		t.Errorf("verifier.cmd = %q, want %q", v.cmd, "true")
+	}
+
+	// No explicit command → nil, even in a Go module dir (NO auto-detection).
+	goModDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(goModDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveBreachVerifier(SessionConfig{VerifyCommand: "", WorkingDir: goModDir}); got != nil {
+		t.Errorf("expected nil (no auto-detect for breach verify), got verifier cmd=%q", got.cmd)
+	}
+}
+
 func TestDetectVerifyCommand_GoProject(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/test\n\ngo 1.21\n"), 0644); err != nil {

--- a/docs/superpowers/plans/2026-06-05-issue-303-pr1-turn-limit-guard.md
+++ b/docs/superpowers/plans/2026-06-05-issue-303-pr1-turn-limit-guard.md
@@ -1,0 +1,1112 @@
+# #303 PR1 — Turn-Limit Guard (verify → classify) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On native-backend turn-limit exhaustion, run an explicit verify pass and classify the breach: verified-green → `OutcomeSuccess` (advances through the pipeline's own success-path commit node), `LoopDetected` → pathological `OutcomeFail`, anything else → `OutcomeFail` + `turn_breach_class=operator_decision`. A `turn_breach_policy: fail` opt-out reproduces today's guillotine exactly.
+
+**Architecture:** Three layers, each with one job. **agent/** is mechanism: when `SessionConfig.VerifyOnBreach` is set and the loop exhausted without a detected loop, run one verify pass (explicit command only) and record `SessionResult.BreachVerify` (tri-state). **codergen** is policy: `buildConfig` sets `VerifyOnBreach = (policy != "fail")`; a new `classifyBreach` helper maps facts → (`Outcome.Status`, `turn_breach_class`). **engine** is unchanged — green takes the success edge; non-green takes the fail edge (`fallback_target`/strict-failure). Persisting the green tree is the pipeline's success-path commit node (build_product already has `CommitIfDirty`, #297); the engine never commits product code.
+
+**Tech Stack:** Go. Tests with the standard `testing` package. Native agent loop in `agent/`, handler dispatch in `pipeline/handlers/`, engine in `pipeline/`. Complexity gates `gocyclo`/`gocognit` ≤8 via `make complexity` (CI-only; NOT in the pre-commit hook).
+
+**Spec:** `docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md`
+
+**Scope:** PR1 only. The operator-decision `wait.human` node + warm `continue +N` are **PR2** (separate plan). No `.dip` edits in PR1.
+
+**Windows note:** `agent/verify.go` is `//go:build !windows`, and `agent/session.go` already calls `newVerifier` unconditionally — so `agent/` is already non-compiling on Windows today (pre-existing; the verification matrix is linux+darwin). PR1 adds `resolveBreachVerifier` alongside `newVerifier` in the same `!windows` file and calls it the same way; it does not change the Windows status and adds no stub (a stub for one function wouldn't make the package compile while `newVerifier` remains unstubbed).
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `agent/result.go` | `SessionResult` + new `BreachVerifyState` enum & field | Modify |
+| `agent/result_test.go` | zero-value/enum test | Modify |
+| `agent/config.go` | `SessionConfig.VerifyOnBreach` flag | Modify |
+| `agent/verify.go` | `resolveBreachVerifier` (explicit-command-only verifier) | Modify |
+| `agent/session.go` | run verify-on-breach at the exhaustion site | Modify |
+| `agent/session_test.go` | agent-layer verify-on-breach tests | Modify |
+| `pipeline/context.go` | `ContextKeyTurnBreachClass` + class value constants | Modify |
+| `pipeline/node_config.go` | `AgentNodeConfig.TurnBreachPolicy` + accessor read | Modify |
+| `pipeline/trace.go` | `SessionStats.BreachVerify` field | Modify |
+| `pipeline/handlers/transcript.go` | carry `BreachVerify` into `buildSessionStats` | Modify |
+| `pipeline/handlers/codergen.go` | `buildConfig` flag; `classifyBreach`; rewire `buildSuccessOutcome`; thread `native` | Modify |
+| `pipeline/handlers/codergen_test.go` | codergen classification tests | Modify |
+| `pipeline/handlers/codergen_breach_test.go` | new: focused breach-classification tests | Create |
+| `CHANGELOG.md` | [Unreleased] entry | Modify |
+
+---
+
+## Task 1: `BreachVerifyState` enum + `SessionResult.BreachVerify`
+
+**Files:**
+- Modify: `agent/result.go:14-34`
+- Test: `agent/result_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `agent/result_test.go`:
+
+```go
+func TestBreachVerifyState_ZeroValueIsNotRun(t *testing.T) {
+	var r SessionResult
+	if r.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("zero-value BreachVerify = %v, want BreachVerifyNotRun", r.BreachVerify)
+	}
+	if BreachVerifyNotRun != 0 {
+		t.Errorf("BreachVerifyNotRun = %d, want 0 (safe default)", BreachVerifyNotRun)
+	}
+	if BreachVerifyPassed == BreachVerifyFailed {
+		t.Error("BreachVerifyPassed and BreachVerifyFailed must be distinct")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./agent/ -run TestBreachVerifyState_ZeroValueIsNotRun`
+Expected: FAIL — `undefined: BreachVerifyNotRun` / `r.BreachVerify undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `agent/result.go`, add the type + constants above the `SessionResult` struct (after the imports/`package` block, before `type SessionResult struct`):
+
+```go
+// BreachVerifyState records the result of the verify-on-breach pass (#303).
+// The zero value is BreachVerifyNotRun, so an unset field is always the safe
+// "could not verify" state — never mistaken for a pass.
+type BreachVerifyState int
+
+const (
+	BreachVerifyNotRun BreachVerifyState = iota // no verify ran (not a breach, no explicit command, or loop detected)
+	BreachVerifyPassed                          // verify command exited 0
+	BreachVerifyFailed                          // verify failed (non-zero exit) or errored
+)
+```
+
+In the `SessionResult` struct, add the field directly after `LoopDetected bool` (result.go:21):
+
+```go
+	LoopDetected       bool
+	BreachVerify       BreachVerifyState // #303: result of the verify-on-breach pass
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./agent/ -run TestBreachVerifyState_ZeroValueIsNotRun`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/result.go agent/result_test.go
+git commit -m "feat(agent): add BreachVerifyState tri-state to SessionResult (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `SessionConfig.VerifyOnBreach` flag
+
+**Files:**
+- Modify: `agent/config.go:42-51`
+
+This flag is the seam: codergen (which knows the policy) sets it; the agent (mechanism only) reads it. No test of its own — it is a plain config field exercised in Task 4.
+
+- [ ] **Step 1: Add the field**
+
+In `agent/config.go`, immediately after the `VerifyCommand` field (config.go:51), add:
+
+```go
+	// VerifyOnBreach, when true, makes the session run one verify pass after
+	// the turn loop exhausts (MaxTurns reached without a detected loop), using
+	// VerifyCommand only (never auto-detection — see resolveBreachVerifier).
+	// The pipeline layer sets this to (turn_breach_policy != "fail") so the
+	// opt-out path pays no verify cost. Independent of VerifyAfterEdit. (#303)
+	VerifyOnBreach bool
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./agent/`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add agent/config.go
+git commit -m "feat(agent): add SessionConfig.VerifyOnBreach flag (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `resolveBreachVerifier` (explicit-command-only)
+
+**Files:**
+- Modify: `agent/verify.go` (after `newVerifier`, ~verify.go:141)
+- Test: `agent/verify_test.go`
+
+`newVerifier` returns nil when `!VerifyAfterEdit` and falls back to auto-detection. The breach verifier must (a) ignore the `VerifyAfterEdit` gate and (b) use the **explicit** `VerifyCommand` ONLY — auto-detected commands must NOT grant a breach success (spec decision #5: closes the coarse/empty-suite hole).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `agent/verify_test.go`:
+
+```go
+func TestResolveBreachVerifier_ExplicitCommandOnly(t *testing.T) {
+	// Explicit command → a verifier is returned regardless of VerifyAfterEdit.
+	v := resolveBreachVerifier(SessionConfig{
+		VerifyAfterEdit: false,
+		VerifyCommand:   "true",
+		WorkingDir:      t.TempDir(),
+	})
+	if v == nil {
+		t.Fatal("expected a verifier when VerifyCommand is set, got nil")
+	}
+	if v.cmd != "true" {
+		t.Errorf("verifier.cmd = %q, want %q", v.cmd, "true")
+	}
+
+	// No explicit command → nil, even in a Go module dir (NO auto-detection).
+	goModDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(goModDir, "go.mod"), []byte("module x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveBreachVerifier(SessionConfig{VerifyCommand: "", WorkingDir: goModDir}); got != nil {
+		t.Errorf("expected nil (no auto-detect for breach verify), got verifier cmd=%q", got.cmd)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./agent/ -run TestResolveBreachVerifier_ExplicitCommandOnly`
+Expected: FAIL — `undefined: resolveBreachVerifier`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `agent/verify.go`, after `newVerifier` (verify.go:141), add:
+
+```go
+// resolveBreachVerifier returns a verifier for the verify-on-breach pass (#303),
+// or nil when no EXPLICIT verify command is configured. Unlike newVerifier it
+// ignores the VerifyAfterEdit gate (a breach should be able to rescue green work
+// even when in-loop verification was off) but it deliberately does NOT fall back
+// to detectVerifyCommand: only an author-specified command may grant a breach
+// success, so a coarse/auto-detected suite can never silently advance incomplete
+// work. broadCmd is intentionally empty — the breach check is a single focused
+// pass.
+func resolveBreachVerifier(cfg SessionConfig) *verifier {
+	cmd := strings.TrimSpace(cfg.VerifyCommand)
+	if cmd == "" {
+		return nil
+	}
+	return &verifier{cmd: cmd, workDir: cfg.WorkingDir}
+}
+```
+
+(`strings` and `filepath`/`os` are already imported in verify.go / verify_test.go.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./agent/ -run TestResolveBreachVerifier_ExplicitCommandOnly`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add agent/verify.go agent/verify_test.go
+git commit -m "feat(agent): resolveBreachVerifier (explicit command only) for #303
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Wire verify-on-breach into `session.Run`
+
+**Files:**
+- Modify: `agent/session.go:205-212`
+- Test: `agent/session_test.go`
+
+When the loop exhausts (`!stoppedNaturally` → `MaxTurnsUsed = true`) and no loop was detected, run one verify pass (when `VerifyOnBreach` + explicit command) and record `BreachVerify`. A real execution error (binary missing, bad workdir — distinct from a test failure) maps to `BreachVerifyFailed` and is surfaced via `EventVerify` (never swallowed). The block is reached only when `runTurnLoop` returned `err == nil` (provider errors return early at session.go:206-208), so verify-on-breach can never mask a provider error.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `agent/session_test.go`. Helper to drive plain exhaustion without tripping loop detection (varying tool-call names):
+
+```go
+// exhaustingResponses returns n tool-call responses with VARYING names so the
+// loop-detector never fires (each turn's signature differs), forcing the loop
+// to run to MaxTurns → plain exhaustion (MaxTurnsUsed=true, LoopDetected=false).
+func exhaustingResponses(n int) []*llm.Response {
+	resps := make([]*llm.Response, n)
+	for i := range resps {
+		resps[i] = makeToolCallResponse(fmt.Sprintf("tool_%d", i))
+	}
+	return resps
+}
+
+func writeScript(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestSession_VerifyOnBreach_Green_RecordsPassed(t *testing.T) {
+	dir := t.TempDir()
+	pass := writeScript(t, dir, "pass.sh", "#!/bin/sh\nexit 0\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = pass
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.MaxTurnsUsed || res.LoopDetected {
+		t.Fatalf("want plain exhaustion, got MaxTurnsUsed=%v LoopDetected=%v", res.MaxTurnsUsed, res.LoopDetected)
+	}
+	if res.BreachVerify != BreachVerifyPassed {
+		t.Errorf("BreachVerify = %v, want BreachVerifyPassed", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_Red_RecordsFailed(t *testing.T) {
+	dir := t.TempDir()
+	fail := writeScript(t, dir, "fail.sh", "#!/bin/sh\nexit 1\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = fail
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyFailed {
+		t.Errorf("BreachVerify = %v, want BreachVerifyFailed", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_NoExplicitCommand_NotRun(t *testing.T) {
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = t.TempDir()
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = "" // no explicit command → no breach verify
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want BreachVerifyNotRun", res.BreachVerify)
+	}
+}
+
+func TestSession_VerifyOnBreach_DisabledFlag_NoRun(t *testing.T) {
+	dir := t.TempDir()
+	pass := writeScript(t, dir, "pass.sh", "#!/bin/sh\nexit 0\n")
+	client := &mockCompleter{responses: exhaustingResponses(3)}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 3
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = false // flag off → mechanism never runs
+	cfg.VerifyCommand = pass
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want BreachVerifyNotRun (flag off)", res.BreachVerify)
+	}
+}
+
+func TestSession_LoopDetected_SkipsBreachVerify(t *testing.T) {
+	dir := t.TempDir()
+	// A verify that would create a sentinel file IF it ran. Loop detection must
+	// skip verify, so the sentinel must be absent.
+	sentinel := filepath.Join(dir, "verify_ran")
+	script := writeScript(t, dir, "touch.sh", "#!/bin/sh\ntouch "+sentinel+"\nexit 0\n")
+	// Identical tool-call names every turn → loop detector fires.
+	resps := make([]*llm.Response, 10)
+	for i := range resps {
+		resps[i] = makeToolCallResponse("read")
+	}
+	client := &mockCompleter{responses: resps}
+	cfg := DefaultConfig()
+	cfg.MaxTurns = 10
+	cfg.WorkingDir = dir
+	cfg.VerifyOnBreach = true
+	cfg.VerifyCommand = script
+	sess := mustNewSession(t, client, cfg)
+
+	res, err := sess.Run(context.Background(), "go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !res.LoopDetected {
+		t.Fatalf("expected LoopDetected=true")
+	}
+	if res.BreachVerify != BreachVerifyNotRun {
+		t.Errorf("BreachVerify = %v, want NotRun (verify must skip on loop)", res.BreachVerify)
+	}
+	if _, statErr := os.Stat(sentinel); statErr == nil {
+		t.Error("verify ran on a detected loop (sentinel exists) — must be skipped")
+	}
+}
+```
+
+Ensure `fmt`, `os`, `filepath` are imported in `agent/session_test.go` (add any missing).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./agent/ -run 'TestSession_VerifyOnBreach|TestSession_LoopDetected_SkipsBreachVerify'`
+Expected: FAIL — `BreachVerify` stays `BreachVerifyNotRun` (no wiring yet), so the Green/Red assertions fail. (The skip test passes vacuously now — it becomes a real control after Step 3.)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `agent/session.go`, replace the exhaustion block (session.go:210-212):
+
+```go
+	if !stoppedNaturally {
+		result.MaxTurnsUsed = true
+	}
+```
+
+with:
+
+```go
+	if !stoppedNaturally {
+		result.MaxTurnsUsed = true
+		// #303 verify-on-breach: only on plain exhaustion (not a detected
+		// loop), only when the pipeline asked for it via VerifyOnBreach, and
+		// only against an explicit command. Reached only when runTurnLoop
+		// returned err==nil above, so a provider error is never masked.
+		if s.config.VerifyOnBreach && !result.LoopDetected {
+			result.BreachVerify = s.runBreachVerify(ctx)
+		}
+	}
+```
+
+Add the method (place near `runVerifyLoop`, session.go:~408):
+
+```go
+// runBreachVerify runs a single verify pass after turn exhaustion and maps the
+// result to a BreachVerifyState. A real execution error (binary missing, bad
+// workdir — NOT a test failure) is surfaced via EventVerify and treated as
+// Failed (non-green): per CLAUDE.md we never swallow it, and a breach must never
+// advance on an unverifiable tree.
+func (s *Session) runBreachVerify(ctx context.Context) BreachVerifyState {
+	v := resolveBreachVerifier(s.config)
+	if v == nil {
+		return BreachVerifyNotRun
+	}
+	res, err := v.run(ctx)
+	if err != nil {
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: execution error: %v", err)})
+		return BreachVerifyFailed
+	}
+	if res.Passed {
+		s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: passed (%s)", res.Command)})
+		return BreachVerifyPassed
+	}
+	s.emit(Event{Type: EventVerify, SessionID: s.id, Text: fmt.Sprintf("verify-on-breach: failed (exit %d, %s)", res.ExitCode, res.Command)})
+	return BreachVerifyFailed
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./agent/ -run 'TestSession_VerifyOnBreach|TestSession_LoopDetected_SkipsBreachVerify'`
+Expected: PASS (all five).
+
+- [ ] **Step 5: Run the agent race + full agent suite**
+
+Run: `go test -race -short ./agent/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add agent/session.go agent/session_test.go
+git commit -m "feat(agent): run verify-on-breach at turn-exhaustion, record BreachVerify (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Context key + class constants
+
+**Files:**
+- Modify: `pipeline/context.go:52-55`
+
+- [ ] **Step 1: Add constants**
+
+In `pipeline/context.go`, after the `ContextKeyTurnLimitMsg` block (context.go:55), add:
+
+```go
+	// ContextKeyTurnBreachClass classifies a turn-limit breach under the
+	// guard policy (#303). Set by the codergen handler on a breach; read by
+	// pipeline edge conditions (e.g. `when ctx.turn_breach_class = operator_decision`).
+	// Absent on normal success and on the turn_breach_policy: fail opt-out path
+	// (which reproduces today's guillotine exactly).
+	ContextKeyTurnBreachClass = "turn_breach_class"
+
+	// Turn-breach classification values (#303).
+	TurnBreachClassPathological     = "pathological"     // loop / no-progress → stop
+	TurnBreachClassVerifiedGreen    = "verified_green"   // breach verify passed → advance as success
+	TurnBreachClassOperatorDecision = "operator_decision" // steady progress, non-green → operator/fallback
+)
+```
+
+Wait — these must go INSIDE the existing `const (` block. Add them as the final entries before the closing `)` of that block (do not open a new `const`). Verify the block boundaries when editing.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./pipeline/`
+Expected: builds clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pipeline/context.go
+git commit -m "feat(pipeline): add turn_breach_class context key + class constants (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: `AgentNodeConfig.TurnBreachPolicy` + accessor
+
+**Files:**
+- Modify: `pipeline/node_config.go` (struct ~line 48; accessor default ~line 106; read ~line 150)
+- Test: `pipeline/node_config_test.go`
+
+Default is `"guard"`; `"fail"` is the opt-out; an unrecognized value warns and defaults to guard (the classify helper treats non-"fail" as guard, so a typo is safe by construction — Task 8 adds the parse-time guard).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pipeline/node_config_test.go`:
+
+```go
+func TestAgentConfig_TurnBreachPolicy(t *testing.T) {
+	// Default when unset.
+	n := &pipeline.Node{Attrs: map[string]string{}}
+	if got := n.AgentConfig(nil).TurnBreachPolicy; got != "guard" {
+		t.Errorf("default TurnBreachPolicy = %q, want %q", got, "guard")
+	}
+	// Node override.
+	n2 := &pipeline.Node{Attrs: map[string]string{"turn_breach_policy": "fail"}}
+	if got := n2.AgentConfig(nil).TurnBreachPolicy; got != "fail" {
+		t.Errorf("TurnBreachPolicy = %q, want %q", got, "fail")
+	}
+	// Graph default, node-overridable.
+	n3 := &pipeline.Node{Attrs: map[string]string{}}
+	if got := n3.AgentConfig(map[string]string{"turn_breach_policy": "fail"}).TurnBreachPolicy; got != "fail" {
+		t.Errorf("graph TurnBreachPolicy = %q, want %q", got, "fail")
+	}
+}
+```
+
+(Confirm the test package matches the file — node_config_test.go is `package pipeline_test`; the snippet uses `pipeline.Node`. If the file is `package pipeline`, drop the `pipeline.` qualifiers.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pipeline/ -run TestAgentConfig_TurnBreachPolicy`
+Expected: FAIL — `cfg.TurnBreachPolicy undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) Add the field to `AgentNodeConfig` (node_config.go, near MaxTurns ~line 59):
+
+```go
+	MaxTurns        int
+	TurnBreachPolicy string // #303: "guard" (default) or "fail" (opt-out)
+```
+
+(b) Set the default in the struct literal in `AgentConfig` (node_config.go:100-108), alongside `ReflectOnError: true`:
+
+```go
+	cfg := AgentNodeConfig{
+		ReflectOnError:   true,
+		TurnBreachPolicy: "guard", // #303 default: graduated guard
+	}
+```
+
+(c) Add the graph-default-then-node-override read. Place it next to the `max_turns` read (node_config.go:126-130). Note: `turn_breach_policy` arrives via a dippin `params:` block, which the adapter spills into `n.Attrs`; read both graph and node attrs:
+
+```go
+	if v, ok := graphAttrs["turn_breach_policy"]; ok && v != "" {
+		cfg.TurnBreachPolicy = v
+	}
+	if v, ok := n.Attrs["turn_breach_policy"]; ok && v != "" {
+		cfg.TurnBreachPolicy = v
+	}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pipeline/ -run TestAgentConfig_TurnBreachPolicy`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/node_config.go pipeline/node_config_test.go
+git commit -m "feat(pipeline): AgentNodeConfig.TurnBreachPolicy (guard default / fail opt-out) (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Carry `BreachVerify` into the trace
+
+**Files:**
+- Modify: `pipeline/trace.go:13-38` (`SessionStats`)
+- Modify: `pipeline/handlers/transcript.go:87-114` (`buildSessionStats`)
+- Test: `pipeline/handlers/transcript_test.go` (or codergen test in Task 8)
+
+The AC "trace shows verify+commit, not fail" requires the verify result to reach the trace. `SessionResult.BreachVerify` reaches the trace only via `buildSessionStats`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pipeline/handlers/transcript_test.go` (create if absent; `package handlers`):
+
+```go
+func TestBuildSessionStats_CarriesBreachVerify(t *testing.T) {
+	stats := buildSessionStats(agent.SessionResult{BreachVerify: agent.BreachVerifyPassed})
+	if stats.BreachVerify != int(agent.BreachVerifyPassed) {
+		t.Errorf("SessionStats.BreachVerify = %d, want %d", stats.BreachVerify, int(agent.BreachVerifyPassed))
+	}
+}
+```
+
+(Imports: `testing`, `github.com/2389-research/tracker/agent`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pipeline/handlers/ -run TestBuildSessionStats_CarriesBreachVerify`
+Expected: FAIL — `stats.BreachVerify undefined`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) In `pipeline/trace.go`, add to `SessionStats` (after `EstimateSource`):
+
+```go
+	// BreachVerify is the verify-on-breach result (#303): 0=not-run, 1=passed,
+	// 2=failed. Mirrors agent.BreachVerifyState as an int so the trace JSON is
+	// self-contained. Non-zero only on a turn-limit breach under guard policy.
+	BreachVerify int `json:"breach_verify,omitempty"`
+```
+
+(b) In `pipeline/handlers/transcript.go` `buildSessionStats`, add to the returned struct literal:
+
+```go
+		BreachVerify:     int(r.BreachVerify),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pipeline/handlers/ -run TestBuildSessionStats_CarriesBreachVerify`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/trace.go pipeline/handlers/transcript.go pipeline/handlers/transcript_test.go
+git commit -m "feat(pipeline): carry BreachVerify into SessionStats trace (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: `classifyBreach` + rewire `buildSuccessOutcome` (the core)
+
+**Files:**
+- Modify: `pipeline/handlers/codergen.go` (`buildConfig` ~668; `buildOutcome` 482/109; `buildSuccessOutcome` 543-587; new `classifyBreach`)
+- Test: `pipeline/handlers/codergen_breach_test.go` (create)
+
+This is the keystone. It (1) sets `VerifyOnBreach` from policy in `buildConfig`, (2) threads `native` from `Execute` down to `buildSuccessOutcome`, (3) replaces the flat breach→fail with `classifyBreach`, (4) ensures `auto_status` cannot manufacture a breach success and `applyDeclaredWrites` demotion clears the green marker. The classification is extracted into a helper to keep `buildSuccessOutcome` under the ≤8 complexity gate.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `pipeline/handlers/codergen_breach_test.go`:
+
+```go
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestClassifyBreach_VerifiedGreenAdvancesAsSuccess(t *testing.T) {
+	status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeSuccess {
+		t.Errorf("status = %q, want success", status)
+	}
+	if class != pipeline.TurnBreachClassVerifiedGreen {
+		t.Errorf("class = %q, want %q", class, pipeline.TurnBreachClassVerifiedGreen)
+	}
+}
+
+func TestClassifyBreach_LoopDetectedAlwaysPathological(t *testing.T) {
+	// Even a green verify cannot rescue a detected loop.
+	status, class := classifyBreach("guard", agent.SessionResult{LoopDetected: true, BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeFail {
+		t.Errorf("status = %q, want fail", status)
+	}
+	if class != pipeline.TurnBreachClassPathological {
+		t.Errorf("class = %q, want %q", class, pipeline.TurnBreachClassPathological)
+	}
+}
+
+func TestClassifyBreach_RedAndNotRunRouteToOperator(t *testing.T) {
+	for _, bv := range []agent.BreachVerifyState{agent.BreachVerifyFailed, agent.BreachVerifyNotRun} {
+		status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: bv}, true)
+		if status != pipeline.OutcomeFail || class != pipeline.TurnBreachClassOperatorDecision {
+			t.Errorf("bv=%v: got (%q,%q), want (fail,operator_decision)", bv, status, class)
+		}
+	}
+}
+
+func TestClassifyBreach_FailPolicyIsGuillotine(t *testing.T) {
+	status, class := classifyBreach("fail", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeFail {
+		t.Errorf("opt-out status = %q, want fail", status)
+	}
+	if class != "" {
+		t.Errorf("opt-out class = %q, want empty (no marker)", class)
+	}
+}
+
+func TestClassifyBreach_NonNativeIsGuillotine(t *testing.T) {
+	status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, false)
+	if status != pipeline.OutcomeFail || class != "" {
+		t.Errorf("non-native got (%q,%q), want (fail, \"\")", status, class)
+	}
+}
+```
+
+Add an Execute-level test in `pipeline/handlers/codergen_breach_test.go` proving the green breach surfaces as a success outcome with the marker (drives the full native path with `alwaysToolCallCompleter` + an explicit passing verify command):
+
+```go
+func TestExecute_BreachGreen_AdvancesAsSuccessWithMarker(t *testing.T) {
+	workdir := t.TempDir()
+	pass := workdir + "/pass.sh"
+	if err := writeFile755(pass, "#!/bin/sh\nexit 0\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":         "build it",
+			"max_turns":      "3",
+			"verify_command": pass,
+			// turn_breach_policy defaults to "guard"
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("status = %q, want success (verified-green breach)", out.Status)
+	}
+	if out.ContextUpdates[pipeline.ContextKeyTurnBreachClass] != pipeline.TurnBreachClassVerifiedGreen {
+		t.Errorf("turn_breach_class = %q, want verified_green", out.ContextUpdates[pipeline.ContextKeyTurnBreachClass])
+	}
+}
+
+func TestExecute_BreachRed_FailsWithOperatorMarker(t *testing.T) {
+	workdir := t.TempDir()
+	fail := workdir + "/fail.sh"
+	if err := writeFile755(fail, "#!/bin/sh\nexit 1\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "build it", "max_turns": "3", "verify_command": fail},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("status = %q, want fail", out.Status)
+	}
+	if out.ContextUpdates[pipeline.ContextKeyTurnBreachClass] != pipeline.TurnBreachClassOperatorDecision {
+		t.Errorf("turn_breach_class = %q, want operator_decision", out.ContextUpdates[pipeline.ContextKeyTurnBreachClass])
+	}
+}
+
+func TestExecute_TurnBreachPolicyFail_PinsGuillotine(t *testing.T) {
+	workdir := t.TempDir()
+	pass := workdir + "/pass.sh"
+	if err := writeFile755(pass, "#!/bin/sh\nexit 0\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt": "build it", "max_turns": "3",
+			"verify_command":     pass,
+			"turn_breach_policy": "fail", // opt-out
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Byte-for-byte today's behavior: fail + exact message, NO marker.
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("opt-out status = %q, want fail", out.Status)
+	}
+	wantMsg := `node "Implement": agent exhausted turn limit (3 turns) without completing`
+	if got := out.ContextUpdates[pipeline.ContextKeyTurnLimitMsg]; got != wantMsg {
+		t.Errorf("turn_limit_msg = %q, want %q", got, wantMsg)
+	}
+	if _, present := out.ContextUpdates[pipeline.ContextKeyTurnBreachClass]; present {
+		t.Error("opt-out must NOT set turn_breach_class")
+	}
+}
+
+func writeFile755(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o755)
+}
+```
+
+(Add imports `context`, `os` to the test file.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pipeline/handlers/ -run 'TestClassifyBreach|TestExecute_Breach|TestExecute_TurnBreachPolicyFail'`
+Expected: FAIL — `undefined: classifyBreach`; Execute green test fails (today returns fail, no marker).
+
+- [ ] **Step 3: Write the implementation**
+
+(a) `buildConfig` — set the flag from policy. After the verify-command copy (codergen.go:~691, after `config.VerifyCommand = cfg.VerifyCommand`), add:
+
+```go
+	config.VerifyOnBreach = cfg.TurnBreachPolicy != "fail"
+```
+
+(b) Add the helper (place after `buildTurnLimitMsg`, codergen.go:~624):
+
+```go
+// classifyBreach maps a turn-limit breach to (status, turn_breach_class) under
+// the turn_breach_policy (#303). Called only when buildTurnLimitMsg != "".
+//   - policy "fail" or non-native backend → today's guillotine (fail, no marker).
+//   - LoopDetected → pathological (fail).
+//   - BreachVerifyPassed → verified-green (success; the pipeline's success edge
+//     persists the tree).
+//   - everything else (Failed / NotRun) → operator_decision (fail; routes to
+//     fallback / an operator gate). Never silently advances.
+func classifyBreach(policy string, r agent.SessionResult, native bool) (pipeline.TerminalStatus, string) {
+	if policy == "fail" || !native {
+		return pipeline.OutcomeFail, ""
+	}
+	switch {
+	case r.LoopDetected:
+		return pipeline.OutcomeFail, pipeline.TurnBreachClassPathological
+	case r.BreachVerify == agent.BreachVerifyPassed:
+		return pipeline.OutcomeSuccess, pipeline.TurnBreachClassVerifiedGreen
+	default:
+		return pipeline.OutcomeFail, pipeline.TurnBreachClassOperatorDecision
+	}
+}
+```
+
+(c) Thread `native` through. Change `buildOutcome` signature (codergen.go:482) and call (codergen.go:109), and `buildSuccessOutcome` signature (codergen.go:543) and call (codergen.go:494), adding a trailing `native bool` param. In `Execute` (codergen.go:74), compute it from the resolved backend (mirrors `trackExternalBackendUsage`'s type switch):
+
+```go
+	_, native := backend.(*NativeBackend)
+```
+
+and pass `native` into `h.buildOutcome(node, prompt, artifactRoot, sessResult, &collector, priorEpisodes, native)`, then `h.buildSuccessOutcome(node, prompt, artifactRoot, responseText, responseArtifact, sessResult, priorEpisodes, native)`.
+
+(d) Rewire `buildSuccessOutcome`. Replace the current breach + auto_status block (codergen.go:552-573) with the guarded version. The key safety change: on a breach, `auto_status` may NOT upgrade to success.
+
+Replace:
+
+```go
+	status := pipeline.OutcomeSuccess
+	turnLimitMsg := buildTurnLimitMsg(node, sessResult)
+	if turnLimitMsg != "" {
+		status = pipeline.OutcomeFail
+	}
+
+	if node.Attrs["auto_status"] == "true" {
+		status = parseAutoStatus(responseText)
+	}
+```
+
+with:
+
+```go
+	status := pipeline.OutcomeSuccess
+	turnLimitMsg := buildTurnLimitMsg(node, sessResult)
+	var breachClass string
+	if turnLimitMsg != "" {
+		// #303: a breach is classified, not unconditionally failed.
+		policy := node.AgentConfig(h.graphAttrs).TurnBreachPolicy
+		status, breachClass = classifyBreach(policy, sessResult, native)
+	}
+
+	// auto_status: an explicit STATUS line is authoritative on NORMAL completion.
+	// On a breach it must NOT manufacture success — a missing/early STATUS line
+	// defaults parseAutoStatus to success, which would silently advance
+	// unverified work (#303 decision #5). So apply it only when not a breach.
+	if node.Attrs["auto_status"] == "true" && turnLimitMsg == "" {
+		status = parseAutoStatus(responseText)
+	}
+```
+
+(e) Marker write + declared-writes precedence. After `applyDeclaredWrites` (codergen.go:571-573) and before the `turnLimitMsg` context write (codergen.go:574-576), set the marker using the FINAL status:
+
+```go
+	if applyDeclaredWrites(node, outcome.ContextUpdates, responseText, "Response JSON") {
+		outcome.Status = string(pipeline.OutcomeFail)
+	}
+	// #303: write the breach class only after the final status is known, and
+	// never leave a verified_green marker on a Fail (a declared-writes failure
+	// can demote a green breach). Absent on the opt-out / non-native path
+	// (breachClass == "").
+	if breachClass != "" {
+		if outcome.Status == string(pipeline.OutcomeFail) && breachClass == pipeline.TurnBreachClassVerifiedGreen {
+			breachClass = pipeline.TurnBreachClassOperatorDecision
+		}
+		outcome.ContextUpdates[pipeline.ContextKeyTurnBreachClass] = breachClass
+	}
+```
+
+Note: the existing `outcome.Status` is set from `status` at the struct literal (codergen.go:562-563) — leave that as-is; it now carries the classified status. The `applyEpisodeContextUpdates` call (codergen.go:570) stays before this block so episodes are carried on the green path (warm advance).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pipeline/handlers/ -run 'TestClassifyBreach|TestExecute_Breach|TestExecute_TurnBreachPolicyFail'`
+Expected: PASS.
+
+- [ ] **Step 5: Add the auto_status + declared-writes guard tests**
+
+Append to `pipeline/handlers/codergen_breach_test.go`:
+
+```go
+func TestExecute_BreachRed_AutoStatusCannotForceSuccess(t *testing.T) {
+	workdir := t.TempDir()
+	fail := workdir + "/fail.sh"
+	if err := writeFile755(fail, "#!/bin/sh\nexit 1\n"); err != nil {
+		t.Fatal(err)
+	}
+	// alwaysToolCallCompleter emits no STATUS line → parseAutoStatus would
+	// default to success. The breach guard must prevent that.
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt": "build it", "max_turns": "3",
+			"verify_command": fail,
+			"auto_status":    "true",
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("status = %q, want fail (auto_status must not rescue a red breach)", out.Status)
+	}
+}
+```
+
+Run: `go test ./pipeline/handlers/ -run TestExecute_BreachRed_AutoStatusCannotForceSuccess`
+Expected: PASS (fails-first if the auto_status guard is omitted).
+
+- [ ] **Step 6: Verify the complexity gate**
+
+Run: `gocyclo -over 8 pipeline/handlers/codergen.go; gocognit -over 8 pipeline/handlers/codergen.go`
+Expected: no output for `buildSuccessOutcome` / `classifyBreach` (both ≤8). If `buildSuccessOutcome` exceeds 8, extract the marker-write block into a helper `applyBreachMarker(outcome, breachClass)` and re-run.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pipeline/handlers/codergen.go pipeline/handlers/codergen_breach_test.go
+git commit -m "feat(codergen): classify turn-limit breach (verify-green→success, loop→fail, else→operator) (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Non-native backend regression guard
+
+**Files:**
+- Test: `pipeline/handlers/codergen_breach_test.go`
+
+Prove a non-native backend never gets the marker / never auto-advances on a breach. `classifyBreach(..., native=false)` already returns `(fail, "")` — this is the unit guard (the `TestClassifyBreach_NonNativeIsGuillotine` from Task 8 covers it). Add an explicit comment-test asserting the contract is intentional so a future refactor that drops the `native` guard fails here.
+
+- [ ] **Step 1: Confirm the guard test exists and passes**
+
+Run: `go test ./pipeline/handlers/ -run TestClassifyBreach_NonNativeIsGuillotine`
+Expected: PASS. (No new code; this task is the explicit checkpoint that the native guard is covered. If it is missing, add it per Task 8 Step 1.)
+
+- [ ] **Step 2: Commit (if any change)**
+
+```bash
+git add pipeline/handlers/codergen_breach_test.go
+git commit -m "test(codergen): pin non-native breach to today's behavior (#303)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: build_product case-study rescue (routing-level proof)
+
+**Files:**
+- Test: `pipeline/build_product_failure_routing_test.go`
+
+No `.dip` change. Prove that build_product's existing graph routes a green breach (`OutcomeSuccess`) through `Implement -> CommitIfDirty` (which persists the product tree, #297), NOT `-> EscalateMilestone`. This is where "green work is persisted" is verified — at the routing level, not via the (default-off) artifact repo.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `pipeline/build_product_failure_routing_test.go` (study the existing helpers there for loading the embedded graph and reading edges; reuse them):
+
+```go
+// #303: a verified-green breach returns OutcomeSuccess, so Implement takes its
+// SUCCESS edge to CommitIfDirty (which commits the product tree, #297) rather
+// than the failure edge to EscalateMilestone. This is the case-study rescue.
+func TestBuildProduct_Implement_SuccessEdge_GoesToCommitIfDirty(t *testing.T) {
+	g := loadBuildProductGraph(t) // existing helper in this test file
+	var successTarget string
+	for _, e := range g.OutgoingEdges("Implement") {
+		if edgeMatchesSuccess(e) { // condition contains outcome = success
+			successTarget = e.To
+		}
+	}
+	if successTarget != "CommitIfDirty" {
+		t.Errorf("Implement success edge → %q, want CommitIfDirty (green-breach persistence path)", successTarget)
+	}
+}
+```
+
+If `loadBuildProductGraph` / `edgeMatchesSuccess` helpers don't exist verbatim, adapt to the file's actual helpers (it already asserts `Implement -> CommitIfDirty -> TestMilestone` per #297's `TestBuildProductCommitIfDirtyCheckpoint` — model the new test on it; this test may already be partly covered there, in which case extend that test with a comment tying it to #303 rather than duplicating).
+
+- [ ] **Step 2: Run test to verify it passes (regression, not fail-first)**
+
+Run: `go test ./pipeline/ -run TestBuildProduct_Implement_SuccessEdge_GoesToCommitIfDirty`
+Expected: PASS — the edge already exists (#297). This test documents the #303 dependency so a future `.dip` change that reroutes the success edge can't silently break the rescue.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pipeline/build_product_failure_routing_test.go
+git commit -m "test(build_product): pin Implement success edge → CommitIfDirty as the #303 green-breach rescue
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: CHANGELOG + full verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Under `## [Unreleased]`, in `### Added` (create the subsection if absent):
+
+```markdown
+### Added
+- **Graduated turn-limit guard (#303, Phase-1 turn-limit track).** On native-backend
+  turn-limit exhaustion, the engine no longer fails unconditionally: it runs an
+  explicit verify pass and classifies the breach. A verified-green tree advances as
+  success (routing through the pipeline's commit-on-success node, e.g. build_product's
+  `CommitIfDirty`); a detected loop is classified pathological and stops; anything
+  else fails with `ctx.turn_breach_class = operator_decision` for routing. A
+  `turn_breach_policy: fail` node attribute (declare under a `params:` block) opts
+  back into the previous always-fail behavior. Builds on #302/#295/#297.
+```
+
+- [ ] **Step 2: Full verification matrix**
+
+```bash
+go build ./...
+GOOS=darwin GOARCH=arm64 go build ./...
+go test ./... -short
+go test -race -short ./pipeline/ ./agent/
+make complexity
+dippin doctor examples/build_product.dip examples/ask_and_execute.dip examples/build_product_with_superspec.dip
+```
+
+Expected: all green; `make complexity` reports nothing over 8; `dippin doctor` shows build_product A (90), ask_and_execute A (95), build_product_with_superspec A (100) — unchanged (no `.dip` touched).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog for #303 graduated turn-limit guard (PR1)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 4: Adversarial self-review before PR**
+
+Re-read the diff against the spec's invariants. Confirm by inspection + test:
+- No path to `OutcomeSuccess` on a breach except `BreachVerify==Passed` (green) — incl. `auto_status` and declared-writes paths.
+- `LoopDetected` always fails (never success), even with a green verify.
+- Opt-out (`turn_breach_policy: fail`) reproduces the exact `turn_limit_msg` and sets no marker.
+- Non-native backends are unchanged.
+- Provider errors still hard-fail (verify-on-breach is behind `err==nil`).
+
+---
+
+## Self-Review (plan vs spec)
+
+**Spec coverage:**
+- verify-on-breach (agent) → Tasks 1–4. ✓
+- policy seam via `SessionConfig.VerifyOnBreach` → Tasks 2, 8(a). ✓
+- strict green bar (explicit command, auto_status can't force success, auto-detect→operator) → Tasks 3, 8(d). ✓
+- classify (green/loop/non-green) + native guard → Task 8(b). ✓
+- complexity helper extraction + `make complexity` in verification → Tasks 8(6), 11. ✓
+- `turn_breach_policy` typed accessor, guard default, params-block note → Task 6. ✓
+- context marker + class constants → Task 5. ✓
+- trace carries BreachVerify → Task 7. ✓
+- opt-out byte-for-byte pin (msg + marker absent) → Task 8 `TestExecute_TurnBreachPolicyFail_PinsGuillotine`. ✓
+- case-study rescue at routing level (not artifact repo) → Task 10. ✓
+- CHANGELOG → Task 11. ✓
+- PR2 items (operator node, warm continue) → explicitly deferred. ✓
+
+**Type consistency:** `BreachVerifyState`/`BreachVerifyNotRun/Passed/Failed` (Task 1) used in Tasks 3/4/7/8. `VerifyOnBreach` (Task 2) set in 8(a), read in 4. `TurnBreachPolicy` (Task 6) read in 8(d). `classifyBreach(policy string, r agent.SessionResult, native bool) (pipeline.TerminalStatus, string)` (Task 8) called consistently. `ContextKeyTurnBreachClass` + `TurnBreachClass*` (Task 5) used in 8/tests. `SessionStats.BreachVerify int` (Task 7). Consistent.
+
+**Placeholder scan:** none — every code step shows full code; the only "adapt to existing helpers" note is Task 10, which points at the concrete existing test (`TestBuildProductCommitIfDirtyCheckpoint`) to model.

--- a/docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md
+++ b/docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md
@@ -1,0 +1,213 @@
+# #303 — Turn-limit breach = guard, not guillotine
+
+**Issue:** #303 (P1, area/engine + area/agent + refactor). Epic #308, Phase 1.
+**Builds on (all merged into `main`):** #302 (`CommitWIP` recoverable refs, PR #315),
+#295 (graph-level `fallback_target` catch-all, PR #311), #297 (build_product
+commit-first / stop-when-green, PR #314).
+**Branch:** `fix/303-turn-limit-guard` (off `origin/main` @ `003d91a`).
+
+## Problem
+
+Turn-limit exhaustion maps unconditionally to `OutcomeFail`. `codergen.go`
+`buildSuccessOutcome` flips status to `OutcomeFail` whenever `buildTurnLimitMsg`
+is non-empty (codergen.go:553-556). That conflates two very different
+situations:
+
+- **Pathological** — a looping / no-progress agent. Stopping is correct.
+- **Steady progress that ran out of a coarse budget** — e.g. `code-goblin` run
+  `7b6e08c9e2b2`, GREEN at turn 48 (`go test ./...` + `go vet` passed) but
+  uncommitted. The breach discarded the milestone; the cross-review/FinalSpecCheck
+  safety net never ran.
+
+`buildTurnLimitMsg` (codergen.go:616-624) *already* distinguishes `LoopDetected`
+from plain exhaustion — but only in the message text. The distinction never
+picks an outcome.
+
+## Key findings from the code (these shape the design)
+
+1. **The success path already commits the dirty tree.** `advanceToNextNode →
+   emitGitCommit → CommitNode` runs `git add .` + `git commit` in the artifact
+   repo on *every* successful node (engine.go:450, git_artifacts.go:131). So
+   **"commit-if-green" needs no new engine commit code**: if codergen classifies
+   a green breach as `OutcomeSuccess`, the existing machinery commits and
+   advances. `CommitWIP` (#302) stays on the fail paths only. → no double-commit,
+   no orphan ref, no new primitive.
+
+2. **The verify affordance is reusable as-is.** `newVerifier(cfg)` +
+   `verifier.run(ctx)` (agent/verify.go) already run *outside* the `MaxTurns`
+   budget. Verify-on-breach = run it once after the turn loop exhausts.
+
+3. **`wait.human` already does everything the operator node needs.** Freeform +
+   labeled-edges mode + `LabeledFreeformInterviewer`; `AutoApproveInterviewer` /
+   `AutopilotInterviewer` / `WebhookInterviewer` all implement the interfaces and
+   carry `Actor()`. The autonomous default is the existing
+   `default_choice` / `TimeoutAction` machinery — so reusing `wait.human` makes
+   `--auto-approve` / `--autopilot` / `--webhook-url` work for free.
+
+4. **dippin-lang v0.35.0:** `max_turns` and `fallback_target` are first-class
+   node attrs; `defaults:` carries `max_total_tokens` / `max_cost_cents` /
+   `max_wall_time`. There is **no** first-class `turn_breach_policy` attr — it
+   rides via `node.Attrs` (Params pass-through). To be verified with
+   `dippin validate` before PR2 relies on it; PR1 needs it only parseable.
+
+## Design decisions (agreed)
+
+| # | Subtlety | Decision |
+|---|----------|----------|
+| 1 | Layering seam | Three-layer contract (below). agent produces facts; codergen turns facts into outcome + a `turn_breach_class` marker; engine routes/commits with existing machinery. |
+| 2 | Operator-node shape | **Reuse `wait.human`** (no new handler). Reached via author-wired `when ctx.turn_breach_class = operator_decision` edge. Autonomous default via existing interviewer machinery. |
+| 3 | commit-if-green vs `CommitWIP` | Green breach → `OutcomeSuccess` → existing success-path `CommitNode` commits the dirty tree as a real advance. `CommitWIP` unchanged, fail-paths only. |
+| 4 | New `.dip` attrs | `turn_breach_policy` (+ PR2's continue-cap) via `node.Attrs` Params pass-through, read through a typed accessor on `AgentNodeConfig`. Default behavior needs **no** `.dip` change. |
+| 5 | Never silent-advance | A non-green breach is `OutcomeFail` → routes to `fallback_target`/halt with WIP preserved (#302). Verify failure ≠ success. Provider errors still hard-fail (untouched). |
+| — | Default policy | **`guard` is the default.** `turn_breach_policy: fail` opts back into today's guillotine. |
+| — | Delivery | **Two PRs.** PR1 = core (this doc's focus). PR2 = operator node + warm continue+N. |
+
+## The seam — three layers
+
+```
+agent/ (facts)                codergen (classify)              engine (route/commit)
+─────────────────             ───────────────────             ─────────────────────
+runTurnLoop exhausts          buildSuccessOutcome reads        success → emitGitCommit
+  → MaxTurnsUsed=true           MaxTurnsUsed / LoopDetected       commits dirty tree (exists)
+  → (new) verify-on-breach      / BreachVerify + policy         fail → commitWIPBeforeRouting
+  → SessionResult.BreachVerify  → Outcome.Status                  (#302) → fallback/operator
+                                + ctx.turn_breach_class
+```
+
+No logic is smeared across layers: each layer has one job and a typed contract.
+
+## PR1 — verify → commit-if-green → classify (core)
+
+**Go only. No `.dip` edits. dippin doctor unchanged (A grade, nothing touched).**
+Scope: the **native** backend (`agent.Session`). claude-code/acp breach handling
+is unchanged (they don't drive `agent.Session`'s turn loop); noted, not solved.
+
+### 1. agent layer — verify-on-breach (facts)
+
+- `agent/result.go`: add `BreachVerify BreachVerifyState` to `SessionResult`.
+  Tri-state: `BreachVerifyNotRun` (0, default) / `BreachVerifyPassed` /
+  `BreachVerifyFailed`. Tri-state (not `bool`) so codergen can tell "verified
+  failing" from "could not verify" — both are non-green, but the distinction is
+  useful in the trace and for #304 later.
+- `agent/session.go`: after `runTurnLoop` returns `stoppedNaturally == false`
+  (the existing `result.MaxTurnsUsed = true` site, session.go:210-212), and only
+  when **not** `LoopDetected` (pathological skips verify — we're stopping
+  regardless), run a single verify pass and record the state.
+- `agent/verify.go`: add `resolveBreachVerifyCommand(cfg)` — resolves
+  `cfg.VerifyCommand` else `detectVerifyCommand(cfg.WorkingDir)`, **independent of
+  the `VerifyAfterEdit` gate** (the point of verify-on-breach is to rescue green
+  work even when the in-loop verifier was off). No command resolvable →
+  `BreachVerifyNotRun` → treated as non-green downstream (safe; never advances).
+  Reuse `verifier{cmd,workDir}.run(ctx)`; emit the existing `EventVerify`.
+
+### 2. codergen layer — classify (outcome + marker)
+
+`pipeline/handlers/codergen.go` `buildSuccessOutcome`. Add a typed
+`TurnBreachPolicy` field to `AgentNodeConfig` (node_config.go) read from
+`turn_breach_policy` (default `guard`; `fail` = opt-out). Replace the flat
+"`turnLimitMsg != "" → Fail`" with:
+
+```
+if turnLimitMsg != "" {                      // a breach happened
+  switch policy {
+  case "fail":                               // opt-out: today's guillotine, pinned
+      status = OutcomeFail
+      class  = "" (unset — preserve exact prior behavior)
+  default: // "guard"
+      switch {
+      case sessResult.LoopDetected:          // pathological
+          status = OutcomeFail;  class = "pathological"
+      case sessResult.BreachVerify == Passed: // green → rescue
+          status = OutcomeSuccess; class = "verified_green"
+      default:                                // steady progress, non-green
+          status = OutcomeFail;  class = "operator_decision"
+      }
+  }
+}
+```
+
+- `auto_status: true` still overrides (an explicit STATUS line is authoritative)
+  — applied after, exactly as today.
+- `class` is written to `ctx.turn_breach_class` (new `ContextKeyTurnBreachClass`)
+  so PR2's operator edge can route on it. Also keep setting
+  `ctx.turn_limit_msg` (unchanged).
+- Green path keeps `last_response` / `episode_summaries` updates, so the advance
+  is a normal warm success — the trace entry is `success` and carries the
+  verify result, **not** fail (AC: "trace shows verify+commit, not fail").
+
+### 3. engine layer — nothing new for green
+
+Green breach → `OutcomeSuccess` → existing `emitGitCommit`/`CommitNode` commits
+the dirty tree. Non-green/pathological → `OutcomeFail` → existing
+`commitWIPBeforeRouting` (#302) + `fallback_target`/strict-failure routing
+(#295). No engine edits in PR1 beyond what the marker needs (a context key).
+
+### PR1 tests (TDD — each watched failing first; negative control)
+
+agent:
+- `TestSession_VerifyOnBreach_Green_RecordsPassed` — exhaust turns with a green
+  tree → `SessionResult.BreachVerify == Passed`.
+- `TestSession_VerifyOnBreach_Red_RecordsFailed`.
+- `TestSession_VerifyOnBreach_NoCommand_NotRun`.
+- `TestSession_LoopDetected_SkipsBreachVerify` — pathological never verifies.
+
+codergen:
+- `TestCodergen_BreachGreen_AdvancesAsSuccess` — `BreachVerify=Passed` →
+  `OutcomeSuccess`, `ctx.turn_breach_class=verified_green`. *(fails today: returns fail)*
+- `TestCodergen_LoopDetected_ClassifiesPathologicalFail` — always fail, never
+  success, regardless of verify.
+- `TestCodergen_BreachNonGreen_RoutesOperatorMarker` — `OutcomeFail` +
+  `class=operator_decision`.
+- `TestCodergen_TurnBreachPolicyFail_PinsGuillotine` — opt-out reproduces today's
+  outcome **and** error/message byte-for-byte; no `turn_breach_class` set.
+
+engine (integration):
+- `TestEngine_BreachGreen_CommitsDirtyTreeAndAdvances` — drive a node to a
+  green breach; assert the artifact repo committed the file (CommitNode) and the
+  run advanced past the node, no `tracker/wip/...` ref created.
+- `TestEngine_BreachNonGreen_PreservesWIPAndRoutesFallback` — non-green breach
+  still makes a WIP ref (#302 path) and routes to `fallback_target`.
+
+Negative control: with the codergen classification reverted, the green/operator
+tests fail (node returns fail / no marker) — confirmed, then restored.
+
+## PR2 — operator-decision node + warm continue (follow-up, separate PR)
+
+Sketch only; finalized in its own plan.
+
+- **Operator node = `wait.human`** with labeled edges:
+  `continue` / `commit_advance` / `stop` / `abandon`. Reached via
+  `<Implement> -> <Operator> when ctx.turn_breach_class = operator_decision`.
+- **Autonomous default** = node `default_choice` + `TimeoutAction` → the issue's
+  safe default (`stop + commit-WIP + route-to-fallback`, never silent advance).
+  `--auto-approve` (deterministic first/default), `--autopilot <persona>` (LLM
+  judge), `--webhook-url` (external callback) all flow through the existing
+  interviewer machinery — no parallel path.
+- **`continue +N` = warm resume.** `continue` edge routes back to the codergen
+  node; on re-entry it bumps `MaxTurns` by N and carries `PriorEpisodeSummaries`
+  (already populated via `applyEpisodeContextUpdates` →
+  `ContextKeyEpisodeSummaries` → `injectPriorEpisodes`). Bounded by a **cap**
+  (turn cap and/or cost ceiling) enforced with a per-node circuit breaker — a
+  disk counter à la build_product's `fix_attempts` (CLAUDE.md: the checkpoint
+  restart counter is global and unsafe for this).
+- **`.dip` attrs:** the continue-cap (+ operator-node shape) ride via Params
+  pass-through; `dippin validate` confirmed first. If rejected → request a
+  dippin-lang grammar change (never `go install`).
+- **build_product wiring + dippin doctor/simulate** re-run to A grade and
+  100% terminate-success once the operator node is added.
+
+## Out of scope (do not touch)
+
+#304 (cost + no-progress detector — PR1 may *consume* a no-progress signal later
+but works without it; `LoopDetected` suffices for pathological), #298, #299,
+#300/#301, #305, #306, #313.
+
+## Verification (both PRs)
+
+`go build ./...` · `GOOS=darwin GOARCH=arm64 go build ./...` ·
+`go test ./... -short` · `go test -race -short ./pipeline/ ./agent/` ·
+`dippin doctor examples/build_product.dip examples/ask_and_execute.dip
+examples/build_product_with_superspec.dip` (A grade; PR1 touches no `.dip`).
+CHANGELOG under [Unreleased]: graduated turn-limit guard
+(verify → commit-if-green → classify → operator decision) + `turn_breach_policy`
+opt-out; builds on #302/#295; completes the Phase-1 turn-limit track.

--- a/docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md
+++ b/docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md
@@ -5,209 +5,276 @@
 #295 (graph-level `fallback_target` catch-all, PR #311), #297 (build_product
 commit-first / stop-when-green, PR #314).
 **Branch:** `fix/303-turn-limit-guard` (off `origin/main` @ `003d91a`).
+**Status:** revised after a 6-expert panel review (2026-06-05). The review
+corrected the central persistence mechanism and surfaced several real bugs; this
+revision absorbs every CRITICAL and IMPORTANT finding. See "Review corrections".
 
 ## Problem
 
 Turn-limit exhaustion maps unconditionally to `OutcomeFail`. `codergen.go`
 `buildSuccessOutcome` flips status to `OutcomeFail` whenever `buildTurnLimitMsg`
-is non-empty (codergen.go:553-556). That conflates two very different
-situations:
+is non-empty (codergen.go:553-556). That conflates two situations:
 
 - **Pathological** — a looping / no-progress agent. Stopping is correct.
 - **Steady progress that ran out of a coarse budget** — e.g. `code-goblin` run
-  `7b6e08c9e2b2`, GREEN at turn 48 (`go test ./...` + `go vet` passed) but
-  uncommitted. The breach discarded the milestone; the cross-review/FinalSpecCheck
-  safety net never ran.
+  `7b6e08c9e2b2`, GREEN at turn 48 (`go test ./...` + `go vet`) but uncommitted.
+  The breach discarded the milestone; the cross-review/FinalSpecCheck safety net
+  never ran. (In build_product today, `Implement`'s success edge routes to
+  `CommitIfDirty` (#297); on a *fail*/breach it routes to `EscalateMilestone`
+  and the commit node is never reached — so the green tree is lost.)
 
-`buildTurnLimitMsg` (codergen.go:616-624) *already* distinguishes `LoopDetected`
-from plain exhaustion — but only in the message text. The distinction never
-picks an outcome.
+`buildTurnLimitMsg` (codergen.go:616-624) already distinguishes `LoopDetected`
+from plain exhaustion, but only in the message text — the distinction never picks
+an outcome.
 
-## Key findings from the code (these shape the design)
+## How persistence ACTUALLY works (corrected by review — read this first)
 
-1. **The success path already commits the dirty tree.** `advanceToNextNode →
-   emitGitCommit → CommitNode` runs `git add .` + `git commit` in the artifact
-   repo on *every* successful node (engine.go:450, git_artifacts.go:131). So
-   **"commit-if-green" needs no new engine commit code**: if codergen classifies
-   a green breach as `OutcomeSuccess`, the existing machinery commits and
-   advances. `CommitWIP` (#302) stays on the fail paths only. → no double-commit,
-   no orphan ref, no new primitive.
+The original spec assumed the engine's success path commits the dirty tree. **It
+does not, in any real run:**
 
-2. **The verify affordance is reusable as-is.** `newVerifier(cfg)` +
-   `verifier.run(ctx)` (agent/verify.go) already run *outside* the `MaxTurns`
-   budget. Verify-on-breach = run it once after the turn loop exhausts.
+- `WithGitArtifacts` is **never called outside tests** (verified: no non-test
+  caller in the repo). So in a normal `tracker run`, the engine's git repo is
+  `nil` and `CommitNode` / `CommitWIP` / `commitWIPBeforeRouting` are **all
+  no-ops** (graceful skip). #302's WIP preservation only fires when a *library
+  embedder* opts into `WithGitArtifacts` — not the CLI.
+- Even when enabled, the artifact repo lives at `<workdir>/.tracker/runs/<runID>`
+  (engine_run.go:316-318; `git -C <dir>`) — a sibling of the agent's working
+  tree, not its root. `git add .` there cannot stage product code written to
+  `<workdir>/`.
 
-3. **`wait.human` already does everything the operator node needs.** Freeform +
-   labeled-edges mode + `LabeledFreeformInterviewer`; `AutoApproveInterviewer` /
-   `AutopilotInterviewer` / `WebhookInterviewer` all implement the interfaces and
-   carry `Actor()`. The autonomous default is the existing
-   `default_choice` / `TimeoutAction` machinery — so reusing `wait.human` makes
-   `--auto-approve` / `--autopilot` / `--webhook-url` work for free.
+**Product code is persisted entirely by `.dip` tool nodes and the agent's own
+commits.** build_product's `CommitIfDirty` (#297) does `git status --porcelain`
+→ `git add -A` → `git -c user.name=... commit` in the **working-tree product
+repo** (build_product.dip:462-482), on `Implement`'s success edge.
 
-4. **dippin-lang v0.35.0:** `max_turns` and `fallback_target` are first-class
-   node attrs; `defaults:` carries `max_total_tokens` / `max_cost_cents` /
-   `max_wall_time`. There is **no** first-class `turn_breach_policy` attr — it
-   rides via `node.Attrs` (Params pass-through). To be verified with
-   `dippin validate` before PR2 relies on it; PR1 needs it only parseable.
+**Consequence for #303:** "commit-if-green" is NOT an engine commit. It is
+purely a **reclassification**: a green breach returns `OutcomeSuccess`, which
+takes the node's *success* edge — and in build_product that edge already routes
+through `CommitIfDirty`, which commits the product tree. PR1 therefore needs
+**zero engine commit code** (true — but because returning success routes through
+the pipeline's own commit-on-success node, not because the engine commits
+anything). For a pipeline with no commit-on-success node, persisting green work
+is the pipeline author's responsibility — exactly as all product persistence
+already works in tracker. This boundary (engine never reaches into the user's
+real working repo) matches #302's explicit design and is preserved.
 
-## Design decisions (agreed)
+## Reusable mechanisms (confirmed against code)
+
+1. **The verify affordance.** `newVerifier(cfg)` + `verifier.run(ctx)`
+   (agent/verify.go) run *outside* the `MaxTurns` budget. Verify-on-breach = run
+   it once after the turn loop exhausts. Caveat: `newVerifier` returns nil when
+   `!cfg.VerifyAfterEdit` and the whole file is `//go:build !windows`.
+2. **`wait.human`** (PR2) already supports 4 labeled edges + autonomous
+   interviewers (`AutoApprove`/`Autopilot`/`Webhook`).
+3. **dippin v0.35.0:** `max_turns`/`fallback_target` first-class; `defaults:` has
+   the budget ceilings. No turn-breach attr exists. A custom attr is accepted
+   **only inside a `params:` block** — a bare `turn_breach_policy:` on an agent
+   node is a **fatal parse error** (empirically verified). Params spill into
+   `node.Attrs` via dippin_adapter.go:297-301 (only if no typed field set the key).
+
+## Design decisions (squad consensus)
 
 | # | Subtlety | Decision |
 |---|----------|----------|
-| 1 | Layering seam | Three-layer contract (below). agent produces facts; codergen turns facts into outcome + a `turn_breach_class` marker; engine routes/commits with existing machinery. |
-| 2 | Operator-node shape | **Reuse `wait.human`** (no new handler). Reached via author-wired `when ctx.turn_breach_class = operator_decision` edge. Autonomous default via existing interviewer machinery. |
-| 3 | commit-if-green vs `CommitWIP` | Green breach → `OutcomeSuccess` → existing success-path `CommitNode` commits the dirty tree as a real advance. `CommitWIP` unchanged, fail-paths only. |
-| 4 | New `.dip` attrs | `turn_breach_policy` (+ PR2's continue-cap) via `node.Attrs` Params pass-through, read through a typed accessor on `AgentNodeConfig`. Default behavior needs **no** `.dip` change. |
-| 5 | Never silent-advance | A non-green breach is `OutcomeFail` → routes to `fallback_target`/halt with WIP preserved (#302). Verify failure ≠ success. Provider errors still hard-fail (untouched). |
+| 1 | Layering seam | Three-layer contract (below). agent produces facts; codergen classifies into outcome + `turn_breach_class` marker; engine routes with existing machinery. **The decision to run verify-on-breach is policy → codergen sets a `VerifyOnBreach` flag in `SessionConfig`; the agent stays mechanism-only.** |
+| 2 | Operator-node shape | **Reuse `wait.human`** (PR2). Reached via author-wired `when ctx.turn_breach_class = operator_decision`. |
+| 3 | commit-if-green | **Classification only.** Green breach → `OutcomeSuccess` → the pipeline's success-path commit node persists the tree (build_product: #297 `CommitIfDirty`). No engine commit code. |
+| 4 | New `.dip` attrs | `turn_breach_policy` inside a **`params:` block** (the only form v0.35.0 accepts), read through a typed `AgentNodeConfig` accessor. Default (`guard`) needs **no** `.dip` change. |
+| 5 | Never silent-advance | The ONLY path to success on a breach is `BreachVerify==Passed` from an **explicit** `cfg.VerifyCommand`. `auto_status` cannot manufacture success on a breach; auto-detected-only verify → `operator_decision`. |
 | — | Default policy | **`guard` is the default.** `turn_breach_policy: fail` opts back into today's guillotine. |
-| — | Delivery | **Two PRs.** PR1 = core (this doc's focus). PR2 = operator node + warm continue+N. |
+| — | Delivery | **Two PRs.** PR1 = classification core (this doc's focus). PR2 = operator node + warm continue+N. |
 
 ## The seam — three layers
 
 ```
-agent/ (facts)                codergen (classify)              engine (route/commit)
-─────────────────             ───────────────────             ─────────────────────
-runTurnLoop exhausts          buildSuccessOutcome reads        success → emitGitCommit
-  → MaxTurnsUsed=true           MaxTurnsUsed / LoopDetected       commits dirty tree (exists)
-  → (new) verify-on-breach      / BreachVerify + policy         fail → commitWIPBeforeRouting
-  → SessionResult.BreachVerify  → Outcome.Status                  (#302) → fallback/operator
-                                + ctx.turn_breach_class
+agent/ (mechanism, native only)        codergen (policy + classify)        engine (route)
+───────────────────────────────        ────────────────────────────        ──────────────
+runTurnLoop exhausts → MaxTurnsUsed     buildConfig sets cfg.VerifyOnBreach  success → take success edge
+if cfg.VerifyOnBreach && !LoopDetected    = (policy != "fail")                 (pipeline's commit node
+  → run verify once (explicit cmd only) classifyBreach(node,sessResult,policy)  persists the tree)
+  → SessionResult.BreachVerify            → status + class                    fail → fallback_target /
+                                          buildSessionStats carries BreachVerify   strict-failure (#295),
+                                          ctx.turn_breach_class = class             WIP if git-artifacts on
 ```
 
-No logic is smeared across layers: each layer has one job and a typed contract.
+## PR1 — verify → classify (core). Go only. No `.dip` edits.
 
-## PR1 — verify → commit-if-green → classify (core)
+Scope: the **native** backend only (`agent.Session`). claude-code/acp never set
+`MaxTurnsUsed`, so they never enter the breach branch today — but PR1 adds an
+**explicit native guard** so a future change to their result-building can't
+silently misclassify (see step 2).
 
-**Go only. No `.dip` edits. dippin doctor unchanged (A grade, nothing touched).**
-Scope: the **native** backend (`agent.Session`). claude-code/acp breach handling
-is unchanged (they don't drive `agent.Session`'s turn loop); noted, not solved.
-
-### 1. agent layer — verify-on-breach (facts)
+### 1. agent layer — verify-on-breach (mechanism)
 
 - `agent/result.go`: add `BreachVerify BreachVerifyState` to `SessionResult`.
-  Tri-state: `BreachVerifyNotRun` (0, default) / `BreachVerifyPassed` /
-  `BreachVerifyFailed`. Tri-state (not `bool`) so codergen can tell "verified
-  failing" from "could not verify" — both are non-green, but the distinction is
-  useful in the trace and for #304 later.
-- `agent/session.go`: after `runTurnLoop` returns `stoppedNaturally == false`
-  (the existing `result.MaxTurnsUsed = true` site, session.go:210-212), and only
-  when **not** `LoopDetected` (pathological skips verify — we're stopping
-  regardless), run a single verify pass and record the state.
-- `agent/verify.go`: add `resolveBreachVerifyCommand(cfg)` — resolves
-  `cfg.VerifyCommand` else `detectVerifyCommand(cfg.WorkingDir)`, **independent of
-  the `VerifyAfterEdit` gate** (the point of verify-on-breach is to rescue green
-  work even when the in-loop verifier was off). No command resolvable →
-  `BreachVerifyNotRun` → treated as non-green downstream (safe; never advances).
-  Reuse `verifier{cmd,workDir}.run(ctx)`; emit the existing `EventVerify`.
+  Tri-state enum: `BreachVerifyNotRun` (0, zero value) / `BreachVerifyPassed` /
+  `BreachVerifyFailed`. (Enum, not a bool pair, so "couldn't verify" ≠ "verified
+  red"; the zero value is the safe NotRun.)
+- `agent/config.go`: add `VerifyOnBreach bool` to `SessionConfig`. The *agent*
+  reads only this flag — it never sees `turn_breach_policy`.
+- `agent/session.go`: at the `result.MaxTurnsUsed = true` site (session.go:210-212),
+  if `cfg.VerifyOnBreach && !result.LoopDetected`, run one verify pass and record
+  `BreachVerify`. Gated behind `runTurnLoop` returning `err == nil` (provider
+  errors return early — verify-on-breach must never mask them).
+- `agent/verify.go` (+ `verify_windows.go` no-op stub): add
+  `resolveBreachVerifier(cfg)` — returns a verifier **only when `cfg.VerifyCommand`
+  is explicitly set** (NOT auto-detected; decision #5). Independent of the
+  `VerifyAfterEdit` gate. Reuse `verifier.run`; emit `EventVerify`. A real
+  execution error (binary missing, bad workdir — distinct from a test failure)
+  → `BreachVerifyFailed` **and** surface the error text via `EventVerify` /
+  `ctx` (CLAUDE.md: never swallow). No explicit command → `NotRun`.
 
-### 2. codergen layer — classify (outcome + marker)
+### 2. codergen layer — policy + classify
 
-`pipeline/handlers/codergen.go` `buildSuccessOutcome`. Add a typed
-`TurnBreachPolicy` field to `AgentNodeConfig` (node_config.go) read from
-`turn_breach_policy` (default `guard`; `fail` = opt-out). Replace the flat
-"`turnLimitMsg != "" → Fail`" with:
+- `pipeline/node_config.go`: add `TurnBreachPolicy string` to `AgentNodeConfig`,
+  read from `turn_breach_policy` (graph-default then node-override; struct-literal
+  default `"guard"`). An unrecognized value warns and defaults to `guard`.
+- `pipeline/handlers/codergen.go` `buildConfig`: set
+  `config.VerifyOnBreach = (policy != "fail")` so the opt-out path pays no verify
+  cost.
+- **Extract** the classification into a helper to stay under the gocyclo/gocognit
+  ≤8 gate (`buildSuccessOutcome` is already at 8/8):
 
-```
-if turnLimitMsg != "" {                      // a breach happened
-  switch policy {
-  case "fail":                               // opt-out: today's guillotine, pinned
-      status = OutcomeFail
-      class  = "" (unset — preserve exact prior behavior)
-  default: // "guard"
-      switch {
-      case sessResult.LoopDetected:          // pathological
-          status = OutcomeFail;  class = "pathological"
-      case sessResult.BreachVerify == Passed: // green → rescue
-          status = OutcomeSuccess; class = "verified_green"
-      default:                                // steady progress, non-green
-          status = OutcomeFail;  class = "operator_decision"
-      }
+  ```
+  // classifyBreach returns (status, class). Called only when turnLimitMsg != "".
+  func classifyBreach(policy string, r agent.SessionResult, native bool) (TerminalStatus, string) {
+    if policy == "fail" || !native { return OutcomeFail, "" }   // opt-out / non-native: today's behavior
+    switch {
+    case r.LoopDetected:                  return OutcomeFail,    "pathological"
+    case r.BreachVerify == Passed:        return OutcomeSuccess, "verified_green"
+    default:                              return OutcomeFail,    "operator_decision" // Failed OR NotRun
+    }
   }
-}
-```
+  ```
 
-- `auto_status: true` still overrides (an explicit STATUS line is authoritative)
-  — applied after, exactly as today.
-- `class` is written to `ctx.turn_breach_class` (new `ContextKeyTurnBreachClass`)
-  so PR2's operator edge can route on it. Also keep setting
-  `ctx.turn_limit_msg` (unchanged).
-- Green path keeps `last_response` / `episode_summaries` updates, so the advance
-  is a normal warm success — the trace entry is `success` and carries the
-  verify result, **not** fail (AC: "trace shows verify+commit, not fail").
+- In `buildSuccessOutcome`: when `turnLimitMsg != ""`, call `classifyBreach`.
+  Write `ctx.turn_breach_class` (new `ContextKeyTurnBreachClass`) **only when
+  class != ""** (absent, not empty, on the opt-out path).
+- **auto_status (decision #5):** on a breach (`turnLimitMsg != ""`), `auto_status`
+  must NOT be able to upgrade a non-green classification to success. Apply
+  `auto_status` only on the non-breach path, or only let it *downgrade* on a
+  breach — a missing/early `STATUS:` line (which `parseAutoStatus` defaults to
+  success) cannot manufacture a breach success.
+- **applyDeclaredWrites precedence:** it can flip status → Fail *after*
+  classification. Write `turn_breach_class` only after the final status is known
+  (or clear `verified_green` if a declared-writes failure demotes to Fail) so the
+  trace is never `Fail` + `verified_green`.
+- `pipeline/handlers/transcript.go` `buildSessionStats` + `pipeline.SessionStats`:
+  carry `BreachVerify` so the trace entry actually shows the verify result
+  (AC: "trace shows verify+commit, not fail").
+- Determine `native` from the resolved backend (`selectBackend`), threaded into
+  the classify call.
 
-### 3. engine layer — nothing new for green
+### 3. engine layer — nothing new
 
-Green breach → `OutcomeSuccess` → existing `emitGitCommit`/`CommitNode` commits
-the dirty tree. Non-green/pathological → `OutcomeFail` → existing
-`commitWIPBeforeRouting` (#302) + `fallback_target`/strict-failure routing
-(#295). No engine edits in PR1 beyond what the marker needs (a context key).
+Green breach → `OutcomeSuccess` → success edge (pipeline's commit node persists).
+Non-green/pathological → `OutcomeFail` → existing `fallback_target` (#295) /
+strict-failure routing (+ `commitWIPBeforeRouting` when git-artifacts is on). The
+new `turn_breach_class` marker is advisory; routing is still governed by fail-edge
+selection — a node without an operator edge falls back to #295/halt. Context-key
+marker (not a typed `Outcome` field) is required because edge conditions can read
+only `PipelineContext` strings, never `Outcome` fields (condition.go).
 
 ### PR1 tests (TDD — each watched failing first; negative control)
 
-agent:
-- `TestSession_VerifyOnBreach_Green_RecordsPassed` — exhaust turns with a green
-  tree → `SessionResult.BreachVerify == Passed`.
-- `TestSession_VerifyOnBreach_Red_RecordsFailed`.
-- `TestSession_VerifyOnBreach_NoCommand_NotRun`.
-- `TestSession_LoopDetected_SkipsBreachVerify` — pathological never verifies.
+agent (`agent/session_test.go`, `agent/verify_test.go` patterns; mock completer +
+`MaxTurns` drives exhaustion, temp-dir shell scripts as `VerifyCommand`):
+- `TestSession_VerifyOnBreach_Green_RecordsPassed` (explicit cmd, exit 0).
+- `TestSession_VerifyOnBreach_Red_RecordsFailed` (exit 1).
+- `TestSession_VerifyOnBreach_NoExplicitCommand_NotRun` (auto-detect not used).
+- `TestSession_VerifyOnBreach_ExecError_RecordsFailedAndSurfaces`.
+- `TestSession_LoopDetected_SkipsBreachVerify` — assert via a sentinel side-effect
+  (verify writes a file; assert absent) so it fails-first once verify is added
+  without the loop guard.
+- `TestSession_VerifyOnBreach_DisabledFlag_NoRun` (`VerifyOnBreach=false`).
 
-codergen:
-- `TestCodergen_BreachGreen_AdvancesAsSuccess` — `BreachVerify=Passed` →
-  `OutcomeSuccess`, `ctx.turn_breach_class=verified_green`. *(fails today: returns fail)*
-- `TestCodergen_LoopDetected_ClassifiesPathologicalFail` — always fail, never
-  success, regardless of verify.
-- `TestCodergen_BreachNonGreen_RoutesOperatorMarker` — `OutcomeFail` +
-  `class=operator_decision`.
+codergen (`pipeline/handlers/codergen_test.go`):
+- `TestCodergen_BreachGreen_AdvancesAsSuccess` — asserts `OutcomeSuccess` **and**
+  `ctx.turn_breach_class=verified_green` (both, so dropping the marker fails).
+- `TestCodergen_LoopDetected_ClassifiesPathologicalFail` — `BreachVerify=Passed`
+  ignored; assert `class=pathological` (the marker is the fail-first signal,
+  since status is already fail today).
+- `TestCodergen_BreachNonGreen_RoutesOperatorMarker` (`Failed` → operator).
+- `TestCodergen_BreachNotRun_RoutesOperatorMarker` (tri-state `NotRun` → operator
+  — proves the `default` arm catches the zero value).
 - `TestCodergen_TurnBreachPolicyFail_PinsGuillotine` — opt-out reproduces today's
-  outcome **and** error/message byte-for-byte; no `turn_breach_class` set.
+  outcome + the **exact** `buildTurnLimitMsg` string (hard-coded golden), asserts
+  `turn_breach_class` **absent**; covers BOTH plain-exhaustion and LoopDetected.
+- `TestCodergen_BreachGreen_AutoStatusCannotForceSuccessWhenRed` — auto_status:true
+  + verify RED/NotRun + no STATUS line → stays Fail.
+- `TestCodergen_BreachGreen_DeclaredWritesDemotion_ClearsMarker`.
+- `TestCodergen_NonNativeBackend_BreachUnchanged` — claude-code/acp result → no
+  marker, today's behavior.
 
-engine (integration):
-- `TestEngine_BreachGreen_CommitsDirtyTreeAndAdvances` — drive a node to a
-  green breach; assert the artifact repo committed the file (CommitNode) and the
-  run advanced past the node, no `tracker/wip/...` ref created.
-- `TestEngine_BreachNonGreen_PreservesWIPAndRoutesFallback` — non-green breach
-  still makes a WIP ref (#302 path) and routes to `fallback_target`.
+build_product .dip-level (`pipeline/build_product_failure_routing_test.go`): the
+case-study rescue is proven at the routing level — a green breach takes the
+`Implement -> CommitIfDirty` success edge (not `-> EscalateMilestone`). (This,
+not an artifact-repo assertion, is where "green work is persisted" is verified.)
 
-Negative control: with the codergen classification reverted, the green/operator
-tests fail (node returns fail / no marker) — confirmed, then restored.
+Verification adds `make complexity` (CI-only gate) to catch the ≤8 break.
 
 ## PR2 — operator-decision node + warm continue (follow-up, separate PR)
 
-Sketch only; finalized in its own plan.
+Sketch; finalized in its own plan. Review-flagged hazards to design around:
 
-- **Operator node = `wait.human`** with labeled edges:
-  `continue` / `commit_advance` / `stop` / `abandon`. Reached via
-  `<Implement> -> <Operator> when ctx.turn_breach_class = operator_decision`.
-- **Autonomous default** = node `default_choice` + `TimeoutAction` → the issue's
-  safe default (`stop + commit-WIP + route-to-fallback`, never silent advance).
-  `--auto-approve` (deterministic first/default), `--autopilot <persona>` (LLM
-  judge), `--webhook-url` (external callback) all flow through the existing
-  interviewer machinery — no parallel path.
-- **`continue +N` = warm resume.** `continue` edge routes back to the codergen
-  node; on re-entry it bumps `MaxTurns` by N and carries `PriorEpisodeSummaries`
-  (already populated via `applyEpisodeContextUpdates` →
-  `ContextKeyEpisodeSummaries` → `injectPriorEpisodes`). Bounded by a **cap**
-  (turn cap and/or cost ceiling) enforced with a per-node circuit breaker — a
-  disk counter à la build_product's `fix_attempts` (CLAUDE.md: the checkpoint
-  restart counter is global and unsafe for this).
-- **`.dip` attrs:** the continue-cap (+ operator-node shape) ride via Params
-  pass-through; `dippin validate` confirmed first. If rejected → request a
-  dippin-lang grammar change (never `go install`).
-- **build_product wiring + dippin doctor/simulate** re-run to A grade and
-  100% terminate-success once the operator node is added.
+- **Operator node = `wait.human`, freeform mode**, labeled edges
+  `continue` / `commit_advance` / `stop` / `abandon`, reached via
+  `when ctx.turn_breach_class = operator_decision` (ordered before the
+  unconditional `-> EscalateMilestone` fallback; narrow `= operator_decision` so
+  `pathological` still falls through to the catch-all).
+- **Autonomous default — footgun:** freeform mode reads the `default` attr (NOT
+  `default_choice`). Must pin `default: stop`, and order `stop`/`abandon` before
+  `continue` so a missing-default regression fails safe. `AutoApprove`/`Webhook`
+  resolve to the default; **`--autopilot lax`/`mentor` bias to "forward progress"
+  and are not deterministically safe** — document, and frame the prompt so
+  "continue" is the risky option.
+- **Warm `continue +N` needs NEW plumbing:** `MaxTurns` is read statically;
+  nothing reads context. PR2 must add a context/disk-driven `MaxTurns` override in
+  `buildConfig`. `PriorEpisodeSummaries` already carry across (warm) for free.
+- **Cap circuit-breaker** in a tool node that gates the operator's `continue`
+  edge (mirror build_product `fix_attempts`), since the global `RestartCount`
+  (engine) is shared across all loops and unsuitable. `BudgetGuard` covers only a
+  global cost backstop, not a per-loop ceiling.
+- **`commitWIPBeforeRouting` bypass:** it runs only inside `checkStrictFailure`,
+  which early-returns when a node has conditional edges — so adding the operator
+  conditional edge means the fail→operator route skips WIP. (Moot while
+  git-artifacts is off, but real if enabled.) Address in PR2.
+- **dippin:** the continue attr/cap rides in a `params:` block. New cycle +
+  4-way gate expands `dippin simulate -all-paths`; every operator edge must be
+  labeled and reach a terminal (DIP005). Re-run doctor/simulate to A / 100%.
+- **UX:** rely on the standard `last_response` append (`\n\n---\n`) so the gate
+  routes through `ReviewHybridContent` (fullscreen glamour) — don't inline the
+  long message into the node `label`.
+- **Windows:** breach-verify entry point guarded by a `_windows.go` stub.
 
-## Out of scope (do not touch)
+## Review corrections (what changed from the first draft)
 
-#304 (cost + no-progress detector — PR1 may *consume* a no-progress signal later
-but works without it; `LoopDetected` suffices for pathological), #298, #299,
+1. commit-if-green is classification-only; the engine does not (and by default
+   cannot) persist the product tree — the pipeline's commit-on-success node does.
+2. Verify-on-breach decision moved out of `agent/` via `SessionConfig.VerifyOnBreach`.
+3. Strict green bar: explicit `VerifyCommand` required; `auto_status` can't force
+   breach success; auto-detected-only → operator.
+4. Explicit native guard in `classifyBreach`.
+5. `classifyBreach` helper extraction to satisfy the ≤8 complexity gate (CI-only).
+6. `turn_breach_policy` must live in a `params:` block (bare = fatal parse error).
+7. `BreachVerify` added to `buildSessionStats` so the trace shows it.
+8. Opt-out pin hard-codes the golden message + asserts marker absent + covers loop.
+9. Verify execution-error handling defined (→ Failed + surfaced).
+10. PR2 footguns documented (auto-approve default attr, MaxTurns plumbing,
+    RestartCount, WIP-bypass-on-conditional-edge, simulate cycle, Windows).
+
+## Out of scope
+
+#304 (cost + no-progress detector — the `classifyBreach` switch leaves a clean
+extension point; `LoopDetected` suffices for pathological now), #298, #299,
 #300/#301, #305, #306, #313.
 
 ## Verification (both PRs)
 
 `go build ./...` · `GOOS=darwin GOARCH=arm64 go build ./...` ·
 `go test ./... -short` · `go test -race -short ./pipeline/ ./agent/` ·
-`dippin doctor examples/build_product.dip examples/ask_and_execute.dip
-examples/build_product_with_superspec.dip` (A grade; PR1 touches no `.dip`).
+**`make complexity`** (the ≤8 gate that the pre-commit hook skips) ·
+`dippin doctor` on the three core pipelines (A grade; PR1 touches no `.dip`).
 CHANGELOG under [Unreleased]: graduated turn-limit guard
-(verify → commit-if-green → classify → operator decision) + `turn_breach_policy`
-opt-out; builds on #302/#295; completes the Phase-1 turn-limit track.
+(verify → classify → operator decision) + `turn_breach_policy` opt-out; builds on
+#302/#295/#297; completes the Phase-1 turn-limit track.

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -202,6 +202,25 @@ func TestBuildProductCommitIfDirtyCheckpoint(t *testing.T) {
 	}
 }
 
+// TestBuildProductIssue303GreenBreachRescuePath pins the #303 case-study rescue
+// at the routing level (NOT the engine artifact repo, which is off by default
+// and commits a different dir). With the graduated guard, a turn-limit breach
+// whose tree verifies green returns OutcomeSuccess, so Implement takes its
+// `ctx.outcome = success` edge to CommitIfDirty — which commits the product
+// working tree (#297) — instead of the failure edge to EscalateMilestone.
+// That is exactly how the code-goblin run 7b6e08c9e2b2 (green at turn 48 but
+// uncommitted) would now be saved. This test guards against a future .dip edit
+// that reroutes the success edge and silently breaks the rescue.
+func TestBuildProductIssue303GreenBreachRescuePath(t *testing.T) {
+	g := loadBuildProduct(t)
+	if !hasEdgeWithCondition(g, "Implement", "CommitIfDirty", "ctx.outcome = success") {
+		t.Error("Implement success edge no longer reaches CommitIfDirty — #303 green-breach work would not be persisted")
+	}
+	if !hasEdgeTo(g, "CommitIfDirty", "TestMilestone") {
+		t.Error("CommitIfDirty must continue to TestMilestone so a rescued green breach advances")
+	}
+}
+
 // hasEdgeTo reports whether the node has any outgoing edge to the given target.
 func hasEdgeTo(g *Graph, from, to string) bool {
 	for _, e := range g.OutgoingEdges(from) {

--- a/pipeline/context.go
+++ b/pipeline/context.go
@@ -54,6 +54,18 @@ const (
 	// from turn-limit exhaustion; absent on normal success.
 	ContextKeyTurnLimitMsg = "turn_limit_msg"
 
+	// ContextKeyTurnBreachClass classifies a turn-limit breach under the guard
+	// policy (#303). Set by the codergen handler on a breach; read by pipeline
+	// edge conditions (e.g. `when ctx.turn_breach_class = operator_decision`).
+	// Absent on normal success and on the turn_breach_policy: fail opt-out path
+	// (which reproduces today's guillotine exactly).
+	ContextKeyTurnBreachClass = "turn_breach_class"
+
+	// Turn-breach classification values (#303).
+	TurnBreachClassPathological     = "pathological"      // loop / no-progress → stop
+	TurnBreachClassVerifiedGreen    = "verified_green"    // breach verify passed → advance as success
+	TurnBreachClassOperatorDecision = "operator_decision" // steady progress, non-green → operator/fallback
+
 	// ContextKeyEpisodeSummary stores the most recent codergen session's episode
 	// summary (tool attempts + outcomes).
 	ContextKeyEpisodeSummary = "episode_summary"

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -75,6 +75,11 @@ func (h *CodergenHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	if backendErr != nil {
 		return pipeline.Outcome{}, fmt.Errorf("node %q: %w", node.ID, backendErr)
 	}
+	// #303: turn-breach guard applies only to the native backend (claude-code /
+	// acp don't drive agent.Session's turn loop and never set MaxTurnsUsed/
+	// BreachVerify). Make that an explicit guard, not an accident of field
+	// population. Mirrors trackExternalBackendUsage's type switch.
+	_, native := backend.(*NativeBackend)
 	// writable_paths gate (#272 G2) at the dispatcher layer. NativeBackend.Run
 	// also runs configureJail with the same gate, but only the native path
 	// reaches it — buildRunConfig switches Extra to ClaudeCodeConfig / ACPConfig
@@ -106,7 +111,7 @@ func (h *CodergenHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	if runErr != nil {
 		return h.handleRunError(runErr, node, prompt, artifactRoot, sessResult, &collector, priorEpisodes)
 	}
-	return h.buildOutcome(node, prompt, artifactRoot, sessResult, &collector, priorEpisodes)
+	return h.buildOutcome(node, prompt, artifactRoot, sessResult, &collector, priorEpisodes, native)
 }
 
 // trackExternalBackendUsage reports token usage for backends that bypass the LLM middleware.
@@ -479,7 +484,7 @@ func (h *CodergenHandler) handleRunError(runErr error, node *pipeline.Node, prom
 // through failure edges when present, stops on strict-failure-edge otherwise),
 // OutcomeFail/OutcomeRetry for empty sessions, or OutcomeSuccess for normal
 // completion. auto_status can override any of these.
-func (h *CodergenHandler) buildOutcome(node *pipeline.Node, prompt, artifactRoot string, sessResult agent.SessionResult, collector *transcriptCollector, priorEpisodes []string) (pipeline.Outcome, error) {
+func (h *CodergenHandler) buildOutcome(node *pipeline.Node, prompt, artifactRoot string, sessResult agent.SessionResult, collector *transcriptCollector, priorEpisodes []string, native bool) (pipeline.Outcome, error) {
 	responseText := collector.text()
 	responseArtifact := collector.transcript()
 	if responseArtifact == "" {
@@ -491,7 +496,7 @@ func (h *CodergenHandler) buildOutcome(node *pipeline.Node, prompt, artifactRoot
 		return outcome, err
 	}
 
-	return h.buildSuccessOutcome(node, prompt, artifactRoot, responseText, responseArtifact, sessResult, priorEpisodes)
+	return h.buildSuccessOutcome(node, prompt, artifactRoot, responseText, responseArtifact, sessResult, priorEpisodes, native)
 }
 
 // buildEmptyResponseOutcome handles the two empty-response cases and returns
@@ -540,7 +545,7 @@ func emptyResponseStatusMsg(nodeID string, emptyAPIResponse bool) (pipeline.Term
 
 // buildSuccessOutcome handles the normal (non-empty) completion path, including
 // turn-limit exhaustion and auto_status overrides.
-func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artifactRoot, responseText, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string) (pipeline.Outcome, error) {
+func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artifactRoot, responseText, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string, native bool) (pipeline.Outcome, error) {
 	// Determine status. Turn-limit exhaustion and loop detection default to
 	// OutcomeFail so the engine routes through explicit failure edges (e.g.
 	// "when ctx.outcome = fail"). On nodes without failure edges, the
@@ -549,15 +554,7 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 	//
 	// auto_status overrides the default for both turn-exhaustion and normal
 	// completion: the agent's explicit STATUS line is authoritative.
-	status := pipeline.OutcomeSuccess
-	turnLimitMsg := buildTurnLimitMsg(node, sessResult)
-	if turnLimitMsg != "" {
-		status = pipeline.OutcomeFail
-	}
-
-	if node.Attrs["auto_status"] == "true" {
-		status = parseAutoStatus(responseText)
-	}
+	status, turnLimitMsg, breachClass := h.resolveTerminalStatus(node, responseText, sessResult, native)
 
 	outcome := pipeline.Outcome{
 		Status: string(status),
@@ -571,6 +568,7 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 	if applyDeclaredWrites(node, outcome.ContextUpdates, responseText, "Response JSON") {
 		outcome.Status = string(pipeline.OutcomeFail)
 	}
+	applyBreachMarker(outcome.ContextUpdates, outcome.Status, breachClass)
 	if turnLimitMsg != "" {
 		outcome.ContextUpdates[pipeline.ContextKeyTurnLimitMsg] = turnLimitMsg
 	}
@@ -621,6 +619,62 @@ func buildTurnLimitMsg(node *pipeline.Node, sessResult agent.SessionResult) stri
 		return fmt.Sprintf("node %q: agent entered tool call loop (detected after %d turns)", node.ID, sessResult.Turns)
 	}
 	return fmt.Sprintf("node %q: agent exhausted turn limit (%d turns) without completing", node.ID, sessResult.Turns)
+}
+
+// resolveTerminalStatus determines the node's terminal status, the turn-limit
+// message, and the #303 breach class. On a breach it classifies via the
+// turn_breach_policy; auto_status (an explicit STATUS line) is authoritative on
+// NORMAL completion only — it must NOT manufacture success on a breach, since a
+// missing/early STATUS line defaults parseAutoStatus to success and would
+// silently advance unverified work (#303 decision #5).
+func (h *CodergenHandler) resolveTerminalStatus(node *pipeline.Node, responseText string, sessResult agent.SessionResult, native bool) (pipeline.TerminalStatus, string, string) {
+	status := pipeline.OutcomeSuccess
+	turnLimitMsg := buildTurnLimitMsg(node, sessResult)
+	var breachClass string
+	if turnLimitMsg != "" {
+		policy := node.AgentConfig(h.graphAttrs).TurnBreachPolicy
+		status, breachClass = classifyBreach(policy, sessResult, native)
+	}
+	if node.Attrs["auto_status"] == "true" && turnLimitMsg == "" {
+		status = parseAutoStatus(responseText)
+	}
+	return status, turnLimitMsg, breachClass
+}
+
+// applyBreachMarker writes the #303 turn_breach_class to the context updates,
+// using the FINAL status. It never leaves a verified_green marker on a Fail (a
+// declared-writes failure can demote a green breach to fail). No-op when
+// breachClass is empty (opt-out / non-native / non-breach).
+func applyBreachMarker(updates map[string]string, status, breachClass string) {
+	if breachClass == "" {
+		return
+	}
+	if status == string(pipeline.OutcomeFail) && breachClass == pipeline.TurnBreachClassVerifiedGreen {
+		breachClass = pipeline.TurnBreachClassOperatorDecision
+	}
+	updates[pipeline.ContextKeyTurnBreachClass] = breachClass
+}
+
+// classifyBreach maps a turn-limit breach to (status, turn_breach_class) under
+// the turn_breach_policy (#303). Called only when buildTurnLimitMsg != "".
+//   - policy "fail" or non-native backend → today's guillotine (fail, no marker).
+//   - LoopDetected → pathological (fail).
+//   - BreachVerifyPassed → verified-green (success; the pipeline's success edge
+//     persists the tree, e.g. build_product's CommitIfDirty).
+//   - everything else (Failed / NotRun) → operator_decision (fail; routes to
+//     fallback / an operator gate). Never silently advances.
+func classifyBreach(policy string, r agent.SessionResult, native bool) (pipeline.TerminalStatus, string) {
+	if policy == "fail" || !native {
+		return pipeline.OutcomeFail, ""
+	}
+	switch {
+	case r.LoopDetected:
+		return pipeline.OutcomeFail, pipeline.TurnBreachClassPathological
+	case r.BreachVerify == agent.BreachVerifyPassed:
+		return pipeline.OutcomeSuccess, pipeline.TurnBreachClassVerifiedGreen
+	default:
+		return pipeline.OutcomeFail, pipeline.TurnBreachClassOperatorDecision
+	}
 }
 
 // buildConfig constructs a SessionConfig from the node's attributes, using
@@ -697,6 +751,8 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	if cfg.MaxVerifyRetries > 0 {
 		config.MaxVerifyRetries = cfg.MaxVerifyRetries
 	}
+	// #303: run verify-on-breach unless the node opted into the guillotine.
+	config.VerifyOnBreach = cfg.TurnBreachPolicy != "fail"
 	if cfg.PlanBeforeExecuteSet {
 		config.PlanBeforeExecute = cfg.PlanBeforeExecute
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -546,14 +546,11 @@ func emptyResponseStatusMsg(nodeID string, emptyAPIResponse bool) (pipeline.Term
 // buildSuccessOutcome handles the normal (non-empty) completion path, including
 // turn-limit exhaustion and auto_status overrides.
 func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artifactRoot, responseText, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string, native bool) (pipeline.Outcome, error) {
-	// Determine status. Turn-limit exhaustion and loop detection default to
-	// OutcomeFail so the engine routes through explicit failure edges (e.g.
-	// "when ctx.outcome = fail"). On nodes without failure edges, the
-	// strict-failure-edge rule stops the pipeline — which is correct: if the
-	// pipeline author didn't handle agent failure, silently continuing is worse.
-	//
-	// auto_status overrides the default for both turn-exhaustion and normal
-	// completion: the agent's explicit STATUS line is authoritative.
+	// Determine status, the turn-limit message, and the #303 breach class.
+	// A turn-limit breach is classified (verify-green→success, loop→fail,
+	// else→operator) rather than unconditionally failed; auto_status is honored
+	// only on normal completion, never to rescue a breach. See
+	// resolveTerminalStatus / classifyBreach.
 	status, turnLimitMsg, breachClass := h.resolveTerminalStatus(node, responseText, sessResult, native)
 
 	outcome := pipeline.Outcome{

--- a/pipeline/handlers/codergen_breach_test.go
+++ b/pipeline/handlers/codergen_breach_test.go
@@ -1,0 +1,172 @@
+// ABOUTME: Tests for #303 turn-limit breach classification in the codergen handler.
+// ABOUTME: Covers classifyBreach unit cases + end-to-end Execute breach outcomes.
+package handlers
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestClassifyBreach_VerifiedGreenAdvancesAsSuccess(t *testing.T) {
+	status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeSuccess {
+		t.Errorf("status = %q, want success", status)
+	}
+	if class != pipeline.TurnBreachClassVerifiedGreen {
+		t.Errorf("class = %q, want %q", class, pipeline.TurnBreachClassVerifiedGreen)
+	}
+}
+
+func TestClassifyBreach_LoopDetectedAlwaysPathological(t *testing.T) {
+	// Even a green verify cannot rescue a detected loop.
+	status, class := classifyBreach("guard", agent.SessionResult{LoopDetected: true, BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeFail {
+		t.Errorf("status = %q, want fail", status)
+	}
+	if class != pipeline.TurnBreachClassPathological {
+		t.Errorf("class = %q, want %q", class, pipeline.TurnBreachClassPathological)
+	}
+}
+
+func TestClassifyBreach_RedAndNotRunRouteToOperator(t *testing.T) {
+	for _, bv := range []agent.BreachVerifyState{agent.BreachVerifyFailed, agent.BreachVerifyNotRun} {
+		status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: bv}, true)
+		if status != pipeline.OutcomeFail || class != pipeline.TurnBreachClassOperatorDecision {
+			t.Errorf("bv=%v: got (%q,%q), want (fail,operator_decision)", bv, status, class)
+		}
+	}
+}
+
+func TestClassifyBreach_FailPolicyIsGuillotine(t *testing.T) {
+	status, class := classifyBreach("fail", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, true)
+	if status != pipeline.OutcomeFail {
+		t.Errorf("opt-out status = %q, want fail", status)
+	}
+	if class != "" {
+		t.Errorf("opt-out class = %q, want empty (no marker)", class)
+	}
+}
+
+func TestClassifyBreach_NonNativeIsGuillotine(t *testing.T) {
+	status, class := classifyBreach("guard", agent.SessionResult{BreachVerify: agent.BreachVerifyPassed}, false)
+	if status != pipeline.OutcomeFail || class != "" {
+		t.Errorf("non-native got (%q,%q), want (fail, \"\")", status, class)
+	}
+}
+
+func writeFile755(path, body string) error {
+	return os.WriteFile(path, []byte(body), 0o755)
+}
+
+func TestExecute_BreachGreen_AdvancesAsSuccessWithMarker(t *testing.T) {
+	workdir := t.TempDir()
+	pass := workdir + "/pass.sh"
+	if err := writeFile755(pass, "#!/bin/sh\nexit 0\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":         "build it",
+			"max_turns":      "3",
+			"verify_command": pass,
+			// turn_breach_policy defaults to "guard"
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("status = %q, want success (verified-green breach)", out.Status)
+	}
+	if out.ContextUpdates[pipeline.ContextKeyTurnBreachClass] != pipeline.TurnBreachClassVerifiedGreen {
+		t.Errorf("turn_breach_class = %q, want verified_green", out.ContextUpdates[pipeline.ContextKeyTurnBreachClass])
+	}
+}
+
+func TestExecute_BreachRed_FailsWithOperatorMarker(t *testing.T) {
+	workdir := t.TempDir()
+	fail := workdir + "/fail.sh"
+	if err := writeFile755(fail, "#!/bin/sh\nexit 1\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "build it", "max_turns": "3", "verify_command": fail},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("status = %q, want fail", out.Status)
+	}
+	if out.ContextUpdates[pipeline.ContextKeyTurnBreachClass] != pipeline.TurnBreachClassOperatorDecision {
+		t.Errorf("turn_breach_class = %q, want operator_decision", out.ContextUpdates[pipeline.ContextKeyTurnBreachClass])
+	}
+}
+
+func TestExecute_TurnBreachPolicyFail_PinsGuillotine(t *testing.T) {
+	workdir := t.TempDir()
+	pass := workdir + "/pass.sh"
+	if err := writeFile755(pass, "#!/bin/sh\nexit 0\n"); err != nil {
+		t.Fatal(err)
+	}
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt": "build it", "max_turns": "3",
+			"verify_command":     pass,
+			"turn_breach_policy": "fail", // opt-out
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	// Byte-for-byte today's behavior: fail + exact message, NO marker.
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("opt-out status = %q, want fail", out.Status)
+	}
+	wantMsg := `node "Implement": agent exhausted turn limit (3 turns) without completing`
+	if got := out.ContextUpdates[pipeline.ContextKeyTurnLimitMsg]; got != wantMsg {
+		t.Errorf("turn_limit_msg = %q, want %q", got, wantMsg)
+	}
+	if _, present := out.ContextUpdates[pipeline.ContextKeyTurnBreachClass]; present {
+		t.Error("opt-out must NOT set turn_breach_class")
+	}
+}
+
+func TestExecute_BreachRed_AutoStatusCannotForceSuccess(t *testing.T) {
+	workdir := t.TempDir()
+	fail := workdir + "/fail.sh"
+	if err := writeFile755(fail, "#!/bin/sh\nexit 1\n"); err != nil {
+		t.Fatal(err)
+	}
+	// alwaysToolCallCompleter emits no STATUS line → parseAutoStatus would
+	// default to success. The breach guard must prevent that.
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt": "build it", "max_turns": "3",
+			"verify_command": fail,
+			"auto_status":    "true",
+		},
+	}
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("status = %q, want fail (auto_status must not rescue a red breach)", out.Status)
+	}
+}

--- a/pipeline/handlers/codergen_test.go
+++ b/pipeline/handlers/codergen_test.go
@@ -1059,10 +1059,14 @@ func TestCodergenHandlerMaxTurnsExhaustedIsFail(t *testing.T) {
 	// This test exercises the failure path; the success test below verifies absence.
 }
 
-func TestCodergenHandlerMaxTurnsWithAutoStatusSuccess(t *testing.T) {
-	// When auto_status is true and the agent explicitly emitted STATUS:success
-	// before hitting the turn limit, the outcome should be success. The
-	// turn_limit_msg is still set (for diagnostics) but status is overridden.
+func TestCodergenHandlerMaxTurnsWithAutoStatus_BreachIgnoresAutoStatus(t *testing.T) {
+	// #303: auto_status MUST NOT manufacture success on a turn-limit breach.
+	// Here the agent emits STATUS:success but then keeps making tool calls and
+	// exhausts its turn budget — a stale/unreliable success claim. Under the
+	// graduated guard (default policy) with no explicit verify_command, the
+	// breach verify is NotRun, so the breach classifies to operator_decision
+	// and the outcome is FAIL — never a silent advance past unverified work.
+	// (Previously auto_status overrode this to success; that hole is closed.)
 	workdir := t.TempDir()
 
 	// Both responses include tool calls, so with max_turns=2 the agent
@@ -1111,15 +1115,20 @@ func TestCodergenHandlerMaxTurnsWithAutoStatusSuccess(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if outcome.Status != string(pipeline.OutcomeSuccess) {
-		t.Errorf("expected outcome %q when auto_status emits success despite turn limit, got %q",
-			pipeline.OutcomeSuccess, outcome.Status)
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("expected outcome %q (auto_status must not rescue a breach), got %q",
+			pipeline.OutcomeFail, outcome.Status)
 	}
 
-	// turn_limit_msg is still set (MaxTurnsUsed was true) even though
-	// auto_status overrode the status to success. Diagnostics are preserved.
+	// The breach is classified for routing: no explicit verify command → NotRun
+	// → operator_decision (steady progress, non-green).
+	if got := outcome.ContextUpdates[pipeline.ContextKeyTurnBreachClass]; got != pipeline.TurnBreachClassOperatorDecision {
+		t.Errorf("turn_breach_class = %q, want operator_decision", got)
+	}
+
+	// turn_limit_msg is still set (MaxTurnsUsed was true) for diagnostics.
 	if outcome.ContextUpdates[pipeline.ContextKeyTurnLimitMsg] == "" {
-		t.Error("expected turn_limit_msg to be set for diagnostics even on auto_status success")
+		t.Error("expected turn_limit_msg to be set for diagnostics on a breach")
 	}
 }
 

--- a/pipeline/handlers/transcript.go
+++ b/pipeline/handlers/transcript.go
@@ -110,6 +110,7 @@ func buildSessionStats(r agent.SessionResult) *pipeline.SessionStats {
 		Provider:         r.Provider,
 		Estimated:        estimated,
 		EstimateSource:   source,
+		BreachVerify:     int(r.BreachVerify),
 	}
 }
 

--- a/pipeline/handlers/transcript_test.go
+++ b/pipeline/handlers/transcript_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
+func TestBuildSessionStats_CarriesBreachVerify(t *testing.T) {
+	stats := buildSessionStats(agent.SessionResult{BreachVerify: agent.BreachVerifyPassed})
+	if stats.BreachVerify != int(agent.BreachVerifyPassed) {
+		t.Errorf("SessionStats.BreachVerify = %d, want %d", stats.BreachVerify, int(agent.BreachVerifyPassed))
+	}
+}
+
 func floatNear(a, b, epsilon float64) bool {
 	diff := a - b
 	if diff < 0 {

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -53,12 +53,13 @@ type AgentNodeConfig struct {
 	PlanBeforeExecute    bool
 	PlanBeforeExecuteSet bool
 
-	Model           string
-	Provider        string
-	SystemPrompt    string
-	MaxTurns        int
-	CommandTimeout  time.Duration
-	ReasoningEffort string
+	Model            string
+	Provider         string
+	SystemPrompt     string
+	MaxTurns         int
+	TurnBreachPolicy string // #303: "guard" (default) or "fail" (opt-out)
+	CommandTimeout   time.Duration
+	ReasoningEffort  string
 
 	ResponseFormat string
 	ResponseSchema string
@@ -104,6 +105,8 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 		// consumers that copy cfg.ReflectOnError directly don't accidentally
 		// disable reflection on untouched nodes.
 		ReflectOnError: true,
+		// #303: graduated guard is the default; turn_breach_policy: fail opts out.
+		TurnBreachPolicy: "guard",
 	}
 	// Non-overridable (node-only) simple strings.
 	cfg.Backend = n.Attrs["backend"]
@@ -127,6 +130,14 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {
 			cfg.MaxTurns = i
 		}
+	}
+	// #303 turn_breach_policy: graph default then node override. Arrives via a
+	// dippin params: block, spilled into n.Attrs by the adapter.
+	if v, ok := graphAttrs["turn_breach_policy"]; ok && v != "" {
+		cfg.TurnBreachPolicy = v
+	}
+	if v, ok := n.Attrs["turn_breach_policy"]; ok && v != "" {
+		cfg.TurnBreachPolicy = v
 	}
 	if v := n.Attrs["command_timeout"]; v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {

--- a/pipeline/node_config_test.go
+++ b/pipeline/node_config_test.go
@@ -8,6 +8,24 @@ import (
 	"time"
 )
 
+func TestAgentConfig_TurnBreachPolicy(t *testing.T) {
+	// Default when unset.
+	n := &Node{Attrs: map[string]string{}}
+	if got := n.AgentConfig(nil).TurnBreachPolicy; got != "guard" {
+		t.Errorf("default TurnBreachPolicy = %q, want %q", got, "guard")
+	}
+	// Node override.
+	n2 := &Node{Attrs: map[string]string{"turn_breach_policy": "fail"}}
+	if got := n2.AgentConfig(nil).TurnBreachPolicy; got != "fail" {
+		t.Errorf("TurnBreachPolicy = %q, want %q", got, "fail")
+	}
+	// Graph default, node-overridable.
+	n3 := &Node{Attrs: map[string]string{}}
+	if got := n3.AgentConfig(map[string]string{"turn_breach_policy": "fail"}).TurnBreachPolicy; got != "fail" {
+		t.Errorf("graph TurnBreachPolicy = %q, want %q", got, "fail")
+	}
+}
+
 func TestAgentConfig_EmptyNode(t *testing.T) {
 	n := &Node{Attrs: map[string]string{}}
 	cfg := n.AgentConfig(nil)

--- a/pipeline/trace.go
+++ b/pipeline/trace.go
@@ -38,6 +38,10 @@ type SessionStats struct {
 	// buildSessionStats from llm.Usage.Raw.
 	Estimated      bool   `json:"estimated,omitempty"`
 	EstimateSource string `json:"estimate_source,omitempty"`
+	// BreachVerify is the verify-on-breach result (#303): 0=not-run, 1=passed,
+	// 2=failed. Mirrors agent.BreachVerifyState as an int so the trace JSON is
+	// self-contained. Non-zero only on a turn-limit breach under guard policy.
+	BreachVerify int `json:"breach_verify,omitempty"`
 }
 
 // TraceEntry records the execution of a single pipeline node.


### PR DESCRIPTION
## Summary

**PR1 of 2** for #303 (Phase-1 turn-limit track; builds on merged #302/#295/#297). Refs epic #308.

Turn-limit exhaustion no longer maps unconditionally to `OutcomeFail`. On a **native-backend** breach the engine now runs a verify pass and *classifies* the breach instead of guillotining it:

- **verified-green** → `OutcomeSuccess`, advancing through the pipeline's own commit-on-success node (build_product's `CommitIfDirty`, #297). This alone would have saved `code-goblin` run `7b6e08c9e2b2` (green at turn 48 but discarded).
- **LoopDetected** → pathological, `OutcomeFail` (stops, as today).
- **anything else** (verify red / not-run) → `OutcomeFail` + `ctx.turn_breach_class = operator_decision` for routing.
- `turn_breach_policy: fail` (declare under a `params:` block) opts back into today's guillotine, byte-for-byte.

PR2 will add the operator-decision `wait.human` node + warm `continue +N` and will close #303.

## The design was panel-reviewed first

A 6-expert panel reviewed the design before any code. It corrected the original premise and caught five real bugs the first draft would have shipped — all absorbed here:

1. **commit-if-green is classification-only.** The engine's git machinery is **off by default** (`WithGitArtifacts` is never wired in the CLI) and, even when on, commits the *artifact* dir — not the agent's working tree. So persistence is the pipeline's job (build_product's `CommitIfDirty`); PR1 adds **zero** engine commit code. Verified at the routing level (`TestBuildProductIssue303GreenBreachRescuePath`), not via the artifact repo.
2. **`auto_status` can no longer manufacture a breach success.** `parseAutoStatus` defaults to success on a missing `STATUS:` line (the normal outcome of running out of turns); applying it on a breach defeated the "never silent-advance" invariant. It's now honored only on normal completion. (Updated `TestCodergenHandlerMaxTurnsWithAutoStatus_BreachIgnoresAutoStatus` to pin the new safe contract.)
3. **The verify-on-breach *decision* lives in codergen, not the agent.** codergen sets `SessionConfig.VerifyOnBreach = (policy != "fail")`; the agent is mechanism-only, so the opt-out path pays no verify cost.
4. **Native-only is an explicit guard**, not an accident of which backend populates `MaxTurnsUsed`.
5. **Strict green bar:** only an author-specified `verify_command` can grant a breach success (no auto-detection), so a coarse/empty suite can't silently advance incomplete work.

## Layering

- **agent/** (mechanism): `SessionResult.BreachVerify` tri-state; `resolveBreachVerifier` (explicit command only); one verify pass at exhaustion when `VerifyOnBreach && !LoopDetected`, gated behind `err==nil` so provider errors are never masked.
- **codergen** (policy): `AgentNodeConfig.TurnBreachPolicy`; `classifyBreach(policy, result, native)`; `resolveTerminalStatus`/`applyBreachMarker` helpers keep `buildSuccessOutcome` ≤8.
- **engine**: unchanged — green takes the success edge, non-green the fail edge (`fallback_target`/strict-failure, #295/#302). The `turn_breach_class` marker is a context key (edge conditions can't read `Outcome` fields).

## Tests (TDD, negative-control)

Agent: green/red/no-command/disabled/loop-skips-verify. codergen: `classifyBreach` matrix (green→success, loop→pathological, red+not-run→operator, fail-policy & non-native→guillotine), Execute-level green/red/opt-out-pin/auto_status-can't-rescue. Trace carries `BreachVerify`. build_product rescue-path routing pin.

## Verification

- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓ · `go test -race -short ./pipeline/ ./agent/` ✓ · `make vet` ✓ · `make lint` ✓
- `dippin doctor` — build_product A 90, ask_and_execute A 95, build_product_with_superspec A 100 (unchanged; no `.dip` touched)
- New helpers verified ≤8 gocyclo/gocognit; `buildSuccessOutcome` kept ≤8 via extraction.

## Out of scope (PR2 / other issues)

Operator-decision node + warm continue+N (PR2, closes #303); #304 cost/no-progress detector; #298–#306/#313.

Design + plan: `docs/superpowers/specs/2026-06-05-issue-303-turn-limit-guard-design.md`, `docs/superpowers/plans/2026-06-05-issue-303-pr1-turn-limit-guard.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783273591&installation_id=131176874&pr_number=317&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F317&signature=5b04f09f95991d258dbea0bda9312eebf60eaab271e3ac5491c0615d8a5d6a31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Turn-limit guard: native backends now verify work upon turn exhaustion and classify outcomes for operator review instead of immediate failure
  * New `turn_breach_policy` configuration option (default: "guard"; set to "fail" to restore previous behavior)
  * Session traces now record verification-on-breach results for diagnostics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->