### PR TITLE
feat(build_product): language-native quality gate fallback when no Makefile (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shipped with no linter ever running), `run_project_ci_gate` now falls through to
   language-native gates for **every** detected toolchain (polyglot, not
   first-match): Go `go vet ./...` (+ `golangci-lint` if present), JS/TS `tsc
-  --noEmit`/`eslint`, Python `ruff`/`mypy`, Rust `cargo fmt --check`/`cargo clippy`.
-  Optional linters absent → one-line INFO skip (never an error); a present gate
-  that fails routes to the fix loop. The `0`/`2`/`N` return contract is preserved —
+  --noEmit`/`eslint` (each gated on the project's opt-in config — `tsconfig.json`
+  / an eslint config — so a plain-JS repo with a global `tsc`/`eslint` on PATH is
+  not spuriously failed), Python `ruff`/`mypy`, Rust `cargo fmt --check`/`cargo
+  clippy`. Optional linters absent or not configured → one-line INFO skip (never
+  an error); a present, configured gate that fails routes to the fix loop. The `0`/`2`/`N` return contract is preserved —
   `rc=2` stays reserved for the Makefile-present-but-`make`-missing escalation;
   language-gate failures collapse to `rc=1`. **Behavior change:** no-Makefile Go
   repos now enforce `go vet` on every milestone (previously green on tests alone).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **build_product: language-native quality gate fallback** (closes #299, refs
+  epic #308 Phase 2 — first item). Closes the no-Makefile blind spot: when a repo
+  has no Makefile `ci`/`check`/`lint` target (the `code-goblin` failure mode —
+  shipped with no linter ever running), `run_project_ci_gate` now falls through to
+  language-native gates for **every** detected toolchain (polyglot, not
+  first-match): Go `go vet ./...` (+ `golangci-lint` if present), JS/TS `tsc
+  --noEmit`/`eslint`, Python `ruff`/`mypy`, Rust `cargo fmt --check`/`cargo clippy`.
+  Optional linters absent → one-line INFO skip (never an error); a present gate
+  that fails routes to the fix loop. The `0`/`2`/`N` return contract is preserved —
+  `rc=2` stays reserved for the Makefile-present-but-`make`-missing escalation;
+  language-gate failures collapse to `rc=1`. **Behavior change:** no-Makefile Go
+  repos now enforce `go vet` on every milestone (previously green on tests alone).
+  Both `TestMilestone` and `FinalBuild` inherit it via the shared `ci-probe.sh`
+  helper. `.dip`-only change; no engine code.
 - **build_product: per-node build-context file** (closes #298, refs epic #308
   Phase 1; **completes the Phase-1 track** alongside #295/#296/#302/#297/#303).
   Cures per-node rediscovery amnesia (the `code-goblin` run `7b6e08c9e2b2` burned

--- a/docs/superpowers/plans/2026-06-08-issue-299-language-native-quality-gate.md
+++ b/docs/superpowers/plans/2026-06-08-issue-299-language-native-quality-gate.md
@@ -1,0 +1,876 @@
+# Language-native quality gate fallback (#299) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a repo has no Makefile `ci`/`check`/`lint` target, `run_project_ci_gate` must still enforce language-native lint/vet/format gates (Go/JS/TS/Python/Rust) instead of silently passing on the test runner alone — closing the no-Makefile blind spot from epic #308 Phase 2 (#299).
+
+**Architecture:** Pure `.dip` change to `examples/build_product.dip`. The shared `ci-probe.sh` heredoc (written by the `Setup` node, sourced by `TestMilestone` and `FinalBuild`) gains a new `run_language_native_gates` helper. `run_project_ci_gate`'s two early `return 0` skip paths now call it. The awk Makefile-target parser and the `make` path are untouched. Five prose sites that describe the old "no Makefile → skipped" semantics are corrected. Tests: graph string-asserts (negative-control) + a hermetic runtime shell test.
+
+**Tech Stack:** dippin `.dip` workflow DSL, POSIX `sh`, Go `testing` (package `pipeline`), `dippin` CLI for validate/doctor/simulate.
+
+**Branch:** `fix/299-language-native-quality-gate` (already created off `main`). The design spec is `docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md` — read it first.
+
+---
+
+## Context the executor needs
+
+**The file under change:** `examples/build_product.dip`. All line numbers below are verified against `main` as of 2026-06-08 but **re-grep before editing** (they drift). Key anchors:
+- `grep -n 'run_project_ci_gate\|PROBE_EOF\|no Makefile present\|no project CI target' examples/build_product.dip`
+- The helper `run_project_ci_gate` is at `:51-92`, inside `cat > .ai/build/ci-probe.sh <<'PROBE_EOF'` (`:41`) … `PROBE_EOF` (`:93`), which lives in the `Setup` node (`tool Setup`, `:22`).
+- Callers: `TestMilestone` sources at `:587` and runs `run_project_ci_gate || CI_RC=$?` at `:589`, branching on `CI_RC` at `:590-597`. `FinalBuild` sources at `:1247` and runs `run_project_ci_gate` bare (under `set -eu`) at `:1248`.
+
+**The heredoc is `<<'PROBE_EOF'` (quoted):** every `$` inside is written literally to `ci-probe.sh` and expands at runtime when sourced. Do NOT unquote it; do NOT escape the new `$?`/`$LANG_RC`/`$TARGET`.
+
+**Return-code contract (load-bearing):** `0` clean / `2` make-missing→escalate-to-human / `N` failure→fix-loop. `TestMilestone:590` treats `CI_RC -eq 2` as *exactly* "make missing." The new gates must **never** return 2 — they collapse to `return 1`.
+
+**`set -e` semantics (why every gate needs `|| LANG_RC=$?`):** the helper is sourced into `set -eu` shells. `TestMilestone` calls it in a `|| CI_RC=$?` context (set -e ignored throughout the body), but `FinalBuild` calls it **bare** (set -e active in the body). Under FinalBuild's active set -e, a bare failing gate would abort the node immediately. The `|| LANG_RC=$?` on every gate neutralizes set -e per-gate so all gates run and accumulate; the function then returns 1, which propagates to FinalBuild correctly.
+
+**Marker-last / substring-match constraint:** the engine edges substring-match `ctx.tool_stdout contains escalate` / `tests-pass`. No new INFO line may contain the literal tokens `escalate` or `tests-pass`. (The existing make-missing line says "escalat**ing**" — safe, it doesn't contain "escalate".) The helper prints no routing marker; callers print `tests-pass`/`escalate`/`final-build-pass` last.
+
+**Local pre-commit hooks are NOT installed** in this clone (`.git/hooks/` has only `*.sample`); `make test` runs via the pre-commit framework only if `pre-commit install` was run. This is how #298's `(RED)` commit (`ad0fe76`) landed a failing test. **You may commit the negative-control test RED, mirroring that precedent. NEVER use `--no-verify`.** If you find hooks ARE active and they block the RED commit, instead keep the RED proof in-session (run + observe failure) and commit test+impl together — never bypass.
+
+---
+
+## File structure
+
+- **Modify:** `examples/build_product.dip`
+  - `Setup` node heredoc `:51-92`: two 2-line edits inside `run_project_ci_gate`; append new `run_language_native_gates` helper before `PROBE_EOF`; update header comment `:42-50`.
+  - `VerifyMilestone` prompt: prose-sync at `:655-658`, `:745-754`, `:759-765`.
+- **Create:** `pipeline/build_product_quality_gate_test.go` (package `pipeline`) — Layer A string-asserts + Layer B runtime shell test.
+- **Modify:** `CHANGELOG.md` — `[Unreleased]/Added` entry.
+
+---
+
+## Task 1: Negative-control tests (Layer A string-asserts), proven RED
+
+**Files:**
+- Create: `pipeline/build_product_quality_gate_test.go`
+- Reference precedent: `pipeline/build_product_buildcontext_test.go` (uses `loadBuildProduct(t)` and `g.Nodes["Setup"].Attrs["tool_command"]`).
+
+- [ ] **Step 1: Write the Layer A test file.** Each assertion is commented as `negative-control` (RED pre-#299) or `regression-pin` (GREEN, guards removal).
+
+```go
+// ABOUTME: Negative-control + regression guard for issue #299 — the language-native
+// ABOUTME: quality-gate fallback in run_project_ci_gate (ci-probe.sh, Setup node).
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// setupCmd returns the Setup node's tool_command, where the ci-probe.sh heredoc lives.
+func setupCmd(t *testing.T) string {
+	t.Helper()
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["Setup"]
+	if !ok {
+		t.Fatal("Setup node missing from build_product graph")
+	}
+	return n.Attrs["tool_command"]
+}
+
+// Test 1 — negative-control: the Go core gate `go vet ./...` must appear in the
+// probe. Absent from Setup pre-#299 (verified count=0) → RED before implementation.
+func TestQualityGateGoVetPresent(t *testing.T) {
+	if !strings.Contains(setupCmd(t), "go vet ./...") {
+		t.Error("ci-probe.sh has no `go vet ./...` language-native gate (#299)")
+	}
+}
+
+// Test 2 — negative-control: optional linters wired (run-if-present).
+func TestQualityGateOptionalLintersPresent(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, tool := range []string{
+		"golangci-lint run",
+		"tsc --noEmit",
+		"eslint .",
+		"ruff check .",
+		"mypy .",
+		"cargo fmt --check",
+		"cargo clippy -- -D warnings",
+	} {
+		if !strings.Contains(cmd, tool) {
+			t.Errorf("ci-probe.sh missing language-native gate %q (#299)", tool)
+		}
+	}
+}
+
+// Test 3 — negative-control: all four toolchain detectors present INSIDE the probe
+// (they live in the test-runner elif elsewhere, NOT in Setup pre-#299; their presence
+// in Setup's tool_command is what #299 adds).
+func TestQualityGateDetectorsPresent(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, det := range []string{"go.mod", "package.json", "pyproject.toml", "Cargo.toml"} {
+		if !strings.Contains(cmd, det) {
+			t.Errorf("ci-probe.sh missing toolchain detector %q (#299)", det)
+		}
+	}
+}
+
+// Test 4 — negative-control: optional tools are command-v guarded (absence → skip,
+// never failure). Assert each optional tool is preceded by a `command -v` guard.
+func TestQualityGateOptionalToolsGuarded(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, tool := range []string{"golangci-lint", "tsc", "eslint", "ruff", "mypy", "cargo"} {
+		if !strings.Contains(cmd, "command -v "+tool) {
+			t.Errorf("optional tool %q is not `command -v`-guarded (#299)", tool)
+		}
+	}
+}
+
+// Test 5 — regression-pin: the Makefile path is preserved byte-for-byte. `make
+// "$TARGET"` and the awk parser must survive (GREEN now and after; guards removal).
+func TestQualityGateMakefilePathPreserved(t *testing.T) {
+	cmd := setupCmd(t)
+	if !strings.Contains(cmd, `make "$TARGET" 2>&1`) {
+		t.Error("Makefile gate `make \"$TARGET\" 2>&1` was removed/altered (#299 regression)")
+	}
+	if !strings.Contains(cmd, "awk -v t=\"$TARGET\"") {
+		t.Error("awk Makefile-target parser was altered (#299 must not touch it)")
+	}
+}
+
+// Test 6 — regression-pin (semantic): rc=2 stays sole-sourced to the make-missing
+// branch. Exactly one `return 2`, and it is adjacent to `command -v make` — no
+// `return 2` may appear after any language-native gate marker.
+func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
+	cmd := setupCmd(t)
+	if n := strings.Count(cmd, "return 2"); n != 1 {
+		t.Fatalf("expected exactly one `return 2` (make-missing only), found %d (#299)", n)
+	}
+	makeIdx := strings.Index(cmd, "command -v make")
+	ret2Idx := strings.Index(cmd, "return 2")
+	if makeIdx == -1 || ret2Idx < makeIdx {
+		t.Error("`return 2` is not anchored to the `command -v make` branch (#299 rc contract)")
+	}
+	// No return 2 after the first language-native gate marker.
+	if g := strings.Index(cmd, "language-native gate"); g != -1 {
+		if strings.Contains(cmd[g:], "return 2") {
+			t.Error("a `return 2` appears within/after the language-native gates — rc=2 must stay make-missing-only (#299)")
+		}
+	}
+}
+
+// Test 7 — regression-pin: the gate stays CENTRALIZED. Both callers must still
+// source ci-probe.sh and call run_project_ci_gate (one helper, two callers — no
+// duplicated gate logic in the caller bodies).
+func TestQualityGateStaysCentralized(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"TestMilestone", "FinalBuild"} {
+		cmd := g.Nodes[id].Attrs["tool_command"]
+		if !strings.Contains(cmd, ". .ai/build/ci-probe.sh") {
+			t.Errorf("%s no longer sources ci-probe.sh (#299)", id)
+		}
+		if !strings.Contains(cmd, "run_project_ci_gate") {
+			t.Errorf("%s no longer calls run_project_ci_gate (#299)", id)
+		}
+		// No duplicated gate: callers must not grow their own `go vet`.
+		if strings.Contains(cmd, "go vet") {
+			t.Errorf("%s grew its own `go vet` — gate must stay in the shared helper (#299)", id)
+		}
+	}
+}
+
+// Test 8 — prose negative-control: VerifyMilestone no longer claims the no-Makefile
+// path is "correctly skipped". RED until the prose-sync edit (Task 3).
+func TestQualityGateVerifyPromptTruthful(t *testing.T) {
+	g := loadBuildProduct(t)
+	p := g.Nodes["VerifyMilestone"].Attrs["prompt"]
+	if strings.Contains(p, "correctly skipped (no Makefile") {
+		t.Error("VerifyMilestone prompt still says the no-Makefile path is skipped — false after #299")
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests, verify they FAIL (RED).**
+
+Run: `go test ./pipeline/ -run 'TestQualityGate' -v`
+Expected: Tests 1–4 and 8 FAIL (`go vet`, the optional linters, the guards, and the prose are absent pre-#299); Tests 5–7 PASS (regression-pins on existing structure). Confirm 1–4 and 8 are RED — that is the negative-control proof.
+
+- [ ] **Step 3: Commit the RED tests** (mirrors #298 `ad0fe76`).
+
+```bash
+git add pipeline/build_product_quality_gate_test.go
+git commit -m "test(299): negative-control tests for language-native quality gate (RED)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Implement the `run_language_native_gates` helper + wire the two fall-throughs
+
+**Files:**
+- Modify: `examples/build_product.dip` (Setup heredoc `:51-92`, header `:42-50`).
+
+- [ ] **Step 1: Edit the no-Makefile early return** (`:57-60`). Re-grep first: `grep -n 'no Makefile present, no project CI gate' examples/build_product.dip`.
+
+Replace:
+```sh
+        if [ -z "$MAKEFILE" ]; then
+          echo "INFO: no Makefile present, no project CI gate to run"
+          return 0
+        fi
+```
+with:
+```sh
+        if [ -z "$MAKEFILE" ]; then
+          echo "INFO: no Makefile present — running language-native gates (#299)"
+          run_language_native_gates
+          return $?
+        fi
+```
+
+- [ ] **Step 2: Edit the no-matching-target return** (`:90-91`). Re-grep: `grep -n 'no project CI target in' examples/build_product.dip`.
+
+Replace:
+```sh
+        echo "INFO: no project CI target in $MAKEFILE (looked for: ci, check, lint)"
+        return 0
+      }
+```
+with:
+```sh
+        echo "INFO: no project CI target in $MAKEFILE (looked for: ci, check, lint) — running language-native gates (#299)"
+        run_language_native_gates
+        return $?
+      }
+```
+
+- [ ] **Step 3: Append the `run_language_native_gates` helper** immediately after `run_project_ci_gate`'s closing `}` and before `PROBE_EOF`. Re-grep the `PROBE_EOF` line: `grep -n 'PROBE_EOF' examples/build_product.dip` (use the SECOND match — the closing delimiter). Insert before it:
+
+```sh
+      # Language-native quality-gate fallback (issue #299, epic #308 Phase 2).
+      # Reached from run_project_ci_gate when no Makefile ci/check/lint target
+      # ran. Runs gates for EVERY detected toolchain (polyglot, not first-match).
+      # Returns 0 (clean / nothing to gate) or 1 (some gate failed) — NEVER 2;
+      # rc=2 stays reserved for the make-missing case in run_project_ci_gate.
+      #
+      # INVARIANT: every gate command MUST end in `|| LANG_RC=$?`. These nodes run
+      # `set -eu`; FinalBuild calls the gate BARE (set -e active in the body), so a
+      # bare failing gate would abort the node before later gates/markers run. The
+      # `|| LANG_RC=$?` neutralizes set -e per gate and accumulates the failure.
+      # "Core" tools fail when they FAIL; "optional" tools are command-v guarded so
+      # ABSENCE is a one-line INFO skip (never a failure, never rc=2).
+      run_language_native_gates() {
+        LANG_RC=0
+        RAN_ANY=""
+        # Go — `go vet` is the core gate (go is present by go.mod detection).
+        if [ -f go.mod ]; then
+          RAN_ANY=1
+          echo "--- go vet ./... (language-native gate, #299) ---"
+          go vet ./... 2>&1 || LANG_RC=$?
+          if command -v golangci-lint >/dev/null 2>&1; then
+            echo "--- golangci-lint run (language-native gate, #299) ---"
+            golangci-lint run 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: golangci-lint not installed — skipping (optional, #299)"
+          fi
+        fi
+        # JS/TS — both run-if-present.
+        if [ -f package.json ]; then
+          RAN_ANY=1
+          if command -v tsc >/dev/null 2>&1; then
+            echo "--- tsc --noEmit (language-native gate, #299) ---"
+            tsc --noEmit 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: tsc not installed — skipping (optional, #299)"
+          fi
+          if command -v eslint >/dev/null 2>&1; then
+            echo "--- eslint . (language-native gate, #299) ---"
+            eslint . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: eslint not installed — skipping (optional, #299)"
+          fi
+        fi
+        # Python — both run-if-present.
+        if [ -f pyproject.toml ]; then
+          RAN_ANY=1
+          if command -v ruff >/dev/null 2>&1; then
+            echo "--- ruff check . (language-native gate, #299) ---"
+            ruff check . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: ruff not installed — skipping (optional, #299)"
+          fi
+          if command -v mypy >/dev/null 2>&1; then
+            echo "--- mypy . (language-native gate, #299) ---"
+            mypy . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: mypy not installed — skipping (optional, #299)"
+          fi
+        fi
+        # Rust — run-if-present (cargo gates both fmt and clippy).
+        if [ -f Cargo.toml ]; then
+          RAN_ANY=1
+          if command -v cargo >/dev/null 2>&1; then
+            echo "--- cargo fmt --check (language-native gate, #299) ---"
+            cargo fmt --check 2>&1 || LANG_RC=$?
+            echo "--- cargo clippy -- -D warnings (language-native gate, #299) ---"
+            cargo clippy -- -D warnings 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: cargo not installed — skipping (optional, #299)"
+          fi
+        fi
+        if [ -z "$RAN_ANY" ]; then
+          echo "INFO: no recognized toolchain (go.mod/package.json/pyproject.toml/Cargo.toml) — no language-native gate (#299)"
+        fi
+        if [ "$LANG_RC" -ne 0 ]; then
+          return 1
+        fi
+        return 0
+      }
+```
+
+- [ ] **Step 4: Update the helper header comment** (`:42-50`). Re-grep: `grep -n 'Source this file, then call' examples/build_product.dip`. Replace the `Returns:` block so it is truthful:
+
+Replace:
+```sh
+      # Source this file, then call `run_project_ci_gate`. Returns:
+      #   0  — clean (no Makefile, no matching target, OR
+      #        `make <TARGET>` exited 0)
+      #   2  — Makefile present but `make` not installed (caller
+      #        should escalate; LLM fix loop can't install a binary)
+      #   N  — `make <TARGET>` exited with non-zero N
+      #        (caller should fail / retry)
+      # Sets PROJECT_CI_RAN to the chosen target on a real run,
+      # empty string otherwise.
+```
+with:
+```sh
+      # Source this file, then call `run_project_ci_gate`. Returns:
+      #   0  — clean: `make <TARGET>` exited 0, OR (no Makefile gate
+      #        ran) the language-native gates passed / no toolchain
+      #        was detected (issue #299).
+      #   2  — Makefile present but `make` not installed (caller
+      #        should escalate; LLM fix loop can't install a binary).
+      #        rc=2 is reserved for THIS case only.
+      #   N  — a gate failed: `make <TARGET>` exited non-zero, OR a
+      #        language-native gate (go vet / golangci-lint / tsc /
+      #        eslint / ruff / mypy / cargo fmt|clippy) failed
+      #        (collapsed to 1; caller should fail / retry).
+      # Sets PROJECT_CI_RAN to the chosen target on a real `make` run,
+      # empty string otherwise (incl. the language-native fall-through).
+```
+
+- [ ] **Step 5: Run Layer A tests, verify Tests 1–7 PASS.**
+
+Run: `go test ./pipeline/ -run 'TestQualityGate' -v`
+Expected: Tests 1–7 PASS; Test 8 still FAILS (prose not yet edited — Task 3).
+
+- [ ] **Step 6: Validate the .dip still parses.**
+
+Run: `dippin validate examples/build_product.dip`
+Expected: passes (no parse error). If `dippin` is not on PATH, STOP and ask the user — do NOT `go install` it.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add examples/build_product.dip
+git commit -m "feat(build_product): language-native quality gate fallback (#299)
+
+run_project_ci_gate now falls through to run_language_native_gates when no
+Makefile ci/check/lint target ran. Runs go vet (+ golangci-lint), tsc/eslint,
+ruff/mypy, cargo fmt/clippy for every detected toolchain; optional tools absent
+=> INFO skip; failures collapse to rc=1 (never 2). awk/make path untouched.
+
+Refs epic #308 Phase 2 (first item).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Prose-sync — keep VerifyMilestone truthful
+
+**Files:**
+- Modify: `examples/build_product.dip` (`VerifyMilestone` prompt `:655-765`).
+
+- [ ] **Step 1: Fix the preamble** (`:655-658`). Re-grep: `grep -n 'OR the probe correctly skipped' examples/build_product.dip`.
+
+Replace:
+```
+      (when a Makefile with a `ci`/`check`/`lint` target was present)
+      OR the probe correctly skipped (no Makefile, or no matching
+      target). The sentinel does NOT prove every check executed —
+```
+with:
+```
+      (a Makefile `ci`/`check`/`lint` target, OR — when no such target
+      ran — the language-native gates: go vet/golangci-lint, tsc/eslint,
+      ruff/mypy, cargo fmt/clippy for each detected toolchain, #299)
+      OR there was nothing to gate (no recognized toolchain). The
+      sentinel does NOT prove every check executed —
+```
+
+- [ ] **Step 2: Fix VERIFY item 6 "validly skipped"** (`:745-754`). Re-grep: `grep -n 'passed-or-was-validly-skipped AND its project' examples/build_product.dip`.
+
+Replace:
+```
+         runner passed-or-was-validly-skipped AND its project CI gate
+         passed-or-was-validly-skipped (see the preamble above for the
+         exact "validly skipped" rules). The sentinel is emitted at
+```
+with:
+```
+         runner passed-or-was-validly-skipped AND its project CI gate
+         passed (a Makefile target OR the language-native gates, #299)
+         or had nothing to gate (see the preamble above for the exact
+         rules). The sentinel is emitted at
+```
+
+- [ ] **Step 3: Fix the cause description** (`:759-765`). Re-grep: `grep -n 'CI_RC==2' examples/build_product.dip`. Read the surrounding lines and broaden any text that scopes "the project CI gate" to Makefile-only, noting that a language-native gate failure folds into `TEST_EXIT` → FixMilestone (routing unchanged). Make the minimal edit that removes the Makefile-only implication; keep the rc=2 = make-missing statement (still true). Example: if the text says the project CI gate is the `make` gate, add "(or a language-native gate, #299)".
+
+- [ ] **Step 4: Run the prose test, verify Test 8 PASSES.**
+
+Run: `go test ./pipeline/ -run 'TestQualityGateVerifyPromptTruthful' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Re-validate + commit.**
+
+```bash
+dippin validate examples/build_product.dip
+git add examples/build_product.dip
+git commit -m "docs(build_product): sync VerifyMilestone prose to language-native gate (#299)
+
+After #299 'no Makefile' no longer means 'skipped' — language gates run.
+Update the preamble, VERIFY item 6, and the cause description so the
+doc-in-prompt stays truthful.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Runtime shell test (Layer B — the behavioral driver)
+
+**Files:**
+- Modify: `pipeline/build_product_quality_gate_test.go` (add the runtime test).
+
+This is the test that proves the *behavior* (string-asserts only prove text presence). It extracts the `ci-probe.sh` body from the loaded `Setup` tool_command, writes it to a temp file, and sources it under a hermetic env in fixture repos.
+
+- [ ] **Step 1: Add the runtime test harness + cases.**
+
+```go
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// extractProbe pulls the ci-probe.sh body (between `<<'PROBE_EOF'` and the closing
+// `PROBE_EOF`) out of the LOADED (dippin-dedented) Setup tool_command — the exact
+// bytes tracker writes to disk at runtime.
+func extractProbe(t *testing.T) string {
+	t.Helper()
+	cmd := setupCmd(t)
+	const open = "<<'PROBE_EOF'\n"
+	i := strings.Index(cmd, open)
+	if i == -1 {
+		t.Fatal("could not find ci-probe.sh heredoc open in Setup command")
+	}
+	rest := cmd[i+len(open):]
+	j := strings.Index(rest, "PROBE_EOF")
+	if j == -1 {
+		t.Fatal("could not find ci-probe.sh heredoc close")
+	}
+	return rest[:j]
+}
+
+// hermeticEnv builds an env that deterministically excludes optional linters
+// (golangci-lint/ruff/etc. typically live in ~/go/bin or ~/.local/bin, not in the
+// dir-of-go or /usr/bin:/bin) and runs go offline.
+func hermeticEnv(t *testing.T, goDir, home, gocache string) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + goDir + ":/usr/bin:/bin",
+		"HOME=" + home,
+		"GOCACHE=" + gocache,
+		"GOPROXY=off",
+		"GOFLAGS=",
+	}
+}
+
+// runGate sources the probe in dir and returns combined output + the parsed rc and
+// PROJECT_CI_RAN. PATH override lets the make-missing case drop make.
+func runGate(t *testing.T, probe, dir string, env []string) (out string, rc int, ciRan string) {
+	t.Helper()
+	probePath := filepath.Join(t.TempDir(), "ci-probe.sh")
+	if err := os.WriteFile(probePath, []byte(probe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := ". " + probePath + `; run_project_ci_gate; echo "RC=$?"; echo "RAN=[$PROJECT_CI_RAN]"`
+	c := exec.Command("sh", "-c", script)
+	c.Dir = dir
+	c.Env = env
+	b, _ := c.CombinedOutput()
+	out = string(b)
+	if m := regexp.MustCompile(`RC=(\d+)`).FindStringSubmatch(out); m != nil {
+		rc = atoi(m[1])
+	} else {
+		t.Fatalf("no RC marker in output:\n%s", out)
+	}
+	if m := regexp.MustCompile(`RAN=\[([^\]]*)\]`).FindStringSubmatch(out); m != nil {
+		ciRan = m[1]
+	}
+	return out, rc, ciRan
+}
+
+func atoi(s string) int { n := 0; for _, r := range s { n = n*10 + int(r-'0') }; return n }
+
+// writeGoModule writes a minimal module; `vetViolation` injects an unreachable-code /
+// printf-mismatch that `go vet` flags.
+func writeGoModule(t *testing.T, dir string, vetViolation bool) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	src := "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"ok\") }\n"
+	if vetViolation {
+		// Printf format/arg mismatch — a deterministic, offline `go vet` error.
+		src = "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Printf(\"%d\\n\", \"not-an-int\") }\n"
+	}
+	mustWrite(t, filepath.Join(dir, "main.go"), src)
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunProjectCIGateRuntime(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not available; skipping runtime gate test")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping runtime gate test")
+	}
+	goDir := filepath.Dir(goBin)
+	probe := extractProbe(t)
+
+	// (b) clean Go repo → rc 0.
+	t.Run("clean_go_rc0", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("clean Go repo: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("clean Go repo: go vet did not run\n%s", out)
+		}
+	})
+
+	// (a) Go vet violation → rc != 0 AND rc != 2.
+	t.Run("go_vet_violation_rc1", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 0 || rc == 2 {
+			t.Errorf("vet violation: rc=%d want non-zero and != 2\n%s", rc, out)
+		}
+	})
+
+	// (c) golangci-lint absent → INFO skip line, rc != 2.
+	t.Run("golangci_absent_info_skip", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 2 {
+			t.Errorf("optional-absent must not yield rc=2\n%s", out)
+		}
+		if !strings.Contains(out, "golangci-lint not installed") {
+			t.Errorf("expected golangci-lint INFO skip line\n%s", out)
+		}
+	})
+
+	// (e) empty repo → rc 0 + no-toolchain note.
+	t.Run("empty_repo_rc0", func(t *testing.T) {
+		dir := t.TempDir()
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("empty repo: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "no recognized toolchain") {
+			t.Errorf("empty repo: expected no-toolchain note\n%s", out)
+		}
+	})
+
+	// (f) build-only Makefile (no ci/check/lint) + vet violation → falls through
+	// to language gates: rc != 0 AND PROJECT_CI_RAN empty (make CI path didn't win).
+	t.Run("build_only_makefile_falls_through", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true)
+		mustWrite(t, filepath.Join(dir, "Makefile"), "build:\n\tgo build ./...\n")
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 0 || rc == 2 {
+			t.Errorf("build-only Makefile: rc=%d want non-zero != 2 (vet must run)\n%s", rc, out)
+		}
+		if ciRan != "" {
+			t.Errorf("build-only Makefile: PROJECT_CI_RAN=%q want empty (no make CI target)\n%s", ciRan, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("build-only Makefile: go vet did not run\n%s", out)
+		}
+	})
+
+	// (d) Makefile `ci:` target wins → PROJECT_CI_RAN=ci AND go vet did NOT run.
+	t.Run("makefile_ci_target_wins", func(t *testing.T) {
+		if _, err := exec.LookPath("make"); err != nil {
+			t.Skip("make not available")
+		}
+		dir := t.TempDir()
+		writeGoModule(t, dir, true) // vet would fail IF it ran — it must not
+		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo running-ci\n")
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if ciRan != "ci" {
+			t.Errorf("Makefile ci target: PROJECT_CI_RAN=%q want ci\n%s", ciRan, out)
+		}
+		if rc != 0 {
+			t.Errorf("Makefile ci (echo) target: rc=%d want 0\n%s", rc, out)
+		}
+		if strings.Contains(out, "go vet ./...") {
+			t.Errorf("Makefile ci won but go vet ALSO ran — precedence broken\n%s", out)
+		}
+	})
+
+	// (h) Makefile present, make uninstalled → rc 2 BEFORE any language gate.
+	t.Run("make_missing_rc2", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo hi\n")
+		// PATH without /usr/bin:/bin so `command -v make` fails; only goDir present.
+		env := []string{"PATH=" + goDir, "HOME=" + t.TempDir(), "GOCACHE=" + t.TempDir(), "GOPROXY=off"}
+		out, rc, _ := runGate(t, probe, dir, env)
+		if rc != 2 {
+			t.Errorf("make missing: rc=%d want 2\n%s", rc, out)
+		}
+		if strings.Contains(out, "go vet ./...") {
+			t.Errorf("make-missing must short-circuit BEFORE language gates\n%s", out)
+		}
+	})
+
+	// (i) polyglot: clean Go + package.json → BOTH stacks detected (proves not
+	// first-match): go vet marker AND a node-stack INFO/skip line both present.
+	t.Run("polyglot_runs_all_stacks", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		mustWrite(t, filepath.Join(dir, "package.json"), "{\"name\":\"x\",\"version\":\"0.0.0\"}\n")
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("polyglot clean: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("polyglot: Go stack did not run\n%s", out)
+		}
+		// tsc/eslint absent under hermetic PATH → INFO skip lines prove the JS
+		// stack was entered (not first-match-stopped at Go).
+		if !strings.Contains(out, "tsc not installed") && !strings.Contains(out, "eslint not installed") {
+			t.Errorf("polyglot: JS stack was not entered (first-match bug?)\n%s", out)
+		}
+	})
+
+	// (g) optional absent + core fails simultaneously → rc 1, not 2.
+	t.Run("optional_absent_core_fails_rc1", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true) // go vet fails; golangci-lint absent
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 1 {
+			t.Errorf("core-fail + optional-absent: rc=%d want 1\n%s", rc, out)
+		}
+		if !strings.Contains(out, "golangci-lint not installed") {
+			t.Errorf("expected golangci-lint INFO skip alongside the core failure\n%s", out)
+		}
+	})
+}
+```
+
+> **Notes for the executor:**
+> - Merge the `import` block with Task 1's (single block; don't duplicate `strings`/`testing`).
+> - Verify the chosen vet violation actually trips `go vet` on the installed toolchain: `cd /tmp/x && go vet ./...` on the printf-mismatch snippet should print a `Printf` diagnostic and exit non-zero. If your Go version doesn't flag it, use a different deterministic vet error (e.g. an unreachable `return`). Adjust the fixture, not the assertion.
+> - If `/usr/bin`/`/bin` differ on the host (rare), derive coreutils dir dynamically; the gate needs `sed`/`awk` only on the Makefile path (cases d/f), which include `/usr/bin:/bin`.
+
+- [ ] **Step 2: Run the full runtime test.**
+
+Run: `go test ./pipeline/ -run 'TestRunProjectCIGateRuntime' -v`
+Expected: all subtests PASS (or `t.Skip` where a tool is unavailable). If `makefile_ci_target_wins` shows `go vet` ran, the precedence is broken — fix `run_project_ci_gate`, not the test.
+
+- [ ] **Step 3: Run the whole package + build.**
+
+Run: `go build ./... && go test ./pipeline/ -run 'TestQualityGate|TestRunProjectCIGate' -v && go test ./... -short`
+Expected: green.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add pipeline/build_product_quality_gate_test.go
+git commit -m "test(299): runtime behavioral test for language-native quality gate
+
+Hermetic (env -i-style PATH, GOPROXY=off, no-toolchain go.mod) source-and-run
+of run_project_ci_gate across fixture repos: vet-violation→rc!=0&!=2, clean→0,
+optional-absent→INFO skip & rc!=2, build-only Makefile falls through, make-ci
+wins (no vet), make-missing→rc2-before-gates, polyglot runs all stacks.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]` → `### Added`, after the #298 entry around `:25`).
+
+- [ ] **Step 1: Add the entry** at the top of `### Added` under `## [Unreleased]`:
+
+```markdown
+- **build_product: language-native quality gate fallback** (closes #299, refs
+  epic #308 Phase 2 — first item). Closes the no-Makefile blind spot: when a repo
+  has no Makefile `ci`/`check`/`lint` target (the `code-goblin` failure mode —
+  shipped with no linter ever running), `run_project_ci_gate` now falls through to
+  language-native gates for **every** detected toolchain (polyglot, not
+  first-match): Go `go vet ./...` (+ `golangci-lint` if present), JS/TS `tsc
+  --noEmit`/`eslint`, Python `ruff`/`mypy`, Rust `cargo fmt --check`/`cargo clippy`.
+  Optional linters absent → one-line INFO skip (never an error); a present gate
+  that fails routes to the fix loop. The `0`/`2`/`N` return contract is preserved —
+  `rc=2` stays reserved for the Makefile-present-but-`make`-missing escalation;
+  language-gate failures collapse to `rc=1`. **Behavior change:** no-Makefile Go
+  repos now enforce `go vet` on every milestone (previously green on tests alone).
+  Both `TestMilestone` and `FinalBuild` inherit it via the shared `ci-probe.sh`
+  helper. `.dip`-only change; no engine code.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(299): CHANGELOG entry for language-native quality gate (#299)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full verification + PR
+
+- [ ] **Step 1: dippin gates.**
+
+```bash
+dippin validate examples/build_product.dip
+dippin doctor examples/build_product.dip examples/ask_and_execute.dip examples/build_product_with_superspec.dip
+dippin simulate -all-paths examples/build_product.dip
+```
+Expected: `validate` passes; `doctor` is **A** grade across all three (build_product baseline A 90/100 — must not regress); `simulate -all-paths` reports 100% terminate success with no new cycle / dead-stop. If `dippin` is not on PATH, STOP and ask the user (they install it from a local checkout — do NOT `go install`).
+
+- [ ] **Step 2: Go gates.**
+
+```bash
+go build ./...
+go test ./... -short
+gofmt -l pipeline/build_product_quality_gate_test.go   # must print nothing
+```
+Expected: build clean; tests green; gofmt clean.
+
+- [ ] **Step 3: Adversarial self-review** (before pushing). Walk each explicitly:
+  - **rc-contract:** grep the probe — exactly one `return 2`, anchored to `command -v make`; `run_language_native_gates` returns only via `return 1` / `return 0`.
+  - **optional-absent ≠ rc2:** the runtime `optional_absent_core_fails_rc1` + `golangci_absent_info_skip` subtests cover it.
+  - **polyglot-all-stacks:** `polyglot_runs_all_stacks` proves the JS stack is entered after Go.
+  - **VerifyMilestone-prompt-truthful:** re-read `:655-765` — no remaining "no Makefile → skipped" claim.
+  - **Makefile-path-unchanged:** `git diff main -- examples/build_product.dip` shows the awk block and `make "$TARGET"` untouched; only the two `return 0`s, the header, the new function, and the prose changed.
+  - **#305 untouched:** the test-runner `if/elif` chains (`:561-578`, `:1230-1239`) are NOT in the diff.
+
+- [ ] **Step 4: Push + open the PR.**
+
+```bash
+git push -u origin fix/299-language-native-quality-gate
+gh pr create --title "feat(build_product): language-native quality gate fallback when no Makefile (#299)" --body "$(cat <<'EOF'
+Closes #299. Refs epic #308 Phase 2 (first item).
+
+## What
+
+`run_project_ci_gate` (shared `ci-probe.sh` helper, sourced by `TestMilestone` and
+`FinalBuild`) only enforced quality when a Makefile `ci`/`check`/`lint` target
+existed. A single-language repo with no such target shipped green on the test
+runner alone — no lint/vet/format gate ever ran (the `code-goblin` failure mode).
+
+This adds a `run_language_native_gates` fallback, reached from both of
+`run_project_ci_gate`'s former early `return 0` paths (no Makefile, **and** Makefile
+with no matching target). It runs gates for **every** detected toolchain:
+
+| Toolchain | Core (always) | Optional (run-if-present) |
+|-----------|---------------|---------------------------|
+| Go (`go.mod`) | `go vet ./...` | `golangci-lint run` |
+| JS/TS (`package.json`) | — | `tsc --noEmit`, `eslint .` |
+| Python (`pyproject.toml`) | — | `ruff check .`, `mypy .` |
+| Rust (`Cargo.toml`) | — | `cargo fmt --check`, `cargo clippy -- -D warnings` |
+
+## Design subtleties (deliberate)
+
+- **Return-code contract preserved.** `0` clean / `2` make-missing→escalate-to-human
+  / `N` failure→fix-loop. Language-gate failures **collapse to `rc=1`** — a linter
+  exiting 2 can never masquerade as the make-missing escalation. `rc=2` stays
+  reserved for the make-missing case (no *new* rc=2 source introduced).
+- **Optional-absent is an INFO skip, never rc=2.** Escalating a human because `mypy`
+  isn't installed would be wrong. Only `command -v`-guarded; absence → one-line note.
+- **Polyglot — all detected stacks run** (independent `if`, not first-match). The
+  adjacent test-runner `if/elif` is **#305, out of scope** and untouched here.
+- **Both no-gate paths fall through** (incl. a build-only Makefile) — slightly
+  exceeds the issue's literal "no Makefile" wording; closes the blind spot fully.
+- **`set -eu` safe:** every gate ends in `|| LANG_RC=$?` (FinalBuild calls the gate
+  bare under active `set -e`); a guard comment pins this invariant.
+- **awk/make path untouched** — gates live in a new sibling helper; only the two
+  `return 0` blocks, the header comment, and VerifyMilestone prose changed.
+- **VerifyMilestone prose synced** — "no Makefile" no longer means "skipped."
+
+## Out of scope / follow-up
+
+- Pre-existing make-path rc=2 leak (`make "$TARGET"; return $?` propagates GNU
+  make's native exit 2 on recipe errors): filed as **#320**. Fixing it would change
+  existing Makefile-gate behavior (an acceptance criterion), so it's deliberately
+  not touched here.
+
+## Tests
+
+- Graph string-asserts (negative-control, RED-first per the #296/#297/#298 pattern):
+  `go vet`/linters/detectors present in the probe; rc=2 anchored to `command -v
+  make`; gate stays centralized; VerifyMilestone prose truthful.
+- Hermetic **runtime** shell test (the behavioral driver): sources the extracted
+  `ci-probe.sh` under an isolated PATH/`GOPROXY=off` in fixture repos — vet
+  violation→rc≠0&≠2, clean→0, optional-absent→INFO skip & rc≠2, build-only Makefile
+  falls through, `make ci` wins (no vet), make-missing→rc2-before-gates, polyglot
+  runs all stacks.
+
+## Verification
+
+`dippin validate` ✓ · `dippin doctor` A grade ✓ · `dippin simulate -all-paths` 100%
+terminate ✓ · `go build ./... && go test ./... -short` ✓
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Address bot review** (CodeRabbit/Copilot/Codex). Per `superpowers:receiving-code-review`: verify each comment against the actual code, fix valid ones, decline invalid ones with a technical rationale, reply in-thread, keep the PR body + CHANGELOG in sync, keep CI green. NEVER `--no-verify`.
+
+---
+
+## Self-review against the spec
+
+- **Go core gate `go vet` always + golangci optional** → Task 2 Step 3 ✓
+- **JS/TS/Python/Rust run-if-present** → Task 2 Step 3 ✓
+- **Polyglot independent `if`** → Task 2 Step 3 + Task 4 `polyglot_runs_all_stacks` ✓
+- **rc collapse to 1, never 2** → Task 2 Step 3 (`if LANG_RC != 0 → return 1`) + Task 1 Test 6 + Task 4 `make_missing_rc2`/`optional_absent_core_fails_rc1` ✓
+- **Both no-gate paths fall through** → Task 2 Steps 1–2 + Task 4 `build_only_makefile_falls_through` ✓
+- **Makefile path byte-for-byte** → Task 1 Test 5 + Task 6 Step 3 diff check ✓
+- **Both callers inherit, no duplicate gate** → Task 1 Test 7 ✓
+- **`set -eu` safe + guard comment** → Task 2 Step 3 INVARIANT comment ✓
+- **No INFO line contains `escalate`/`tests-pass`** → verified in the gate text (Task 2 Step 3) ✓
+- **Prose-sync all 5 sites** (header + 2 INFO strings in-gate + preamble + item-6 ×2) → Task 2 Step 4 (header + INFO strings) + Task 3 ✓
+- **#305 test-runner untouched** → Task 6 Step 3 ✓
+- **CHANGELOG Added, epic Phase 2, behavior-change framing** → Task 5 ✓
+- **Follow-up #320 referenced** → Task 6 PR body ✓
+- **dippin validate/doctor/simulate + go gates** → Task 6 Steps 1–2 ✓

--- a/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
@@ -1,0 +1,206 @@
+# Issue #299 — Language-native quality gate fallback when no Makefile exists
+
+**Epic:** #308 Phase 2 ("Enforce quality regardless of spec/language"), first item.
+**Scope:** `.dip`-only change to `examples/build_product.dip` + one new test file + CHANGELOG. No engine Go changes.
+**Status:** design (squad-reviewed 2026-06-08; five-expert panel consensus folded in).
+
+## Problem
+
+`run_project_ci_gate` in the `.ai/build/ci-probe.sh` heredoc (Setup node, `examples/build_product.dip:51-92`) only enforces quality when a Makefile with a top-level `ci`/`check`/`lint` target exists. A single-language repo with **no such Makefile target** gets the early `return 0` (lines `:57-60` no-Makefile; `:90-91` Makefile-but-no-matching-target) and the milestone ships green on the language test runner (`go test ./...`) alone — no lint/vet/format gate ever runs. This is the `code-goblin` failure mode: a Go repo with no `.golangci.yml` and an unguarded complexity ceiling, because nothing ran a linter.
+
+The helper is sourced by two callers — `TestMilestone` (`:587-589`, branches on `CI_RC`) and `FinalBuild` (`:1247-1248`, propagates via `set -eu`) — so a single change to the helper fixes both.
+
+## The change
+
+Replace the two early `return 0` skip paths with a **fall-through** to a language-native quality-gate block appended to the *same* function. The Makefile branch is preserved byte-for-byte; only the two `return 0`s become fall-throughs.
+
+### Return-code contract (load-bearing — unchanged)
+
+```
+0  — clean (Makefile target ran clean, OR language-native gates passed, OR nothing to gate)
+2  — Makefile present but `make` not installed (escalate to human; LLM can't install a binary)
+N  — gate failure (route to the fix loop)
+```
+
+The language-native block **collapses every gate failure to `return 1`** — never 2:
+
+```sh
+if [ "$LANG_RC" -ne 0 ]; then return 1; fi
+return 0
+```
+
+This is mandatory, not stylistic: `TestMilestone:590` treats `CI_RC -eq 2` as *exactly* "make missing → escalate, reset attempts, skip the fix loop." A linter that exits 2 (golangci-lint/mypy/tsc can on internal/config errors) must NOT masquerade as that. Using `return "$LANG_RC"` (raw tool code) would leak a 2 — forbidden.
+
+### Toolchain gates (polyglot — run ALL detected, not first-match)
+
+Independent `if` blocks (not `elif`). Each runs if its project file is present:
+
+| Toolchain | Detect | Gates |
+|-----------|--------|-------|
+| Go | `go.mod` | `go vet ./...` (**always** — core; go is present by go.mod detection); `golangci-lint run` *if on PATH* |
+| JS/TS | `package.json` | `tsc --noEmit` *if on PATH*; `eslint .` *if on PATH* |
+| Python | `pyproject.toml` | `ruff check .` *if on PATH*; `mypy .` *if on PATH* |
+| Rust | `Cargo.toml` | `cargo fmt --check` + `cargo clippy -- -D warnings` *if cargo on PATH* |
+
+**Core vs optional** (issue subtlety 2): "core" means *when the tool runs, its failure is fatal* — NOT that its absence is fatal. `go vet` is the only unguarded gate (runs whenever `go.mod` exists). Every other tool is `command -v`-guarded: **absent → one-line INFO skip (never rc=2, never a failure); present-and-failing → accumulate into `LANG_RC` and propagate**. This applies uniformly to every run gate, so the only thing the core/optional distinction governs in code is whether `go vet` carries a `command -v` guard (it does not).
+
+### Both no-gate paths fall through (decided)
+
+The fallback fires in **both** "no Makefile at all" *and* "Makefile present but no `ci`/`check`/`lint` target." A repo with a build-only Makefile still has no lint gate; running language-native gates there closes the same blind spot. This slightly exceeds the issue's literal "no Makefile" wording — flagged in the PR body. A real `ci`/`check`/`lint` target still wins and short-circuits via the unchanged `make "$TARGET"; return $?` path.
+
+### Proposed helper body (POSIX sh, matching existing style)
+
+```sh
+run_project_ci_gate() {
+  PROJECT_CI_RAN=""; MAKEFILE=""
+  for mf in Makefile makefile GNUmakefile; do
+    if [ -f "$mf" ]; then MAKEFILE="$mf"; break; fi
+  done
+  if [ -n "$MAKEFILE" ]; then
+    if ! command -v make >/dev/null 2>&1; then
+      echo "ERROR: $MAKEFILE present but 'make' not installed — escalating"
+      return 2                              # ONLY source of rc=2 — unchanged
+    fi
+    for TARGET in ci check lint; do
+      if <existing sed|awk target-parse — UNCHANGED>; then
+        echo "--- running make $TARGET (project CI gate from $MAKEFILE) ---"
+        PROJECT_CI_RAN="$TARGET"
+        make "$TARGET" 2>&1; return $?       # Makefile WINS — unchanged
+      fi
+    done
+    echo "INFO: no project CI target in $MAKEFILE — running language-native gates (#299)"
+  else
+    echo "INFO: no Makefile present — running language-native gates (#299)"
+  fi
+
+  # ── language-native quality-gate fallback (#299) ──
+  # Every gate MUST end in `|| LANG_RC=$?` — a bare failing gate would abort the
+  # node under `set -e` (these nodes run `set -eu`). Optional tools are skipped
+  # via `command -v`; rc=2 is reserved for the make-missing case above only.
+  LANG_RC=0; RAN_ANY=""
+  if [ -f go.mod ]; then
+    RAN_ANY=1
+    echo "--- go vet ./... (language-native gate, #299) ---"
+    go vet ./... 2>&1 || LANG_RC=$?
+    if command -v golangci-lint >/dev/null 2>&1; then
+      echo "--- golangci-lint run (language-native gate, #299) ---"
+      golangci-lint run 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: golangci-lint not installed — skipping (optional, #299)"
+    fi
+  fi
+  if [ -f package.json ]; then
+    RAN_ANY=1
+    if command -v tsc >/dev/null 2>&1; then
+      echo "--- tsc --noEmit (language-native gate, #299) ---"
+      tsc --noEmit 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: tsc not installed — skipping (optional, #299)"
+    fi
+    if command -v eslint >/dev/null 2>&1; then
+      echo "--- eslint . (language-native gate, #299) ---"
+      eslint . 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: eslint not installed — skipping (optional, #299)"
+    fi
+  fi
+  if [ -f pyproject.toml ]; then
+    RAN_ANY=1
+    if command -v ruff >/dev/null 2>&1; then
+      echo "--- ruff check . (language-native gate, #299) ---"
+      ruff check . 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: ruff not installed — skipping (optional, #299)"
+    fi
+    if command -v mypy >/dev/null 2>&1; then
+      echo "--- mypy . (language-native gate, #299) ---"
+      mypy . 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: mypy not installed — skipping (optional, #299)"
+    fi
+  fi
+  if [ -f Cargo.toml ]; then
+    RAN_ANY=1
+    if command -v cargo >/dev/null 2>&1; then
+      echo "--- cargo fmt --check (language-native gate, #299) ---"
+      cargo fmt --check 2>&1 || LANG_RC=$?
+      echo "--- cargo clippy -- -D warnings (language-native gate, #299) ---"
+      cargo clippy -- -D warnings 2>&1 || LANG_RC=$?
+    else
+      echo "INFO: cargo not installed — skipping (optional, #299)"
+    fi
+  fi
+  if [ -z "$RAN_ANY" ]; then
+    echo "INFO: no recognized toolchain (go.mod/package.json/pyproject.toml/Cargo.toml) — no language-native gate (#299)"
+  fi
+  if [ "$LANG_RC" -ne 0 ]; then return 1; fi
+  return 0
+}
+```
+
+Constraints honored: no `|| true` (failures surface); no INFO line contains the literal tokens `escalate` or `tests-pass` (the edges substring-match `ctx.tool_stdout`); the helper prints no routing marker (callers print `tests-pass`/`escalate`/`final-build-pass` LAST, surviving the 64KB tail cap); `LANG_RC` holds the last failing code but the caller only branches on zero/non-zero. `LANG_RC`/`RAN_ANY` leak into the sourcing shell (consistent with the existing `MAKEFILE`/`TARGET`/`PROJECT_CI_RAN` leaks); neither caller references those names (verified).
+
+## Prose-sync edits (subtlety 5 — keep doc-in-prompt honest)
+
+After this change, "no Makefile" / "no matching target" no longer means "skipped." Every site asserting otherwise becomes false and must be corrected:
+
+1. **Helper header `:42-50`** — rewrite the `Returns:` block: rc=0 now includes "language-native gates passed / no toolchain detected," and "no Makefile / no matching target" can now return 1.
+2. **In-function INFO strings `:58`, `:90`** — "no project CI gate to run" / "no project CI target" become "running language-native gates" (already in the proposed body above).
+3. **VerifyMilestone preamble `:655-658`** — "OR the probe correctly skipped (no Makefile, or no matching target)" → the no-gate paths now run language-native gates; valid-skip is now "no recognized toolchain."
+4. **VerifyMilestone item 6 `:745-754`** — "passed-or-was-validly-skipped" / "validly skipped" rules updated to match (3).
+5. **VerifyMilestone item 6 cause description `:759-765`** — the "project CI gate" is no longer Makefile-only; note language-native gate failures fold into `TEST_EXIT` → FixMilestone (routing unchanged; only the cause text broadens).
+
+Optional one-liners (truthful-but-understated, low priority): TestMilestone comment `:544-551`, FinalBuild comment `:1241-1246`.
+
+## Out of scope (deliberate)
+
+- **Pre-existing make-path rc=2 leak.** GNU `make` exits 2 on any recipe error, so the *untouched* `make "$TARGET"; return $?` path already routes ordinary `make ci` failures to escalate-to-human rather than the fix loop. Fixing it would change "existing Makefile-gate behavior," violating an acceptance criterion. **Decline inline; file a follow-up issue.** This spec claims only that the language-native block introduces **no new rc=2 source** — not that rc=2 is globally sole-sourced.
+- **Missing core toolchain** (`go.mod` present but `go` binary absent) returns 1 → fix loop, not rc=2. Accepted per #299's explicit "rc=2 = make-missing only" and because TestMilestone's `go build`/`go test` runs *before* the gate and fails first. Documented, not changed.
+- **Test-runner if/elif first-match** (`:561-578`, `:1230-1239`) — that is #305 (polyglot test runner), Phase 3. This change touches only the gate, never the test runner. The asymmetry (gate uses independent `if`, runner stays `elif`) is intentional for this issue.
+
+## Tests (TDD, negative-control RED-first, per the #296/#297/#298 precedent)
+
+New file `pipeline/build_product_quality_gate_test.go`, package `pipeline`, using the existing `loadBuildProduct(t)` helper.
+
+### Layer A — graph string assertions (read `Setup.Attrs["tool_command"]`)
+
+Each assertion labeled in a comment as **negative-control** (RED pre-#299) or **regression-pin** (GREEN, guards removal). Verified absent from the Setup node pre-change (count=0): `go vet`, `golangci-lint`, `ruff`, `eslint`, `tsc`, `mypy`, `cargo clippy`, `cargo fmt`, and the `package.json`/`pyproject.toml`/`Cargo.toml` detectors (these live in the test-runner elif, *not* in Setup's heredoc — so asserting their presence in Setup IS a valid driver).
+
+- **Negative-controls:** `go vet ./...`, `golangci-lint run`, `ruff check`, `eslint`, `tsc --noEmit`, `mypy`, `cargo clippy`, `cargo fmt --check`, and the three detectors present in Setup's heredoc.
+- **Regression-pins:** `make "$TARGET"` and the awk parse survive; `return 2` appears exactly once **and is adjacent to `command -v make`** (semantic pin, not just count — assert `command -v make` precedes the sole `return 2` and no `return 2` follows any `language-native gate` marker); both `TestMilestone` and `FinalBuild` still `. .ai/build/ci-probe.sh` and call `run_project_ci_gate` (gate stays centralized — stronger than "no `go vet` in callers").
+- **Prose negative-control:** VerifyMilestone prompt no longer contains "correctly skipped (no Makefile".
+
+### Layer B — runtime shell test (the behavioral driver)
+
+Extract the heredoc body from the **loaded** (dippin-dedented) Setup `tool_command` — between `<<'PROBE_EOF'\n` and `\nPROBE_EOF` — write to a temp file, and source it. `t.Skip` when `go` or `sh` is unavailable. Run each case under hermetic env:
+
+```
+env -i  PATH=$(dirname $(command -v go)):/usr/bin:/bin  HOME=<t.TempDir>  GOCACHE=<t.TempDir>  GOPROXY=off
+```
+
+Fixture `go.mod` uses `go 1.22` with **no `toolchain` directive** and zero deps (so `GOPROXY=off` never resolves). No `git` needed (the gate doesn't use it). The restricted PATH deterministically removes golangci-lint/ruff/etc.
+
+Cases:
+- (a) Go repo with a `go vet` violation → rc≠0 **and** rc≠2.
+- (b) clean Go repo → rc=0.
+- (c) golangci-lint absent (restricted PATH) → output has the INFO skip line, rc≠2.
+- (d) Makefile with a `ci:` target (+ a go.mod vet violation) → make wins: `PROJECT_CI_RAN=ci`, rc reflects make, and the `go vet` marker is **absent** (proves precedence — gate didn't run).
+- (e) empty dir → rc=0 + "no recognized toolchain".
+- (f) **build-only Makefile (no ci/check/lint) + go.mod vet violation → rc≠0 AND `PROJECT_CI_RAN=""`** — the key both-paths case.
+- (g) optional tool absent + core gate fails simultaneously → rc=1, not 2 (+ INFO skip line).
+- (h) Makefile present, `make` uninstalled (PATH without make, with go) → rc=2 still fires *before* any language gate.
+- (i) polyglot proof: clean Go + `package.json` → output contains **both** the `go vet` marker AND a node-stack INFO/skip line (proves not first-match), rc=0.
+
+No coverage/complexity-hook risk: the complexity gate excludes `_test.go`; coverage is aggregate and the new test is additive; both layers assert on embedded `.dip` data, not new production Go.
+
+## Verification
+
+- `dippin validate examples/build_product.dip` — passes.
+- `dippin doctor examples/build_product.dip examples/ask_and_execute.dip examples/build_product_with_superspec.dip` — A grade across the board (build_product baseline A 90/100).
+- `dippin simulate -all-paths examples/build_product.dip` — 100% terminate success, no new cycle / dead-stop.
+- `go build ./... && go test ./... -short` — green; each new test proven RED before its wiring.
+- CHANGELOG.md `[Unreleased]/Added` — language-native quality gate fallback closing the no-Makefile blind spot; epic #308 Phase 2; framed as a behavior change (no-Makefile repos now enforce `go vet`).
+
+## Follow-up issue to file
+
+Pre-existing make-path rc=2 leak: `make "$TARGET"; return $?` (`:86-87`) propagates GNU make's native exit 2 on ordinary recipe failures, so a normal `make ci` lint failure escalates-to-human instead of routing to the fix loop, contradicting the contract VerifyMilestone's prose describes. Out of scope for #299 (fixing it changes Makefile-gate behavior).

--- a/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
@@ -38,11 +38,13 @@ Independent `if` blocks (not `elif`). Each runs if its project file is present:
 | Toolchain | Detect | Gates |
 |-----------|--------|-------|
 | Go | `go.mod` | `go vet ./...` (**always** — core; go is present by go.mod detection); `golangci-lint run` *if on PATH* |
-| JS/TS | `package.json` | `tsc --noEmit` *if on PATH*; `eslint .` *if on PATH* |
+| JS/TS | `package.json` | `tsc --noEmit` *if `tsconfig.json` present and tsc on PATH*; `eslint .` *if an eslint config present and eslint on PATH* |
 | Python | `pyproject.toml` | `ruff check .` *if on PATH*; `mypy .` *if on PATH* |
 | Rust | `Cargo.toml` | `cargo fmt --check` + `cargo clippy -- -D warnings` *if cargo on PATH* |
 
 **Core vs optional** (issue subtlety 2): "core" means *when the tool runs, its failure is fatal* — NOT that its absence is fatal. `go vet` is the only unguarded gate (runs whenever `go.mod` exists). Every other tool is `command -v`-guarded: **absent → one-line INFO skip (never rc=2, never a failure); present-and-failing → accumulate into `LANG_RC` and propagate**. This applies uniformly to every run gate, so the only thing the core/optional distinction governs in code is whether `go vet` carries a `command -v` guard (it does not).
+
+**JS/TS opt-in refinement (Codex PR #321 P2):** `tsc`/`eslint` are gated not only on `command -v` but also on the project having opted into the tool — `tsconfig.json` for `tsc`, an eslint config file (`eslint.config.*`, `.eslintrc*`, or an `eslintConfig` key in `package.json`) for `eslint`. A plain-JS repo (just `package.json`) where the runner image happens to have a global `tsc`/`eslint` on PATH would otherwise be failed spuriously: bare `tsc --noEmit` exits non-zero when no `tsconfig.json`/inputs exist, and `eslint .` errors when no config is found. The not-configured case is a one-line INFO skip, identical in spirit to the not-installed case. Go/Python/Rust gates are unaffected (`go vet`/`ruff`/`mypy`/`cargo` behave sensibly under their own project markers).
 
 ### Both no-gate paths fall through (decided)
 

--- a/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-299-language-native-quality-gate-design.md
@@ -12,7 +12,7 @@ The helper is sourced by two callers — `TestMilestone` (`:587-589`, branches o
 
 ## The change
 
-Replace the two early `return 0` skip paths with a **fall-through** to a language-native quality-gate block appended to the *same* function. The Makefile branch is preserved byte-for-byte; only the two `return 0`s become fall-throughs.
+Replace the two early `return 0` skip paths with a call to a **new sibling helper `run_language_native_gates`** (defined in the same `ci-probe.sh` heredoc). The Makefile branch — detection loop, `make`-missing rc=2, the awk target-parser, and `make "$TARGET"; return $?` — is preserved **byte-for-byte**; only the two `return 0` blocks change to `run_language_native_gates; return $?` (mirroring the existing `make "$TARGET" 2>&1; return $?` idiom, which has identical `set -e` semantics under both callers). Extracting the gates into their own function leaves the awk untouched and makes the block independently unit-testable — a refinement of the reviewed inline sketch with identical runtime behavior.
 
 ### Return-code contract (load-bearing — unchanged)
 
@@ -201,6 +201,6 @@ No coverage/complexity-hook risk: the complexity gate excludes `_test.go`; cover
 - `go build ./... && go test ./... -short` — green; each new test proven RED before its wiring.
 - CHANGELOG.md `[Unreleased]/Added` — language-native quality gate fallback closing the no-Makefile blind spot; epic #308 Phase 2; framed as a behavior change (no-Makefile repos now enforce `go vet`).
 
-## Follow-up issue to file
+## Follow-up issue (filed: #320)
 
-Pre-existing make-path rc=2 leak: `make "$TARGET"; return $?` (`:86-87`) propagates GNU make's native exit 2 on ordinary recipe failures, so a normal `make ci` lint failure escalates-to-human instead of routing to the fix loop, contradicting the contract VerifyMilestone's prose describes. Out of scope for #299 (fixing it changes Makefile-gate behavior).
+Pre-existing make-path rc=2 leak: `make "$TARGET"; return $?` (`:86-87`) propagates GNU make's native exit 2 on ordinary recipe failures, so a normal `make ci` lint failure escalates-to-human instead of routing to the fix loop, contradicting the contract VerifyMilestone's prose describes. Out of scope for #299 (fixing it changes Makefile-gate behavior). Tracked in **#320**.

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -45,7 +45,10 @@ workflow BuildProduct
       #        was detected (issue #299).
       #   2  — Makefile present but `make` not installed (caller
       #        should escalate; LLM fix loop can't install a binary).
-      #        rc=2 is reserved for THIS case only.
+      #        This helper emits an explicit rc=2 ONLY here; the
+      #        language-native block never returns 2. (Caveat: the
+      #        `make <TARGET>` path below can still propagate make's own
+      #        native exit 2 on a recipe error — pre-existing, #320.)
       #   N  — a gate failed (caller should fail / retry): `make
       #        <TARGET>` exits with make's own non-zero code, whereas a
       #        failing language-native gate (go vet / golangci-lint /
@@ -180,10 +183,22 @@ workflow BuildProduct
         if [ -f Cargo.toml ]; then
           RAN_ANY=1
           if command -v cargo >/dev/null 2>&1; then
-            echo "--- cargo fmt --check (language-native gate, #299) ---"
-            cargo fmt --check 2>&1 || LANG_RC=$?
-            echo "--- cargo clippy -- -D warnings (language-native gate, #299) ---"
-            cargo clippy -- -D warnings 2>&1 || LANG_RC=$?
+            # rustfmt/clippy are separate toolchain components — `cargo` can be
+            # present without them. A missing component is a tooling absence
+            # (same class as an optional tool not installed), not a code defect,
+            # so gate each subcommand on its own availability (#299).
+            if cargo fmt --version >/dev/null 2>&1; then
+              echo "--- cargo fmt --check (language-native gate, #299) ---"
+              cargo fmt --check 2>&1 || LANG_RC=$?
+            else
+              echo "INFO: cargo fmt (rustfmt) not installed — skipping (optional, #299)"
+            fi
+            if cargo clippy --version >/dev/null 2>&1; then
+              echo "--- cargo clippy -- -D warnings (language-native gate, #299) ---"
+              cargo clippy -- -D warnings 2>&1 || LANG_RC=$?
+            else
+              echo "INFO: cargo clippy not installed — skipping (optional, #299)"
+            fi
           else
             echo "INFO: cargo not installed — skipping (optional, #299)"
           fi

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -46,10 +46,11 @@ workflow BuildProduct
       #   2  — Makefile present but `make` not installed (caller
       #        should escalate; LLM fix loop can't install a binary).
       #        rc=2 is reserved for THIS case only.
-      #   N  — a gate failed: `make <TARGET>` exited non-zero, OR a
-      #        language-native gate (go vet / golangci-lint / tsc /
-      #        eslint / ruff / mypy / cargo fmt|clippy) failed
-      #        (collapsed to 1; caller should fail / retry).
+      #   N  — a gate failed (caller should fail / retry): `make
+      #        <TARGET>` exits with make's own non-zero code, whereas a
+      #        failing language-native gate (go vet / golangci-lint /
+      #        tsc / eslint / ruff / mypy / cargo fmt|clippy) ALWAYS
+      #        collapses to exactly 1 — never an arbitrary N, never 2.
       # Sets PROJECT_CI_RAN to the chosen target on a real `make` run,
       # empty string otherwise (incl. the language-native fall-through).
       run_project_ci_gate() {

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -40,14 +40,18 @@ workflow BuildProduct
       # between the two nodes; this prevents that class of bug.
       cat > .ai/build/ci-probe.sh <<'PROBE_EOF'
       # Source this file, then call `run_project_ci_gate`. Returns:
-      #   0  — clean (no Makefile, no matching target, OR
-      #        `make <TARGET>` exited 0)
+      #   0  — clean: `make <TARGET>` exited 0, OR (no Makefile gate
+      #        ran) the language-native gates passed / no toolchain
+      #        was detected (issue #299).
       #   2  — Makefile present but `make` not installed (caller
-      #        should escalate; LLM fix loop can't install a binary)
-      #   N  — `make <TARGET>` exited with non-zero N
-      #        (caller should fail / retry)
-      # Sets PROJECT_CI_RAN to the chosen target on a real run,
-      # empty string otherwise.
+      #        should escalate; LLM fix loop can't install a binary).
+      #        rc=2 is reserved for THIS case only.
+      #   N  — a gate failed: `make <TARGET>` exited non-zero, OR a
+      #        language-native gate (go vet / golangci-lint / tsc /
+      #        eslint / ruff / mypy / cargo fmt|clippy) failed
+      #        (collapsed to 1; caller should fail / retry).
+      # Sets PROJECT_CI_RAN to the chosen target on a real `make` run,
+      # empty string otherwise (incl. the language-native fall-through).
       run_project_ci_gate() {
         PROJECT_CI_RAN=""
         MAKEFILE=""
@@ -55,8 +59,9 @@ workflow BuildProduct
           if [ -f "$mf" ]; then MAKEFILE="$mf"; break; fi
         done
         if [ -z "$MAKEFILE" ]; then
-          echo "INFO: no Makefile present, no project CI gate to run"
-          return 0
+          echo "INFO: no Makefile present — running language-native gates (#299)"
+          run_language_native_gates
+          return $?
         fi
         if ! command -v make >/dev/null 2>&1; then
           echo "ERROR: $MAKEFILE present but 'make' not installed — escalating"
@@ -87,7 +92,87 @@ workflow BuildProduct
             return $?
           fi
         done
-        echo "INFO: no project CI target in $MAKEFILE (looked for: ci, check, lint)"
+        echo "INFO: no project CI target in $MAKEFILE (looked for: ci, check, lint) — running language-native gates (#299)"
+        run_language_native_gates
+        return $?
+      }
+      # Language-native quality-gate fallback (issue #299, epic #308 Phase 2).
+      # Reached from run_project_ci_gate when no Makefile ci/check/lint target
+      # ran. Runs gates for EVERY detected toolchain (polyglot, not first-match).
+      # Returns 0 (clean / nothing to gate) or 1 (some gate failed) — NEVER 2;
+      # rc=2 stays reserved for the make-missing case in run_project_ci_gate.
+      #
+      # INVARIANT: every gate command MUST end in `|| LANG_RC=$?`. These nodes run
+      # `set -eu`; FinalBuild calls the gate BARE (set -e active in the body), so a
+      # bare failing gate would abort the node before later gates/markers run. The
+      # `|| LANG_RC=$?` neutralizes set -e per gate and accumulates the failure.
+      # "Core" tools fail when they FAIL; "optional" tools are command-v guarded so
+      # ABSENCE is a one-line INFO skip (never a failure, never rc=2).
+      run_language_native_gates() {
+        LANG_RC=0
+        RAN_ANY=""
+        # Go — `go vet` is the core gate (go is present by go.mod detection).
+        if [ -f go.mod ]; then
+          RAN_ANY=1
+          echo "--- go vet ./... (language-native gate, #299) ---"
+          go vet ./... 2>&1 || LANG_RC=$?
+          if command -v golangci-lint >/dev/null 2>&1; then
+            echo "--- golangci-lint run (language-native gate, #299) ---"
+            golangci-lint run 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: golangci-lint not installed — skipping (optional, #299)"
+          fi
+        fi
+        # JS/TS — both run-if-present.
+        if [ -f package.json ]; then
+          RAN_ANY=1
+          if command -v tsc >/dev/null 2>&1; then
+            echo "--- tsc --noEmit (language-native gate, #299) ---"
+            tsc --noEmit 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: tsc not installed — skipping (optional, #299)"
+          fi
+          if command -v eslint >/dev/null 2>&1; then
+            echo "--- eslint . (language-native gate, #299) ---"
+            eslint . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: eslint not installed — skipping (optional, #299)"
+          fi
+        fi
+        # Python — both run-if-present.
+        if [ -f pyproject.toml ]; then
+          RAN_ANY=1
+          if command -v ruff >/dev/null 2>&1; then
+            echo "--- ruff check . (language-native gate, #299) ---"
+            ruff check . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: ruff not installed — skipping (optional, #299)"
+          fi
+          if command -v mypy >/dev/null 2>&1; then
+            echo "--- mypy . (language-native gate, #299) ---"
+            mypy . 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: mypy not installed — skipping (optional, #299)"
+          fi
+        fi
+        # Rust — run-if-present (cargo gates both fmt and clippy).
+        if [ -f Cargo.toml ]; then
+          RAN_ANY=1
+          if command -v cargo >/dev/null 2>&1; then
+            echo "--- cargo fmt --check (language-native gate, #299) ---"
+            cargo fmt --check 2>&1 || LANG_RC=$?
+            echo "--- cargo clippy -- -D warnings (language-native gate, #299) ---"
+            cargo clippy -- -D warnings 2>&1 || LANG_RC=$?
+          else
+            echo "INFO: cargo not installed — skipping (optional, #299)"
+          fi
+        fi
+        if [ -z "$RAN_ANY" ]; then
+          echo "INFO: no recognized toolchain (go.mod/package.json/pyproject.toml/Cargo.toml) — no language-native gate (#299)"
+        fi
+        if [ "$LANG_RC" -ne 0 ]; then
+          return 1
+        fi
         return 0
       }
       PROBE_EOF

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -738,9 +738,11 @@ workflow BuildProduct
       `go.mod` / `package.json` / `pyproject.toml` / `Cargo.toml`
       was detected) OR no known build system was detected and the
       runner was skipped; AND the project CI gate ran and returned 0
-      (when a Makefile with a `ci`/`check`/`lint` target was present)
-      OR the probe correctly skipped (no Makefile, or no matching
-      target). The sentinel does NOT prove every check executed —
+      (a Makefile `ci`/`check`/`lint` target, OR — when no such target
+      ran — the language-native gates: go vet/golangci-lint, tsc/eslint,
+      ruff/mypy, cargo fmt/clippy for each detected toolchain, #299)
+      OR there was nothing to gate (no recognized toolchain). The
+      sentinel does NOT prove every check executed —
       only that none failed. Treat its presence as authoritative for
       "TestMilestone step succeeded"; if a milestone implies tests
       must have RUN (not skipped), check the visible probe / test
@@ -831,8 +833,9 @@ workflow BuildProduct
          ${ctx.tool_stdout} is authoritative for "TestMilestone step
          succeeded" — TestMilestone prints it when its language-stack
          runner passed-or-was-validly-skipped AND its project CI gate
-         passed-or-was-validly-skipped (see the preamble above for the
-         exact "validly skipped" rules). The sentinel is emitted at
+         passed (a Makefile target OR the language-native gates, #299)
+         or had nothing to gate (see the preamble above for the exact
+         rules). The sentinel is emitted at
          end-of-command via `printf`, and `tool_stdout` keeps the
          tail of stdout, so the sentinel survives truncation by
          construction — its presence is reliable, its absence is
@@ -849,7 +852,9 @@ workflow BuildProduct
                 → `printf 'escalate'` + exit 1 (routes to
                 EscalateMilestone)
            (iii) TEST_EXIT!=0 && ATTEMPTS<=3 → NO marker + exit 1
-                (normal in-progress failure — routes to FixMilestone)
+                (normal in-progress failure — routes to FixMilestone;
+                a failing language-native gate (#299) folds into
+                TEST_EXIT here, so it routes the same way)
          Under normal routing only path (i) reaches VerifyMilestone,
          so the contract for THIS node is: "if you see me, the
          upstream tool emitted `tests-pass`." The three sentinel

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -123,20 +123,40 @@ workflow BuildProduct
             echo "INFO: golangci-lint not installed — skipping (optional, #299)"
           fi
         fi
-        # JS/TS — both run-if-present.
+        # JS/TS — run-if-present AND only if the project opted into the tool
+        # (config file present). A plain-JS repo (package.json, no tsconfig /
+        # no eslint config) must NOT fail just because a global tsc/eslint is on
+        # PATH: bare `tsc --noEmit` exits non-zero on a project with no tsconfig,
+        # and `eslint .` errors with no config — gating on PATH alone would
+        # mis-route such a repo to the fix loop (Codex PR #321 P2, #299).
         if [ -f package.json ]; then
           RAN_ANY=1
-          if command -v tsc >/dev/null 2>&1; then
-            echo "--- tsc --noEmit (language-native gate, #299) ---"
-            tsc --noEmit 2>&1 || LANG_RC=$?
+          if [ -f tsconfig.json ]; then
+            if command -v tsc >/dev/null 2>&1; then
+              echo "--- tsc --noEmit (language-native gate, #299) ---"
+              tsc --noEmit 2>&1 || LANG_RC=$?
+            else
+              echo "INFO: tsc not installed — skipping (optional, #299)"
+            fi
           else
-            echo "INFO: tsc not installed — skipping (optional, #299)"
+            echo "INFO: no tsconfig.json — skipping tsc (not a TypeScript project, #299)"
           fi
-          if command -v eslint >/dev/null 2>&1; then
-            echo "--- eslint . (language-native gate, #299) ---"
-            eslint . 2>&1 || LANG_RC=$?
+          ESLINT_CFG=""
+          for ec in eslint.config.js eslint.config.mjs eslint.config.cjs eslint.config.ts .eslintrc.js .eslintrc.cjs .eslintrc.yaml .eslintrc.yml .eslintrc.json .eslintrc; do
+            if [ -f "$ec" ]; then ESLINT_CFG="$ec"; break; fi
+          done
+          if [ -z "$ESLINT_CFG" ] && grep -q '"eslintConfig"' package.json 2>/dev/null; then
+            ESLINT_CFG="package.json"
+          fi
+          if [ -n "$ESLINT_CFG" ]; then
+            if command -v eslint >/dev/null 2>&1; then
+              echo "--- eslint . (language-native gate, #299) ---"
+              eslint . 2>&1 || LANG_RC=$?
+            else
+              echo "INFO: eslint not installed — skipping (optional, #299)"
+            fi
           else
-            echo "INFO: eslint not installed — skipping (optional, #299)"
+            echo "INFO: no eslint config — skipping eslint (not configured, #299)"
           fi
         fi
         # Python — both run-if-present.

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -157,13 +157,44 @@ func extractProbe(t *testing.T) string {
 	return rest[:j]
 }
 
-// hermeticEnv builds an env that deterministically excludes optional linters
-// (golangci-lint/ruff/etc. typically live in ~/go/bin or ~/.local/bin, not in the
-// dir-of-go or /usr/bin:/bin) and runs go offline.
-func hermeticEnv(t *testing.T, goDir, home, gocache string) []string {
+// hermeticEnv builds an env whose PATH is a freshly-created temp bin containing
+// ONLY symlinks to the tools the gate legitimately needs: go, sh, the coreutils
+// the Makefile-parse path (`sed | awk`) and the eslint-config check (`grep`) use,
+// and make when the case requires it. Optional linters (golangci-lint/tsc/eslint/
+// ruff/mypy/cargo) are therefore GUARANTEED absent regardless of what the host has
+// in /usr/bin, so the "not installed" INFO assertions can't flake on a machine
+// that happens to ship one of them in a system dir (CodeRabbit, PR #321). go runs
+// offline (GOPROXY=off) with an isolated cache. (NB: keeping /usr/bin:/bin on PATH
+// — as an earlier draft did — would have leaked any system-installed linter; but
+// dropping it naively would also drop sed/awk and break the Makefile-parse cases,
+// hence the explicit allowlist of symlinks below.)
+func hermeticEnv(t *testing.T, home, gocache string, withMake bool) []string {
 	t.Helper()
+	binDir := t.TempDir()
+	link := func(name string, required bool) {
+		src, err := exec.LookPath(name)
+		if err != nil {
+			if required {
+				t.Fatalf("%s not available: %v", name, err)
+			}
+			return
+		}
+		if err := os.Symlink(src, filepath.Join(binDir, name)); err != nil {
+			t.Fatalf("symlink %s: %v", name, err)
+		}
+	}
+	link("go", true)
+	link("sh", true)
+	// echo is for make's recipe direct-exec (a `@echo ...` rule runs without a
+	// shell, so make resolves echo via PATH); the rest serve the gate's own probe.
+	for _, u := range []string{"sed", "awk", "grep", "cat", "echo"} {
+		link(u, false)
+	}
+	if withMake {
+		link("make", true)
+	}
 	return []string{
-		"PATH=" + goDir + ":/usr/bin:/bin",
+		"PATH=" + binDir,
 		"HOME=" + home,
 		"GOCACHE=" + gocache,
 		"GOPROXY=off",
@@ -183,12 +214,15 @@ func runGate(t *testing.T, probe, dir string, env []string) (out string, rc int,
 	c := exec.Command("sh", "-c", script)
 	c.Dir = dir
 	c.Env = env
-	b, _ := c.CombinedOutput()
+	// A non-nil err here is normal — the gate exits non-zero on a gate failure, and
+	// we parse the real rc from the RC= marker. Only surface runErr if the marker is
+	// absent (shell couldn't exec / syntax error), so failures aren't opaque.
+	b, runErr := c.CombinedOutput()
 	out = string(b)
 	if m := regexp.MustCompile(`RC=(\d+)`).FindStringSubmatch(out); m != nil {
 		rc = atoi(m[1])
 	} else {
-		t.Fatalf("no RC marker in output:\n%s", out)
+		t.Fatalf("no RC marker in output (exec err: %v):\n%s", runErr, out)
 	}
 	if m := regexp.MustCompile(`RAN=\[([^\]]*)\]`).FindStringSubmatch(out); m != nil {
 		ciRan = m[1]
@@ -239,7 +273,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	t.Run("clean_go_rc0", func(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, false)
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc != 0 {
 			t.Errorf("clean Go repo: rc=%d want 0\n%s", rc, out)
 		}
@@ -252,7 +286,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	t.Run("go_vet_violation_rc1", func(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, true)
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc == 0 || rc == 2 {
 			t.Errorf("vet violation: rc=%d want non-zero and != 2\n%s", rc, out)
 		}
@@ -262,7 +296,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	t.Run("golangci_absent_info_skip", func(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, false)
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc == 2 {
 			t.Errorf("optional-absent must not yield rc=2\n%s", out)
 		}
@@ -274,7 +308,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	// (e) empty repo → rc 0 + no-toolchain note.
 	t.Run("empty_repo_rc0", func(t *testing.T) {
 		dir := t.TempDir()
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc != 0 {
 			t.Errorf("empty repo: rc=%d want 0\n%s", rc, out)
 		}
@@ -286,10 +320,13 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	// (f) build-only Makefile (no ci/check/lint) + vet violation → falls through
 	// to language gates: rc != 0 AND PROJECT_CI_RAN empty (make CI path didn't win).
 	t.Run("build_only_makefile_falls_through", func(t *testing.T) {
+		if _, err := exec.LookPath("make"); err != nil {
+			t.Skip("make not available") // Makefile present → gate needs make to fall through (else rc=2)
+		}
 		dir := t.TempDir()
 		writeGoModule(t, dir, true)
 		mustWrite(t, filepath.Join(dir, "Makefile"), "build:\n\tgo build ./...\n")
-		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), true))
 		if rc == 0 || rc == 2 {
 			t.Errorf("build-only Makefile: rc=%d want non-zero != 2 (vet must run)\n%s", rc, out)
 		}
@@ -309,7 +346,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, true) // vet would fail IF it ran — it must not
 		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo running-ci\n")
-		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), true))
 		if ciRan != "ci" {
 			t.Errorf("Makefile ci target: PROJECT_CI_RAN=%q want ci\n%s", ciRan, out)
 		}
@@ -326,9 +363,9 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, false)
 		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo hi\n")
-		// PATH without /usr/bin:/bin so `command -v make` fails; only goDir present.
-		env := []string{"PATH=" + goDir, "HOME=" + t.TempDir(), "GOCACHE=" + t.TempDir(), "GOPROXY=off"}
-		out, rc, _ := runGate(t, probe, dir, env)
+		// withMake=false: make is not symlinked into the hermetic bin, so the gate's
+		// `command -v make` fails and it returns rc=2 before any language gate.
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc != 2 {
 			t.Errorf("make missing: rc=%d want 2\n%s", rc, out)
 		}
@@ -343,7 +380,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, false)
 		mustWrite(t, filepath.Join(dir, "package.json"), "{\"name\":\"x\",\"version\":\"0.0.0\"}\n")
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc != 0 {
 			t.Errorf("polyglot clean: rc=%d want 0\n%s", rc, out)
 		}
@@ -387,7 +424,7 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 	t.Run("optional_absent_core_fails_rc1", func(t *testing.T) {
 		dir := t.TempDir()
 		writeGoModule(t, dir, true) // go vet fails; golangci-lint absent
-		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false))
 		if rc != 1 {
 			t.Errorf("core-fail + optional-absent: rc=%d want 1\n%s", rc, out)
 		}

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -200,9 +200,13 @@ func hermeticEnv(t *testing.T, home, gocache string, withMake bool) []string {
 	for _, u := range []string{"sed", "awk", "grep"} {
 		link(u, true)
 	}
-	// echo is for make's recipe direct-exec (a `@echo ...` rule runs without a
-	// shell, so make resolves echo via PATH; its absence fails loud where used);
-	// cat is a belt-and-suspenders helper. Both genuinely optional.
+	// echo: GNU make has a no-shell optimization — a recipe line with NO shell
+	// metacharacters is exec'd DIRECTLY (not via /bin/sh), so make resolves the
+	// command via PATH. The `ci:` fixture's `@echo running-ci` has none, so echo
+	// must be on PATH (empirically: makefile_ci_target_wins fails with "make: echo:
+	// No such file or directory" without it). A recipe WITH a metacharacter (|,>,&&,
+	// …) would instead go through /bin/sh, where echo is a builtin — but this
+	// fixture doesn't. cat is a belt-and-suspenders helper. Both genuinely optional.
 	for _, u := range []string{"echo", "cat"} {
 		link(u, false)
 	}

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -226,7 +226,12 @@ func runGate(t *testing.T, probe, dir string, env []string) (out string, rc int,
 	if err := os.WriteFile(probePath, []byte(probe), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	script := ". " + probePath + `; run_project_ci_gate; echo "RC=$?"; echo "RAN=[$PROJECT_CI_RAN]"`
+	// Run under `set -eu` and capture rc via `|| rc=$?` — the exact shape TestMilestone
+	// uses (`run_project_ci_gate || CI_RC=$?` under set -eu). This adds set -u coverage
+	// and realistic shell options; the FinalBuild bare-call-under-set-e path (where a
+	// missing `|| LANG_RC=$?` guard would abort mid-function) is covered separately by
+	// TestRunProjectCIGateSetEBareCall.
+	script := "set -eu; . " + probePath + `; rc=0; run_project_ci_gate || rc=$?; echo "RC=$rc"; echo "RAN=[$PROJECT_CI_RAN]"`
 	c := exec.Command("sh", "-c", script)
 	c.Dir = dir
 	c.Env = env
@@ -252,6 +257,31 @@ func atoi(s string) int {
 		n = n*10 + int(r-'0')
 	}
 	return n
+}
+
+// sourceAndRun sources the probe then runs `body` under `set -eu` in dir, returning
+// combined output and the process exit code. Unlike runGate it parses no RC marker —
+// it's for the FinalBuild bare-call invariant, where set -e may abort the script
+// before any trailing marker prints.
+func sourceAndRun(t *testing.T, probe, dir string, env []string, body string) (string, int) {
+	t.Helper()
+	probePath := filepath.Join(t.TempDir(), "ci-probe.sh")
+	if err := os.WriteFile(probePath, []byte(probe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := exec.Command("sh", "-c", "set -eu\n. "+probePath+"\n"+body)
+	c.Dir = dir
+	c.Env = env
+	b, err := c.CombinedOutput()
+	code := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("exec failed: %v\n%s", err, string(b))
+		}
+		code = ee.ExitCode()
+	}
+	return string(b), code
 }
 
 // writeGoModule writes a minimal module; `vetViolation` injects an unreachable-code /
@@ -446,6 +476,61 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		}
 		if !strings.Contains(out, "golangci-lint not installed") {
 			t.Errorf("expected golangci-lint INFO skip alongside the core failure\n%s", out)
+		}
+	})
+}
+
+// TestRunProjectCIGateSetEBareCall covers the FinalBuild invariant that the main
+// runtime harness (which captures rc via `|| rc=$?`, suppressing set -e inside the
+// function) cannot: FinalBuild calls `run_project_ci_gate` BARE under `set -eu`, so
+// a gate missing its `|| LANG_RC=$?` guard would abort the function the instant a
+// gate fails — before the remaining gates run and before the function's own return.
+func TestRunProjectCIGateSetEBareCall(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go not available; skipping runtime gate test")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping runtime gate test")
+	}
+	probe := extractProbe(t)
+
+	// Negative control for the guard invariant: on a vet-violation repo, a bare call
+	// under set -e must still run PAST the failing go vet to the golangci-lint INFO
+	// line (proving the failure was accumulated via `|| LANG_RC=$?`, not aborted),
+	// then return non-zero so set -e stops before the trailing marker. If any gate
+	// lost its guard, set -e would abort at that gate and golangci's INFO line would
+	// be absent.
+	t.Run("failing_gate_runs_all_then_propagates", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true)
+		out, code := sourceAndRun(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false),
+			"run_project_ci_gate\necho REACHED-END")
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("go vet did not run\n%s", out)
+		}
+		if !strings.Contains(out, "golangci-lint not installed") {
+			t.Errorf("function aborted at the failing go vet — a gate is missing its `|| LANG_RC=$?` guard\n%s", out)
+		}
+		if strings.Contains(out, "REACHED-END") {
+			t.Errorf("set -e should have aborted after the gate returned non-zero\n%s", out)
+		}
+		if code == 0 {
+			t.Errorf("expected non-zero exit from a bare set -e call on a failing gate\n%s", out)
+		}
+	})
+
+	// Happy path: a clean repo's bare call under set -eu reaches the trailing marker
+	// (all gates pass → return 0 → no spurious abort).
+	t.Run("clean_gate_reaches_end", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		out, code := sourceAndRun(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), false),
+			"run_project_ci_gate\necho REACHED-END")
+		if !strings.Contains(out, "REACHED-END") {
+			t.Errorf("clean repo bare call did not reach end (spurious set -e abort?)\n%s", out)
+		}
+		if code != 0 {
+			t.Errorf("clean repo bare call: exit=%d want 0\n%s", code, out)
 		}
 	})
 }

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -176,20 +176,34 @@ func hermeticEnv(t *testing.T, home, gocache string, withMake bool) []string {
 	link := func(name string, required bool) {
 		src, err := exec.LookPath(name)
 		if err != nil {
+			// A required tool absent is an environment limitation, not a code
+			// defect — skip the case (the suite already skips when go/sh/make are
+			// absent) rather than failing the whole run.
 			if required {
-				t.Fatalf("%s not available: %v", name, err)
+				t.Skipf("%s not available; skipping runtime gate test", name)
 			}
 			return
 		}
 		if err := os.Symlink(src, filepath.Join(binDir, name)); err != nil {
-			t.Fatalf("symlink %s: %v", name, err)
+			// Symlinks unsupported (e.g. Windows without Developer Mode) — skip,
+			// matching the precedent in git_preflight_test.go.
+			t.Skipf("cannot symlink %s (likely a platform without symlink support): %v", name, err)
 		}
 	}
 	link("go", true)
 	link("sh", true)
+	// sed/awk/grep are load-bearing, not decorative: the Makefile-target parser is
+	// `sed | awk` and the eslint-config check greps package.json. Require them so a
+	// host missing one SKIPS rather than silently passing a parse-dependent case for
+	// the wrong reason (a missing sed/awk would make the parser find no target and
+	// fall through, masquerading as "no CI target").
+	for _, u := range []string{"sed", "awk", "grep"} {
+		link(u, true)
+	}
 	// echo is for make's recipe direct-exec (a `@echo ...` rule runs without a
-	// shell, so make resolves echo via PATH); the rest serve the gate's own probe.
-	for _, u := range []string{"sed", "awk", "grep", "cat", "echo"} {
+	// shell, so make resolves echo via PATH; its absence fails loud where used);
+	// cat is a belt-and-suspenders helper. Both genuinely optional.
+	for _, u := range []string{"echo", "cat"} {
 		link(u, false)
 	}
 	if withMake {

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -350,10 +350,36 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		if !strings.Contains(out, "go vet ./...") {
 			t.Errorf("polyglot: Go stack did not run\n%s", out)
 		}
-		// tsc/eslint absent under hermetic PATH → INFO skip lines prove the JS
-		// stack was entered (not first-match-stopped at Go).
-		if !strings.Contains(out, "tsc not installed") && !strings.Contains(out, "eslint not installed") {
+		// package.json present but no tsconfig/eslint config → the JS block emits
+		// its config-skip lines, proving it was entered (not first-match-stopped
+		// at Go). Robust whether or not tsc/eslint are on PATH.
+		if !strings.Contains(out, "skipping tsc") && !strings.Contains(out, "skipping eslint") {
 			t.Errorf("polyglot: JS stack was not entered (first-match bug?)\n%s", out)
+		}
+	})
+
+	// (j) plain-JS repo (package.json, NO tsconfig.json) must NOT run tsc even
+	// when a global tsc is on PATH — bare `tsc --noEmit` exits non-zero on a
+	// non-TypeScript project and would mis-route to the fix loop (Codex PR #321
+	// P2). The tsc gate is opt-in via tsconfig.json. This subtest puts a real
+	// global tsc (if installed) on PATH to exercise the exact reported scenario.
+	t.Run("js_no_tsconfig_skips_tsc", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWrite(t, filepath.Join(dir, "package.json"), "{\"name\":\"x\",\"version\":\"0.0.0\"}\n")
+		pathDirs := goDir + ":/usr/bin:/bin"
+		if tscPath, err := exec.LookPath("tsc"); err == nil {
+			pathDirs = filepath.Dir(tscPath) + ":" + pathDirs // face a real global tsc
+		}
+		env := []string{"PATH=" + pathDirs, "HOME=" + t.TempDir(), "GOCACHE=" + t.TempDir(), "GOPROXY=off", "GOFLAGS="}
+		out, rc, _ := runGate(t, probe, dir, env)
+		if rc != 0 {
+			t.Errorf("plain-JS repo (no tsconfig): rc=%d want 0 (tsc must be skipped)\n%s", rc, out)
+		}
+		if strings.Contains(out, "tsc --noEmit (language-native gate") {
+			t.Errorf("tsc ran despite no tsconfig.json — must skip (Codex #321 P2)\n%s", out)
+		}
+		if !strings.Contains(out, "no tsconfig.json") {
+			t.Errorf("expected the no-tsconfig skip message\n%s", out)
 		}
 	})
 

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -1,0 +1,131 @@
+// ABOUTME: Negative-control + regression guard for issue #299 — the language-native
+// ABOUTME: quality-gate fallback in run_project_ci_gate (ci-probe.sh, Setup node).
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// setupCmd returns the Setup node's tool_command, where the ci-probe.sh heredoc lives.
+func setupCmd(t *testing.T) string {
+	t.Helper()
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["Setup"]
+	if !ok {
+		t.Fatal("Setup node missing from build_product graph")
+	}
+	return n.Attrs["tool_command"]
+}
+
+// Test 1 — negative-control: the Go core gate `go vet ./...` must appear in the
+// probe. Absent from Setup pre-#299 (verified count=0) → RED before implementation.
+func TestQualityGateGoVetPresent(t *testing.T) {
+	if !strings.Contains(setupCmd(t), "go vet ./...") {
+		t.Error("ci-probe.sh has no `go vet ./...` language-native gate (#299)")
+	}
+}
+
+// Test 2 — negative-control: optional linters wired (run-if-present).
+func TestQualityGateOptionalLintersPresent(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, tool := range []string{
+		"golangci-lint run",
+		"tsc --noEmit",
+		"eslint .",
+		"ruff check .",
+		"mypy .",
+		"cargo fmt --check",
+		"cargo clippy -- -D warnings",
+	} {
+		if !strings.Contains(cmd, tool) {
+			t.Errorf("ci-probe.sh missing language-native gate %q (#299)", tool)
+		}
+	}
+}
+
+// Test 3 — negative-control: all four toolchain detectors present INSIDE the probe
+// (they live in the test-runner elif elsewhere, NOT in Setup pre-#299; their presence
+// in Setup's tool_command is what #299 adds).
+func TestQualityGateDetectorsPresent(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, det := range []string{"go.mod", "package.json", "pyproject.toml", "Cargo.toml"} {
+		if !strings.Contains(cmd, det) {
+			t.Errorf("ci-probe.sh missing toolchain detector %q (#299)", det)
+		}
+	}
+}
+
+// Test 4 — negative-control: optional tools are command-v guarded (absence → skip,
+// never failure). Assert each optional tool is preceded by a `command -v` guard.
+func TestQualityGateOptionalToolsGuarded(t *testing.T) {
+	cmd := setupCmd(t)
+	for _, tool := range []string{"golangci-lint", "tsc", "eslint", "ruff", "mypy", "cargo"} {
+		if !strings.Contains(cmd, "command -v "+tool) {
+			t.Errorf("optional tool %q is not `command -v`-guarded (#299)", tool)
+		}
+	}
+}
+
+// Test 5 — regression-pin: the Makefile path is preserved byte-for-byte. `make
+// "$TARGET"` and the awk parser must survive (GREEN now and after; guards removal).
+func TestQualityGateMakefilePathPreserved(t *testing.T) {
+	cmd := setupCmd(t)
+	if !strings.Contains(cmd, `make "$TARGET" 2>&1`) {
+		t.Error("Makefile gate `make \"$TARGET\" 2>&1` was removed/altered (#299 regression)")
+	}
+	if !strings.Contains(cmd, "awk -v t=\"$TARGET\"") {
+		t.Error("awk Makefile-target parser was altered (#299 must not touch it)")
+	}
+}
+
+// Test 6 — regression-pin (semantic): rc=2 stays sole-sourced to the make-missing
+// branch. Exactly one `return 2`, and it is adjacent to `command -v make` — no
+// `return 2` may appear after any language-native gate marker.
+func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
+	cmd := setupCmd(t)
+	if n := strings.Count(cmd, "return 2"); n != 1 {
+		t.Fatalf("expected exactly one `return 2` (make-missing only), found %d (#299)", n)
+	}
+	makeIdx := strings.Index(cmd, "command -v make")
+	ret2Idx := strings.Index(cmd, "return 2")
+	if makeIdx == -1 || ret2Idx < makeIdx {
+		t.Error("`return 2` is not anchored to the `command -v make` branch (#299 rc contract)")
+	}
+	// No return 2 after the first language-native gate marker.
+	if g := strings.Index(cmd, "language-native gate"); g != -1 {
+		if strings.Contains(cmd[g:], "return 2") {
+			t.Error("a `return 2` appears within/after the language-native gates — rc=2 must stay make-missing-only (#299)")
+		}
+	}
+}
+
+// Test 7 — regression-pin: the gate stays CENTRALIZED. Both callers must still
+// source ci-probe.sh and call run_project_ci_gate (one helper, two callers — no
+// duplicated gate logic in the caller bodies).
+func TestQualityGateStaysCentralized(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"TestMilestone", "FinalBuild"} {
+		cmd := g.Nodes[id].Attrs["tool_command"]
+		if !strings.Contains(cmd, ". .ai/build/ci-probe.sh") {
+			t.Errorf("%s no longer sources ci-probe.sh (#299)", id)
+		}
+		if !strings.Contains(cmd, "run_project_ci_gate") {
+			t.Errorf("%s no longer calls run_project_ci_gate (#299)", id)
+		}
+		// No duplicated gate: callers must not grow their own `go vet`.
+		if strings.Contains(cmd, "go vet") {
+			t.Errorf("%s grew its own `go vet` — gate must stay in the shared helper (#299)", id)
+		}
+	}
+}
+
+// Test 8 — prose negative-control: VerifyMilestone no longer claims the no-Makefile
+// path is "correctly skipped". RED until the prose-sync edit (Task 3).
+func TestQualityGateVerifyPromptTruthful(t *testing.T) {
+	g := loadBuildProduct(t)
+	p := g.Nodes["VerifyMilestone"].Attrs["prompt"]
+	if strings.Contains(p, "correctly skipped (no Makefile") {
+		t.Error("VerifyMilestone prompt still says the no-Makefile path is skipped — false after #299")
+	}
+}

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -83,9 +83,11 @@ func TestQualityGateMakefilePathPreserved(t *testing.T) {
 	}
 }
 
-// Test 6 — regression-pin (semantic): rc=2 stays sole-sourced to the make-missing
-// branch. Exactly one `return 2`, and it is adjacent to `command -v make` — no
-// `return 2` may appear after any language-native gate marker.
+// Test 6 — regression-pin (semantic): the only EXPLICIT `return 2` statement is
+// the make-missing branch. Exactly one `return 2`, adjacent to `command -v make`,
+// and none after any language-native gate marker. (This pins the source code, not
+// runtime rc uniqueness: the `make "$TARGET"` path can still propagate make's own
+// native exit 2 on a recipe error — pre-existing, tracked in #320.)
 func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
 	cmd := setupCmd(t)
 	if n := strings.Count(cmd, "return 2"); n != 1 {

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -231,8 +231,10 @@ func runGate(t *testing.T, probe, dir string, env []string) (out string, rc int,
 	// and realistic shell options; the FinalBuild bare-call-under-set-e path (where a
 	// missing `|| LANG_RC=$?` guard would abort mid-function) is covered separately by
 	// TestRunProjectCIGateSetEBareCall.
-	script := "set -eu; . " + probePath + `; rc=0; run_project_ci_gate || rc=$?; echo "RC=$rc"; echo "RAN=[$PROJECT_CI_RAN]"`
-	c := exec.Command("sh", "-c", script)
+	// Pass the probe path as $1 rather than interpolating it into the script, so a
+	// temp dir with spaces/special chars can't break sourcing (Copilot, PR #321).
+	script := `set -eu; . "$1"; rc=0; run_project_ci_gate || rc=$?; echo "RC=$rc"; echo "RAN=[$PROJECT_CI_RAN]"`
+	c := exec.Command("sh", "-c", script, "sh", probePath)
 	c.Dir = dir
 	c.Env = env
 	// A non-nil err here is normal — the gate exits non-zero on a gate failure, and
@@ -269,7 +271,8 @@ func sourceAndRun(t *testing.T, probe, dir string, env []string, body string) (s
 	if err := os.WriteFile(probePath, []byte(probe), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	c := exec.Command("sh", "-c", "set -eu\n. "+probePath+"\n"+body)
+	// $1 carries the probe path (not interpolated) — space/special-char safe (PR #321).
+	c := exec.Command("sh", "-c", "set -eu\n. \"$1\"\n"+body, "sh", probePath)
 	c.Dir = dir
 	c.Env = env
 	b, err := c.CombinedOutput()

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -92,8 +92,12 @@ func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
 	if makeIdx == -1 || ret2Idx < makeIdx {
 		t.Error("`return 2` is not anchored to the `command -v make` branch (#299 rc contract)")
 	}
-	// No return 2 after the first language-native gate marker.
-	if g := strings.Index(cmd, "language-native gate"); g != -1 {
+	// No return 2 within/after the language-native gate execution markers. Anchor
+	// on the parenthesized gate marker `(language-native gate,` (the form emitted
+	// by each run gate inside run_language_native_gates) — NOT the prose "running
+	// language-native gates" references in run_project_ci_gate's INFO echoes, which
+	// precede the make-missing `return 2` in text and would false-positive.
+	if g := strings.Index(cmd, "(language-native gate,"); g != -1 {
 		if strings.Contains(cmd[g:], "return 2") {
 			t.Error("a `return 2` appears within/after the language-native gates — rc=2 must stay make-missing-only (#299)")
 		}

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -3,6 +3,10 @@
 package pipeline
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -132,4 +136,237 @@ func TestQualityGateVerifyPromptTruthful(t *testing.T) {
 	if strings.Contains(p, "correctly skipped (no Makefile") {
 		t.Error("VerifyMilestone prompt still says the no-Makefile path is skipped — false after #299")
 	}
+}
+
+// extractProbe pulls the ci-probe.sh body (between `<<'PROBE_EOF'` and the closing
+// `PROBE_EOF`) out of the LOADED (dippin-dedented) Setup tool_command — the exact
+// bytes tracker writes to disk at runtime.
+func extractProbe(t *testing.T) string {
+	t.Helper()
+	cmd := setupCmd(t)
+	const open = "<<'PROBE_EOF'\n"
+	i := strings.Index(cmd, open)
+	if i == -1 {
+		t.Fatal("could not find ci-probe.sh heredoc open in Setup command")
+	}
+	rest := cmd[i+len(open):]
+	j := strings.Index(rest, "PROBE_EOF")
+	if j == -1 {
+		t.Fatal("could not find ci-probe.sh heredoc close")
+	}
+	return rest[:j]
+}
+
+// hermeticEnv builds an env that deterministically excludes optional linters
+// (golangci-lint/ruff/etc. typically live in ~/go/bin or ~/.local/bin, not in the
+// dir-of-go or /usr/bin:/bin) and runs go offline.
+func hermeticEnv(t *testing.T, goDir, home, gocache string) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + goDir + ":/usr/bin:/bin",
+		"HOME=" + home,
+		"GOCACHE=" + gocache,
+		"GOPROXY=off",
+		"GOFLAGS=",
+	}
+}
+
+// runGate sources the probe in dir and returns combined output + the parsed rc and
+// PROJECT_CI_RAN. PATH override lets the make-missing case drop make.
+func runGate(t *testing.T, probe, dir string, env []string) (out string, rc int, ciRan string) {
+	t.Helper()
+	probePath := filepath.Join(t.TempDir(), "ci-probe.sh")
+	if err := os.WriteFile(probePath, []byte(probe), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := ". " + probePath + `; run_project_ci_gate; echo "RC=$?"; echo "RAN=[$PROJECT_CI_RAN]"`
+	c := exec.Command("sh", "-c", script)
+	c.Dir = dir
+	c.Env = env
+	b, _ := c.CombinedOutput()
+	out = string(b)
+	if m := regexp.MustCompile(`RC=(\d+)`).FindStringSubmatch(out); m != nil {
+		rc = atoi(m[1])
+	} else {
+		t.Fatalf("no RC marker in output:\n%s", out)
+	}
+	if m := regexp.MustCompile(`RAN=\[([^\]]*)\]`).FindStringSubmatch(out); m != nil {
+		ciRan = m[1]
+	}
+	return out, rc, ciRan
+}
+
+func atoi(s string) int {
+	n := 0
+	for _, r := range s {
+		n = n*10 + int(r-'0')
+	}
+	return n
+}
+
+// writeGoModule writes a minimal module; `vetViolation` injects an unreachable-code /
+// printf-mismatch that `go vet` flags.
+func writeGoModule(t *testing.T, dir string, vetViolation bool) {
+	t.Helper()
+	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.test\n\ngo 1.22\n")
+	src := "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"ok\") }\n"
+	if vetViolation {
+		// Printf format/arg mismatch — a deterministic, offline `go vet` error.
+		src = "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Printf(\"%d\\n\", \"not-an-int\") }\n"
+	}
+	mustWrite(t, filepath.Join(dir, "main.go"), src)
+}
+
+func mustWrite(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunProjectCIGateRuntime(t *testing.T) {
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go not available; skipping runtime gate test")
+	}
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping runtime gate test")
+	}
+	goDir := filepath.Dir(goBin)
+	probe := extractProbe(t)
+
+	// (b) clean Go repo → rc 0.
+	t.Run("clean_go_rc0", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("clean Go repo: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("clean Go repo: go vet did not run\n%s", out)
+		}
+	})
+
+	// (a) Go vet violation → rc != 0 AND rc != 2.
+	t.Run("go_vet_violation_rc1", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 0 || rc == 2 {
+			t.Errorf("vet violation: rc=%d want non-zero and != 2\n%s", rc, out)
+		}
+	})
+
+	// (c) golangci-lint absent → INFO skip line, rc != 2.
+	t.Run("golangci_absent_info_skip", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 2 {
+			t.Errorf("optional-absent must not yield rc=2\n%s", out)
+		}
+		if !strings.Contains(out, "golangci-lint not installed") {
+			t.Errorf("expected golangci-lint INFO skip line\n%s", out)
+		}
+	})
+
+	// (e) empty repo → rc 0 + no-toolchain note.
+	t.Run("empty_repo_rc0", func(t *testing.T) {
+		dir := t.TempDir()
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("empty repo: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "no recognized toolchain") {
+			t.Errorf("empty repo: expected no-toolchain note\n%s", out)
+		}
+	})
+
+	// (f) build-only Makefile (no ci/check/lint) + vet violation → falls through
+	// to language gates: rc != 0 AND PROJECT_CI_RAN empty (make CI path didn't win).
+	t.Run("build_only_makefile_falls_through", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true)
+		mustWrite(t, filepath.Join(dir, "Makefile"), "build:\n\tgo build ./...\n")
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc == 0 || rc == 2 {
+			t.Errorf("build-only Makefile: rc=%d want non-zero != 2 (vet must run)\n%s", rc, out)
+		}
+		if ciRan != "" {
+			t.Errorf("build-only Makefile: PROJECT_CI_RAN=%q want empty (no make CI target)\n%s", ciRan, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("build-only Makefile: go vet did not run\n%s", out)
+		}
+	})
+
+	// (d) Makefile `ci:` target wins → PROJECT_CI_RAN=ci AND go vet did NOT run.
+	t.Run("makefile_ci_target_wins", func(t *testing.T) {
+		if _, err := exec.LookPath("make"); err != nil {
+			t.Skip("make not available")
+		}
+		dir := t.TempDir()
+		writeGoModule(t, dir, true) // vet would fail IF it ran — it must not
+		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo running-ci\n")
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if ciRan != "ci" {
+			t.Errorf("Makefile ci target: PROJECT_CI_RAN=%q want ci\n%s", ciRan, out)
+		}
+		if rc != 0 {
+			t.Errorf("Makefile ci (echo) target: rc=%d want 0\n%s", rc, out)
+		}
+		if strings.Contains(out, "go vet ./...") {
+			t.Errorf("Makefile ci won but go vet ALSO ran — precedence broken\n%s", out)
+		}
+	})
+
+	// (h) Makefile present, make uninstalled → rc 2 BEFORE any language gate.
+	t.Run("make_missing_rc2", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@echo hi\n")
+		// PATH without /usr/bin:/bin so `command -v make` fails; only goDir present.
+		env := []string{"PATH=" + goDir, "HOME=" + t.TempDir(), "GOCACHE=" + t.TempDir(), "GOPROXY=off"}
+		out, rc, _ := runGate(t, probe, dir, env)
+		if rc != 2 {
+			t.Errorf("make missing: rc=%d want 2\n%s", rc, out)
+		}
+		if strings.Contains(out, "go vet ./...") {
+			t.Errorf("make-missing must short-circuit BEFORE language gates\n%s", out)
+		}
+	})
+
+	// (i) polyglot: clean Go + package.json → BOTH stacks detected (proves not
+	// first-match): go vet marker AND a node-stack INFO/skip line both present.
+	t.Run("polyglot_runs_all_stacks", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, false)
+		mustWrite(t, filepath.Join(dir, "package.json"), "{\"name\":\"x\",\"version\":\"0.0.0\"}\n")
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 0 {
+			t.Errorf("polyglot clean: rc=%d want 0\n%s", rc, out)
+		}
+		if !strings.Contains(out, "go vet ./...") {
+			t.Errorf("polyglot: Go stack did not run\n%s", out)
+		}
+		// tsc/eslint absent under hermetic PATH → INFO skip lines prove the JS
+		// stack was entered (not first-match-stopped at Go).
+		if !strings.Contains(out, "tsc not installed") && !strings.Contains(out, "eslint not installed") {
+			t.Errorf("polyglot: JS stack was not entered (first-match bug?)\n%s", out)
+		}
+	})
+
+	// (g) optional absent + core fails simultaneously → rc 1, not 2.
+	t.Run("optional_absent_core_fails_rc1", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGoModule(t, dir, true) // go vet fails; golangci-lint absent
+		out, rc, _ := runGate(t, probe, dir, hermeticEnv(t, goDir, t.TempDir(), t.TempDir()))
+		if rc != 1 {
+			t.Errorf("core-fail + optional-absent: rc=%d want 1\n%s", rc, out)
+		}
+		if !strings.Contains(out, "golangci-lint not installed") {
+			t.Errorf("expected golangci-lint INFO skip alongside the core failure\n%s", out)
+		}
+	})
 }


### PR DESCRIPTION
Closes #299. Refs epic #308 Phase 2 (first item).

## What

`run_project_ci_gate` (shared `ci-probe.sh` helper, sourced by `TestMilestone` and
`FinalBuild`) only enforced quality when a Makefile `ci`/`check`/`lint` target
existed. A single-language repo with no such target shipped green on the test
runner alone — no lint/vet/format gate ever ran (the `code-goblin` failure mode).

This adds a `run_language_native_gates` fallback, reached from both of
`run_project_ci_gate`'s former early `return 0` paths (no Makefile, **and** Makefile
with no matching target). It runs gates for **every** detected toolchain:

