### PR TITLE
feat(build_product): no-requirement-left-behind — Decompose coverage + owner-or-fail Verify (#300)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to an owning milestone. A verification that is **neither owned by a milestone
   nor a documented-deferred `DO NOT implement` item** emits `COVERAGE_GAPS:<n>` +
   `STATUS:fail`, routing to a human to re-plan instead of silently building with a
-  dropped test. `VerifyMilestone` and `FinalSpecCheck` gain the matching
-  owner-or-deferred rule: a requirement may not be waved through as "future work"
-  unless a named milestone owns it or a `DO NOT implement` entry documents the
-  deferral. `.dip`-only change; no engine code. **Behavior change:** a
+  dropped test. `VerifyMilestone` (mid-build) and `FinalSpecCheck` (final gate)
+  gain the matching no-unowned-deferral rule: a requirement may not be waved
+  through as "future work" unless a milestone owns it — and at the final gate,
+  where every planned milestone is already complete, only a SPEC-documented
+  future-phase deferral (a `DO NOT implement` entry) qualifies, since an
+  owned-but-unimplemented requirement is a failure, not future work.
+  `.dip`-only change; no engine code. **Behavior change:** a
   decomposition that drops a mandated test now fails at planning time rather than
   shipping the gap.
 - **build_product: language-native quality gate fallback** (closes #299, refs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **build_product: no-requirement-left-behind** (closes #300, refs epic #308
+  Phase 2 — second item). Stops spec-mandated verifications from vanishing from a
+  build. `Decompose` now carries `auto_status: true` — which makes its previously
+  **dead** `Decompose -> EscalateReview when fail` edge live (an agent node
+  defaults to success unless `auto_status` reads its `STATUS:` line) — and runs a
+  coverage gate: it enumerates every spec-mandated verification from `SPEC.md`
+  first, decomposes, assigns owners last, and writes a
+  `.ai/decisions/requirement-coverage.md` table mapping each mandated verification
+  to an owning milestone. A verification that is **neither owned by a milestone
+  nor a documented-deferred `DO NOT implement` item** emits `COVERAGE_GAPS:<n>` +
+  `STATUS:fail`, routing to a human to re-plan instead of silently building with a
+  dropped test. `VerifyMilestone` and `FinalSpecCheck` gain the matching
+  owner-or-deferred rule: a requirement may not be waved through as "future work"
+  unless a named milestone owns it or a `DO NOT implement` entry documents the
+  deferral. `.dip`-only change; no engine code. **Behavior change:** a
+  decomposition that drops a mandated test now fails at planning time rather than
+  shipping the gap.
 - **build_product: language-native quality gate fallback** (closes #299, refs
   epic #308 Phase 2 — first item). Closes the no-Makefile blind spot: when a repo
   has no Makefile `ci`/`check`/`lint` target (the `code-goblin` failure mode —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nor a documented-deferred `DO NOT implement` item** emits `COVERAGE_GAPS:<n>` +
   `STATUS:fail`, routing to a human to re-plan instead of silently building with a
   dropped test. `VerifyMilestone` (mid-build) and `FinalSpecCheck` (final gate)
-  gain the matching no-unowned-deferral rule: a requirement may not be waved
-  through as "future work" unless a milestone owns it — and at the final gate,
-  where every planned milestone is already complete, only a SPEC-documented
-  future-phase deferral (a `DO NOT implement` entry) qualifies, since an
-  owned-but-unimplemented requirement is a failure, not future work.
+  gain the matching no-unowned-deferral rule. Mid-build, a requirement may not be
+  waved through as "future work" unless a named **later** milestone owns it (the
+  current or an earlier milestone owning it is not a valid deferral — it should
+  already be done). At the final gate, where every planned milestone is already
+  complete, "owned" is no excuse at all — only a SPEC-documented future-phase
+  deferral (a `DO NOT implement` entry) qualifies, since an owned-but-unimplemented
+  requirement is a failure, not future work.
   `.dip`-only change; no engine code. **Behavior change:** a
   decomposition that drops a mandated test now fails at planning time rather than
   shipping the gap.

--- a/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
+++ b/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
@@ -330,8 +330,9 @@ Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
 
 ```
          A requirement may NOT be waved through as "future work" or "a
-         later milestone" unless it is EITHER (a) owned — a named milestone
-         in .ai/decisions/milestones.md has a "Done when" line covering it
+         later milestone" unless it is EITHER (a) owned — a named LATER
+         milestone in .ai/decisions/milestones.md has a "Done when" line
+         covering it
          (`grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
          cite the milestone number + the Done-when line verbatim) — OR (b)
          deferred — SPEC.md defers it to a named later phase AND a milestone's

--- a/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
+++ b/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
@@ -138,12 +138,22 @@ func TestVerifyMilestoneOwnerOrFailRule(t *testing.T) {
 	}
 }
 
-// Test 5 — negative-control: FinalSpecCheck gains the same owner-or-deferred rule.
+// Test 5 — negative-control: FinalSpecCheck gains the DEFERRED-ONLY rule. At the
+// final gate every milestone is complete, so "owned" is not an excuse — only a
+// SPEC-documented future-phase deferral passes. Pin the distinctive owned-is-not-
+// an-excuse clause, not just generic tokens: a regression to "owned OR deferred"
+// (as in VerifyMilestone) must FAIL this test (CodeRabbit PR #322).
 func TestFinalSpecCheckOwnerOrFailRule(t *testing.T) {
 	p := promptOf(t, loadBuildProduct(t), "FinalSpecCheck")
-	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+	subs := []string{
+		"future work",
+		"DO NOT implement",
+		`"owned" by a milestone is NOT an acceptable excuse`,
+		"do NOT emit the terminal STATUS:success",
+	}
+	for _, sub := range subs {
 		if !strings.Contains(p, sub) {
-			t.Errorf("FinalSpecCheck prompt missing owner-or-deferred substring %q (#300)", sub)
+			t.Errorf("FinalSpecCheck prompt missing deferred-only substring %q (#300)", sub)
 		}
 	}
 }
@@ -187,7 +197,12 @@ func TestDecomposeOutEdgesUnchanged(t *testing.T) {
 func TestVerifyAndFinalKeepAutoStatus(t *testing.T) {
 	g := loadBuildProduct(t)
 	for _, id := range []string{"VerifyMilestone", "FinalSpecCheck"} {
-		if g.Nodes[id].Attrs["auto_status"] != "true" {
+		n, ok := g.Nodes[id]
+		if !ok {
+			t.Errorf("%s node missing from build_product graph (#300)", id)
+			continue
+		}
+		if n.Attrs["auto_status"] != "true" {
 			t.Errorf("%s lost auto_status:true — its STATUS:fail gate is dead (#300)", id)
 		}
 	}

--- a/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
+++ b/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
@@ -391,13 +391,15 @@ with:
       - Is it implemented correctly?
       - Was nothing extra added beyond what the spec asked for?
       - If it is NOT implemented and the report defers it to "future work":
-        that deferral is acceptable ONLY when it is EITHER owned by a named
-        milestone in .ai/decisions/milestones.md (grep `^#+ *[Mm]ilestone`
-        and cite the milestone + its "Done when" line) OR documented-deferred
-        (SPEC.md defers to a named phase AND a "DO NOT implement" block records
-        it, citing the spec section). A future-work deferral that is neither
-        keeps the early STATUS:fail in place — do NOT emit the terminal
-        STATUS:success (issue #300).
+        every planned milestone is already complete at THIS gate, so being
+        "owned" by a milestone is NOT an acceptable excuse — that milestone
+        should have built it, and an owned-but-unimplemented requirement is
+        a failure, not future work. The deferral is acceptable ONLY when
+        SPEC.md itself defers the behavior to a named later phase AND a
+        "DO NOT implement" block in .ai/decisions/milestones.md records that
+        deferral, citing the spec section (cite both). A future-work deferral
+        that is not SPEC-documented as deferred keeps the early STATUS:fail
+        in place — do NOT emit the terminal STATUS:success (issue #300).
 
       Also verify:
 ```

--- a/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
+++ b/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
@@ -112,13 +112,16 @@ func TestDecomposeCoverageTablePrompt(t *testing.T) {
 }
 
 // Test 3 — negative-control: Decompose's coverage gate carves out documented
-// deferrals (the DO-NOT-implement / deferred case) so it does not false-fail a
-// correct decomposition that properly defers Phase-2+ work.
+// deferrals via a 3-way classification (owned | deferred | UNOWNED). Asserts
+// tokens UNIQUE to the #300 block ("UNOWNED", "neither owned") — NOT the bare
+// "DO NOT implement"/"deferred", which the pre-existing anti-scope-creep block
+// already contains (would be a no-op assertion; test-reviewer I1, verified
+// count=0 for UNOWNED/neither-owned, count>0 for DO-NOT-implement/deferred).
 func TestDecomposeDeferralCarveout(t *testing.T) {
 	p := promptOf(t, loadBuildProduct(t), "Decompose")
-	for _, sub := range []string{"DO NOT implement", "deferred"} {
+	for _, sub := range []string{"UNOWNED", "neither owned"} {
 		if !strings.Contains(p, sub) {
-			t.Errorf("Decompose coverage gate missing deferral-carveout substring %q (#300)", sub)
+			t.Errorf("Decompose coverage gate missing 3-way-classification substring %q (#300)", sub)
 		}
 	}
 }

--- a/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
+++ b/docs/superpowers/plans/2026-06-08-issue-300-no-requirement-left-behind.md
@@ -1,0 +1,610 @@
+# No-requirement-left-behind (#300) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `build_product.dip` refuse to drop a spec-mandated verification — `Decompose` must assign every mandated test/check to a milestone (writing a coverage table and FAILING when one is unowned), and `VerifyMilestone`/`FinalSpecCheck` must reject a "future work" deferral that no named milestone owns.
+
+**Architecture:** Pure `.dip` change to `examples/build_product.dip` (no engine Go). The load-bearing change is adding `auto_status: true` to the `Decompose` agent node so its existing-but-dead `Decompose -> EscalateReview when ctx.outcome = fail` edge becomes live (an agent node defaults to `OutcomeSuccess` unless `auto_status` consults its `STATUS:` line — `pipeline/handlers/codergen.go:627-637`). Decompose then enumerates mandated verifications from `SPEC.md` FIRST, decomposes, assigns owners LAST, writes `.ai/decisions/requirement-coverage.md`, and emits `STATUS:fail` only when a verification is neither owned by a milestone nor a documented-deferred (`DO NOT implement`) item. `VerifyMilestone` check 5 and `FinalSpecCheck` get the same owner-or-deferred-or-fail rule. Tests are graph string/edge asserts (no runtime test — this is agent-prompt rules with no executable shell).
+
+**Tech Stack:** dippin `.dip` workflow DSL, Go `testing` (package `pipeline`), `dippin` CLI for validate/doctor/simulate.
+
+**Branch:** `fix/300-no-requirement-left-behind` (already created off `main`). Design spec: `docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md` — read it first; it carries the five-expert squad consensus this plan implements.
+
+---
+
+## Context the executor needs
+
+**The file under change:** `examples/build_product.dip`. All line numbers below are verified against the branch as of 2026-06-08 but **RE-GREP before every edit** (they drift — #299 already shifted everything once). Anchors:
+- `grep -n 'agent Decompose\|agent VerifyMilestone\|agent FinalSpecCheck\|known_failures\|SPEC GAPS BEYOND\|For EVERY requirement\|tool Cleanup' examples/build_product.dip`
+- `Decompose` node: header at `:436`, attrs `model/provider/reasoning_effort` at `:438-440`, `prompt:` at `:441`, the `known_failures` block ends at `:481`, blank line `:482`, then `human ApprovePlan` at `:483`.
+- `VerifyMilestone` node: header `:743`, `auto_status: true` already at `:748`, check 5 "SPEC GAPS BEYOND MILESTONE NOTES" at `:861-866`, the Decompose-dropped prose at `:759-763` and `:865`.
+- `FinalSpecCheck` node: header `:1378`, `auto_status: true` already at `:1385`, "For EVERY requirement…" block at `:1485-1488`, "Also verify / No UNEXPECTED leftover files in .ai/build/" at `:1490-1498`, terminal STATUS rules at `:1505-1513`.
+- `Cleanup` tool: `:1557`, the "Keep: .ai/decisions/…" comment at `:1564`.
+- Edges block `:1584-1658`. Relevant: `Decompose -> ApprovePlan when ctx.outcome = success` (`:1586`), `Decompose -> EscalateReview when ctx.outcome = fail` (`:1587`), `VerifyMilestone -> FixMilestone when ctx.outcome = fail` (`:1604`), `FinalSpecCheck -> EscalateReview when ctx.outcome = fail` (`:1652`).
+
+**Indentation:** Decompose/VerifyMilestone/FinalSpecCheck prompts are indented 6 spaces under `prompt:`. Node attrs (`model:`, `auto_status:`) are indented 4 spaces. Match exactly or dippin's dedent changes the emitted text.
+
+**STATUS / outcome mechanics (load-bearing — verified in `pipeline/handlers/codergen.go`):**
+- `resolveTerminalStatus` (`:627-639`) defaults `status = OutcomeSuccess` and only calls `parseAutoStatus(responseText)` when `node.Attrs["auto_status"] == "true"`. So **Decompose without `auto_status` always yields success** — its fail edge is dead until we add the attr.
+- `parseAutoStatus` (`:795-812`) is **last-STATUS-line-wins**, skips lines inside ``` fences, defaults to success when no STATUS line. `parseStatusLine` (`:824-840`) requires the value to be EXACTLY `success`/`fail`/`retry` — `STATUS:fail (2 unowned)` returns "" and is ignored (→ silent success on Decompose's fail-open default). It also recognizes `retry` — Decompose has no retry edge, so the prompt must forbid `STATUS:retry`.
+
+**No active pre-commit hook** in this clone (`.git/hooks/` has only `*.sample`), so the RED test commit in Task 1 is safe. **NEVER use `--no-verify`.** If you find hooks ARE active and they block the RED commit, keep the RED proof in-session (run + observe failure) and commit test+impl together — never bypass.
+
+**Marker/token constraint:** no new prompt text may contain the bare literal tokens `escalate` or `tests-pass` (engine edges substring-match `ctx.tool_stdout`; these agent prompts route via `auto_status`, so it's defensive — but stay clean). The node name `EscalateReview` is fine (it's `Escalate`, not bare `escalate`); avoid a standalone word `escalate`.
+
+---
+
+## File structure
+
+- **Modify:** `examples/build_product.dip`
+  - `Decompose` (`:436`): add `auto_status: true` attr; append the coverage-gate block to the prompt.
+  - `VerifyMilestone` (`:861` check 5; `:759-763` prose-sync): append owner-or-deferred rule; add the Decompose-coverage cross-reference note.
+  - `FinalSpecCheck` (`:1488`): insert owner-or-deferred rule; note `.ai/decisions/*.md` artifacts aren't "extras".
+  - `Cleanup` (`:1564`): add `requirement-coverage` to the preserved-decisions comment.
+- **Create:** `pipeline/build_product_requirement_coverage_test.go` (package `pipeline`) — string + edge asserts, reusing helpers from `build_product_failure_routing_test.go`.
+- **Modify:** `CHANGELOG.md` — `[Unreleased]/Added` entry.
+
+---
+
+## Task 1: Negative-control + regression tests, proven RED
+
+**Files:**
+- Create: `pipeline/build_product_requirement_coverage_test.go`
+- Reuse (do NOT redefine): `loadBuildProduct`, `hasEdgeWithCondition`, `hasUnconditionalEdgeTo` from `pipeline/build_product_failure_routing_test.go` (same package).
+
+- [ ] **Step 1: Write the test file.** Each assertion is commented `negative-control` (RED pre-#300) or `regression-pin` (GREEN now, guards removal).
+
+```go
+// ABOUTME: Negative-control + regression guard for issue #300 — no-requirement-left-behind:
+// ABOUTME: Decompose coverage-table gate + owner-or-deferred "future work" rule in Verify/FinalSpecCheck.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// promptOf returns the named node's prompt attr (where the agent-rule text lives).
+func promptOf(t *testing.T, g *Graph, id string) string {
+	t.Helper()
+	n, ok := g.Nodes[id]
+	if !ok {
+		t.Fatalf("%s node missing from build_product graph (#300)", id)
+	}
+	return n.Attrs["prompt"]
+}
+
+// Test 1 — regression-pin AND the load-bearing #300 pin: Decompose must carry
+// auto_status:true. Without it, resolveTerminalStatus (codergen.go:635) defaults
+// the node to OutcomeSuccess and the `Decompose -> EscalateReview when fail` edge
+// is DEAD — a dropped requirement can never fail the node. This single test ties
+// the attr to the fail edge so a future removal of either is caught.
+func TestDecomposeFailEdgeIsLive(t *testing.T) {
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["Decompose"]
+	if !ok {
+		t.Fatal("Decompose node missing (#300)")
+	}
+	if n.Attrs["auto_status"] != "true" {
+		t.Error("Decompose lacks auto_status:true — its `outcome = fail` edge is DEAD (codergen.go:635); a dropped requirement cannot fail the node (#300)")
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "EscalateReview", "ctx.outcome = fail") {
+		t.Error("Decompose has no `ctx.outcome = fail` edge to EscalateReview (#300)")
+	}
+}
+
+// Test 2 — negative-control: Decompose writes the coverage table and uses the
+// coverage-mapping language. Distinctive new substrings (NOT the bare token
+// "SPEC.md", which is already GREEN at Decompose :467 — "SPEC.md may define a
+// Fingerprint" — and would prove nothing).
+func TestDecomposeCoverageTablePrompt(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "Decompose")
+	for _, sub := range []string{
+		"requirement-coverage.md",
+		"Owning milestone",
+		"mandated",
+		"COVERAGE_GAPS",
+	} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("Decompose prompt missing coverage-gate substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 3 — negative-control: Decompose's coverage gate carves out documented
+// deferrals (the DO-NOT-implement / deferred case) so it does not false-fail a
+// correct decomposition that properly defers Phase-2+ work.
+func TestDecomposeDeferralCarveout(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "Decompose")
+	for _, sub := range []string{"DO NOT implement", "deferred"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("Decompose coverage gate missing deferral-carveout substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 4 — negative-control: VerifyMilestone check 5 gains the owner-or-deferred
+// "future work" rule. Anchor tokens matched SEPARATELY (not a full sentence) so
+// benign rewording doesn't flake.
+func TestVerifyMilestoneOwnerOrFailRule(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "VerifyMilestone")
+	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("VerifyMilestone prompt missing owner-or-deferred substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 5 — negative-control: FinalSpecCheck gains the same owner-or-deferred rule.
+func TestFinalSpecCheckOwnerOrFailRule(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "FinalSpecCheck")
+	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("FinalSpecCheck prompt missing owner-or-deferred substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 6 — negative-control (prose-sync truthfulness pin, mirrors #299's
+// TestQualityGateVerifyPromptTruthful): VerifyMilestone's prompt acknowledges
+// that Decompose now owns a coverage gate (defense-in-depth cross-reference).
+func TestVerifyMilestoneMentionsCoverageGate(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "VerifyMilestone")
+	if !strings.Contains(p, "requirement-coverage.md") {
+		t.Error("VerifyMilestone prompt does not cross-reference requirement-coverage.md — prose-sync drift (#300)")
+	}
+}
+
+// Test 7 — regression-pin: Decompose's out-edges are EXACTLY the conditional
+// success→ApprovePlan and fail→EscalateReview pair. No new edge, no unconditional
+// fallback (which CLAUDE.md forbids near loop targets). Use OutgoingEdges (filters
+// on e.From) — NOT a loose g.Edges scan, which the incoming restart edges
+// ApprovePlan->Decompose and ResetReviewBudget->Decompose would pollute.
+func TestDecomposeOutEdgesUnchanged(t *testing.T) {
+	g := loadBuildProduct(t)
+	out := g.OutgoingEdges("Decompose")
+	if len(out) != 2 {
+		t.Fatalf("Decompose has %d out-edges, want exactly 2 (#300)", len(out))
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "ApprovePlan", "ctx.outcome = success") {
+		t.Error("Decompose lost its success→ApprovePlan edge (#300)")
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "EscalateReview", "ctx.outcome = fail") {
+		t.Error("Decompose lost its fail→EscalateReview edge (#300)")
+	}
+	for _, e := range out {
+		if e.Condition == "" {
+			t.Errorf("Decompose grew an unconditional out-edge → %s (forbidden near loop targets, #300)", e.To)
+		}
+	}
+}
+
+// Test 8 — regression-pin: the downstream gates keep auto_status:true (their
+// STATUS:fail is what enforces the owner-or-deferred rule).
+func TestVerifyAndFinalKeepAutoStatus(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"VerifyMilestone", "FinalSpecCheck"} {
+		if g.Nodes[id].Attrs["auto_status"] != "true" {
+			t.Errorf("%s lost auto_status:true — its STATUS:fail gate is dead (#300)", id)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests, verify the negative-controls FAIL (RED).**
+
+Run: `go test ./pipeline/ -run 'TestDecompose|TestVerifyMilestone|TestFinalSpecCheck|TestVerifyAndFinal' -v`
+Expected:
+- **RED (negative-control):** `TestDecomposeCoverageTablePrompt`, `TestDecomposeDeferralCarveout`, `TestVerifyMilestoneOwnerOrFailRule`, `TestFinalSpecCheckOwnerOrFailRule`, `TestVerifyMilestoneMentionsCoverageGate`. Also `TestDecomposeFailEdgeIsLive` is RED on the `auto_status` half (the fail edge exists, but `auto_status` is absent).
+- **GREEN (regression-pin):** `TestDecomposeOutEdgesUnchanged`, `TestVerifyAndFinalKeepAutoStatus`.
+Confirm the five+one negative-controls are RED — that is the proof.
+
+- [ ] **Step 3: Commit the RED tests** (mirrors #298 `ad0fe76` / #299 precedent — no active hook).
+
+```bash
+git add pipeline/build_product_requirement_coverage_test.go
+git commit -m "test(300): negative-control tests for no-requirement-left-behind (RED)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Decompose — auto_status + coverage-gate block
+
+**Files:**
+- Modify: `examples/build_product.dip` (`Decompose` attrs `:438-440`, prompt tail `:476-481`).
+
+- [ ] **Step 1: Add `auto_status: true` to the Decompose node.** Re-grep: `grep -n 'agent Decompose' examples/build_product.dip`, then read the 4 lines after it. Insert after `reasoning_effort: high`.
+
+Replace:
+```
+    model: claude-opus-4-6
+    provider: anthropic
+    reasoning_effort: high
+    prompt:
+      Based on the spec analysis, decompose the work into ordered milestones.
+```
+with:
+```
+    model: claude-opus-4-6
+    provider: anthropic
+    reasoning_effort: high
+    auto_status: true
+    prompt:
+      Based on the spec analysis, decompose the work into ordered milestones.
+```
+
+- [ ] **Step 2: Append the coverage-gate block** to the Decompose prompt, immediately after the `known_failures` paragraph (ends `:481` "…where they should start passing.") and before the blank line preceding `human ApprovePlan`. Re-grep: `grep -n 'where they should start passing' examples/build_product.dip`. Insert after that line (6-space prompt indentation):
+
+```
+      ── REQUIREMENT COVERAGE (issue #300, epic #308 Phase 2) ──
+      No spec-mandated verification may be left unowned. Do this in THIS
+      order — the ordering is load-bearing (it stops you from back-filling
+      the table to match milestones you already wrote, which would make
+      the gate decorative):
+
+      1. FIRST, before writing any milestone, read SPEC.md and list every
+         spec-mandated verification into the LEFT columns of
+         .ai/decisions/requirement-coverage.md. A line is "spec-mandated"
+         ONLY if SPEC.md uses an obligation word (MUST / SHALL / "is
+         required to" / "the test must" / a named test function or
+         acceptance criterion) AND names a concrete, checkable behavior
+         (a specific input/output, a numeric bound, a named error path).
+         Aspirational words ("fast", "robust", "clean") with no checkable
+         threshold are NOT mandated — do not list them. State how many you
+         found; if none, write the line: SPEC mandates no named
+         verifications (never leave the table silently empty — a silent
+         empty table hides under-extraction). Table columns:
+           | Mandated verification | SPEC.md source (line/section) | Owning milestone |
+
+      2. THEN decompose into milestones as the rules above describe.
+
+      3. FINALLY, fill the "Owning milestone" column. You may NOT add rows
+         here and you may NOT invent a milestone to cover a verification.
+         Each verification resolves to exactly one of:
+         - owned: a milestone's "Done when" line covers it. Confirm with
+           `grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
+           cite `Milestone <N>: <the Done-when line, verbatim>`. A
+           milestone that only mentions the topic in prose does NOT own it.
+         - deferred: SPEC.md itself defers the behavior to a named later
+           phase AND a milestone's "DO NOT implement" block records that
+           deferral citing the spec section. Cite both. (This carve-out
+           keeps the gate consistent with the anti-scope-creep machinery
+           above — a correctly-deferred Phase-2+ feature is NOT a gap.)
+         - UNOWNED: neither owned nor deferred. This is the bug this gate
+           exists to catch.
+
+      Then re-read .ai/decisions/requirement-coverage.md, count the UNOWNED
+      rows, and emit on its own line: COVERAGE_GAPS: <count>. Then your
+      terminal STATUS line:
+        - every row owned or deferred (count 0) -> STATUS:success
+        - any row UNOWNED (count > 0) -> list the unowned verification(s)
+          ABOVE the STATUS line, then STATUS:fail (this routes to a human
+          to re-plan rather than silently building with a dropped test).
+      The final line must be EXACTLY `STATUS:success` or `STATUS:fail` —
+      no parentheses, no counts, no trailing words (a trailing count makes
+      the parser drop the line and default to success), OUTSIDE any code
+      fence, alone on its line. Emit only success or fail — never
+      STATUS:retry (this node has no retry route).
+```
+
+- [ ] **Step 3: Run the Decompose tests, verify they pass.**
+
+Run: `go test ./pipeline/ -run 'TestDecompose' -v`
+Expected: `TestDecomposeFailEdgeIsLive`, `TestDecomposeCoverageTablePrompt`, `TestDecomposeDeferralCarveout`, `TestDecomposeOutEdgesUnchanged` all PASS. (`TestVerifyMilestone*` / `TestFinalSpecCheck*` still RED — Tasks 3/4.)
+
+- [ ] **Step 4: Validate the .dip still parses.**
+
+Run: `dippin validate examples/build_product.dip`
+Expected: passes. If `dippin` is not on PATH, STOP and ask the user — do NOT `go install` it.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add examples/build_product.dip
+git commit -m "feat(build_product): Decompose coverage gate — every mandated verification owns a milestone (#300)
+
+Add auto_status:true (makes the dead Decompose->EscalateReview fail edge
+live) + a coverage-gate block: enumerate mandated verifications from SPEC.md
+FIRST, decompose, assign owners LAST into .ai/decisions/requirement-coverage.md,
+emit COVERAGE_GAPS:<n> + STATUS:fail when a verification is neither owned by a
+milestone nor a documented-deferred (DO NOT implement) item.
+
+Refs epic #308 Phase 2 (second item).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: VerifyMilestone — owner-or-deferred rule + prose-sync note
+
+**Files:**
+- Modify: `examples/build_product.dip` (`VerifyMilestone` check 5 `:861-866`).
+
+- [ ] **Step 1: Append the owner-or-deferred rule to check 5.** Re-grep: `grep -n 'SPEC GAPS BEYOND MILESTONE NOTES' examples/build_product.dip`, read through the end of item 5 (the line "…Cross-check against SPEC.md directly."). Insert immediately after that line, inside item 5 (9-space indentation to match the item body):
+
+```
+         A requirement may NOT be waved through as "future work" or "a
+         later milestone" unless it is EITHER (a) owned — a named milestone
+         in .ai/decisions/milestones.md has a "Done when" line covering it
+         (`grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
+         cite the milestone number + the Done-when line verbatim) — OR (b)
+         deferred — SPEC.md defers it to a named later phase AND a milestone's
+         "DO NOT implement" block records that deferral citing the spec
+         section (cite both; consistent with check 4's deferred-field rule).
+         A deferral that is neither owned nor documented-deferred is a
+         dropped requirement: STATUS:fail. (This is the code-goblin miss —
+         the verifier saw the 429/cancel gap and waved it through as "future
+         work" with no owning milestone.) Cross-check against
+         .ai/decisions/requirement-coverage.md (written by Decompose) when
+         present; if it disagrees with a live SPEC.md re-read, SPEC.md wins.
+```
+
+This single insertion satisfies BOTH `TestVerifyMilestoneOwnerOrFailRule` (anchors `future work` + `milestones.md` + `DO NOT implement`) and `TestVerifyMilestoneMentionsCoverageGate` (substring `requirement-coverage.md`).
+
+- [ ] **Step 2: Run the VerifyMilestone tests, verify they pass.**
+
+Run: `go test ./pipeline/ -run 'TestVerifyMilestone|TestVerifyAndFinal' -v`
+Expected: `TestVerifyMilestoneOwnerOrFailRule`, `TestVerifyMilestoneMentionsCoverageGate`, `TestVerifyAndFinalKeepAutoStatus` PASS. (`TestFinalSpecCheckOwnerOrFailRule` still RED — Task 4.)
+
+- [ ] **Step 3: Validate + commit.**
+
+```bash
+dippin validate examples/build_product.dip
+git add examples/build_product.dip
+git commit -m "feat(build_product): VerifyMilestone rejects unowned future-work deferrals (#300)
+
+Check 5 now fails a requirement waved through as 'future work' unless a named
+milestone owns it (Done-when line) or it is a documented-deferred DO-NOT-implement
+item. Cross-references Decompose's requirement-coverage.md (prose-sync).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: FinalSpecCheck — owner-or-deferred rule + artifact hygiene
+
+**Files:**
+- Modify: `examples/build_product.dip` (`FinalSpecCheck` "For EVERY requirement" `:1485-1488`; the `.ai/build/` allowlist note `:1490-1498`; `Cleanup` comment `:1564`).
+
+- [ ] **Step 1: Insert the owner-or-deferred rule** into the "For EVERY requirement" block. Re-grep: `grep -n 'For EVERY requirement, prescription' examples/build_product.dip`. Insert after the "Was nothing extra added…" line and before the blank line preceding "Also verify:" (6-space indentation):
+
+Replace:
+```
+      For EVERY requirement, prescription, and instruction in the spec:
+      - Is it implemented?
+      - Is it implemented correctly?
+      - Was nothing extra added beyond what the spec asked for?
+
+      Also verify:
+```
+with:
+```
+      For EVERY requirement, prescription, and instruction in the spec:
+      - Is it implemented?
+      - Is it implemented correctly?
+      - Was nothing extra added beyond what the spec asked for?
+      - If it is NOT implemented and the report defers it to "future work":
+        that deferral is acceptable ONLY when it is EITHER owned by a named
+        milestone in .ai/decisions/milestones.md (grep `^#+ *[Mm]ilestone`
+        and cite the milestone + its "Done when" line) OR documented-deferred
+        (SPEC.md defers to a named phase AND a "DO NOT implement" block records
+        it, citing the spec section). A future-work deferral that is neither
+        keeps the early STATUS:fail in place — do NOT emit the terminal
+        STATUS:success (issue #300).
+
+      Also verify:
+```
+
+(Note: FinalSpecCheck is fail-closed — the rule BLOCKS the terminal `STATUS:success`; it must NOT say "emit STATUS:fail", which mid-prose would just be overridden by the final success line.)
+
+- [ ] **Step 2: Note that `.ai/decisions/*.md` artifacts are not "extras".** Re-grep: `grep -n 'No UNEXPECTED leftover files in .ai/build' examples/build_product.dip`. The allowlist is correctly `.ai/build/`-scoped (the new `requirement-coverage.md` is in `.ai/decisions/`, so no collision — this is documentation hygiene only). Read the bullet; append a sentence to it (keep its existing indentation). Change the end of that bullet from:
+```
+        review-codex.md, review-gemini.md). Only flag files outside
+        this explicit allowlist.
+```
+to:
+```
+        review-codex.md, review-gemini.md). Only flag files outside
+        this explicit allowlist. (.ai/decisions/*.md workflow artifacts —
+        spec-analysis, milestones, requirement-coverage (#300), compliance —
+        are expected outputs, never "extras".)
+```
+
+- [ ] **Step 3: Add `requirement-coverage` to the Cleanup preserved-decisions comment.** Re-grep: `grep -n 'Keep: .ai/decisions/' examples/build_product.dip`. Replace:
+```
+      # Keep: .ai/decisions/ (spec-analysis, milestones, review-synthesis, compliance)
+```
+with:
+```
+      # Keep: .ai/decisions/ (spec-analysis, milestones, requirement-coverage, review-synthesis, compliance)
+```
+
+- [ ] **Step 4: Run the FinalSpecCheck tests + full new file, verify all green.**
+
+Run: `go test ./pipeline/ -run 'TestDecompose|TestVerifyMilestone|TestFinalSpecCheck|TestVerifyAndFinal' -v`
+Expected: ALL eight tests PASS.
+
+- [ ] **Step 5: Validate + commit.**
+
+```bash
+dippin validate examples/build_product.dip
+git add examples/build_product.dip
+git commit -m "feat(build_product): FinalSpecCheck rejects unowned future-work deferrals (#300)
+
+Final gate now blocks STATUS:success on a future-work deferral that no named
+milestone owns and no DO-NOT-implement entry documents. Document
+requirement-coverage.md as an expected .ai/decisions/ artifact (Cleanup + the
+FinalSpecCheck 'not extras' note).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: CHANGELOG
+
+**Files:**
+- Modify: `CHANGELOG.md` (`[Unreleased]` → `### Added`, at the TOP, above the #299 entry).
+
+- [ ] **Step 1: Add the entry.** Re-grep: `grep -n '## \[Unreleased\]' CHANGELOG.md`, insert at the top of `### Added`:
+
+```markdown
+- **build_product: no-requirement-left-behind** (closes #300, refs epic #308
+  Phase 2 — second item). Stops spec-mandated verifications from vanishing from a
+  build. `Decompose` now carries `auto_status: true` — which makes its previously
+  **dead** `Decompose -> EscalateReview when fail` edge live (an agent node
+  defaults to success unless `auto_status` reads its `STATUS:` line) — and runs a
+  coverage gate: it enumerates every spec-mandated verification from `SPEC.md`
+  first, decomposes, assigns owners last, and writes a
+  `.ai/decisions/requirement-coverage.md` table mapping each mandated verification
+  to an owning milestone. A verification that is **neither owned by a milestone
+  nor a documented-deferred `DO NOT implement` item** emits `COVERAGE_GAPS:<n>` +
+  `STATUS:fail`, routing to a human to re-plan instead of silently building with a
+  dropped test. `VerifyMilestone` and `FinalSpecCheck` gain the matching
+  owner-or-deferred rule: a requirement may not be waved through as "future work"
+  unless a named milestone owns it or a `DO NOT implement` entry documents the
+  deferral. `.dip`-only change; no engine code. **Behavior change:** a
+  decomposition that drops a mandated test now fails at planning time rather than
+  shipping the gap.
+```
+
+- [ ] **Step 2: Commit.**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(300): CHANGELOG entry for no-requirement-left-behind (#300)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full verification + PR
+
+- [ ] **Step 1: dippin gates.**
+
+```bash
+dippin validate examples/build_product.dip
+dippin doctor examples/build_product.dip examples/ask_and_execute.dip examples/build_product_with_superspec.dip
+dippin simulate -all-paths examples/build_product.dip
+```
+Expected: `validate` passes; `doctor` is **A** across all three (build_product baseline A 90/100 — must not regress; a squad reviewer empirically confirmed `auto_status` keeps it byte-identical); `simulate -all-paths` reports 100% terminate, no new cycle / dead-stop (the now-live `Decompose -> EscalateReview` fail path is reachable and terminates). If `dippin` is not on PATH, STOP and ask the user — do NOT `go install` it.
+
+- [ ] **Step 2: Go gates.**
+
+```bash
+go build ./...
+go test ./... -short
+gofmt -l pipeline/build_product_requirement_coverage_test.go   # must print nothing
+```
+Expected: build clean; tests green; gofmt clean.
+
+- [ ] **Step 3: Adversarial self-review** (before pushing). Walk each:
+  - **Dead-edge revived:** `grep -n 'auto_status' examples/build_product.dip` shows Decompose now has it; `TestDecomposeFailEdgeIsLive` passes.
+  - **No new edges / no loop-target fallback:** `git diff main -- examples/build_product.dip` shows ZERO changes in the edges block (`:1584-1658`); `TestDecomposeOutEdgesUnchanged` passes.
+  - **Deferral carve-out present** in all three nodes (Decompose, VerifyMilestone, FinalSpecCheck) — guards against false-failing correctly-deferred work.
+  - **STATUS hygiene:** Decompose's new text forbids trailing-count/retry and requires outside-fence; no bare `escalate`/`tests-pass` token in any new prose (`git diff main -- examples/build_product.dip | grep -nE '\bescalate\b|tests-pass'` → only `EscalateReview` node refs, no bare token).
+  - **Coverage table NOT in milestones.md:** the new prompt writes only `requirement-coverage.md`.
+  - **#301 untouched:** no new `SpecLint` subgraph; `git diff main --stat` shows only `build_product.dip`, the test file, CHANGELOG, and the docs/superpowers specs/plans.
+
+- [ ] **Step 4: Push + open the PR.**
+
+```bash
+git push -u origin fix/300-no-requirement-left-behind
+gh pr create --title "feat(build_product): no-requirement-left-behind — Decompose coverage + owner-or-fail Verify (#300)" --body "$(cat <<'EOF'
+Closes #300. Refs epic #308 Phase 2 (second item, after #299/PR #321).
+
+## What
+
+Two failure modes let spec-mandated requirements vanish from a `build_product`
+run: (1) `Decompose` could omit a mandated test from every milestone's "Done
+when"; (2) `VerifyMilestone`/`FinalSpecCheck` could wave a requirement through as
+"future work" without confirming a later milestone owns it. On the `code-goblin`
+run, a synthetic-429 test and a cancel-within-100ms test were owned by no
+milestone and the verifier waved the gap through.
+
+## The change (`.dip`-only, no engine code)
+
+- **`Decompose`** gains `auto_status: true` — which makes its previously **dead**
+  `Decompose -> EscalateReview when ctx.outcome = fail` edge live (an agent node
+  defaults to `OutcomeSuccess` unless `auto_status` consults its `STATUS:` line —
+  `pipeline/handlers/codergen.go:627-637`). It then runs a **coverage gate**:
+  enumerate mandated verifications from `SPEC.md` FIRST, decompose, assign owners
+  LAST into `.ai/decisions/requirement-coverage.md`, emit `COVERAGE_GAPS:<n>` +
+  `STATUS:fail` when a verification is **neither owned by a milestone nor a
+  documented-deferred `DO NOT implement` item**.
+- **`VerifyMilestone` check 5 + `FinalSpecCheck`** gain the matching
+  owner-or-deferred rule: a "future work" deferral is rejected unless a named
+  milestone owns it (cite the "Done when" line) or a `DO NOT implement` entry
+  documents the deferral.
+
+## Design subtleties (from a five-expert squad review of the design)
+
+- **DO-NOT-implement carve-out (critical).** The owner-or-fail rule is a 3-way
+  classification `owned | deferred | UNOWNED`, failing only on UNOWNED — so it does
+  NOT contradict the existing anti-scope-creep machinery by false-failing a
+  correct decomposition that properly defers Phase-2+ work.
+- **Read-back gate, not tail-token judgment.** Decompose re-reads the table and
+  counts UNOWNED rows (`COVERAGE_GAPS:<n>`) rather than relying on a holistic
+  final-token judgment — the run that drops a requirement is the one most likely
+  to garble its STATUS line.
+- **Closed inclusion test** for "spec-mandated verification" (obligation word +
+  checkable behavior; aspirational lines get `N/A`, never a fail) — prevents
+  false-fail human fatigue.
+- **STATUS hygiene** (exact token, outside fence, only success/fail — never
+  `retry`) copied from `FinalSpecCheck`'s existing warnings.
+
+## Out of scope / follow-up
+
+- **#301 (spec-coherence preflight)** — its rule (f) will later FEED this coverage
+  table; #300 stays self-sufficient (Decompose derives the mandated list from
+  SPEC.md itself). Soft, one-directional coupling.
+- **Decompose-retry circuit breaker** — the now-live `Decompose -> EscalateReview
+  -> retry -> Decompose` cycle consumes the global restart budget under
+  autopilot/headless drivers (the same property the existing review-retry loop
+  has). The DO-NOT-implement carve-out removes the deterministic re-fail trigger;
+  a dedicated `decompose_attempts` breaker is a structural change left as a
+  follow-up.
+
+## Tests
+
+`pipeline/build_product_requirement_coverage_test.go` — graph string/edge asserts,
+RED-first (no runtime test: this is agent-prompt rules with no executable shell).
+`TestDecomposeFailEdgeIsLive` pins the `auto_status`↔fail-edge coupling (the
+load-bearing change); `TestDecomposeOutEdgesUnchanged` pins no new/unconditional
+Decompose edge; owner-or-deferred and coverage-table prompt rules pinned by
+substring; a prose-sync truthfulness pin.
+
+## Verification
+
+`dippin validate` ✓ · `dippin doctor` A grade (90/100, unchanged) ✓ · `dippin
+simulate -all-paths` 100% terminate ✓ · `go build ./... && go test ./... -short` ✓
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 5: Address bot review** (CodeRabbit/Copilot/Codex). Per `superpowers:receiving-code-review`: verify each comment against the actual code, fix valid ones, decline invalid ones with a technical rationale, reply in-thread, resolve addressed threads, keep the PR body + CHANGELOG in sync, keep CI green. NEVER `--no-verify`. Stop when findings go minor/incorrect.
+
+---
+
+## Self-review against the spec
+
+- **Decompose `auto_status` + dead-edge revival** → Task 2 Step 1 + `TestDecomposeFailEdgeIsLive` ✓
+- **Coverage table + enumerate-first ordering + closed inclusion test + affirmative extraction** → Task 2 Step 2 ✓
+- **DO-NOT-implement deferral carve-out (3-way owned|deferred|UNOWNED)** → Task 2 Step 2 + Task 3 Step 1 + Task 4 Step 1 + `TestDecomposeDeferralCarveout` ✓
+- **Read-back gate + `COVERAGE_GAPS` sentinel + STATUS hygiene (exact token, fence, no retry)** → Task 2 Step 2 ✓
+- **VerifyMilestone owner-or-deferred + prose-sync cross-reference** → Task 3 + Tests 4, 6 ✓
+- **FinalSpecCheck owner-or-deferred (blocks STATUS:success, not "emit fail")** → Task 4 Step 1 + Test 5 ✓
+- **Artifact hygiene (allowlist note + Cleanup comment)** → Task 4 Steps 2–3 ✓
+- **No new edges / no loop-target fallback** → Task 2 (no edge edits) + `TestDecomposeOutEdgesUnchanged` + Task 6 Step 3 diff check ✓
+- **Keep coverage table out of milestones.md** → Task 2 Step 2 (writes only requirement-coverage.md) + Task 6 Step 3 ✓
+- **Restart-budget residual documented** → PR body "Out of scope / follow-up" ✓
+- **#301 untouched / soft coupling noted** → Task 6 Step 3 + PR body ✓
+- **dippin validate/doctor/simulate + go gates + gofmt** → Task 6 Steps 1–2 ✓
+- **CHANGELOG Added, Phase 2 second item, behavior-change framing** → Task 5 ✓

--- a/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
@@ -1,0 +1,143 @@
+# Issue #300 — no-requirement-left-behind (Decompose coverage + owner-or-fail Verify)
+
+**Epic:** #308 Phase 2 ("Enforce quality regardless of spec/language"), **second** item (after #299, merged in PR #321).
+**Scope:** `.dip`-only change to `examples/build_product.dip` + one new test file + CHANGELOG. No engine Go changes.
+**Status:** design (pre squad review, 2026-06-08).
+
+## Problem
+
+Two failure modes let spec-mandated requirements vanish from a `build_product` run:
+
+1. **Decompose drops a requirement.** `Decompose` (`:436`) can produce a set of milestones whose collective "Done when" criteria omit a verification the SPEC explicitly mandates — the test is never assigned to anyone. Its rules cover ordering, size, anti-scope-creep (`DO NOT implement`), and `known_failures`, but **nothing requires every spec-mandated verification to map to a milestone**.
+
+2. **Verify/FinalSpecCheck wave a gap through as "future work."** `VerifyMilestone` check 5 ("SPEC GAPS BEYOND MILESTONE NOTES", `:861`) cross-checks SPEC bullets but has **no rule against deferring a requirement to unowned future work**. `FinalSpecCheck` (`:1378`) asks "is it implemented?" per requirement but does not police future-work deferrals.
+
+On the audited `code-goblin` run, two spec-mandated tests — a synthetic-429 retry test and a cancel-within-100ms test (SPEC lines 290, 323) — were owned by no milestone. The milestone verifier **saw** the gap and explicitly waved it through as "future work"; because the run halted before `FinalSpecCheck` (the silent-halt bug, Phase 0), even the final gate never re-examined it.
+
+## Critical pre-design finding — Decompose's fail-edge is currently dead
+
+`Decompose` has **no `auto_status: true`** attribute (unlike `VerifyMilestone:748` and `FinalSpecCheck:1385`). In `pipeline/handlers/codergen.go:627-637` (`resolveTerminalStatus`), an agent node's terminal status **defaults to `OutcomeSuccess`**, and `parseAutoStatus(responseText)` is only consulted when `node.Attrs["auto_status"] == "true"`. Therefore a normal `Decompose` completion **always yields `outcome=success`**, and the existing edge
+
+```
+Decompose -> EscalateReview  when ctx.outcome = fail        (:1587)
+```
+
+is **dead** — it can never fire from a normal Decompose run today.
+
+**Consequence for #300:** the issue's acceptance criterion — "a mandated test with no owner makes `Decompose` FAIL (routes to EscalateReview)" — cannot be met by prompt prose alone. We must add `auto_status: true` to the `Decompose` node so its STATUS line becomes authoritative, and have the prompt emit `STATUS:success`/`STATUS:fail`. This remains **`.dip`-only** (a node attribute, no engine Go change) but is more than a prose edit, and is the load-bearing change of this issue.
+
+### STATUS pattern decision (settled)
+
+Decompose uses the **simple, VerifyMilestone-style pattern** (`:938-940`), not the fail-closed FinalSpecCheck pattern:
+
+- Every mandated verification has an owner → terminal `STATUS:success`.
+- Any mandated verification is unowned → `STATUS:fail` (routes to `EscalateReview`).
+
+Rationale: the simple pattern keeps Decompose's happy-path contract intact (a successful decomposition that forgets the STATUS line still defaults to success — fail-open on the happy path), and the only *new* way to fail is the explicit unowned-verification case this issue introduces. The fail-closed pattern (STATUS:fail first line / STATUS:success last) would change Decompose's happy-path contract more invasively for marginal benefit on a planning node that has no truncation-sensitive enumeration. Confirmed with the issue author.
+
+## The change
+
+Three substantive edits to `examples/build_product.dip`, plus prose-sync, all `.dip`-only.
+
+### Edit 1 — `Decompose` (`:436`): coverage table + owner-or-fail gate
+
+Add the attribute:
+
+```
+auto_status: true
+```
+
+Append to the Decompose prompt (after the existing decomposition rules and the `known_failures` block, before the node ends):
+
+- **Derive the mandated-verification list from SPEC.md itself.** Read `SPEC.md` and enumerate every verification the spec *mandates*: named tests (e.g. "a test that …", explicitly named test functions), behavioral checks ("must reject …within 100ms"), and acceptance gates. #300 is **self-sufficient** — it derives this list from SPEC.md directly; it does NOT depend on #301's spec-coherence preflight (whose rule (f) will *later* feed this same table — soft coupling, not a hard dependency).
+- **Coverage requirement.** Every mandated verification MUST appear in some milestone's "Done when" criteria.
+- **Coverage table artifact.** Write `.ai/decisions/requirement-coverage.md` — a table mapping each spec-mandated verification → its owning milestone, citing the SPEC.md line/section each came from. Suggested columns: `Mandated verification | SPEC.md source (line/section) | Owning milestone`.
+- **Gate.** If every mandated verification has an owning milestone → emit `STATUS:success` as the terminal line. If ANY mandated verification has no owner, that is a decomposition bug: describe the unowned verification(s) and emit `STATUS:fail` (routes to `EscalateReview` so a human re-plans, rather than the build silently proceeding with a dropped requirement).
+
+The new prompt text contains no literal `escalate`/`tests-pass` tokens (defensive — Decompose's outcome flows through `auto_status`/STATUS, not `ctx.tool_stdout` substring-matching, but kept clean to avoid any cross-node stdout coincidence).
+
+### Edit 2 — `VerifyMilestone` check 5 "SPEC GAPS BEYOND MILESTONE NOTES" (`:861`)
+
+Append an owner-or-fail rule to check 5 (the node already has `auto_status: true`):
+
+> A requirement may NOT be deferred to "future work" / "a later milestone" unless a **named later milestone in `.ai/decisions/milestones.md` actually owns it**. Before accepting any such deferral, `grep` `.ai/decisions/milestones.md` for the owning milestone and cite it (milestone number + the "Done when" line that covers it). If no named milestone owns the deferred requirement → `STATUS:fail`. (This is the exact `code-goblin` miss: the verifier saw the 429/cancel gap and waved it through as "future work" with no owning milestone.) Cross-check against `.ai/decisions/requirement-coverage.md` (written by Decompose) when present.
+
+### Edit 3 — `FinalSpecCheck` (`:1378`)
+
+Append the same owner-or-fail rule into FinalSpecCheck's SPEC.md compliance section (the node already has `auto_status: true` and uses the fail-closed first-line-`STATUS:fail` pattern):
+
+> For EVERY requirement: if it is not implemented and the report defers it to "future work," that deferral is only acceptable when a **named later milestone in `.ai/decisions/milestones.md` owns it** — grep for the owner and cite it. A future-work deferral with no named owner keeps the early `STATUS:fail` in place (do NOT emit the terminal `STATUS:success`).
+
+Because FinalSpecCheck is fail-closed, the rule is phrased as "an unowned deferral blocks the terminal `STATUS:success`" rather than "emit STATUS:fail" — consistent with its existing contract.
+
+### Prose-sync (the #299 doc-in-prompt-truthfulness lesson)
+
+After Edit 1, several existing prose sites that describe Decompose behavior must stay consistent:
+
+- `VerifyMilestone:759-763` ("if Decompose dropped a requirement during milestone planning … the verifier had no path to discover the gap") and `:865` ("a SPEC.md bullet that Decompose dropped silently passed through") — still true, but now Decompose *also* owns a coverage gate. Add a brief note that Decompose writes `requirement-coverage.md` and fails on an unowned mandated verification, so the two layers are described consistently (defense in depth, not contradiction).
+- `EscalateReview` retry copy (`:1538`, "Go back to Decompose and re-plan the build from scratch") — remains truthful; Decompose can now route here directly on a coverage failure.
+
+No prose may state or imply that Decompose "always succeeds" or "cannot fail." (None currently does; this is a guard against introducing such a claim.)
+
+## Edges — no new edges, no unconditional fallbacks to loop targets
+
+This change adds **zero** graph edges. It relies entirely on edges that already exist:
+
+```
+Decompose      -> EscalateReview  when ctx.outcome = fail      (:1587, now LIVE via auto_status)
+Decompose      -> ApprovePlan     when ctx.outcome = success   (:1586)
+VerifyMilestone -> FixMilestone   when ctx.outcome = fail      (:1604)
+VerifyMilestone -> EscalateMilestone                            (:1605, existing unconditional fallback — NOT a loop target)
+FinalSpecCheck -> EscalateReview  when ctx.outcome = fail      (:1652)
+```
+
+Adding `auto_status: true` to Decompose changes only the *node's ability to emit `outcome=fail`* — it does not change routing. The `Decompose -> ApprovePlan when success` / `Decompose -> EscalateReview when fail` pair is exhaustive for Decompose's two STATUS outcomes; no fallback edge is added (and none to a loop target). This satisfies the CLAUDE.md edge-routing rule.
+
+## Testing (RED-first, mirroring `build_product_quality_gate_test.go`)
+
+New file `pipeline/build_product_requirement_coverage_test.go`, package `pipeline`, using `loadBuildProduct(t)` and `g.Nodes[id].Attrs[...]`. This issue is **agent-prompt rules with no executable shell to drive**, so the tests are **graph string-asserts only** — there is no Layer-B runtime shell test (unlike #299, whose `ci-probe.sh` heredoc was executable). A `dippin simulate -all-paths` run (a verification gate, not a Go test) covers reachability/termination.
+
+### Negative-control assertions (RED before the `.dip` edit; verified absent pre-change)
+
+- `Decompose` node has `Attrs["auto_status"] == "true"`.
+- `Decompose` prompt contains `requirement-coverage.md`.
+- `Decompose` prompt contains the coverage-mapping language (e.g. substrings proving "every … mandated …" + "owning milestone" + the `.ai/decisions/requirement-coverage.md` path).
+- `Decompose` prompt instructs reading `SPEC.md` to derive mandated verifications.
+- `VerifyMilestone` prompt contains the owner-or-fail "future work" rule (substrings: `future work` + `milestones.md` + named-owner language).
+- `FinalSpecCheck` prompt contains the owner-or-fail "future work" rule.
+
+### Regression-pin assertions (GREEN before and after; guard against removal/regression)
+
+- The `Decompose -> EscalateReview when ctx.outcome = fail` edge still exists (assert via `g.Edges`).
+- The `Decompose -> ApprovePlan when ctx.outcome = success` edge still exists.
+- `VerifyMilestone` and `FinalSpecCheck` still carry `auto_status: true`.
+- **No unconditional `Decompose -> <X>` edge** was added beyond the two conditional ones (assert Decompose's out-edges are exactly the success→ApprovePlan and fail→EscalateReview pair — no new fallback, no loop-target fallback).
+
+### Test-hygiene notes
+
+- Coverage/complexity hooks exclude `_test.go`; the new file is additive string-asserts on embedded `.dip` data — no new production Go, no coverage regression risk.
+- Assertions use stable substrings, not full-paragraph matches, so benign prompt rewording does not flake them (matching the #299 test's `strings.Contains` discipline).
+
+## Verification gates (all before the PR)
+
+- `dippin validate examples/build_product.dip` — passes.
+- `dippin doctor examples/build_product.dip examples/ask_and_execute.dip examples/build_product_with_superspec.dip` — **A** grade across the board (build_product baseline A 90/100 — must not regress).
+- `dippin simulate -all-paths examples/build_product.dip` — 100% terminate, no new cycle / dead-stop. (Confirms the now-live `Decompose -> EscalateReview` fail path is reachable and terminates.)
+- `go build ./... && go test ./... -short` — green; each new assertion proven RED before the `.dip` edit.
+- `gofmt -l pipeline/build_product_requirement_coverage_test.go` — prints nothing.
+
+## Out of scope (deliberate)
+
+- **#301 (spec-coherence preflight)** — the sibling Phase-2 item. It adds a new `SpecLint` subgraph whose rule (f) enumerates mandated tests to *feed* this issue's coverage table. #300 stays self-sufficient: Decompose derives the mandated-verification list from SPEC.md itself. Do NOT build the preflight here. The coupling is soft and one-directional (future #301 → this table).
+- **#305 / #320 / #304 / #306 / #307** — untouched.
+- The fail-closed-vs-simple STATUS choice for Decompose (settled: simple). No engine change to `parseAutoStatus` or the default-success behavior.
+
+## Soft coupling with #301 (documented, not built)
+
+#301's preflight rule (f) ("Mandated tests enumerated and assignable → emit the list for Decompose to own") will, once built, produce the mandated-verification list that Decompose currently derives itself. When #301 lands, Decompose can consume that list instead of (or in addition to) re-deriving it — a refinement, not a dependency. This issue ships the consumer (the coverage gate) independently.
+
+## Commit / PR
+
+- Branch: `fix/300-no-requirement-left-behind` (off `main`).
+- Commit messages end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. NEVER `--no-verify`.
+- PR title: `feat(build_product): no-requirement-left-behind — Decompose coverage + owner-or-fail Verify (#300)`. Body closes #300, refs epic #308 Phase 2 (second item), notes the soft coupling with #301, ends with the Claude Code generation line.

--- a/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
@@ -39,36 +39,55 @@ Rationale: the simple pattern keeps Decompose's happy-path contract intact (a su
 
 Three substantive edits to `examples/build_product.dip`, plus prose-sync, all `.dip`-only.
 
+> **Squad-review note (2026-06-08, five-expert panel).** The architecture below was validated — the dead-edge finding is correct (one reviewer empirically confirmed `auto_status: true` preserves the `dippin doctor` A 90/100 and all 100 `simulate` paths terminate), and the feared `FinalSpecCheck` allowlist collision was **refuted** (its allowlist is `.ai/build/`-scoped; the new artifact is in `.ai/decisions/`). The panel surfaced two criticals and a cluster of prompt-reliability fixes, all folded into the edits below: the **DO-NOT-implement deferral carve-out** (else the gate false-fails correct decompositions), the **read-back gate** (vs. fail-open tail-token judgment), a **closed inclusion test** for "mandated verification", and **STATUS hygiene**. See "Squad-review consensus folded in" at the end for the full list with sources.
+
 ### Edit 1 — `Decompose` (`:436`): coverage table + owner-or-fail gate
 
-Add the attribute:
+Add the attribute `auto_status: true` to the node. Append to the Decompose prompt (after the existing decomposition rules and the `known_failures` block, before the node ends) a block enforcing this **ordered** procedure — the ordering is load-bearing (it breaks the self-grading loop where an agent back-fills the table from milestones it already wrote, making the gate decorative):
 
-```
-auto_status: true
-```
+1. **FIRST — enumerate, before writing any milestone.** Read `SPEC.md` and write the LEFT columns of `.ai/decisions/requirement-coverage.md` — every *spec-mandated verification* and its SPEC.md source line/section. Do not consult or write milestones during this step. #300 is **self-sufficient**: it derives this list from SPEC.md directly and does NOT depend on #301's preflight (whose rule (f) will *later* feed this same table — soft coupling, not a hard dependency).
+   - **Closed inclusion test for "spec-mandated verification"** (prevents both false-fails and misses): a line qualifies ONLY if the SPEC.md text uses an obligation word (MUST / SHALL / "is required to" / "the test must" / an explicitly named test function or acceptance criterion) AND names a concrete, checkable behavior (a specific input→output, a numeric bound, a named error path). Aspirational adjectives ("fast", "robust", "clean") with no checkable threshold are NOT mandated verifications — do not list them. When unsure whether a line qualifies, list it but mark its owner `N/A — aspirational, no checkable threshold` rather than failing the build.
+   - **Affirmative extraction.** State explicitly how many mandated verifications were found. If zero, write an affirmative `SPEC mandates no named verifications` line — never a silent empty table (a silent-empty table is the under-extraction failure mode, the same bug class relocated).
+2. **THEN decompose** into milestones per the rules above.
+3. **FINALLY — assign owners.** Fill the "Owning milestone" column by matching each pre-listed verification to a milestone. You may NOT add rows in this step, and you may NOT invent a milestone to cover a verification. Each mandated verification resolves to exactly one of three states:
+   - **owned** — a milestone's "Done when" line covers it. "Owns it" means: `grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` returns a milestone whose "Done when" block contains a line covering this exact requirement; cite it as `Milestone <N>: <the Done-when line, verbatim>`. A milestone that merely *mentions* the topic in prose without a covering "Done when" line does NOT own it.
+   - **deferred** — SPEC.md itself defers the behavior to a named later phase AND a milestone's `DO NOT implement` block records that deferral citing the spec section. Cite both. (This carve-out is mandatory: without it the gate contradicts the existing anti-scope-creep machinery — Decompose `:458-471`, VerifyMilestone check 4 `:858-859` — and would `STATUS:fail` a *correct* decomposition that properly defers Phase-2+ work, e.g. the spec's own Phase-1 `Fingerprint` whose consumer is deferred to Phase 6.)
+   - **UNOWNED** — neither owned nor deferred. This is the decomposition bug the issue targets.
 
-Append to the Decompose prompt (after the existing decomposition rules and the `known_failures` block, before the node ends):
+**Gate (read-back, not recall).** After filling the table, re-read `.ai/decisions/requirement-coverage.md` and count the UNOWNED rows. Emit `COVERAGE_GAPS: <N>` (the count) on its own line, then the terminal STATUS line:
+- every row is `owned` or `deferred` (N = 0) → emit `STATUS:success`.
+- any row is `UNOWNED` (N > 0) → list the unowned verification(s) ABOVE the STATUS line, then emit `STATUS:fail` (routes to `EscalateReview` via `:1587` so a human re-plans).
 
-- **Derive the mandated-verification list from SPEC.md itself.** Read `SPEC.md` and enumerate every verification the spec *mandates*: named tests (e.g. "a test that …", explicitly named test functions), behavioral checks ("must reject …within 100ms"), and acceptance gates. #300 is **self-sufficient** — it derives this list from SPEC.md directly; it does NOT depend on #301's spec-coherence preflight (whose rule (f) will *later* feed this same table — soft coupling, not a hard dependency).
-- **Coverage requirement.** Every mandated verification MUST appear in some milestone's "Done when" criteria.
-- **Coverage table artifact.** Write `.ai/decisions/requirement-coverage.md` — a table mapping each spec-mandated verification → its owning milestone, citing the SPEC.md line/section each came from. Suggested columns: `Mandated verification | SPEC.md source (line/section) | Owning milestone`.
-- **Gate.** If every mandated verification has an owning milestone → emit `STATUS:success` as the terminal line. If ANY mandated verification has no owner, that is a decomposition bug: describe the unowned verification(s) and emit `STATUS:fail` (routes to `EscalateReview` so a human re-plans, rather than the build silently proceeding with a dropped requirement).
+**STATUS hygiene (copied from FinalSpecCheck's existing warnings):** the final line must be EXACTLY `STATUS:success` or `STATUS:fail` — no parentheses, no counts, no trailing words (`STATUS:fail (2 unowned)` is dropped by the parser → silent success on a detected gap). Emit it OUTSIDE any code fence, alone on its own line. Emit ONLY `success` or `fail` — never `STATUS:retry` (Decompose has no retry edge; a stray retry re-runs the node under the global restart budget). The new prompt text contains no literal `escalate`/`tests-pass` tokens (defensive — Decompose routes via `auto_status`/STATUS, not `ctx.tool_stdout` substring-match).
 
-The new prompt text contains no literal `escalate`/`tests-pass` tokens (defensive — Decompose's outcome flows through `auto_status`/STATUS, not `ctx.tool_stdout` substring-matching, but kept clean to avoid any cross-node stdout coincidence).
+**Keep the coverage table out of `milestones.md`.** It is its own file (`requirement-coverage.md`); writing milestone-coverage content into `milestones.md` would inflate `PickNextMilestone`'s `grep -ciE '^#{1,3}\s*milestone\s'` count (`:511`).
 
 ### Edit 2 — `VerifyMilestone` check 5 "SPEC GAPS BEYOND MILESTONE NOTES" (`:861`)
 
 Append an owner-or-fail rule to check 5 (the node already has `auto_status: true`):
 
-> A requirement may NOT be deferred to "future work" / "a later milestone" unless a **named later milestone in `.ai/decisions/milestones.md` actually owns it**. Before accepting any such deferral, `grep` `.ai/decisions/milestones.md` for the owning milestone and cite it (milestone number + the "Done when" line that covers it). If no named milestone owns the deferred requirement → `STATUS:fail`. (This is the exact `code-goblin` miss: the verifier saw the 429/cancel gap and waved it through as "future work" with no owning milestone.) Cross-check against `.ai/decisions/requirement-coverage.md` (written by Decompose) when present.
+> A requirement may NOT be waved through as "future work" / "a later milestone" unless it is EITHER (a) **owned** by a named later milestone — `grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and cite the milestone number + the "Done when" line, verbatim, that covers it — OR (b) **deferred**: SPEC.md defers it to a named later phase AND a milestone's `DO NOT implement` block records that deferral citing the spec section (cite both — consistent with check 4's existing deferred-field semantics). A deferral that is neither owned nor documented-deferred → `STATUS:fail`. (This is the exact `code-goblin` miss: the verifier saw the 429/cancel gap and waved it through as "future work" with no owning milestone.) Cross-check against `.ai/decisions/requirement-coverage.md` (written by Decompose) when present; on any disagreement, SPEC.md re-read live is authoritative over the table (consistent with the existing `:754-756` "SPEC.md and source are authoritative" framing).
 
 ### Edit 3 — `FinalSpecCheck` (`:1378`)
 
-Append the same owner-or-fail rule into FinalSpecCheck's SPEC.md compliance section (the node already has `auto_status: true` and uses the fail-closed first-line-`STATUS:fail` pattern):
+Append the same owner-or-deferred-or-fail rule into FinalSpecCheck's SPEC.md compliance section (the node already has `auto_status: true` and uses the fail-closed first-line-`STATUS:fail` pattern):
 
-> For EVERY requirement: if it is not implemented and the report defers it to "future work," that deferral is only acceptable when a **named later milestone in `.ai/decisions/milestones.md` owns it** — grep for the owner and cite it. A future-work deferral with no named owner keeps the early `STATUS:fail` in place (do NOT emit the terminal `STATUS:success`).
+> For EVERY requirement: if it is not implemented and the report defers it to "future work," that deferral is acceptable ONLY when it is EITHER owned by a named later milestone in `.ai/decisions/milestones.md` (grep + cite the milestone and its "Done when" line) OR documented-deferred (SPEC.md defers to a named phase AND a `DO NOT implement` block records it, citing the spec section). A future-work deferral that is neither keeps the early `STATUS:fail` in place (do NOT emit the terminal `STATUS:success`).
 
-Because FinalSpecCheck is fail-closed, the rule is phrased as "an unowned deferral blocks the terminal `STATUS:success`" rather than "emit STATUS:fail" — consistent with its existing contract.
+Because FinalSpecCheck is fail-closed, the rule is phrased as "an unowned/undocumented deferral **blocks** the terminal `STATUS:success`" — NOT "emit STATUS:fail" (which mid-prose would just be one more fail line the final success overrides). Keep this phrasing; do not let an implementer normalize it to Edit 2's "emit STATUS:fail."
+
+### Documenting the new `.ai/decisions/` artifact (hygiene — refuted-collision follow-through)
+
+The feared FinalSpecCheck allowlist collision was refuted (its "no UNEXPECTED leftover files" rule is `.ai/build/`-scoped, `:1491-1498`/`:1509-1510`; `requirement-coverage.md` is in `.ai/decisions/`). But to prevent doc-drift, add `requirement-coverage.md` to the documented set of expected `.ai/decisions/` files (the `Cleanup` comment near `:1564` preserves `.ai/decisions/`), and note in FinalSpecCheck's "nothing extra" framing that `.ai/decisions/*.md` workflow artifacts are not "extras."
+
+### Prose-sync (the #299 doc-in-prompt-truthfulness lesson)
+
+After Edit 1, several existing prose sites that describe Decompose behavior must stay consistent:
+
+- `VerifyMilestone:759-763` ("if Decompose dropped a requirement during milestone planning … the verifier had no path to discover the gap") and `:865` ("a SPEC.md bullet that Decompose dropped silently passed through") — still true, but now Decompose *also* owns a coverage gate. Add a brief note that Decompose writes `requirement-coverage.md` and fails on an unowned mandated verification, so the two layers are described consistently (defense in depth, not contradiction). This note is also the positive prose-sync pin the test plan asserts.
+- `EscalateReview` retry copy (`:1538`, "Go back to Decompose and re-plan the build from scratch") — remains truthful; Decompose can now route here directly on a coverage failure.
+
+No prose may state or imply that Decompose "always succeeds" or "cannot fail." (None currently does; this is a guard against introducing such a claim.)
 
 ### Prose-sync (the #299 doc-in-prompt-truthfulness lesson)
 
@@ -99,24 +118,27 @@ New file `pipeline/build_product_requirement_coverage_test.go`, package `pipelin
 
 ### Negative-control assertions (RED before the `.dip` edit; verified absent pre-change)
 
-- `Decompose` node has `Attrs["auto_status"] == "true"`.
 - `Decompose` prompt contains `requirement-coverage.md`.
-- `Decompose` prompt contains the coverage-mapping language (e.g. substrings proving "every … mandated …" + "owning milestone" + the `.ai/decisions/requirement-coverage.md` path).
-- `Decompose` prompt instructs reading `SPEC.md` to derive mandated verifications.
-- `VerifyMilestone` prompt contains the owner-or-fail "future work" rule (substrings: `future work` + `milestones.md` + named-owner language).
-- `FinalSpecCheck` prompt contains the owner-or-fail "future work" rule.
+- `Decompose` prompt contains the coverage-mapping language (substrings: `Owning milestone` + `mandated`). **Do NOT assert the bare token `SPEC.md`** on the Decompose prompt — it is already GREEN at `:467` ("SPEC.md may define a `Fingerprint`…") and would prove nothing (test-reviewer I1). Assert a distinctive new phrase instead (e.g. `Owning milestone`, and `COVERAGE_GAPS`).
+- `Decompose` prompt contains the `COVERAGE_GAPS` sentinel and the DO-NOT-implement deferral carve-out language (substring `DO NOT implement` within the new gate block, plus `deferred`).
+- `VerifyMilestone` prompt contains the owner-or-fail "future work" rule (anchor tokens matched separately: `future work` + `milestones.md`, plus `DO NOT implement` for the carve-out — not a full-sentence match, so re-wording doesn't flake).
+- `FinalSpecCheck` prompt contains the owner-or-fail "future work" rule (same anchor-token discipline).
 
 ### Regression-pin assertions (GREEN before and after; guard against removal/regression)
 
-- The `Decompose -> EscalateReview when ctx.outcome = fail` edge still exists (assert via `g.Edges`).
+- **`TestDecomposeFailEdgeIsLive` (the load-bearing pin).** Assert `g.Nodes["Decompose"].Attrs["auto_status"] == "true"` AND the `Decompose -> EscalateReview when ctx.outcome = fail` edge exists, in ONE test, with a comment tying them together: *the fail edge is dead without `auto_status` — `codergen.go:635`*. This is the only guard against silently re-deadening the edge; the existing `routesFailure` helper (`build_product_failure_routing_test.go:52`) passes regardless of `auto_status` (it only checks for conditional edges), so without this dedicated pin a future `auto_status` removal goes undetected (test-reviewer C1).
 - The `Decompose -> ApprovePlan when ctx.outcome = success` edge still exists.
 - `VerifyMilestone` and `FinalSpecCheck` still carry `auto_status: true`.
-- **No unconditional `Decompose -> <X>` edge** was added beyond the two conditional ones (assert Decompose's out-edges are exactly the success→ApprovePlan and fail→EscalateReview pair — no new fallback, no loop-target fallback).
+- **No new/unconditional `Decompose` out-edge.** Use `g.OutgoingEdges("Decompose")` (filters on `e.From`), assert `len == 2`, assert each via `hasEdgeWithCondition(g, "Decompose", "ApprovePlan", "ctx.outcome = success")` / `(... "EscalateReview", "ctx.outcome = fail")`, and loop asserting every out-edge has `Condition != ""`. Do **not** scan `g.Edges` loosely — the incoming restart edges `ApprovePlan -> Decompose` (`:1589`) and `ResetReviewBudget -> Decompose` (`:1658`) would pollute a substring match (test-reviewer I2). Condition strings retain the `ctx.` prefix in `Edge.Condition` (verified), so the precedent helpers work verbatim.
 
 ### Test-hygiene notes
 
-- Coverage/complexity hooks exclude `_test.go`; the new file is additive string-asserts on embedded `.dip` data — no new production Go, no coverage regression risk.
-- Assertions use stable substrings, not full-paragraph matches, so benign prompt rewording does not flake them (matching the #299 test's `strings.Contains` discipline).
+- Reuse the existing helpers in `build_product_failure_routing_test.go` (same package `pipeline`): `loadBuildProduct`, `hasEdgeWithCondition`, `hasUnconditionalEdgeTo`. Do NOT redefine them.
+- Add a prose-sync truthfulness pin (mirroring #299's `TestQualityGateVerifyPromptTruthful`): assert the new Decompose-coverage note appears in `VerifyMilestone`'s prompt, so a future edit can't silently drop the defense-in-depth cross-reference (test-reviewer M2).
+- Coverage/complexity hooks exclude `_test.go` and run at CI (`make ci`), not pre-commit; the new file is additive string/edge-asserts on embedded `.dip` data — no new production Go, no coverage regression risk (test-reviewer M1).
+- Assertions use stable substrings, not full-paragraph matches, so benign prompt rewording does not flake them (matching the #299 test's `strings.Contains` discipline). **Re-confirm count-0 of each chosen negative-control substring against the current `.dip` before writing the assertion.**
+
+**Why no Layer-B runtime test (vs. #299).** This issue is agent-prompt rules with no executable shell to drive — string-asserts prove the prompt *text* exists; the LLM's runtime behavior (does it actually fail on an unowned test?) cannot be unit-tested. The durable reachability guard for the now-live fail path is the **graph edge-assert pair above** (edge exists + node can emit fail via `auto_status`), NOT `dippin simulate` — `simulate -all-paths` is a one-time pre-PR CLI confirmation (no in-repo precedent shells out to it from a Go test), not an ongoing gate (test-reviewer I3).
 
 ## Verification gates (all before the PR)
 
@@ -126,11 +148,33 @@ New file `pipeline/build_product_requirement_coverage_test.go`, package `pipelin
 - `go build ./... && go test ./... -short` — green; each new assertion proven RED before the `.dip` edit.
 - `gofmt -l pipeline/build_product_requirement_coverage_test.go` — prints nothing.
 
+## Residual risk (documented, not fixed here)
+
+**Decompose-retry budget drain under autopilot (adversarial C2).** Making Decompose's fail edge live adds a new entry into the *existing* `EscalateReview -> retry -> ResetReviewBudget -> Decompose` (`:1657-1658`) cycle, which loops back to an already-completed node and consumes the **global** `RestartCount` (`engine_run.go`, capped at `max_restarts: 50`, `:9`). The cycle is gated by a human/autopilot decision at the `EscalateReview` gate (default label `accept` → Cleanup, which terminates), so it does not spin autonomously; `dippin simulate -all-paths` confirms termination. The realistic exposure is a `--autopilot lax`/`mid` driver repeatedly choosing "retry" on a genuinely unsatisfiable spec, draining the restart budget a later milestone fix loop would need. **The DO-NOT-implement carve-out (Edit 1, critical #1) removes the main *deterministic* re-fail trigger** — after it, a Decompose `STATUS:fail` signals a genuine, human-fixable spec gap (the intended semantic) rather than a correct-but-rejected plan. A dedicated `decompose_attempts` circuit breaker (analogous to the `review_fix_attempts` counter) would close the residual autopilot case but requires new tool nodes + edges — a structural change beyond this prompt-rule issue. **Filed as a follow-up rather than built here** (note it in the PR body). This is not a regression: the same retry-loop budget property already exists for `ReadSpec`/`FinalSpecCheck -> EscalateReview`.
+
 ## Out of scope (deliberate)
 
 - **#301 (spec-coherence preflight)** — the sibling Phase-2 item. It adds a new `SpecLint` subgraph whose rule (f) enumerates mandated tests to *feed* this issue's coverage table. #300 stays self-sufficient: Decompose derives the mandated-verification list from SPEC.md itself. Do NOT build the preflight here. The coupling is soft and one-directional (future #301 → this table).
+- **A `decompose_attempts` circuit breaker** for the retry-budget residual above — follow-up, not this issue.
 - **#305 / #320 / #304 / #306 / #307** — untouched.
-- The fail-closed-vs-simple STATUS choice for Decompose (settled: simple). No engine change to `parseAutoStatus` or the default-success behavior.
+- The fail-closed-vs-simple STATUS choice for Decompose (settled: simple, hardened with the read-back gate). No engine change to `parseAutoStatus` or the default-success behavior.
+
+## Squad-review consensus folded in (five-expert panel, 2026-06-08)
+
+| # | Finding | Severity | Source(s) | Resolution |
+|---|---------|----------|-----------|------------|
+| 1 | Owner-or-fail collides with the DO-NOT-implement deferral gate → false-fails correct decompositions | CRITICAL | Adversarial C1 + Prompt I3b | 3-way classify `owned\|deferred\|UNOWNED`; fail only UNOWNED; mirrored in all three nodes (Edits 1/2/3) |
+| 2 | Fail-open tail-token judgment is unreliable for the very runs that drop requirements | CRITICAL | Prompt C1/I2 | Read-back gate over `requirement-coverage.md` + `COVERAGE_GAPS: N` sentinel + enforced enumerate→decompose→assign ordering |
+| 3 | "Spec-mandated verification" too fuzzy | IMPORTANT | Prompt I1 | Closed inclusion test (obligation word + checkable behavior; aspirational → `N/A` owner, not fail) |
+| 4 | Empty/pathological spec → vacuous pass (under-extraction) | IMPORTANT | Adversarial I4 | Affirmative extraction count + per-row SPEC.md cite; explicit "mandates none" line |
+| 5 | Restart-budget drain on the now-live retry loop | IMPORTANT | Adversarial C2 | Documented as residual; carve-out removes the deterministic trigger; breaker is a follow-up |
+| 6 | Test-plan gaps | IMPORTANT | Test C1/I1/I2/M2 | `TestDecomposeFailEdgeIsLive` pin; drop bare `SPEC.md` assert; `OutgoingEdges` len==2 + `Condition!=""`; prose-sync pin |
+| 7 | "Named owner" under-specified | MINOR | Prompt I3a | Pinned to `## Milestone N` header + verbatim "Done when" line |
+| 8 | STATUS hygiene (trailing count dropped; fence; retry third outcome) | MINOR | Prompt M1/M2 + Engine-sem 1 | Exact-token + outside-fence + only success/fail warnings copied into Decompose |
+| 9 | Undocumented permanent `.ai/decisions/` artifact | MINOR | Adversarial I3 + Workflow-safety 5a | Document `requirement-coverage.md` in Cleanup + FinalSpecCheck "not extras"; keep out of `milestones.md` |
+| 10 | FinalSpecCheck Edit 3 must keep "blocks STATUS:success" phrasing | MINOR | Prompt M4 | Phrasing pinned in Edit 3 |
+
+**Validated by the panel (no change required):** the dead-edge `auto_status` finding (engine-semantics reviewer empirically confirmed A 90/100 doctor + 100/100 simulate termination); zero CLAUDE.md invariant violations (workflow-safety reviewer); the FinalSpecCheck allowlist collision was **refuted** (`.ai/build/`-scoped, artifact is in `.ai/decisions/`); declared-writes demotion is inert (no `writes:` attr on Decompose); restart re-entry is `auto_status`-safe.
 
 ## Soft coupling with #301 (documented, not built)
 

--- a/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
+++ b/docs/superpowers/specs/2026-06-08-issue-300-no-requirement-left-behind-design.md
@@ -70,11 +70,11 @@ Append an owner-or-fail rule to check 5 (the node already has `auto_status: true
 
 ### Edit 3 — `FinalSpecCheck` (`:1378`)
 
-Append the same owner-or-deferred-or-fail rule into FinalSpecCheck's SPEC.md compliance section (the node already has `auto_status: true` and uses the fail-closed first-line-`STATUS:fail` pattern):
+Append a **deferred-only** rule into FinalSpecCheck's SPEC.md compliance section (the node already has `auto_status: true` and uses the fail-closed first-line-`STATUS:fail` pattern). **This differs from Edit 2 deliberately** (Codex PR #322 P2): `FinalSpecCheck` runs *after every planned milestone is complete*, so "owned by a milestone" is NOT a valid future-work excuse — an owned-but-unimplemented requirement at the final gate is a milestone *failure*, not deferrable work. `VerifyMilestone` (mid-build) keeps the "owned by a *later* milestone" branch because later milestones genuinely haven't run yet; `FinalSpecCheck` drops it and accepts only a SPEC-documented future-phase deferral:
 
-> For EVERY requirement: if it is not implemented and the report defers it to "future work," that deferral is acceptable ONLY when it is EITHER owned by a named later milestone in `.ai/decisions/milestones.md` (grep + cite the milestone and its "Done when" line) OR documented-deferred (SPEC.md defers to a named phase AND a `DO NOT implement` block records it, citing the spec section). A future-work deferral that is neither keeps the early `STATUS:fail` in place (do NOT emit the terminal `STATUS:success`).
+> For EVERY requirement: if it is not implemented and the report defers it to "future work," every planned milestone is already complete at this gate, so being "owned" by a milestone is NOT acceptable — that milestone should have built it. The deferral is acceptable ONLY when SPEC.md itself defers the behavior to a named later phase AND a `DO NOT implement` block in `.ai/decisions/milestones.md` records that deferral, citing the spec section (cite both). A future-work deferral that is not SPEC-documented as deferred keeps the early `STATUS:fail` in place (do NOT emit the terminal `STATUS:success`).
 
-Because FinalSpecCheck is fail-closed, the rule is phrased as "an unowned/undocumented deferral **blocks** the terminal `STATUS:success`" — NOT "emit STATUS:fail" (which mid-prose would just be one more fail line the final success overrides). Keep this phrasing; do not let an implementer normalize it to Edit 2's "emit STATUS:fail."
+Because FinalSpecCheck is fail-closed, the rule is phrased as "a non-SPEC-documented deferral **blocks** the terminal `STATUS:success`" — NOT "emit STATUS:fail" (which mid-prose would just be one more fail line the final success overrides). Keep this phrasing; do not let an implementer normalize it to Edit 2's "emit STATUS:fail."
 
 ### Documenting the new `.ai/decisions/` artifact (hygiene — refuted-collision follow-through)
 
@@ -85,15 +85,6 @@ The feared FinalSpecCheck allowlist collision was refuted (its "no UNEXPECTED le
 After Edit 1, several existing prose sites that describe Decompose behavior must stay consistent:
 
 - `VerifyMilestone:759-763` ("if Decompose dropped a requirement during milestone planning … the verifier had no path to discover the gap") and `:865` ("a SPEC.md bullet that Decompose dropped silently passed through") — still true, but now Decompose *also* owns a coverage gate. Add a brief note that Decompose writes `requirement-coverage.md` and fails on an unowned mandated verification, so the two layers are described consistently (defense in depth, not contradiction). This note is also the positive prose-sync pin the test plan asserts.
-- `EscalateReview` retry copy (`:1538`, "Go back to Decompose and re-plan the build from scratch") — remains truthful; Decompose can now route here directly on a coverage failure.
-
-No prose may state or imply that Decompose "always succeeds" or "cannot fail." (None currently does; this is a guard against introducing such a claim.)
-
-### Prose-sync (the #299 doc-in-prompt-truthfulness lesson)
-
-After Edit 1, several existing prose sites that describe Decompose behavior must stay consistent:
-
-- `VerifyMilestone:759-763` ("if Decompose dropped a requirement during milestone planning … the verifier had no path to discover the gap") and `:865` ("a SPEC.md bullet that Decompose dropped silently passed through") — still true, but now Decompose *also* owns a coverage gate. Add a brief note that Decompose writes `requirement-coverage.md` and fails on an unowned mandated verification, so the two layers are described consistently (defense in depth, not contradiction).
 - `EscalateReview` retry copy (`:1538`, "Go back to Decompose and re-plan the build from scratch") — remains truthful; Decompose can now route here directly on a coverage failure.
 
 No prose may state or imply that Decompose "always succeeds" or "cannot fail." (None currently does; this is a guard against introducing such a claim.)

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1553,13 +1553,15 @@ workflow BuildProduct
       - Is it implemented correctly?
       - Was nothing extra added beyond what the spec asked for?
       - If it is NOT implemented and the report defers it to "future work":
-        that deferral is acceptable ONLY when it is EITHER owned by a named
-        milestone in .ai/decisions/milestones.md (grep `^#+ *[Mm]ilestone`
-        and cite the milestone + its "Done when" line) OR documented-deferred
-        (SPEC.md defers to a named phase AND a "DO NOT implement" block records
-        it, citing the spec section). A future-work deferral that is neither
-        keeps the early STATUS:fail in place — do NOT emit the terminal
-        STATUS:success (issue #300).
+        every planned milestone is already complete at THIS gate, so being
+        "owned" by a milestone is NOT an acceptable excuse — that milestone
+        should have built it, and an owned-but-unimplemented requirement is
+        a failure, not future work. The deferral is acceptable ONLY when
+        SPEC.md itself defers the behavior to a named later phase AND a
+        "DO NOT implement" block in .ai/decisions/milestones.md records that
+        deferral, citing the spec section (cite both). A future-work deferral
+        that is not SPEC-documented as deferred keeps the early STATUS:fail
+        in place — do NOT emit the terminal STATUS:success (issue #300).
 
       Also verify:
       - No UNEXPECTED leftover files in .ai/build/ — the workflow

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -916,8 +916,9 @@ workflow BuildProduct
          criteria — so a SPEC.md bullet that Decompose dropped
          silently passed through. Cross-check against SPEC.md directly.
          A requirement may NOT be waved through as "future work" or "a
-         later milestone" unless it is EITHER (a) owned — a named milestone
-         in .ai/decisions/milestones.md has a "Done when" line covering it
+         later milestone" unless it is EITHER (a) owned — a named LATER
+         milestone in .ai/decisions/milestones.md has a "Done when" line
+         covering it
          (`grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
          cite the milestone number + the Done-when line verbatim) — OR (b)
          deferred — SPEC.md defers it to a named later phase AND a milestone's

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -915,6 +915,21 @@ workflow BuildProduct
          verifier only checked .ai/milestones/current.md's done-when
          criteria — so a SPEC.md bullet that Decompose dropped
          silently passed through. Cross-check against SPEC.md directly.
+         A requirement may NOT be waved through as "future work" or "a
+         later milestone" unless it is EITHER (a) owned — a named milestone
+         in .ai/decisions/milestones.md has a "Done when" line covering it
+         (`grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
+         cite the milestone number + the Done-when line verbatim) — OR (b)
+         deferred — SPEC.md defers it to a named later phase AND a milestone's
+         "DO NOT implement" block records that deferral citing the spec
+         section (cite both; consistent with check 4's deferred-field rule).
+         A deferral that is neither owned nor documented-deferred is a
+         dropped requirement: STATUS:fail. (This is the code-goblin miss —
+         the verifier saw the 429/cancel gap and waved it through as "future
+         work" with no owning milestone.) Cross-check against
+         .ai/decisions/requirement-coverage.md (written by Decompose, #300)
+         when present; if it disagrees with a live SPEC.md re-read, SPEC.md
+         wins.
 
       6. TESTS + CI PASSED: The `tests-pass` sentinel in
          ${ctx.tool_stdout} is authoritative for "TestMilestone step

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1552,6 +1552,14 @@ workflow BuildProduct
       - Is it implemented?
       - Is it implemented correctly?
       - Was nothing extra added beyond what the spec asked for?
+      - If it is NOT implemented and the report defers it to "future work":
+        that deferral is acceptable ONLY when it is EITHER owned by a named
+        milestone in .ai/decisions/milestones.md (grep `^#+ *[Mm]ilestone`
+        and cite the milestone + its "Done when" line) OR documented-deferred
+        (SPEC.md defers to a named phase AND a "DO NOT implement" block records
+        it, citing the spec section). A future-work deferral that is neither
+        keeps the early STATUS:fail in place — do NOT emit the terminal
+        STATUS:success (issue #300).
 
       Also verify:
       - No UNEXPECTED leftover files in .ai/build/ — the workflow
@@ -1561,7 +1569,9 @@ workflow BuildProduct
         the per-node build-context file (build-context.md from #298),
         and reviewers write reports (review-claude.md,
         review-codex.md, review-gemini.md). Only flag files outside
-        this explicit allowlist.
+        this explicit allowlist. (.ai/decisions/*.md workflow artifacts —
+        spec-analysis, milestones, requirement-coverage (#300), compliance —
+        are expected outputs, never "extras".)
       - No TODO/FIXME/HACK comments added
       - All "throw away" items from the spec were actually removed
       - Tests pass (check ${ctx.tool_stdout})
@@ -1627,7 +1637,7 @@ workflow BuildProduct
       set -eu
       # Keep decisions, remove build working files
       rm -rf .ai/build .ai/milestones
-      # Keep: .ai/decisions/ (spec-analysis, milestones, review-synthesis, compliance)
+      # Keep: .ai/decisions/ (spec-analysis, milestones, requirement-coverage, review-synthesis, compliance)
       echo "Preserved decision log in .ai/decisions/"
       ls .ai/decisions/
       printf 'cleanup-done'

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -438,6 +438,7 @@ workflow BuildProduct
     model: claude-opus-4-6
     provider: anthropic
     reasoning_effort: high
+    auto_status: true
     prompt:
       Based on the spec analysis, decompose the work into ordered milestones.
 
@@ -479,6 +480,56 @@ workflow BuildProduct
       line. No comments, no blank lines, no headers — just bare test names like
       TestFooBar. The test runner uses these as a regex skip pattern. Remove
       test names from this file in the milestone where they should start passing.
+
+      ── REQUIREMENT COVERAGE (issue #300, epic #308 Phase 2) ──
+      No spec-mandated verification may be left unowned. Do this in THIS
+      order — the ordering is load-bearing (it stops you from back-filling
+      the table to match milestones you already wrote, which would make
+      the gate decorative):
+
+      1. FIRST, before writing any milestone, read SPEC.md and list every
+         spec-mandated verification into the LEFT columns of
+         .ai/decisions/requirement-coverage.md. A line is "spec-mandated"
+         ONLY if SPEC.md uses an obligation word (MUST / SHALL / "is
+         required to" / "the test must" / a named test function or
+         acceptance criterion) AND names a concrete, checkable behavior
+         (a specific input/output, a numeric bound, a named error path).
+         Aspirational words ("fast", "robust", "clean") with no checkable
+         threshold are NOT mandated — do not list them. State how many you
+         found; if none, write the line: SPEC mandates no named
+         verifications (never leave the table silently empty — a silent
+         empty table hides under-extraction). Table columns:
+           | Mandated verification | SPEC.md source (line/section) | Owning milestone |
+
+      2. THEN decompose into milestones as the rules above describe.
+
+      3. FINALLY, fill the "Owning milestone" column. You may NOT add rows
+         here and you may NOT invent a milestone to cover a verification.
+         Each verification resolves to exactly one of:
+         - owned: a milestone's "Done when" line covers it. Confirm with
+           `grep -nE '^#+ *[Mm]ilestone' .ai/decisions/milestones.md` and
+           cite `Milestone <N>: <the Done-when line, verbatim>`. A
+           milestone that only mentions the topic in prose does NOT own it.
+         - deferred: SPEC.md itself defers the behavior to a named later
+           phase AND a milestone's "DO NOT implement" block records that
+           deferral citing the spec section. Cite both. (This carve-out
+           keeps the gate consistent with the anti-scope-creep machinery
+           above — a correctly-deferred Phase-2+ feature is NOT a gap.)
+         - UNOWNED: neither owned nor deferred. This is the bug this gate
+           exists to catch.
+
+      Then re-read .ai/decisions/requirement-coverage.md, count the UNOWNED
+      rows, and emit on its own line: COVERAGE_GAPS: <count>. Then your
+      terminal STATUS line:
+        - every row owned or deferred (count 0) -> STATUS:success
+        - any row UNOWNED (count > 0) -> list the unowned verification(s)
+          ABOVE the STATUS line, then STATUS:fail (this routes to a human
+          to re-plan rather than silently building with a dropped test).
+      The final line must be EXACTLY `STATUS:success` or `STATUS:fail` —
+      no parentheses, no counts, no trailing words (a trailing count makes
+      the parser drop the line and default to success), OUTSIDE any code
+      fence, alone on its line. Emit only success or fail — never
+      STATUS:retry (this node has no retry route).
 
   human ApprovePlan
     label: "Review the milestone plan. Approve, adjust, or reject."

--- a/pipeline/build_product_requirement_coverage_test.go
+++ b/pipeline/build_product_requirement_coverage_test.go
@@ -130,7 +130,12 @@ func TestDecomposeOutEdgesUnchanged(t *testing.T) {
 func TestVerifyAndFinalKeepAutoStatus(t *testing.T) {
 	g := loadBuildProduct(t)
 	for _, id := range []string{"VerifyMilestone", "FinalSpecCheck"} {
-		if g.Nodes[id].Attrs["auto_status"] != "true" {
+		n, ok := g.Nodes[id]
+		if !ok {
+			t.Errorf("%s node missing from build_product graph (#300)", id)
+			continue
+		}
+		if n.Attrs["auto_status"] != "true" {
 			t.Errorf("%s lost auto_status:true — its STATUS:fail gate is dead (#300)", id)
 		}
 	}

--- a/pipeline/build_product_requirement_coverage_test.go
+++ b/pipeline/build_product_requirement_coverage_test.go
@@ -1,0 +1,137 @@
+// ABOUTME: Negative-control + regression guard for issue #300 — no-requirement-left-behind:
+// ABOUTME: Decompose coverage-table gate + owner-or-deferred "future work" rule in Verify/FinalSpecCheck.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// promptOf returns the named node's prompt attr (where the agent-rule text lives).
+func promptOf(t *testing.T, g *Graph, id string) string {
+	t.Helper()
+	n, ok := g.Nodes[id]
+	if !ok {
+		t.Fatalf("%s node missing from build_product graph (#300)", id)
+	}
+	return n.Attrs["prompt"]
+}
+
+// Test 1 — regression-pin AND the load-bearing #300 pin: Decompose must carry
+// auto_status:true. Without it, resolveTerminalStatus (codergen.go:635) defaults
+// the node to OutcomeSuccess and the `Decompose -> EscalateReview when fail` edge
+// is DEAD — a dropped requirement can never fail the node. This single test ties
+// the attr to the fail edge so a future removal of either is caught.
+func TestDecomposeFailEdgeIsLive(t *testing.T) {
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["Decompose"]
+	if !ok {
+		t.Fatal("Decompose node missing (#300)")
+	}
+	if n.Attrs["auto_status"] != "true" {
+		t.Error("Decompose lacks auto_status:true — its `outcome = fail` edge is DEAD (codergen.go:635); a dropped requirement cannot fail the node (#300)")
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "EscalateReview", "ctx.outcome = fail") {
+		t.Error("Decompose has no `ctx.outcome = fail` edge to EscalateReview (#300)")
+	}
+}
+
+// Test 2 — negative-control: Decompose writes the coverage table and uses the
+// coverage-mapping language. Distinctive new substrings (NOT the bare token
+// "SPEC.md", which is already GREEN at Decompose :467 — "SPEC.md may define a
+// Fingerprint" — and would prove nothing).
+func TestDecomposeCoverageTablePrompt(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "Decompose")
+	for _, sub := range []string{
+		"requirement-coverage.md",
+		"Owning milestone",
+		"mandated",
+		"COVERAGE_GAPS",
+	} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("Decompose prompt missing coverage-gate substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 3 — negative-control: Decompose's coverage gate carves out documented
+// deferrals via a 3-way classification (owned | deferred | UNOWNED) so it does
+// not false-fail a correct decomposition that properly defers Phase-2+ work.
+// Asserts tokens UNIQUE to the #300 block ("UNOWNED", "neither owned") — NOT the
+// bare "DO NOT implement"/"deferred", which the pre-existing anti-scope-creep
+// block already contains (would be a no-op assertion; test-reviewer I1).
+func TestDecomposeDeferralCarveout(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "Decompose")
+	for _, sub := range []string{"UNOWNED", "neither owned"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("Decompose coverage gate missing 3-way-classification substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 4 — negative-control: VerifyMilestone check 5 gains the owner-or-deferred
+// "future work" rule. Anchor tokens matched SEPARATELY (not a full sentence) so
+// benign rewording doesn't flake.
+func TestVerifyMilestoneOwnerOrFailRule(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "VerifyMilestone")
+	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("VerifyMilestone prompt missing owner-or-deferred substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 5 — negative-control: FinalSpecCheck gains the same owner-or-deferred rule.
+func TestFinalSpecCheckOwnerOrFailRule(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "FinalSpecCheck")
+	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+		if !strings.Contains(p, sub) {
+			t.Errorf("FinalSpecCheck prompt missing owner-or-deferred substring %q (#300)", sub)
+		}
+	}
+}
+
+// Test 6 — negative-control (prose-sync truthfulness pin, mirrors #299's
+// TestQualityGateVerifyPromptTruthful): VerifyMilestone's prompt acknowledges
+// that Decompose now owns a coverage gate (defense-in-depth cross-reference).
+func TestVerifyMilestoneMentionsCoverageGate(t *testing.T) {
+	p := promptOf(t, loadBuildProduct(t), "VerifyMilestone")
+	if !strings.Contains(p, "requirement-coverage.md") {
+		t.Error("VerifyMilestone prompt does not cross-reference requirement-coverage.md — prose-sync drift (#300)")
+	}
+}
+
+// Test 7 — regression-pin: Decompose's out-edges are EXACTLY the conditional
+// success→ApprovePlan and fail→EscalateReview pair. No new edge, no unconditional
+// fallback (which CLAUDE.md forbids near loop targets). Use OutgoingEdges (filters
+// on e.From) — NOT a loose g.Edges scan, which the incoming restart edges
+// ApprovePlan->Decompose and ResetReviewBudget->Decompose would pollute.
+func TestDecomposeOutEdgesUnchanged(t *testing.T) {
+	g := loadBuildProduct(t)
+	out := g.OutgoingEdges("Decompose")
+	if len(out) != 2 {
+		t.Fatalf("Decompose has %d out-edges, want exactly 2 (#300)", len(out))
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "ApprovePlan", "ctx.outcome = success") {
+		t.Error("Decompose lost its success→ApprovePlan edge (#300)")
+	}
+	if !hasEdgeWithCondition(g, "Decompose", "EscalateReview", "ctx.outcome = fail") {
+		t.Error("Decompose lost its fail→EscalateReview edge (#300)")
+	}
+	for _, e := range out {
+		if e.Condition == "" {
+			t.Errorf("Decompose grew an unconditional out-edge → %s (forbidden near loop targets, #300)", e.To)
+		}
+	}
+}
+
+// Test 8 — regression-pin: the downstream gates keep auto_status:true (their
+// STATUS:fail is what enforces the owner-or-deferred rule).
+func TestVerifyAndFinalKeepAutoStatus(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"VerifyMilestone", "FinalSpecCheck"} {
+		if g.Nodes[id].Attrs["auto_status"] != "true" {
+			t.Errorf("%s lost auto_status:true — its STATUS:fail gate is dead (#300)", id)
+		}
+	}
+}

--- a/pipeline/build_product_requirement_coverage_test.go
+++ b/pipeline/build_product_requirement_coverage_test.go
@@ -81,12 +81,22 @@ func TestVerifyMilestoneOwnerOrFailRule(t *testing.T) {
 	}
 }
 
-// Test 5 — negative-control: FinalSpecCheck gains the same owner-or-deferred rule.
+// Test 5 — negative-control: FinalSpecCheck gains the DEFERRED-ONLY rule. At the
+// final gate every milestone is complete, so "owned" is not an excuse — only a
+// SPEC-documented future-phase deferral passes. Pin the distinctive owned-is-not-
+// an-excuse clause, not just generic tokens: a regression to "owned OR deferred"
+// (as in VerifyMilestone) must FAIL this test (CodeRabbit PR #322).
 func TestFinalSpecCheckOwnerOrFailRule(t *testing.T) {
 	p := promptOf(t, loadBuildProduct(t), "FinalSpecCheck")
-	for _, sub := range []string{"future work", "milestones.md", "DO NOT implement"} {
+	subs := []string{
+		"future work",
+		"DO NOT implement",
+		`"owned" by a milestone is NOT an acceptable excuse`,
+		"do NOT emit the terminal STATUS:success",
+	}
+	for _, sub := range subs {
 		if !strings.Contains(p, sub) {
-			t.Errorf("FinalSpecCheck prompt missing owner-or-deferred substring %q (#300)", sub)
+			t.Errorf("FinalSpecCheck prompt missing deferred-only substring %q (#300)", sub)
 		}
 	}
 }


### PR DESCRIPTION
Closes #300. Refs epic #308 Phase 2 (second item, after #299/PR #321).

## What

Two failure modes let spec-mandated requirements vanish from a `build_product`
run: (1) `Decompose` could omit a mandated test from every milestone's "Done
when"; (2) `VerifyMilestone`/`FinalSpecCheck` could wave a requirement through as
"future work" without confirming a later milestone owns it. On the `code-goblin`
run, a synthetic-429 test and a cancel-within-100ms test were owned by no
milestone and the verifier waved the gap through.

## The change (`.dip`-only, no engine code)

- **`Decompose`** gains `auto_status: true` — which makes its previously **dead**
  `Decompose -> EscalateReview when ctx.outcome = fail` edge live (an agent node
  defaults to `OutcomeSuccess` unless `auto_status` consults its `STATUS:` line —
  `pipeline/handlers/codergen.go:627-637`). It then runs a **coverage gate**:
  enumerate mandated verifications from `SPEC.md` FIRST, decompose, assign owners
  LAST into `.ai/decisions/requirement-coverage.md`, emit `COVERAGE_GAPS:<n>` +
  `STATUS:fail` when a verification is **neither owned by a milestone nor a
  documented-deferred `DO NOT implement` item**.
- **`VerifyMilestone` check 5 + `FinalSpecCheck`** gain the matching
  owner-or-deferred rule: a "future work" deferral is rejected unless a named
  milestone owns it (cite the "Done when" line) or a `DO NOT implement` entry
  documents the deferral.

## Design subtleties (from a five-expert squad review of the design)

- **DO-NOT-implement carve-out (critical).** The owner-or-fail rule is a 3-way
  classification `owned | deferred | UNOWNED`, failing only on UNOWNED — so it does
  NOT contradict the existing anti-scope-creep machinery by false-failing a
  correct decomposition that properly defers Phase-2+ work.
- **Read-back gate, not tail-token judgment.** Decompose re-reads the table and
  counts UNOWNED rows (`COVERAGE_GAPS:<n>`) rather than relying on a holistic
  final-token judgment — the run that drops a requirement is the one most likely
  to garble its STATUS line.
- **Closed inclusion test** for "spec-mandated verification" (obligation word +
  checkable behavior; aspirational lines get `N/A`, never a fail) — prevents
  false-fail human fatigue.
- **STATUS hygiene** (exact token, outside fence, only success/fail — never
  `retry`) copied from `FinalSpecCheck`'s existing warnings.

## Out of scope / follow-up

- **#301 (spec-coherence preflight)** — its rule (f) will later FEED this coverage
  table; #300 stays self-sufficient (Decompose derives the mandated list from
  SPEC.md itself). Soft, one-directional coupling.
- **Decompose-retry circuit breaker** — the now-live `Decompose -> EscalateReview
  -> retry -> Decompose` cycle consumes the global restart budget under
  autopilot/headless drivers (the same property the existing review-retry loop
  has). The DO-NOT-implement carve-out removes the deterministic re-fail trigger;
  a dedicated `decompose_attempts` breaker is a structural change left as a
  follow-up.

## Tests

`pipeline/build_product_requirement_coverage_test.go` — graph string/edge asserts,
RED-first (no runtime test: this is agent-prompt rules with no executable shell).
`TestDecomposeFailEdgeIsLive` pins the `auto_status`<->fail-edge coupling (the
load-bearing change); `TestDecomposeOutEdgesUnchanged` pins no new/unconditional
Decompose edge; owner-or-deferred and coverage-table prompt rules pinned by
substring; a prose-sync truthfulness pin.

## Verification

`dippin validate` ✓ · `dippin doctor` A grade (build_product 90/100 unchanged;
ask_and_execute 95; superspec 100) ✓ · `dippin simulate -all-paths` 100 paths,
all terminate (now-live Decompose fail path exercised) ✓ · `go build ./... &&
go test ./... -short` ✓ · `gofmt -l` clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783535830&installation_id=131176874&pr_number=322&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F322&signature=68dac80ff3947d7873c98c50729879bd6e8e04c31a40439e4c2796d492eaabfb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced "no requirement left behind" coverage gate across planning, milestone verification, and final compliance
  * Decompose now triggers failure routing when mandated verifications are unowned/unrecorded; unsatisfied items block success

* **Documentation**
  * Added design and plan docs describing the coverage workflow and expected decision artifacts
  * Updated CHANGELOG with Phase 2 compliance behavior

* **Tests**
  * Added regression/negative-control tests validating coverage gating and verification rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->