### PR TITLE
feat(adapter): consume graph-level on_failure; bump dippin v0.35→v0.38 (#309, #327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Graph-level `on_failure` default failure route** (closes #309, refs epic #308,
+  pairs with the #295 strict-failure catch-all). dippin's workflow-level
+  `defaults { on_failure: <NodeID> }` now reaches the engine: the adapter
+  (`extractWorkflowDefaults`) maps it onto `graph.Attrs["fallback_target"]`, the
+  key `Engine.findFallbackTarget` already consults on the strict-failure path. A
+  bare agent failure (incl. turn exhaustion) with no node-level route now escalates
+  to the declared node instead of dead-stopping. Node-level `fallback_target` still
+  wins (it lands in the node's `fallback_retry_target`, consulted first). The three
+  shipped example pipelines now declare `on_failure` as a catch-all
+  (`ask_and_execute`/`build_product_with_superspec` → `EscalateToHuman`,
+  `build_product` → `EscalateReview`).
+
+### Changed
+
+- **Bumped dippin-lang pin v0.35.0 → v0.38.0** (`go.mod` + `PinnedDippinVersion`).
+  Pulls in the `on_failure` defaults field consumed above, plus additive advisory
+  lint (DIP144 "agent node has no failure route", cross-file DIP143/DIP146
+  completeness) that flows through automatically since tracker defers DIP checks to
+  dippin (#239). The new DIP144 is what made the example pipelines' `on_failure`
+  declarations necessary to hold their A `dippin doctor` grade. (#327 — the v0.38
+  bump goal; #310's budget/stall consumption remains.)
+
 - **build_product: no-requirement-left-behind** (closes #300, refs epic #308
   Phase 2 — second item). Stops spec-mandated verifications from vanishing from a
   build. `Decompose` now carries `auto_status: true` — which makes its previously

--- a/examples/ask_and_execute.dip
+++ b/examples/ask_and_execute.dip
@@ -9,6 +9,9 @@ workflow AskAndExecute
     fidelity: summary:high
     model: claude-sonnet-4-6
     provider: anthropic
+    # Graph-level catch-all: any agent failure with no node-level route
+    # escalates to a human instead of dead-stopping (#309).
+    on_failure: EscalateToHuman
 
   agent Start
     label: Start

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -10,6 +10,10 @@ workflow BuildProduct
     fidelity: full
     model: claude-sonnet-4-6
     provider: anthropic
+    # Graph-level catch-all: any agent failure with no node-level route
+    # (fallback_target or a fail edge) escalates to a human instead of
+    # dead-stopping. Node-level routes still take precedence (#309).
+    on_failure: EscalateReview
 
   agent Start
     label: Start

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -10,6 +10,10 @@ workflow BuildProductWithSuperspec
     fidelity: full
     model: claude-sonnet-4-6
     provider: anthropic
+    # Graph-level catch-all: any agent failure with no node-level route
+    # escalates to a human instead of dead-stopping. Node-level routes
+    # still take precedence (#309).
+    on_failure: EscalateToHuman
 
   agent Start
     label: Start

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.35.0
+	github.com/2389-research/dippin-lang v0.38.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/2389-research/dippin-lang v0.35.0 h1:7pAfzZmU+D/Du2pbF/W1/NOljvCSIaoJxSKsfefvQy4=
-github.com/2389-research/dippin-lang v0.35.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.38.0 h1:nkmT0abGrAZDRXmSSERDVcXz1AbxPCDMon4uLK1r9ZY=
+github.com/2389-research/dippin-lang v0.38.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -715,6 +715,11 @@ func extractWorkflowDefaults(defaults ir.WorkflowDefaults, attrs map[string]stri
 		attrs["max_restarts"] = strconv.Itoa(defaults.MaxRestarts)
 	}
 	setIfNonEmpty(attrs, "restart_target", defaults.RestartTarget)
+	// #309: dippin's graph-level `on_failure: <NodeID>` default failure route maps
+	// onto the graph fallback key the engine's strict-failure path reads
+	// (findFallbackTarget, #295). Node-level fallback_target lands in the node's
+	// own fallback_retry_target and is consulted first, so it still wins.
+	setIfNonEmpty(attrs, "fallback_target", defaults.OnFailure)
 	if defaults.CacheTools {
 		attrs["cache_tool_results"] = "true"
 	}

--- a/pipeline/dippin_adapter_on_failure_test.go
+++ b/pipeline/dippin_adapter_on_failure_test.go
@@ -1,0 +1,125 @@
+// ABOUTME: Tests for issue #309 — the adapter maps dippin's graph-level
+// ABOUTME: `on_failure:` default route into graph.Attrs["fallback_target"] so the
+// ABOUTME: #295 strict-failure cascade routes a bare agent failure to it.
+package pipeline
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// onFailureDip is a minimal workflow whose `Work` agent has only an
+// unconditional edge — on failure it must route via the graph-level
+// `on_failure: Escalate` default rather than dead-stopping.
+const onFailureDip = `workflow OnFailureTest
+  start: Start
+  exit: Done
+  defaults
+    on_failure: Escalate
+  agent Start
+    label: Start
+  agent Work
+    label: Work
+    prompt: do the work
+  agent Escalate
+    label: Escalate
+    prompt: escalate to a human
+  agent Done
+    label: Done
+  edges
+    Start -> Work
+    Work -> Done
+    Escalate -> Done
+`
+
+// TestAdapterMapsOnFailureToGraphFallback is the unit-level round-trip: a
+// workflow-level `on_failure: Escalate` must land in graph.Attrs["fallback_target"]
+// (the key the engine's findFallbackTarget reads).
+func TestAdapterMapsOnFailureToGraphFallback(t *testing.T) {
+	g, _, err := LoadDippinWorkflow(onFailureDip, "on_failure.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	if got := g.Attrs["fallback_target"]; got != "Escalate" {
+		t.Errorf("graph fallback_target = %q, want %q (issue #309: on_failure must map to the engine's fallback key)", got, "Escalate")
+	}
+}
+
+// TestOnFailureRoutesFailingAgentAtRuntime is the integration test over a BUILT
+// workflow: load the .dip through the adapter and run it through the engine; a
+// failing agent with no node-level route must reach the on_failure node.
+func TestOnFailureRoutesFailingAgentAtRuntime(t *testing.T) {
+	g, _, err := LoadDippinWorkflow(onFailureDip, "on_failure.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	reg := newTestRegistryWithOutcomes(map[string]Outcome{
+		"Work": {Status: string(OutcomeFail)},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := NewEngine(g, reg).Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+	if edgeTo, ok := traceEdgeTo(result.Trace, "Work"); !ok || edgeTo != "Escalate" {
+		t.Fatalf("Work trace EdgeTo = %q (found=%v), want %q — on_failure default not honored at runtime (issue #309)", edgeTo, ok, "Escalate")
+	}
+}
+
+// onFailurePrecedenceDip declares both a graph-level on_failure and a node-level
+// fallback_target on Work; the node-level route must win.
+const onFailurePrecedenceDip = `workflow OnFailurePrecedence
+  start: Start
+  exit: Done
+  defaults
+    on_failure: GraphEscalate
+  agent Start
+    label: Start
+  agent Work
+    label: Work
+    prompt: do the work
+    fallback_target: NodeEscalate
+  agent NodeEscalate
+    label: NodeEscalate
+    prompt: node-level escalate
+  agent GraphEscalate
+    label: GraphEscalate
+    prompt: graph-level escalate
+  agent Done
+    label: Done
+  edges
+    Start -> Work
+    Work -> Done
+    NodeEscalate -> Done
+    GraphEscalate -> NodeEscalate
+`
+
+// TestNodeFallbackBeatsGraphOnFailure pins the precedence acceptance criterion:
+// a node-level fallback_target wins over the graph-level on_failure default.
+func TestNodeFallbackBeatsGraphOnFailure(t *testing.T) {
+	g, _, err := LoadDippinWorkflow(onFailurePrecedenceDip, "on_failure_precedence.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	if got := g.Attrs["fallback_target"]; got != "GraphEscalate" {
+		t.Fatalf("graph fallback_target = %q, want %q (precondition for the precedence test)", got, "GraphEscalate")
+	}
+	reg := newTestRegistryWithOutcomes(map[string]Outcome{
+		"Work": {Status: string(OutcomeFail)},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := NewEngine(g, reg).Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+	if edgeTo, _ := traceEdgeTo(result.Trace, "Work"); edgeTo != "NodeEscalate" {
+		t.Fatalf("Work trace EdgeTo = %q, want node-level %q (node fallback_target must beat graph on_failure, issue #309)", edgeTo, "NodeEscalate")
+	}
+}

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -23,7 +23,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod. Kept in sync
 // with go.mod by TestPinnedDippinVersionMatchesGoMod.
-const PinnedDippinVersion = "v0.35.0"
+const PinnedDippinVersion = "v0.38.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -139,8 +139,14 @@ func TestDoctor_PipelineFileBundle(t *testing.T) {
 	if pipelineCheck == nil {
 		t.Fatal("Pipeline File check missing when PipelineFile set to a .dipx")
 	}
-	if pipelineCheck.Status != CheckStatusOK {
-		t.Errorf("Pipeline File status = %q, want ok; details=%+v message=%q",
+	// A valid bundle reports ok, or warn for advisory dippin lints unrelated to
+	// this test's intent (e.g. v0.38.0's DIP144 "agent node has no failure
+	// route" fires on dipxtest.MinimalDip's start node — an upstream fixture we
+	// don't control). This test guards the .dipx parse path, not lint
+	// cleanliness; the detail/message checks below pin the warnings that would
+	// actually be a regression (extension or parse errors).
+	if pipelineCheck.Status != CheckStatusOK && pipelineCheck.Status != CheckStatusWarn {
+		t.Errorf("Pipeline File status = %q, want ok or warn; details=%+v message=%q",
 			pipelineCheck.Status, pipelineCheck.Details, pipelineCheck.Message)
 	}
 	// The pre-fix warning leaked through as a detail or message — guard against it.


### PR DESCRIPTION
## What & why

Two coupled items (#309 + the actionable part of #327), shipped as one PR.

**#327 (partial): bump dippin-lang pin v0.35.0 → v0.38.0.** v0.38.0 is now tagged
(the original plan assumed it wasn't); it matches the local checkout and adds the
`on_failure` defaults field plus additive advisory lint. `#327` stays open for the
remaining #310 budget/stall consumption.

**#309: consume dippin's graph-level `on_failure: <NodeID>` default failure route.**
The engine already consults `graph.Attrs["fallback_target"]` on the #295 strict-failure
path, so this is a one-line adapter mapping — no engine change.

## Changes

- **adapter** (`extractWorkflowDefaults`): `defaults.OnFailure` →
  `graph.Attrs["fallback_target"]`. A bare agent failure (incl. turn exhaustion)
  with no node-level route now escalates to the declared node instead of
  dead-stopping. Node-level `fallback_target` still wins (lands in
  `fallback_retry_target`, consulted first by `findFallbackTarget`).
- **pin**: `go.mod` + `PinnedDippinVersion` → v0.38.0.
- **examples**: declare `on_failure` as a catch-all — `ask_and_execute` /
  `build_product_with_superspec` → `EscalateToHuman`, `build_product` →
  `EscalateReview`. v0.38's new advisory **DIP144** ("agent node has no failure
  route") flagged the un-routed agents and dropped all three example `dippin doctor`
  grades below A (F/50, C/70, F/0); the `on_failure` declarations restore A
  (95 / 90 / 100) and dogfood #309.
- **test**: v0.38's DIP144 fires on `dipxtest.MinimalDip` (an upstream fixture) in
  `TestDoctor_PipelineFileBundle`; relaxed that one assertion to accept an advisory
  `warn` while keeping the extension/parse-error guards that were its actual intent.

## TDD / verification

- New `pipeline/dippin_adapter_on_failure_test.go`: adapter round-trip (`on_failure`
  → graph fallback), end-to-end runtime routing over a **built** workflow, and
  node>graph precedence — written first (RED), then the adapter mapping (GREEN).
- `go build ./...`; `go test ./... -short` — all green.
- **doctor/validate verified against the pinned v0.38.0 library** (the runtime):
  `doctor.Diagnose` on all three examples = **grade A**; `LoadDippinWorkflow` (the
  validate path) clean.

> ⚠️ The `dippin` CLI binary on this PATH is a stale pre-v0.37 dev build (rejects
> `on_failure`), so the CLI `dippin doctor`/`validate` commands were not used —
> the gates were run via the pinned library instead, which is more faithful to the
> runtime. Rebuild the CLI from the local v0.38.0 checkout for CLI use:
> `cd /home/clint/code/2389/dippin-lang && go build -o ~/go/bin/dippin ./cmd/dippin`.

## Scope

Out: #310 (budget/stall_timeout/max_turns-breach consumption — separate, ties into
#303/#304 guards) and #313 (blocked on dippin-lang#110). `#327` stays open for #310.

Refs #309, #327, epic #308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783621994&installation_id=131176874&pr_number=328&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F328&signature=b594aaab9e86c1fd346722bf1bcc1a63cb77b61a542c695366cbc2383f3eeb9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workflows can now declare graph-level `on_failure` default failure routing. Unhandled agent failures automatically escalate to a specified fallback node. Node-level handlers take precedence.

* **Documentation**
  * Example workflows updated to demonstrate the new failure routing capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->