| Toolchain | Core (always) | Optional (run-if-present) |
|-----------|---------------|---------------------------|
| Go (`go.mod`) | `go vet ./...` | `golangci-lint run` |
| JS/TS (`package.json`) | — | `tsc --noEmit`, `eslint .` |
| Python (`pyproject.toml`) | — | `ruff check .`, `mypy .` |
| Rust (`Cargo.toml`) | — | `cargo fmt --check`, `cargo clippy -- -D warnings` |

## Design subtleties (deliberate)

- **Return-code contract preserved.** `0` clean / `2` make-missing→escalate-to-human
  / `N` failure→fix-loop. Language-gate failures **collapse to `rc=1`** — a linter
  exiting 2 can never masquerade as the make-missing escalation. `rc=2` stays
  reserved for the make-missing case (no *new* rc=2 source introduced).
- **Optional-absent is an INFO skip, never rc=2.** Escalating a human because `mypy`
  isn't installed would be wrong. Only `command -v`-guarded; absence → one-line note.
- **Polyglot — all detected stacks run** (independent `if`, not first-match). The
  adjacent test-runner `if/elif` is **#305, out of scope** and untouched here.
- **Both no-gate paths fall through** (incl. a build-only Makefile) — slightly
  exceeds the issue's literal "no Makefile" wording; closes the blind spot fully.
