### PR TITLE
feat(llm): wire reasoning_effort through to Anthropic and Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`reasoning_effort` wired through to Anthropic and Gemini** (closes #329). The
+  unified `reasoning_effort` knob (`.dip` node attr) was only consumed by the OpenAI
+  provider; the Anthropic and Gemini translate layers silently dropped it, so
+  `reasoning_effort: low|medium|high` had no effect on Opus or Gemini. Now Anthropic
+  maps it to `output_config.effort` (GA effort knob; `low|medium|high|max`, Opus 4.5+/
+  Sonnet 4.6) and Gemini maps it to `generationConfig.thinkingConfig.thinkingLevel`
+  (Gemini 3+; `minimal|low|medium|high`), with a reasoning-only request still building a
+  `generationConfig`. Empty `reasoning_effort` omits the field → provider default, so
+  existing behavior is unchanged (and `high` is the Anthropic default).
+
 - **Operator-decision node + warm `continue +N` for steady-progress turn breaches**
   (closes #318, completes the #303 PR2 / epic #308 Phase 1 turn-limit track). When a
   native-backend turn-limit breach classifies to `operator_decision` (PR1 #317: steady

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   maps it to `output_config.effort` (GA effort knob; `low|medium|high|max`, Opus 4.5+/
   Sonnet 4.6) and Gemini maps it to `generationConfig.thinkingConfig.thinkingLevel`
   (Gemini 3+; `minimal|low|medium|high`), with a reasoning-only request still building a
-  `generationConfig`. Empty `reasoning_effort` omits the field → provider default, so
-  existing behavior is unchanged (and `high` is the Anthropic default).
+  `generationConfig`. The Gemini mapping is gated on the model — `thinkingLevel` is
+  Gemini 3+ only, so `reasoning_effort` is dropped for Gemini 2.5 and earlier (which
+  reject it), keeping shipped `gemini-2.5-pro` reviewers working. Empty `reasoning_effort`
+  omits the field → provider default, so existing behavior is unchanged (and `high` is the
+  Anthropic default).
 
 - **Operator-decision node + warm `continue +N` for steady-progress turn breaches**
   (closes #318, completes the #303 PR2 / epic #308 Phase 1 turn-limit track). When a

--- a/llm/anthropic/reasoning_effort_test.go
+++ b/llm/anthropic/reasoning_effort_test.go
@@ -1,0 +1,53 @@
+// ABOUTME: Tests that the unified reasoning_effort maps to Anthropic output_config.effort.
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+func TestTranslateRequestReasoningEffort(t *testing.T) {
+	for _, effort := range []string{"low", "medium", "high", "max"} {
+		req := &llm.Request{
+			Model:           "claude-opus-4-6",
+			Messages:        []llm.Message{llm.UserMessage("Decompose this spec")},
+			ReasoningEffort: effort,
+		}
+		body, err := translateRequest(req)
+		if err != nil {
+			t.Fatalf("effort=%s: %v", effort, err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("effort=%s: %v", effort, err)
+		}
+		oc, ok := m["output_config"].(map[string]any)
+		if !ok {
+			t.Fatalf("effort=%s: expected output_config object, got %v", effort, m["output_config"])
+		}
+		if oc["effort"] != effort {
+			t.Errorf("effort=%s: output_config.effort = %v, want %s", effort, oc["effort"], effort)
+		}
+	}
+}
+
+func TestTranslateRequestNoReasoningEffortOmitsOutputConfig(t *testing.T) {
+	req := &llm.Request{
+		Model:    "claude-opus-4-6",
+		Messages: []llm.Message{llm.UserMessage("Hello")},
+		// ReasoningEffort unset
+	}
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := m["output_config"]; ok {
+		t.Errorf("expected no output_config when reasoning_effort unset, got %v", m["output_config"])
+	}
+}

--- a/llm/anthropic/reasoning_effort_test.go
+++ b/llm/anthropic/reasoning_effort_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
+// TestTranslateRequestReasoningEffort verifies that each reasoning_effort level
+// is emitted as output_config.effort in the Anthropic request body (the GA
+// effort knob). "max" is included because it is valid on Opus-tier models.
 func TestTranslateRequestReasoningEffort(t *testing.T) {
 	for _, effort := range []string{"low", "medium", "high", "max"} {
 		req := &llm.Request{
@@ -33,6 +36,9 @@ func TestTranslateRequestReasoningEffort(t *testing.T) {
 	}
 }
 
+// TestTranslateRequestNoReasoningEffortOmitsOutputConfig verifies that when
+// reasoning_effort is unset, the request omits output_config entirely so the
+// model falls back to its API default (high) rather than being pinned.
 func TestTranslateRequestNoReasoningEffortOmitsOutputConfig(t *testing.T) {
 	req := &llm.Request{
 		Model:    "claude-opus-4-6",

--- a/llm/anthropic/translate.go
+++ b/llm/anthropic/translate.go
@@ -29,6 +29,16 @@ type anthropicRequest struct {
 	Temperature *float64           `json:"temperature,omitempty"`
 	TopP        *float64           `json:"top_p,omitempty"`
 	StopSeqs    []string           `json:"stop_sequences,omitempty"`
+
+	OutputConfig *anthropicOutputConfig `json:"output_config,omitempty"`
+}
+
+// anthropicOutputConfig carries the GA reasoning-effort control
+// (output_config.effort: low|medium|high|max). Supported on Opus 4.5+ and
+// Sonnet 4.6; it governs thinking depth and overall token spend. Lower effort
+// yields fewer/terser tokens; "max" is Opus-tier only.
+type anthropicOutputConfig struct {
+	Effort string `json:"effort,omitempty"`
 }
 
 type anthropicMessage struct {
@@ -99,6 +109,13 @@ func translateRequest(req *llm.Request) ([]byte, error) {
 		ar.MaxTokens = *req.MaxTokens
 	} else {
 		ar.MaxTokens = defaultMaxTokens
+	}
+
+	// Map the unified reasoning_effort to Anthropic's output_config.effort.
+	// (OpenAI maps it to reasoning.effort; Gemini to thinkingConfig.thinkingLevel.)
+	// Empty means "unset" — the API defaults to high, so we omit it.
+	if req.ReasoningEffort != "" {
+		ar.OutputConfig = &anthropicOutputConfig{Effort: req.ReasoningEffort}
 	}
 
 	// Extract system/developer messages to top-level system field.

--- a/llm/google/reasoning_effort_test.go
+++ b/llm/google/reasoning_effort_test.go
@@ -49,6 +49,59 @@ func TestTranslateRequestThinkingLevel(t *testing.T) {
 	}
 }
 
+// TestTranslateRequestGemini25OmitsThinkingLevel guards a regression that would
+// break shipped pipelines: thinkingLevel is Gemini 3+ only, and Gemini 2.5
+// models reject it (400). build_product / build_product_with_superspec run their
+// adversarial review on gemini-2.5-pro WITH reasoning_effort: high. So for a
+// Gemini 2.5 model, reasoning_effort must NOT emit thinkingConfig — and when it
+// is the only would-be field, no generationConfig at all (prior behavior).
+func TestTranslateRequestGemini25OmitsThinkingLevel(t *testing.T) {
+	req := &llm.Request{
+		Model:           "gemini-2.5-pro",
+		Messages:        []llm.Message{llm.UserMessage("Review this")},
+		ReasoningEffort: "high",
+	}
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	gc, ok := m["generationConfig"].(map[string]any)
+	if ok {
+		if _, has := gc["thinkingConfig"]; has {
+			t.Errorf("gemini-2.5-pro must not get thinkingConfig (unsupported → 400), got %v", gc["thinkingConfig"])
+		}
+		// reasoning_effort was the only non-default field → no generationConfig at all.
+		t.Errorf("gemini-2.5-pro + reasoning-only must produce no generationConfig, got %v", gc)
+	}
+}
+
+// TestTranslateRequestGemini25KeepsOtherGenConfig verifies the gating is scoped:
+// a Gemini 2.5 request with another gen-config field (temperature) still builds
+// generationConfig — just without thinkingConfig.
+func TestTranslateRequestGemini25KeepsOtherGenConfig(t *testing.T) {
+	temp := 0.5
+	req := &llm.Request{
+		Model:           "gemini-2.5-pro",
+		Messages:        []llm.Message{llm.UserMessage("Review this")},
+		ReasoningEffort: "high",
+		Temperature:     &temp,
+	}
+	gc := genConfig(t, req)
+	if gc == nil {
+		t.Fatal("expected generationConfig (temperature set)")
+	}
+	if _, has := gc["thinkingConfig"]; has {
+		t.Errorf("gemini-2.5-pro must not get thinkingConfig, got %v", gc["thinkingConfig"])
+	}
+	if gc["temperature"] == nil {
+		t.Error("temperature should still be present")
+	}
+}
+
 // TestTranslateRequestReasoningOnlyStillBuildsGenConfig guards the early-return
 // in buildGenerationConfig: a request whose ONLY non-default field is
 // reasoning_effort must still produce a generationConfig carrying thinkingLevel,

--- a/llm/google/reasoning_effort_test.go
+++ b/llm/google/reasoning_effort_test.go
@@ -1,0 +1,83 @@
+// ABOUTME: Tests that the unified reasoning_effort maps to Gemini thinkingConfig.thinkingLevel.
+package google
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+func genConfig(t *testing.T, req *llm.Request) map[string]any {
+	t.Helper()
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	gc, _ := m["generationConfig"].(map[string]any)
+	return gc
+}
+
+func TestTranslateRequestThinkingLevel(t *testing.T) {
+	for _, effort := range []string{"low", "medium", "high", "minimal"} {
+		req := &llm.Request{
+			Model:           "gemini-3-flash-preview",
+			Messages:        []llm.Message{llm.UserMessage("Decompose this spec")},
+			ReasoningEffort: effort,
+		}
+		gc := genConfig(t, req)
+		if gc == nil {
+			t.Fatalf("effort=%s: expected generationConfig", effort)
+		}
+		tc, ok := gc["thinkingConfig"].(map[string]any)
+		if !ok {
+			t.Fatalf("effort=%s: expected thinkingConfig, got %v", effort, gc["thinkingConfig"])
+		}
+		if tc["thinkingLevel"] != effort {
+			t.Errorf("effort=%s: thinkingLevel = %v, want %s", effort, tc["thinkingLevel"], effort)
+		}
+	}
+}
+
+// A request whose ONLY non-default field is reasoning_effort must still build a
+// generationConfig (the early-return guard must not drop it).
+func TestTranslateRequestReasoningOnlyStillBuildsGenConfig(t *testing.T) {
+	req := &llm.Request{
+		Model:           "gemini-3-flash-preview",
+		Messages:        []llm.Message{llm.UserMessage("Hello")},
+		ReasoningEffort: "low",
+	}
+	gc := genConfig(t, req)
+	if gc == nil {
+		t.Fatal("expected generationConfig for reasoning-only request, got none")
+	}
+	tc, ok := gc["thinkingConfig"].(map[string]any)
+	if !ok || tc["thinkingLevel"] != "low" {
+		t.Errorf("expected thinkingLevel=low, got %v", gc["thinkingConfig"])
+	}
+}
+
+func TestTranslateRequestNoReasoningEffortOmitsThinkingConfig(t *testing.T) {
+	req := &llm.Request{
+		Model:    "gemini-3-flash-preview",
+		Messages: []llm.Message{llm.UserMessage("Hello")},
+		// ReasoningEffort unset, no other gen-config fields
+	}
+	body, err := translateRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(body, &m); err != nil {
+		t.Fatal(err)
+	}
+	if gc, ok := m["generationConfig"].(map[string]any); ok {
+		if _, has := gc["thinkingConfig"]; has {
+			t.Errorf("expected no thinkingConfig when reasoning_effort unset, got %v", gc["thinkingConfig"])
+		}
+	}
+}

--- a/llm/google/reasoning_effort_test.go
+++ b/llm/google/reasoning_effort_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/2389-research/tracker/llm"
 )
 
+// genConfig translates req and returns the decoded generationConfig object from
+// the resulting Gemini request body (nil if the request produced none), so the
+// assertions below can stay terse.
 func genConfig(t *testing.T, req *llm.Request) map[string]any {
 	t.Helper()
 	body, err := translateRequest(req)
@@ -22,6 +25,9 @@ func genConfig(t *testing.T, req *llm.Request) map[string]any {
 	return gc
 }
 
+// TestTranslateRequestThinkingLevel verifies that each reasoning_effort level
+// maps to generationConfig.thinkingConfig.thinkingLevel for Gemini 3 models.
+// "minimal" is included because it is a valid Gemini-3 level (≈ thinking off).
 func TestTranslateRequestThinkingLevel(t *testing.T) {
 	for _, effort := range []string{"low", "medium", "high", "minimal"} {
 		req := &llm.Request{
@@ -43,8 +49,10 @@ func TestTranslateRequestThinkingLevel(t *testing.T) {
 	}
 }
 
-// A request whose ONLY non-default field is reasoning_effort must still build a
-// generationConfig (the early-return guard must not drop it).
+// TestTranslateRequestReasoningOnlyStillBuildsGenConfig guards the early-return
+// in buildGenerationConfig: a request whose ONLY non-default field is
+// reasoning_effort must still produce a generationConfig carrying thinkingLevel,
+// rather than being dropped as "no config needed".
 func TestTranslateRequestReasoningOnlyStillBuildsGenConfig(t *testing.T) {
 	req := &llm.Request{
 		Model:           "gemini-3-flash-preview",
@@ -61,6 +69,9 @@ func TestTranslateRequestReasoningOnlyStillBuildsGenConfig(t *testing.T) {
 	}
 }
 
+// TestTranslateRequestNoReasoningEffortOmitsThinkingConfig verifies that when
+// reasoning_effort is unset (and no other gen-config field forces one), the
+// request carries no thinkingConfig, leaving Gemini at its default thinking.
 func TestTranslateRequestNoReasoningEffortOmitsThinkingConfig(t *testing.T) {
 	req := &llm.Request{
 		Model:    "gemini-3-flash-preview",

--- a/llm/google/translate.go
+++ b/llm/google/translate.go
@@ -70,13 +70,22 @@ type geminiToolChoiceConfig struct {
 }
 
 type geminiGenConfig struct {
-	Temperature      *float64        `json:"temperature,omitempty"`
-	MaxOutputTokens  *int            `json:"maxOutputTokens,omitempty"`
-	TopP             *float64        `json:"topP,omitempty"`
-	TopK             *int            `json:"topK,omitempty"`
-	StopSequences    []string        `json:"stopSequences,omitempty"`
-	ResponseMimeType string          `json:"responseMimeType,omitempty"`
-	ResponseSchema   json.RawMessage `json:"responseSchema,omitempty"`
+	Temperature      *float64              `json:"temperature,omitempty"`
+	MaxOutputTokens  *int                  `json:"maxOutputTokens,omitempty"`
+	TopP             *float64              `json:"topP,omitempty"`
+	TopK             *int                  `json:"topK,omitempty"`
+	StopSequences    []string              `json:"stopSequences,omitempty"`
+	ResponseMimeType string                `json:"responseMimeType,omitempty"`
+	ResponseSchema   json.RawMessage       `json:"responseSchema,omitempty"`
+	ThinkingConfig   *geminiThinkingConfig `json:"thinkingConfig,omitempty"`
+}
+
+// geminiThinkingConfig carries the Gemini 3 reasoning control
+// (thinkingConfig.thinkingLevel: minimal|low|medium|high). It is the Gemini-3+
+// replacement for the legacy numeric thinkingBudget; combining the two in one
+// request returns a 400. Gemini 2.5 models do not support thinkingLevel.
+type geminiThinkingConfig struct {
+	ThinkingLevel string `json:"thinkingLevel,omitempty"`
 }
 
 // translateRequest converts a unified llm.Request to Gemini API JSON.
@@ -156,7 +165,7 @@ func translateGeminiTools(tools []llm.ToolDefinition) []geminiToolDecl {
 func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 	needsResponseFormat := responseFormatRequired(req)
 
-	if req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil && len(req.StopSequences) == 0 && !needsResponseFormat {
+	if req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil && len(req.StopSequences) == 0 && !needsResponseFormat && req.ReasoningEffort == "" {
 		return nil
 	}
 
@@ -170,6 +179,11 @@ func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 	}
 	if needsResponseFormat {
 		applyResponseFormat(gc, req.ResponseFormat)
+	}
+	// Map the unified reasoning_effort to Gemini's thinkingConfig.thinkingLevel
+	// (Gemini 3+). low|medium|high map straight through; "minimal" is also valid.
+	if req.ReasoningEffort != "" {
+		gc.ThinkingConfig = &geminiThinkingConfig{ThinkingLevel: req.ReasoningEffort}
 	}
 	return gc
 }

--- a/llm/google/translate.go
+++ b/llm/google/translate.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"strconv"
 	"strings"
 
 	"github.com/2389-research/tracker/llm"
@@ -161,11 +162,33 @@ func translateGeminiTools(tools []llm.ToolDefinition) []geminiToolDecl {
 	return []geminiToolDecl{{FunctionDeclarations: decls}}
 }
 
+// geminiSupportsThinkingLevel reports whether model is Gemini 3 or later — the
+// generations that accept generationConfig.thinkingConfig.thinkingLevel. Gemini
+// 2.5 and earlier reject it with a 400, so callers drop reasoning_effort for
+// them. Parses the major version from a "gemini-<major>[.<minor>]-..." string
+// (tolerating an optional "models/" prefix); anything unrecognized → false.
+func geminiSupportsThinkingLevel(model string) bool {
+	rest := strings.TrimPrefix(strings.TrimPrefix(model, "models/"), "gemini-")
+	major := rest
+	for i, r := range rest {
+		if r < '0' || r > '9' {
+			major = rest[:i]
+			break
+		}
+	}
+	n, err := strconv.Atoi(major)
+	return err == nil && n >= 3
+}
+
 // buildGenerationConfig creates a Gemini generation config from the request fields.
 func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 	needsResponseFormat := responseFormatRequired(req)
+	// thinkingLevel is Gemini 3+ only; Gemini 2.5 and earlier reject it (400).
+	// Gate on the model so reasoning_effort is silently dropped for older models
+	// (preserving prior behavior) instead of breaking shipped 2.5-pro reviewers.
+	useThinking := req.ReasoningEffort != "" && geminiSupportsThinkingLevel(req.Model)
 
-	if req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil && len(req.StopSequences) == 0 && !needsResponseFormat && req.ReasoningEffort == "" {
+	if req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil && len(req.StopSequences) == 0 && !needsResponseFormat && !useThinking {
 		return nil
 	}
 
@@ -182,7 +205,7 @@ func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 	}
 	// Map the unified reasoning_effort to Gemini's thinkingConfig.thinkingLevel
 	// (Gemini 3+). low|medium|high map straight through; "minimal" is also valid.
-	if req.ReasoningEffort != "" {
+	if useThinking {
 		gc.ThinkingConfig = &geminiThinkingConfig{ThinkingLevel: req.ReasoningEffort}
 	}
 	return gc


### PR DESCRIPTION
## Problem

`llm.Request.ReasoningEffort` (the unified `reasoning_effort` set by `.dip` nodes) was only consumed by the **OpenAI** provider. The **Anthropic** and **Gemini** translate layers silently dropped it — so a `.dip` setting `reasoning_effort: low|medium|high` had **no effect** on Opus or Gemini, which always ran at the provider default.

## Fix

- **Anthropic** (`llm/anthropic/translate.go`): map `reasoning_effort` → `output_config.effort` (the GA effort knob; `low|medium|high|max`, supported on Opus 4.5+/Sonnet 4.6).
- **Gemini** (`llm/google/translate.go`): map `reasoning_effort` → `generationConfig.thinkingConfig.thinkingLevel` (Gemini 3+; `minimal|low|medium|high`), and ensure a request whose only non-default field is `reasoning_effort` still builds a `generationConfig`.
- Empty `reasoning_effort` omits the field entirely → provider default, so **existing behavior is unchanged** (and `high` == the Anthropic default, so dips already set to `high` are unaffected).

## Why it matters

On the sprint-decomposition workload, `high` on Opus is not only the costliest setting but actively *truncates* (it over-elaborates and blows the output budget), while `low` produces a complete, coherent plan for ~half the tokens/latency. This change makes the existing `reasoning_effort` knob actually controllable for the two providers where it was being dropped.

## Tests

- `llm/anthropic/reasoning_effort_test.go` — each level maps to `output_config.effort`; unset omits it.
- `llm/google/reasoning_effort_test.go` — each level maps to `thinkingLevel`; a reasoning-only request still builds `generationConfig`; unset omits `thinkingConfig`.
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./llm/...` passes (all 5 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended reasoning-effort control to Anthropic and Google (Gemini) so user-selected effort levels are passed through or omitted to use provider defaults.

* **Tests**
  * Added tests validating effort-level translation and that omitting effort preserves provider-default behavior across providers and model versions.

* **Documentation**
  * Updated changelog to document the provider mappings and omission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783624556&installation_id=131176874&pr_number=329&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F329&signature=bae9c931d043d99a331551c70f4b30fc3212cd208a6f3b92771317b550a8033b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->