### PR TITLE
docs: document tool command shell model

### DIFF
--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -209,7 +209,7 @@ documented in full at
   outcomes.
 - [`context-flow.md`](./context-flow.md) — how
   handlers write and read the shared context.
-- [`handlers/tool.md`](./handlers/tool.md#shell-execution-model) - how tool
+- [`handlers/tool.md`](./handlers/tool.md#shell-execution-model) — how tool
   `command:` / `tool_command` bodies run through `sh -c`, including the
   POSIX `sh` requirement and shebang caveat.
 - [`backends.md`](./backends.md) — how `codergen` delegates to pluggable

--- a/docs/architecture/handlers.md
+++ b/docs/architecture/handlers.md
@@ -209,6 +209,9 @@ documented in full at
   outcomes.
 - [`context-flow.md`](./context-flow.md) — how
   handlers write and read the shared context.
+- [`handlers/tool.md`](./handlers/tool.md#shell-execution-model) - how tool
+  `command:` / `tool_command` bodies run through `sh -c`, including the
+  POSIX `sh` requirement and shebang caveat.
 - [`backends.md`](./backends.md) — how `codergen` delegates to pluggable
   agent backends.
 - [`adapter.md`](./adapter.md) — how dippin-lang IR maps to the shapes

--- a/docs/architecture/handlers/tool.md
+++ b/docs/architecture/handlers/tool.md
@@ -45,6 +45,45 @@ sequenceDiagram
     T-->>E: Outcome status tool_stdout tool_stderr
 ```
 
+## Shell execution model
+
+Tool command bodies run through `sh -c <command>`. This applies to the
+runtime `tool_command` attribute and to Dippin `command:` blocks that compile
+into a tool command body. If a command block starts with a shebang such as
+`#!/usr/bin/env bash`, the shebang is passed to `sh -c` as command text; it is
+not used to select an interpreter. In practice that first line is only a shell
+comment.
+
+Write command bodies as portable POSIX `sh` unless the command explicitly
+invokes another interpreter itself:
+
+```dip
+tool PortableCheck
+  command:
+    #!/bin/sh
+    set -eu
+    if [ -f go.mod ]; then
+      go test ./...
+    fi
+    printf 'tests-pass'
+```
+
+On Ubuntu and many CI hosts, `/bin/sh` is `dash`, not Bash. Avoid Bash-only
+syntax in tool command bodies, including:
+
+- `[[ ... ]]`
+- arrays such as `items=(a b)`
+- `local`
+- `trap ... ERR`
+- `${var,,}` case conversion
+- `${var:offset:length}` substring expansion
+- process substitution such as `<(cmd)`
+
+`set -o pipefail` is not portable to all `/bin/sh` implementations. If a
+pipeline needs Bash-specific behavior, wrap it explicitly, for example
+`bash -c 'set -euo pipefail; ...'`, and make that dependency clear in the
+workflow.
+
 ## Variable expansion and safe-key allowlist
 
 [`expandAndValidateCommand`](../../../pipeline/handlers/tool.go) calls
@@ -106,6 +145,10 @@ before prepending `cd`:
 The final command becomes `cd "<cleaned>" && <command>`. The double-quote
 around `<cleaned>` protects path values with spaces.
 
+The subprocess working directory starts as the workflow run directory. When
+`working_dir` is set, the handler prepends the `cd` command above, so the
+effective command still runs through `sh -c`.
+
 ## Timeout
 
 [`parseTimeout`](../../../pipeline/handlers/tool.go):
@@ -165,6 +208,20 @@ filtered env, because they have their own isolation model (sandbox, container).
 the node declares a `writes:` attr listing expected JSON fields, the handler
 parses stdout as JSON and writes each declared key into context. A parse
 failure or missing declared field flips status to `OutcomeFail`.
+
+Routing sees both the exit-code outcome and any captured stdout markers:
+
+- `ctx.outcome` is `success` for exit code 0 and `fail` for any non-zero exit.
+- `ctx.tool_stdout` and `ctx.tool_stderr` receive the right-trimmed captured
+  tail of each stream.
+- If `marker_grep` is set, the regex scans captured stdout line by line; the
+  last match populates `ctx.tool_marker`.
+- `_TRACKER_ROUTE=<value>` sentinel lines are always scanned from captured
+  stdout, and the last match populates `ctx.tool_route`.
+
+When a tool exits non-zero, strict failure routing still applies unless the
+graph has an explicit failure path, such as an edge guarded by
+`ctx.outcome = fail` or a configured `fallback_target`.
 
 ## Events emitted
 

--- a/docs/architecture/handlers/tool.md
+++ b/docs/architecture/handlers/tool.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 The tool handler runs a shell command in the workflow's working directory
-(the `--workdir`, default the current directory), captures
+(the `--workdir`, which defaults to the current directory), captures
 stdout/stderr, and maps the exit code to a pipeline outcome. It's how a
 pipeline node executes something that's not an LLM agent — running tests,
 invoking a formatter, generating a file, reading a directory, etc. Because
@@ -18,7 +18,7 @@ Ground truth:
 | Attribute | Type | Default | Behavior |
 |-----------|------|---------|----------|
 | `tool_command` | string (required) | — | Shell command to execute. `${ctx.foo}`, `${graph.bar}`, `${params.baz}` variable refs are expanded before execution. |
-| `working_dir` | string | `--workdir` | Prepends `cd "<dir>" && ` to the command, relative to the workflow's working directory. Rejected if it contains shell metacharacters or `..` path traversal. |
+| `working_dir` | string | `--workdir` | Prepends `cd "<dir>" && ` to the command. An absolute path is used as-is; a relative path resolves against the workflow's working directory. Rejected if it contains shell metacharacters or `..` path traversal. |
 | `timeout` | duration | 30s | Per-command wall-clock limit (e.g. `30s`, `5m`). Non-positive or unparseable values error at execution time. |
 | `output_limit` | bytes | 64KB | Per-stream (stdout or stderr) cap. Accepts raw bytes (`65536`), `KB`, or `MB` suffix. Capped at `max_output_limit` (default 10MB, configurable via `--max-output-limit`). |
 
@@ -148,7 +148,7 @@ around `<cleaned>` protects path values with spaces.
 
 The subprocess working directory starts as the workflow's working directory —
 the execution environment's `workDir`, which is the `--workdir` passed to
-`tracker` (default the current directory). This is not the
+`tracker` (defaulting to the current directory). This is not the
 `.tracker/runs/<runID>` artifacts directory. When `working_dir` is set, the
 handler prepends the `cd` command above, so the effective command still runs
 through `sh -c`.

--- a/docs/architecture/handlers/tool.md
+++ b/docs/architecture/handlers/tool.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-The tool handler runs a shell command in the run's working directory, captures
+The tool handler runs a shell command in the workflow's working directory
+(the `--workdir`, default the current directory), captures
 stdout/stderr, and maps the exit code to a pipeline outcome. It's how a
 pipeline node executes something that's not an LLM agent — running tests,
 invoking a formatter, generating a file, reading a directory, etc. Because
@@ -17,7 +18,7 @@ Ground truth:
 | Attribute | Type | Default | Behavior |
 |-----------|------|---------|----------|
 | `tool_command` | string (required) | — | Shell command to execute. `${ctx.foo}`, `${graph.bar}`, `${params.baz}` variable refs are expanded before execution. |
-| `working_dir` | string | run dir | Prepends `cd "<dir>" && ` to the command. Rejected if it contains shell metacharacters or `..` path traversal. |
+| `working_dir` | string | `--workdir` | Prepends `cd "<dir>" && ` to the command, relative to the workflow's working directory. Rejected if it contains shell metacharacters or `..` path traversal. |
 | `timeout` | duration | 30s | Per-command wall-clock limit (e.g. `30s`, `5m`). Non-positive or unparseable values error at execution time. |
 | `output_limit` | bytes | 64KB | Per-stream (stdout or stderr) cap. Accepts raw bytes (`65536`), `KB`, or `MB` suffix. Capped at `max_output_limit` (default 10MB, configurable via `--max-output-limit`). |
 
@@ -145,9 +146,12 @@ before prepending `cd`:
 The final command becomes `cd "<cleaned>" && <command>`. The double-quote
 around `<cleaned>` protects path values with spaces.
 
-The subprocess working directory starts as the workflow run directory. When
-`working_dir` is set, the handler prepends the `cd` command above, so the
-effective command still runs through `sh -c`.
+The subprocess working directory starts as the workflow's working directory —
+the execution environment's `workDir`, which is the `--workdir` passed to
+`tracker` (default the current directory). This is not the
+`.tracker/runs/<runID>` artifacts directory. When `working_dir` is set, the
+handler prepends the `cd` command above, so the effective command still runs
+through `sh -c`.
 
 ## Timeout
 
@@ -215,13 +219,20 @@ Routing sees both the exit-code outcome and any captured stdout markers:
 - `ctx.tool_stdout` and `ctx.tool_stderr` receive the right-trimmed captured
   tail of each stream.
 - If `marker_grep` is set, the regex scans captured stdout line by line; the
-  last match populates `ctx.tool_marker`.
+  last match populates `ctx.tool_marker`. When the regex has a capture group,
+  group 1 is used; otherwise the full match — e.g. `^workspace-(ready|missing)$`
+  sets `ctx.tool_marker` to `ready` or `missing`, not `workspace-ready`.
 - `_TRACKER_ROUTE=<value>` sentinel lines are always scanned from captured
   stdout, and the last match populates `ctx.tool_route`.
 
-When a tool exits non-zero, strict failure routing still applies unless the
-graph has an explicit failure path, such as an edge guarded by
-`ctx.outcome = fail` or a configured `fallback_target`.
+When a tool exits non-zero, the engine dead-stops the node only when it has
+**no** conditional outgoing edge **and** no resolvable `fallback_target`. Any
+conditional edge counts as intentional routing and disables the halt — even one
+unrelated to failure, such as a `ctx.tool_marker = …` route. So marker routing
+and strict-failure protection are not automatic together: a node with only
+marker edges (like the `CheckWorkspace` example, which has no `fallback_target`)
+would not strict-halt on a non-zero exit. To catch failures explicitly, add an
+edge guarded by `ctx.outcome = fail` or configure a `fallback_target`.
 
 ## Events emitted
 

--- a/examples/posix-tool-command.dip
+++ b/examples/posix-tool-command.dip
@@ -1,0 +1,28 @@
+workflow PosixToolCommandExample
+  goal: "Demonstrate portable POSIX sh style for tool command blocks."
+  start: CheckWorkspace
+  exit: Exit
+
+  tool CheckWorkspace
+    label: "Check workspace"
+    timeout: 10s
+    marker_grep: '^workspace-(ready|missing)$'
+    command:
+      #!/bin/sh
+      set -eu
+      if [ -f go.mod ]; then
+        printf 'workspace-ready\n'
+      else
+        printf 'workspace-missing\n'
+      fi
+
+  tool Exit
+    label: "Exit"
+    timeout: 5s
+    command:
+      #!/bin/sh
+      printf 'done\n'
+
+  edges
+    CheckWorkspace -> Exit when ctx.tool_marker = ready
+    CheckWorkspace -> Exit when ctx.tool_marker = missing

--- a/examples/posix-tool-command.dip
+++ b/examples/posix-tool-command.dip
@@ -24,5 +24,7 @@ workflow PosixToolCommandExample
       printf 'done\n'
 
   edges
+    # Both marker values converge on Exit here to keep the illustration small;
+    # in a real workflow each branch would route to distinct follow-up nodes.
     CheckWorkspace -> Exit when ctx.tool_marker = ready
     CheckWorkspace -> Exit when ctx.tool_marker = missing


### PR DESCRIPTION
﻿## Summary
- Document that tool command bodies run through `sh -c <command>`, so shebangs in `command:` blocks do not select the interpreter.
- Add POSIX `sh` guidance, common Bash-only syntax to avoid, and an explicit Bash escape hatch.
- Clarify working-directory, stdout/stderr, marker, route, and failure-routing behavior for tool nodes.
- Add a minimal POSIX-style tool command example under `examples/`.

## Verification
- `git diff --check`
- `go run github.com/2389-research/dippin-lang/cmd/dippin@v0.35.0 check examples/posix-tool-command.dip` (`valid: true`; emitted environment warnings because this Windows environment lacks the WSL `/bin/bash` path used by the shell syntax checker)
- `go test ./internal/... ./llm/... ./tools/jailcheck`

## Notes
- `go test ./...` and `go test ./pipeline/... ./agent/exec/...` do not pass in this Windows environment before this docs-only change due existing build/environment issues: undefined `agent` helpers, missing `agent/exec.NewLocalEnvironment` on this platform, and a Windows file-permission expectation in `cmd/tracker-swebench`.
- `make lint` could not be run because `make` is not installed in this environment.

Closes #324

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783539586&installation_id=131176874&pr_number=325&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F325&signature=5f06206a6e8f54055d07732b76cd089e28c6292b6a492bc4674199cb8a1bc4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded tool handler docs with a Shell execution model, guidance for writing portable POSIX sh scripts, and shebang behavior notes.
  * Added explicit working-directory behavior for subprocesses.
  * Clarified routing and exit-code handling, stdout/stderr capture, marker extraction, and routing sentinel behavior.

* **Examples**
  * Added a new example workflow demonstrating POSIX sh tool commands and marker-based routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->