- **`set -eu` safe:** every gate ends in `|| LANG_RC=$?` (FinalBuild calls the gate
  bare under active `set -e`); a guard comment pins this invariant.
- **awk/make path untouched** — gates live in a new sibling helper; only the two
  `return 0` blocks, the header comment, and VerifyMilestone prose changed.
- **VerifyMilestone prose synced** — "no Makefile" no longer means "skipped."

## Out of scope / follow-up

- Pre-existing make-path rc=2 leak (`make "$TARGET"; return $?` propagates GNU
  make's native exit 2 on recipe errors): filed as **#320**. Fixing it would change
  existing Makefile-gate behavior (an acceptance criterion), so it's deliberately
  not touched here.

## Tests

- Graph string-asserts (negative-control, RED-first per the #296/#297/#298 pattern):
  `go vet`/linters/detectors present in the probe; rc=2 anchored to `command -v
  make`; gate stays centralized; VerifyMilestone prose truthful.
- Hermetic **runtime** shell test (the behavioral driver): sources the extracted
  `ci-probe.sh` under an isolated PATH/`GOPROXY=off` in fixture repos — vet
  violation→rc≠0&≠2, clean→0, optional-absent→INFO skip & rc≠2, build-only Makefile
  falls through, `make ci` wins (no vet), make-missing→rc2-before-gates, polyglot
  runs all stacks.

## Verification

`dippin validate` ✓ · `dippin doctor` A grade ✓ · `dippin simulate -all-paths` 100%
terminate ✓ · `go build ./... && go test ./... -short` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783526639&installation_id=131176874&pr_number=321&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F321&signature=2bebc218a20bbdf195a0cbedc009257422f23d9eb04e2f0bfd4fc0b297c0cd12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added language-native quality gates (Go vet, JS/TS type-check/ESLint, Python ruff/mypy, Rust fmt/clippy) that run automatically when no Makefile CI target exists; polyglot projects run all detected toolchains.

* **Behavior**
  * Optional/missing linters are skipped with INFO (not treated as errors). Return-code contract preserved: env-missing make returns rc=2; language-gate failures collapse to rc=1.

* **Documentation**
  * Added design/spec/plan and updated verifier wording.

* **Tests**
  * Added extensive regression and runtime tests covering multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->