### PR TITLE
fix(build_product): guard against silently-masked cross-review failure (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`build_product.dip`: a silently-missing cross-review no longer reaches
+  synthesis** (refs #313, epic #308; engine half of #313 deferred). The parallel
+  fan-in is success-if-any, so if one reviewer (typically the adversarial
+  `ReviewGemini`) exhausts `max_turns` and never writes its report while the
+  other two succeed, `ReviewParallel` aggregated to success and flowed to
+  `SynthesizeReviews` with that review silently missing. A new `tool` node
+  `CheckReviewsComplete` now runs after `ReviewJoin` and **fails loudly unless all
+  three review reports (`.ai/build/review-{claude,codex,gemini}.md`) are present
+  and non-empty**, routing a partial set to the `EscalateReview` human gate
+  instead of synthesizing from it. A companion `ClearStaleReviews` node wipes the
+  prior round's reports before each fan-out (on both the first-entry and capped
+  re-review paths) so a reviewer that fails on a re-review pass can't be satisfied
+  by a stale file. `.dip`-only change; no engine code. The engine-level fix
+  (configurable fan-in aggregation policy + per-branch fallback routing) remains
+  open on #313 because dippin v0.35.0 cannot carry a per-node fan-in policy
+  attribute on `parallel`/`fan_in` nodes — a dippin-lang grammar change is filed
+  separately.
 - **Unhandled agent failure no longer dead-stops the pipeline** (closes #295,
   refs epic #308, pairs with #296). When an agent node returns `OutcomeFail`
   (including turn-limit exhaustion) and has only unconditional outgoing edges,

--- a/docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md
@@ -1,0 +1,174 @@
+# Issue #313 — Reviewer-completeness guard for `build_product.dip`
+
+**Status:** approved-by-delegation (owner asked the agent to decide, verified via pal consensus)
+**Date:** 2026-06-09
+**Issue:** #313 (`engine: parallel branches bypass strict-failure routing + aggregateStatus masks single-branch failure`) — bug / P1: high / area/engine
+
+## Problem
+
+`ParallelHandler.aggregateStatus` (`pipeline/handlers/parallel.go:324`) and `FanInHandler`
+(`pipeline/handlers/fanin.go`) are **success-if-any**: the parallel node reports
+`OutcomeSuccess` if at least one branch succeeded. In `examples/build_product.dip`
+the three cross-reviewers (`ReviewClaude`, `ReviewCodex`, `ReviewGemini`) run as
+parallel branches and each writes a report to `.ai/build/review-{claude,codex,gemini}.md`.
+If the adversarial `ReviewGemini` exhausts `max_turns` and fails while the other two
+succeed, `ReviewParallel` aggregates to success and flows `ReviewJoin → SynthesizeReviews`
+with Gemini's review **silently missing**. `SynthesizeReviews` has no missing-file guard,
+so a partial review set is synthesized as if complete — the exact "never silently swallow
+errors" violation the project forbids, and it defeats the cross-review safety net of #233/#308.
+
+## The blocker that shapes this design
+
+Issue #313's preferred fix is engine-level (Go): make the fan-in aggregation policy
+configurable (e.g. `all` / `quorum` / required-branch) with the default kept at the
+current `any` for back-compat, then have `build_product.dip` opt into a strict policy.
+
+**That opt-in cannot be expressed in dippin-lang v0.35.0** (the pinned parser tracker
+runs at load time). Verified by reading `parser/parse_nodes.go` **and** empirically with
+`dippin validate`:
+
+- `parallel P -> A, B` (inline) does `expect(TokenNewline)` immediately — a following
+  `params:`/attribute line is a fatal `unexpected top-level identifier`.
+- Block-form `parallel` only accepts `branch:` sub-declarations (model/provider/
+  fidelity/tool_access/writable_paths). No node-level fields.
+- `fan_in J <- A, B` has no block body at all; any trailing field is a fatal parse error.
+- `ir.ParallelConfig` / `ir.FanInConfig` have **no `Params` map** (unlike `AgentConfig`/
+  `SubgraphConfig`), and the graph-level `defaults` block is a fixed schema.
+
+So a per-node `fan_in_policy` attribute cannot reach the engine from `.dip` without a
+**dippin-lang grammar change**, which is a separate repo (must not be edited or
+`go install`-ed here; cross-repo features are filed as issues and shipped via a future
+pinned version). Shipping engine-only policy code now would be unreachable-from-production
+dead code.
+
+**Decision (verified via pal consensus, gpt-5.2, 8/10):** fix the `build_product` symptom
+with a workflow-level guard now; **defer** the engine policy (Defect 1) and per-branch
+fallback threading (Defect 2) to follow-up work gated on the dippin-lang grammar; keep
+#313 open and file the dippin-lang grammar issue.
+
+## Design — all changes in `examples/build_product.dip` (no engine code)
+
+### Node 1: `CheckReviewsComplete` (new `tool` node, after `ReviewJoin`)
+
+Fails (`exit 1`) unless **all three** review files exist and are non-empty; prints which
+are missing for `tracker diagnose` visibility.
+
+```
+tool CheckReviewsComplete
+  label: "Verify All Reviews Present"
+  timeout: 5s
+  command:
+    set -eu
+    # #313 defense-in-depth: parallel fan-in is success-if-any, so a single
+    # reviewer that exhausts max_turns and never writes its report is masked.
+    # Synthesis MUST NOT run on a partial review set — fail loudly and escalate.
+    missing=""
+    for f in review-claude.md review-codex.md review-gemini.md; do
+      [ -s ".ai/build/$f" ] || missing="$missing $f"
+    done
+    if [ -n "$missing" ]; then
+      printf 'review-gate FAIL: missing/empty review(s):%s — escalating instead of synthesizing a partial review set\n' "$missing"
+      exit 1
+    fi
+    printf 'review-gate OK: all 3 reviews present\n'
+```
+
+**Why ALL-3, not 2-of-3:** the canonical #313 scenario is a *single* (adversarial)
+reviewer missing. A 2-of-3 quorum would still proceed with Gemini absent — i.e. it would
+not fix the stated bug. The adversarial reviewer is not optional. (Owner's initial
+"2-of-3" answer was given without issue context and is overridden per the owner's
+instruction to decide; confirmed correct by pal consensus.)
+
+### Node 2: `ClearStaleReviews` (new `tool` node, before `ReviewParallel`)
+
+`rm -f` the three review files so the capped re-review restart loop cannot count a stale
+file from a prior round as "present" (a reviewer that succeeded in round 1 then fails on
+re-review would otherwise be masked by its stale file).
+
+```
+tool ClearStaleReviews
+  label: "Clear Stale Review Reports"
+  timeout: 5s
+  command:
+    set -eu
+    # #313: the guard at CheckReviewsComplete keys on review-file presence.
+    # Clear last round's files so a reviewer that fails THIS round can't be
+    # satisfied by a stale report from a prior re-review pass.
+    mkdir -p .ai/build
+    rm -f .ai/build/review-claude.md .ai/build/review-codex.md .ai/build/review-gemini.md
+    printf 'cleared stale review reports\n'
+```
+
+### Edge changes
+
+```
+# before ReviewParallel: retarget BOTH inbound edges through ClearStaleReviews
+PickNextMilestone    -> ClearStaleReviews  when ctx.tool_stdout contains all-done   # was -> ReviewParallel
+CheckReviewFixBudget -> ClearStaleReviews  when ctx.outcome = success  restart: true # was -> ReviewParallel
+ClearStaleReviews    -> ReviewParallel
+
+# after ReviewJoin: insert the guard between the join and synthesis
+ReviewJoin           -> CheckReviewsComplete                          # was -> SynthesizeReviews
+CheckReviewsComplete -> SynthesizeReviews  when ctx.outcome = success
+CheckReviewsComplete -> EscalateReview     when ctx.outcome = fail
+```
+
+`ReviewParallel -> EscalateReview when ctx.outcome = fail` (the existing all-3-fail
+short-circuit from #296) is **kept** — it handles the case where the parallel itself
+returns fail (all branches failed) before the fan-in is reached. The two escalation
+paths are mutually exclusive (all-fail short-circuits at `ReviewParallel`; ≥1-success
+reaches the guard), so there is no double-routing. `CheckReviewsComplete`'s
+success/fail edges are exhaustive — no unconditional fallback to a loop target (satisfies
+the edge-routing rule). `EscalateReview` is a human freeform gate that does not read
+review artifacts, so clearing them does not break it.
+
+### Comment reconciliation
+
+Rewrite the stale masking comment at `build_product.dip` lines ~1694–1702 to describe the
+guard and that the *engine-level* per-branch routing remains deferred to #313. Add a
+pointer in `pipeline/build_product_failure_routing_test.go` noting the #313 split (the
+existing #296 assertions — reviewer branches carry no `fallback_target`, `ReviewParallel`
+has a conditional fail edge to `EscalateReview` — stay valid).
+
+## Tests (TDD — written first, must fail against current `.dip`)
+
+New `TestBuildProductIssue313ReviewGate` in `pipeline/build_product_failure_routing_test.go`:
+
+- `CheckReviewsComplete` exists and `Handler == "tool"`.
+- `ClearStaleReviews` exists and `Handler == "tool"`.
+- `ReviewJoin -> CheckReviewsComplete` edge exists.
+- `ReviewJoin` no longer routes directly to `SynthesizeReviews` (negative).
+- `CheckReviewsComplete -> SynthesizeReviews when ctx.outcome = success`.
+- `CheckReviewsComplete -> EscalateReview when ctx.outcome = fail`.
+- `ClearStaleReviews -> ReviewParallel` edge exists.
+- `PickNextMilestone` and `CheckReviewFixBudget` route to `ClearStaleReviews` (not
+  directly to `ReviewParallel`); `PickNextMilestone` retains its `all-done` condition and
+  `CheckReviewFixBudget` retains `restart: true`.
+
+Existing `TestBuildProductIssue296FailureRoutes` / `...AgentNodesHaveFailureRouting` must
+stay green (tool nodes are skipped by the codergen-only invariant; `ReviewParallel ->
+EscalateReview` intact).
+
+## Deferred / out of scope (with issue hygiene)
+
+- **Defect 1 (configurable fan-in aggregation policy)** and **Defect 2 (per-branch
+  `fallback_target` threading through `runBranch`)**: deferred — both need the dippin-lang
+  grammar to carry a per-node policy/route to be usable. Keep #313 open; add a comment
+  documenting the grammar blocker and the split. File a dippin-lang issue requesting
+  node-attribute (`params:`) support on `parallel`/`fan_in`.
+- **Optional additive engine observability** (emit a per-branch-status event at fan-in so
+  masked failures are visible in `tracker diagnose`): noted as a future enhancement; not
+  implemented here (keeps this PR surgical).
+- The guard checks presence + non-empty, not content validity. A reviewer that writes a
+  truncated/partial report passes the guard — acceptable residual; the masking bug
+  (silently *missing* review) is fixed, and content-quality is the synthesis step's job.
+
+## Verification gates (all must pass before PR)
+
+- `go build ./...`
+- `go test ./... -short` (esp. `pipeline/`, `pipeline/handlers/`)
+- `dippin validate examples/build_product.dip`
+- `dippin doctor examples/ask_and_execute.dip examples/build_product.dip examples/build_product_with_superspec.dip` — A grade
+- `dippin simulate -all-paths examples/build_product.dip` — confirm the new partial-failure
+  path reaches `EscalateReview` and terminates
+- `CHANGELOG.md` Fixed entry in the same PR

--- a/docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md
+++ b/docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md
@@ -62,15 +62,19 @@ tool CheckReviewsComplete
     # #313 defense-in-depth: parallel fan-in is success-if-any, so a single
     # reviewer that exhausts max_turns and never writes its report is masked.
     # Synthesis MUST NOT run on a partial review set — fail loudly and escalate.
+    # Routes on exit code (ctx.outcome), NOT stdout content, so diagnostics go
+    # to stderr (>&2) — keeps stdout free of routing-marker noise and the dippin
+    # coverage analyzer sees no stdout outputs to match (status "unknown", not
+    # "partial", so the build_product A grade is preserved).
     missing=""
     for f in review-claude.md review-codex.md review-gemini.md; do
       [ -s ".ai/build/$f" ] || missing="$missing $f"
     done
     if [ -n "$missing" ]; then
-      printf 'review-gate FAIL: missing/empty review(s):%s — escalating instead of synthesizing a partial review set\n' "$missing"
+      printf 'review-gate FAIL: missing/empty review(s):%s — escalating instead of synthesizing a partial review set\n' "$missing" >&2
       exit 1
     fi
-    printf 'review-gate OK: all 3 reviews present\n'
+    printf 'review-gate OK: all 3 reviews present\n' >&2
 ```
 
 **Why ALL-3, not 2-of-3:** the canonical #313 scenario is a *single* (adversarial)

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1116,6 +1116,21 @@ workflow BuildProduct
 
   # ─── Phase 3: Cross-Review ─────────────────────────────────
 
+  tool ClearStaleReviews
+    label: "Clear Stale Review Reports"
+    timeout: 5s
+    command:
+      set -eu
+      # issue #313: the fan-in is success-if-any, so a reviewer that exhausts
+      # max_turns and fails is masked. CheckReviewsComplete (after the join)
+      # keys on review-file presence; clear last round's reports so a reviewer
+      # that fails on a re-review pass can't be satisfied by a stale file from
+      # the prior pass. Runs on BOTH inbound paths to ReviewParallel (first
+      # entry from PickNextMilestone and the capped re-review restart loop).
+      mkdir -p .ai/build
+      rm -f .ai/build/review-claude.md .ai/build/review-codex.md .ai/build/review-gemini.md
+      printf 'cleared stale review reports\n'
+
   parallel ReviewParallel -> ReviewClaude, ReviewCodex, ReviewGemini
 
   # Phase 3 reviewers (issue #233 Gap 2). All three carry the same 5-point
@@ -1325,6 +1340,33 @@ workflow BuildProduct
       Write the report to .ai/build/review-gemini.md.
 
   fan_in ReviewJoin <- ReviewClaude, ReviewCodex, ReviewGemini
+
+  tool CheckReviewsComplete
+    label: "Verify All Reviews Present"
+    timeout: 5s
+    command:
+      set -eu
+      # issue #313 defense-in-depth: the parallel fan-in is success-if-any, so
+      # a single reviewer that exhausts max_turns and never writes its report
+      # is silently masked — SynthesizeReviews would synthesize from a partial
+      # set. Require ALL THREE reports present + non-empty; a single missing
+      # review (typically the adversarial ReviewGemini, the one most likely to
+      # exhaust turns) fails the gate and routes to EscalateReview rather than
+      # masking the gap. A 2-of-3 quorum would not fix this — it would still
+      # proceed with the adversarial reviewer absent.
+      # This gate routes on exit code (ctx.outcome), NOT on stdout content, so
+      # all diagnostics go to stderr — keeps stdout free of routing-marker noise
+      # (surfaced by `tracker diagnose` either way) and the dippin coverage
+      # analyzer correctly sees no stdout outputs to match.
+      missing=""
+      for f in review-claude.md review-codex.md review-gemini.md; do
+        [ -s ".ai/build/$f" ] || missing="$missing $f"
+      done
+      if [ -n "$missing" ]; then
+        printf 'review-gate FAIL: missing/empty review(s):%s — escalating instead of synthesizing a partial review set\n' "$missing" >&2
+        exit 1
+      fi
+      printf 'review-gate OK: all 3 reviews present\n' >&2
 
   agent SynthesizeReviews
     label: "Synthesize Reviews"
@@ -1670,7 +1712,7 @@ workflow BuildProduct
 
     # Build loop: pick → implement → test → verify → mark done → pick next
     PickNextMilestone -> Implement  when ctx.tool_stdout not contains all-done
-    PickNextMilestone -> ReviewParallel  when ctx.tool_stdout contains all-done
+    PickNextMilestone -> ClearStaleReviews  when ctx.tool_stdout contains all-done
     PickNextMilestone -> EscalateMilestone
     Implement -> CommitIfDirty  when ctx.outcome = success
     Implement -> EscalateMilestone
@@ -1692,19 +1734,30 @@ workflow BuildProduct
     EscalateMilestone -> Done  label: "abandon"
 
     # Cross-review
+    # ClearStaleReviews wipes prior-round reports before fan-out so the
+    # post-join CheckReviewsComplete guard (issue #313) can't be satisfied by a
+    # stale file from an earlier re-review pass.
+    ClearStaleReviews -> ReviewParallel
     # The three reviewers run as parallel branches; a branch runs via
     # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
     # path, so a per-branch fallback_target would be inert. Route failure on the
     # aggregating ReviewParallel node instead: aggregateStatus is success-if-any,
     # so this fires only when ALL THREE reviewers fail (which would otherwise
     # dead-stop the pipeline). On success the parallel handler's suggested-next
-    # routes to ReviewJoin. A single reviewer failing is masked by aggregateStatus
-    # and needs an engine fix (per-branch routing); tracked separately.
+    # routes to ReviewJoin.
+    #
+    # A SINGLE reviewer failing is NOT caught here (success-if-any masks it) and
+    # cannot be fixed in .dip — dippin v0.35.0 carries no per-node fan-in policy
+    # attribute, so the engine-level configurable-policy fix stays open on #313.
+    # Defense-in-depth lives at CheckReviewsComplete below: it fails loudly if
+    # any of the three review reports is missing/empty and routes to EscalateReview.
     ReviewParallel -> EscalateReview  when ctx.outcome = fail
     ReviewClaude -> ReviewJoin
     ReviewCodex -> ReviewJoin
     ReviewGemini -> ReviewJoin
-    ReviewJoin -> SynthesizeReviews
+    ReviewJoin -> CheckReviewsComplete
+    CheckReviewsComplete -> SynthesizeReviews  when ctx.outcome = success
+    CheckReviewsComplete -> EscalateReview  when ctx.outcome = fail
     SynthesizeReviews -> FinalBuild  when ctx.outcome = success
     SynthesizeReviews -> ApplyReviewFixes  when ctx.outcome = fail
     SynthesizeReviews -> EscalateReview
@@ -1720,7 +1773,7 @@ workflow BuildProduct
     # escalates to a human.
     ApplyReviewFixes -> CheckReviewFixBudget  when ctx.outcome = success
     ApplyReviewFixes -> EscalateReview
-    CheckReviewFixBudget -> ReviewParallel  when ctx.outcome = success  restart: true
+    CheckReviewFixBudget -> ClearStaleReviews  when ctx.outcome = success  restart: true
     CheckReviewFixBudget -> EscalateReview  when ctx.outcome = fail
 
     # Final verification

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -221,6 +221,66 @@ func TestBuildProductIssue303GreenBreachRescuePath(t *testing.T) {
 	}
 }
 
+// TestBuildProductIssue313ReviewGate pins the #313 reviewer-completeness guard.
+// The parallel fan-in is success-if-any, so a single reviewer that exhausts
+// max_turns and never writes its report is masked: ReviewParallel aggregates to
+// success and flows to SynthesizeReviews with that review silently missing. The
+// engine-level fix (configurable fan-in policy) cannot be expressed in dippin
+// v0.35.0 (parallel/fan_in nodes carry no attributes), so the symptom is fixed
+// at the workflow layer:
+//
+//   - ClearStaleReviews (tool) runs before ReviewParallel on BOTH inbound paths
+//     so the capped re-review restart loop can't satisfy the guard with a stale
+//     report from a prior round.
+//   - CheckReviewsComplete (tool) runs after ReviewJoin and fails unless all
+//     three review files are present + non-empty, routing a partial set to the
+//     existing EscalateReview human gate instead of SynthesizeReviews.
+func TestBuildProductIssue313ReviewGate(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	// Both guards are tool nodes.
+	for _, id := range []string{"CheckReviewsComplete", "ClearStaleReviews"} {
+		n, ok := g.Nodes[id]
+		if !ok {
+			t.Fatalf("%s node missing from build_product.dip (issue #313)", id)
+		}
+		if n.Handler != "tool" {
+			t.Errorf("%s handler = %q, want \"tool\" (issue #313)", id, n.Handler)
+		}
+	}
+
+	// Post-join guard: ReviewJoin -> CheckReviewsComplete -> {SynthesizeReviews|EscalateReview}.
+	if !hasEdgeTo(g, "ReviewJoin", "CheckReviewsComplete") {
+		t.Error("ReviewJoin has no edge to CheckReviewsComplete — partial review sets would reach synthesis (issue #313)")
+	}
+	if hasEdgeTo(g, "ReviewJoin", "SynthesizeReviews") {
+		t.Error("ReviewJoin still routes directly to SynthesizeReviews; it must go through CheckReviewsComplete (issue #313)")
+	}
+	if !hasEdgeWithCondition(g, "CheckReviewsComplete", "SynthesizeReviews", "ctx.outcome = success") {
+		t.Error("CheckReviewsComplete has no `ctx.outcome = success` edge to SynthesizeReviews (issue #313)")
+	}
+	if !hasEdgeWithCondition(g, "CheckReviewsComplete", "EscalateReview", "ctx.outcome = fail") {
+		t.Error("CheckReviewsComplete has no `ctx.outcome = fail` edge to EscalateReview — a missing review would not escalate (issue #313)")
+	}
+
+	// Pre-fan-out clear: both inbound paths to ReviewParallel go through ClearStaleReviews.
+	if !hasUnconditionalEdgeTo(g, "ClearStaleReviews", "ReviewParallel") {
+		t.Error("ClearStaleReviews has no edge to ReviewParallel (issue #313)")
+	}
+	if !hasEdgeWithCondition(g, "PickNextMilestone", "ClearStaleReviews", "ctx.tool_stdout contains all-done") {
+		t.Error("PickNextMilestone all-done edge must enter ClearStaleReviews before ReviewParallel (issue #313)")
+	}
+	if !hasEdgeWithCondition(g, "CheckReviewFixBudget", "ClearStaleReviews", "ctx.outcome = success") {
+		t.Error("CheckReviewFixBudget re-review edge must enter ClearStaleReviews before ReviewParallel (issue #313)")
+	}
+	if hasEdgeTo(g, "PickNextMilestone", "ReviewParallel") {
+		t.Error("PickNextMilestone still routes directly to ReviewParallel; it must clear stale reviews first (issue #313)")
+	}
+	if hasEdgeTo(g, "CheckReviewFixBudget", "ReviewParallel") {
+		t.Error("CheckReviewFixBudget still routes directly to ReviewParallel; it must clear stale reviews first (issue #313)")
+	}
+}
+
 // hasEdgeTo reports whether the node has any outgoing edge to the given target.
 func hasEdgeTo(g *Graph, from, to string) bool {
 	for _, e := range g.OutgoingEdges(from) {

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -273,6 +273,12 @@ func TestBuildProductIssue313ReviewGate(t *testing.T) {
 	if !hasEdgeWithCondition(g, "CheckReviewFixBudget", "ClearStaleReviews", "ctx.outcome = success") {
 		t.Error("CheckReviewFixBudget re-review edge must enter ClearStaleReviews before ReviewParallel (issue #313)")
 	}
+	// The re-review edge moved from CheckReviewFixBudget->ReviewParallel to
+	// ->ClearStaleReviews; pin restart:true so a future edit can't drop the loop
+	// semantics (which would also stop clearing stale reports each pass).
+	if !hasEdgeAttr(g, "CheckReviewFixBudget", "ClearStaleReviews", "ctx.outcome = success", "restart", "true") {
+		t.Error("CheckReviewFixBudget -> ClearStaleReviews must keep restart: true (issue #313)")
+	}
 	if hasEdgeTo(g, "PickNextMilestone", "ReviewParallel") {
 		t.Error("PickNextMilestone still routes directly to ReviewParallel; it must clear stale reviews first (issue #313)")
 	}
@@ -296,6 +302,17 @@ func hasEdgeTo(g *Graph, from, to string) bool {
 func hasEdgeWithCondition(g *Graph, from, to, cond string) bool {
 	for _, e := range g.OutgoingEdges(from) {
 		if e.To == to && e.Condition == cond {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEdgeAttr reports whether the node has an outgoing edge to the given target
+// matching both the condition and an edge attribute key=value (e.g. restart).
+func hasEdgeAttr(g *Graph, from, to, cond, key, want string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && e.Condition == cond && e.Attrs[key] == want {
 			return true
 		}
 	}


### PR DESCRIPTION
## What & why

`build_product.dip` runs three cross-reviewers (`ReviewClaude`, `ReviewCodex`,
`ReviewGemini`) as parallel branches; each writes `.ai/build/review-{claude,codex,gemini}.md`.
The parallel fan-in is **success-if-any** (`parallel.go` `aggregateStatus`), so if the
adversarial `ReviewGemini` exhausts `max_turns` and fails while the other two succeed,
`ReviewParallel` aggregates to **success** and flows `ReviewJoin → SynthesizeReviews` with
that review **silently missing** — the exact masking in #313, defeating the #233/#308
cross-review safety net.

## Scope of this PR (the workflow-guard half of #313)

The engine-level fix #313 proposes (configurable fan-in aggregation policy) needs
`build_product.dip` to opt in via a per-node attribute. **dippin v0.35.0 cannot carry any
attribute on `parallel`/`fan_in` nodes** (verified by reading `parser/parse_nodes.go` and
`dippin validate`; see dippin-lang#110). So engine-only policy code would be unreachable
from `.dip` today. This PR fixes the symptom at the workflow layer; **#313 stays open** for
the engine work, gated on dippin-lang#110.

## Changes (`.dip` + test only, no engine code)

- **`CheckReviewsComplete`** (tool, after `ReviewJoin`): fails unless all three review
  reports exist and are non-empty; a missing review routes to the `EscalateReview` human
  gate instead of `SynthesizeReviews`. Routes on exit code; diagnostics go to stderr so the
  dippin coverage analyzer sees no stdout routing markers (keeps the node out of `partial`,
  preserving the A grade).
- **`ClearStaleReviews`** (tool, before `ReviewParallel` on both inbound paths): wipes the
  prior round's reports so a reviewer that fails on a re-review pass can't be satisfied by a
  stale file.
- **ALL-3, not 2-of-3:** the canonical bug is a single adversarial reviewer missing, which a
  quorum would still let through.
- Reconciled the stale masking comment in the edges block; existing #296 routing
  (reviewer branches carry no `fallback_target`; `ReviewParallel → EscalateReview` on
  all-fail) is unchanged.

## Decision record

[`docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md`](docs/superpowers/specs/2026-06-09-issue-313-review-completeness-guard-design.md).
Design + ALL-3-vs-2-of-3 call independently verified via multi-model consensus.

## TDD / verification

- `TestBuildProductIssue313ReviewGate` written first (failed on the missing nodes), then the
  `.dip` wired to pass it.
- `go build ./...`; `go test ./... -short` (all green).
- `dippin validate examples/build_product.dip` — passes.
- `dippin doctor` ask_and_execute / build_product / build_product_with_superspec — **A**
  (build_product 90/100, unchanged from baseline).
- `dippin simulate -all-paths examples/build_product.dip` — 100 paths, all terminate; the new
  `CheckReviewsComplete → EscalateReview` partial-failure path is exercised and reaches the
  human gate.

Refs #313, epic #308. Files dippin-lang#110 for the grammar that unblocks the engine fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783615871&installation_id=131176874&pr_number=326&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F326&signature=b03ff884e9a637f96ae352f38b4f5e9aaa0e00d588743cf352810d3992619011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow to properly detect missing review reports and escalate for human review instead of proceeding with incomplete data
  * Added automatic cleanup of stale review artifacts from previous cycles to prevent false validation positives

* **Tests**
  * Added regression test verifying review completeness validation and escalation routing

* **Documentation**
  * Updated changelog and design specification documenting review completeness safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->