### PR TITLE
feat(turn-guard): operator-decision node + warm continue+N (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Operator-decision node + warm `continue +N` for steady-progress turn breaches**
+  (closes #318, completes the #303 PR2 / epic #308 Phase 1 turn-limit track). When a
+  native-backend turn-limit breach classifies to `operator_decision` (PR1 #317: steady
+  progress, verify ran but not green, no loop), the operator now gets a real choice
+  instead of a bare escalation. In `build_product.dip`, `Implement` routes
+  `when ctx.turn_breach_class = operator_decision` to a new `OperatorDecision`
+  `wait.human` (freeform) gate — **no new handler** — with four labeled edges:
+  `stop` (escalate, preserving work), `abandon` (end the run), `commit_advance`
+  (persist the tree via `CommitIfDirty` and advance), and `continue` (warm retry).
+  - **Deterministically safe unattended default:** the gate pins `default: stop` and
+    lists `stop`/`abandon` *before* `continue`, so `--auto-approve` / `--webhook-url`
+    (and the timeout path) resolve to `stop` — an unattended run never silently
+    advances unverified work. (`--autopilot lax`/`mentor` bias to forward progress and
+    are not deterministically safe; the gate prompt frames `continue` as the risky
+    option.) A pathological breach still narrowly falls through to the existing
+    `EscalateMilestone` catch-all.
+  - **Warm `continue +N`:** a new node-scoped, disk-driven `MaxTurns` override
+    (`.tracker/turn_overrides/<nodeID>`, consulted in `codergen.buildConfig`) lets the
+    capped `ContinueWithMoreTurns` tool node re-enter `Implement` with a bumped turn
+    budget while `PriorEpisodeSummaries` carry across warm. The cap is a per-loop disk
+    counter (not the global engine `RestartCount`); past the cap it escalates instead
+    of looping.
+
 - **Graph-level `on_failure` default failure route** (closes #309, refs epic #308,
   pairs with the #295 strict-failure catch-all). dippin's workflow-level
   `defaults { on_failure: <NodeID> }` now reaches the engine: the adapter

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -727,6 +727,18 @@ workflow BuildProduct
       BUMP=40
       OVR_DIR=".tracker/turn_overrides"
       ATTEMPT_FILE="$OVR_DIR/continue_attempts"
+      # Keep these tracker-internal control files OUT of the product repo. A later
+      # CommitIfDirty runs `git add -A`, which would otherwise commit the counter +
+      # override — polluting the user's repo AND leaving a stale Implement override
+      # that a future run would read (via codergen.buildConfig) before any operator
+      # decision. Ignore them via the LOCAL, untracked .git/info/exclude so we never
+      # touch the user's tracked .gitignore (idempotent; safe outside a git repo).
+      GITDIR=$(git rev-parse --git-dir 2>/dev/null || true)
+      if [ -n "$GITDIR" ]; then
+        mkdir -p "$GITDIR/info"
+        grep -qxF "$OVR_DIR/" "$GITDIR/info/exclude" 2>/dev/null \
+          || echo "$OVR_DIR/" >> "$GITDIR/info/exclude"
+      fi
       mkdir -p "$OVR_DIR"
       ATTEMPTS=0
       if [ -f "$ATTEMPT_FILE" ]; then

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -703,6 +703,47 @@ workflow BuildProduct
       fi
       printf 'commit-if-dirty-done'
 
+  tool ContinueWithMoreTurns
+    label: "Warm continue: bump turn budget (capped)"
+    timeout: 5s
+    command:
+      set -eu
+      # Issue #318 warm continue+N. The operator picked "continue" at the
+      # OperatorDecision gate: re-enter Implement WARM (it keeps its episode
+      # memory across the restart) but with a larger turn budget so it doesn't
+      # breach at the same wall again.
+      #
+      # Per-loop circuit-breaker: a disk counter — NOT the global engine
+      # RestartCount, which is shared across every loop in the run and would
+      # reset/consume budget with the wrong semantics (#318 hazard 3). Once the
+      # cap is exhausted we route to EscalateMilestone via ctx.outcome = fail
+      # (exit 1) instead of looping forever.
+      #
+      # The bump is delivered through the tracker-owned, node-scoped MaxTurns
+      # override file that codergen.buildConfig consults
+      # (.tracker/turn_overrides/<nodeID>); BASE matches Implement's max_turns.
+      CAP=3
+      BASE=50
+      BUMP=40
+      OVR_DIR=".tracker/turn_overrides"
+      ATTEMPT_FILE="$OVR_DIR/continue_attempts"
+      mkdir -p "$OVR_DIR"
+      ATTEMPTS=0
+      if [ -f "$ATTEMPT_FILE" ]; then
+        ATTEMPTS=$(cat "$ATTEMPT_FILE")
+      fi
+      ATTEMPTS=$((ATTEMPTS + 1))
+      echo "$ATTEMPTS" > "$ATTEMPT_FILE"
+      if [ "$ATTEMPTS" -gt "$CAP" ]; then
+        echo "continue cap ($CAP) exhausted after $ATTEMPTS attempt(s) — escalating"
+        printf 'continue-cap-exhausted'
+        exit 1
+      fi
+      NEWMAX=$((BASE + ATTEMPTS * BUMP))
+      echo "$NEWMAX" > "$OVR_DIR/Implement"
+      echo "warm continue $ATTEMPTS/$CAP — bumped Implement max_turns to $NEWMAX"
+      printf 'continue-ok'
+
   tool TestMilestone
     label: "Test Current Milestone"
     timeout: 300s
@@ -1071,6 +1112,10 @@ workflow BuildProduct
 
       # Reset fix attempt counter for next milestone
       rm -f .ai/milestones/fix_attempts
+      # #318: reset the warm-continue cap counter + MaxTurns override at the
+      # milestone boundary so the next milestone's Implement starts at its base
+      # turn budget with a fresh continue allowance.
+      rm -rf .tracker/turn_overrides
       rm .ai/milestones/current.md
       printf "milestone-$NEXT-complete"
 
@@ -1637,6 +1682,41 @@ workflow BuildProduct
       line stays in place. The parser requires `STATUS:<value>` on
       its own line, no leading characters, no fences/tables.
 
+  human OperatorDecision
+    label: "Agent hit its turn limit mid-progress — pick how to proceed"
+    mode: freeform
+    # Issue #318 hazard 1 (CRITICAL): make the unattended default deterministically
+    # SAFE so a headless run never silently advances unverified work. TWO operative
+    # mechanisms, both resolving to "stop":
+    #   1. Edge order — the freeform interviewer's unattended path falls back to the
+    #      FIRST outgoing edge label (labels[0]). The edges below list stop/abandon
+    #      BEFORE continue, so --auto-approve / --webhook-url pick "stop".
+    #   2. `default: stop` — dippin maps this to `default_choice`, which is what the
+    #      gate's TIMEOUT path resolves (HumanConfig.DefaultChoice). Also documents
+    #      intent. (Note: freeform's labels[0] fallback, not default_choice, drives
+    #      the auto-approve path — keep stop first so both agree.)
+    # --autopilot lax/mentor bias to "forward progress" and are NOT deterministically
+    # safe here; the prompt frames "continue" as the RISKY option to bias the LLM
+    # judge away from it.
+    default: stop
+    prompt:
+      The implementation agent ran out of its turn budget while still making
+      steady progress: it did NOT enter a detected loop, and its work did NOT
+      verify green (either of those would have routed elsewhere). Its final
+      status and output are shown below — read them before choosing.
+
+      Options:
+      - **stop** (default; chosen automatically for unattended runs): Treat the
+        milestone as stuck and escalate to the milestone gate. Preserves work.
+        This is the SAFE choice — it never silently advances unverified work.
+      - **abandon**: Kill the pipeline immediately.
+      - **commit_advance**: You have inspected the working tree and judge it good
+        enough. Commit it and advance to verification as if the milestone passed.
+        Only pick this AFTER reviewing the work.
+      - **continue**: RISKY. Hand the agent a fresh, larger turn budget and let
+        it keep going (warm — it keeps its episode memory). Bounded by a hard cap
+        on consecutive continues; past the cap this escalates instead of looping.
+
   human EscalateMilestone
     label: "Milestone stuck — pick how to proceed"
     mode: freeform
@@ -1685,7 +1765,7 @@ workflow BuildProduct
     command:
       set -eu
       # Keep decisions, remove build working files
-      rm -rf .ai/build .ai/milestones
+      rm -rf .ai/build .ai/milestones .tracker/turn_overrides
       # Keep: .ai/decisions/ (spec-analysis, milestones, requirement-coverage, review-synthesis, compliance)
       echo "Preserved decision log in .ai/decisions/"
       ls .ai/decisions/
@@ -1719,7 +1799,26 @@ workflow BuildProduct
     PickNextMilestone -> ClearStaleReviews  when ctx.tool_stdout contains all-done
     PickNextMilestone -> EscalateMilestone
     Implement -> CommitIfDirty  when ctx.outcome = success
+    # #318: a steady-progress turn breach (verify ran but wasn't green, no loop)
+    # routes to the operator-decision gate. Narrow `= operator_decision` so a
+    # pathological breach (and any plain fail) still falls through to the
+    # unconditional EscalateMilestone catch-all below.
+    Implement -> OperatorDecision  when ctx.turn_breach_class = operator_decision
     Implement -> EscalateMilestone
+    # #318 operator-decision routes. stop/abandon are listed BEFORE continue so
+    # the freeform labels[0] fallback (if `default` were ever dropped) is safe.
+    OperatorDecision -> EscalateMilestone      label: "stop"
+    OperatorDecision -> Done                   label: "abandon"
+    OperatorDecision -> CommitIfDirty          label: "commit_advance"
+    OperatorDecision -> ContinueWithMoreTurns  label: "continue"
+    # Capped warm-retry: success re-enters Implement (warm, bumped MaxTurns);
+    # cap-exhausted (fail) escalates instead of looping forever. The trailing
+    # unconditional -> EscalateMilestone is the strict-failure catch-all (mirrors
+    # TestMilestone): conditional edges are tried first, so it only ever fires on
+    # an unexpected outcome — and it keeps the node's printed markers covered.
+    ContinueWithMoreTurns -> Implement          when ctx.outcome = success  restart: true
+    ContinueWithMoreTurns -> EscalateMilestone  when ctx.outcome = fail
+    ContinueWithMoreTurns -> EscalateMilestone
     CommitIfDirty -> TestMilestone
     TestMilestone -> VerifyMilestone  when ctx.outcome = success
     TestMilestone -> EscalateMilestone  when ctx.tool_stdout contains escalate

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -31,6 +31,11 @@ workflow BuildProduct
       mkdir -p .ai/build .ai/decisions .ai/milestones
       echo '.ai/' >> .gitignore 2>/dev/null || true
       sort -u .gitignore -o .gitignore
+      # #318: clear any warm-continue cap counter / MaxTurns override left by a
+      # prior run interrupted before its cleanup. Setup is skipped on checkpoint
+      # resume (already completed), so a deliberately-resumed run keeps its state;
+      # only a fresh run starts the continue allowance clean.
+      rm -rf .tracker/turn_overrides
       if [ ! -f SPEC.md ]; then
         echo "ERROR: SPEC.md not found in repo root"
         exit 1
@@ -742,8 +747,15 @@ workflow BuildProduct
       mkdir -p "$OVR_DIR"
       ATTEMPTS=0
       if [ -f "$ATTEMPT_FILE" ]; then
-        ATTEMPTS=$(cat "$ATTEMPT_FILE")
+        ATTEMPTS=$(cat "$ATTEMPT_FILE" 2>/dev/null || echo 0)
       fi
+      # Reset a corrupted/non-numeric counter (e.g. a prior run interrupted
+      # before MarkMilestoneDone/Cleanup cleared it) so the arithmetic below
+      # can't error under `set -e` and a fresh operator decision isn't denied
+      # its continues by stale junk. Setup also clears this dir at run start.
+      case "$ATTEMPTS" in
+        ''|*[!0-9]*) ATTEMPTS=0 ;;
+      esac
       ATTEMPTS=$((ATTEMPTS + 1))
       echo "$ATTEMPTS" > "$ATTEMPT_FILE"
       if [ "$ATTEMPTS" -gt "$CAP" ]; then

--- a/pipeline/build_product_operator_decision_test.go
+++ b/pipeline/build_product_operator_decision_test.go
@@ -1,0 +1,223 @@
+// ABOUTME: Graph-structure guards for #318 — the operator-decision node that a
+// ABOUTME: steady-progress turn breach (turn_breach_class=operator_decision) routes
+// ABOUTME: to, its four labeled edges, the safe autonomous default, and the cap loop.
+package pipeline
+
+import "testing"
+
+const operatorNodeID = "OperatorDecision"
+
+// outgoingLabels returns the labels of nodeID's outgoing edges in declaration
+// order (empty-label edges are skipped, matching collectEdgeLabels in the
+// human handler — the unattended freeform fallback uses labels[0]).
+func outgoingLabels(g *Graph, nodeID string) []string {
+	var labels []string
+	for _, e := range g.OutgoingEdges(nodeID) {
+		if e.Label != "" {
+			labels = append(labels, e.Label)
+		}
+	}
+	return labels
+}
+
+// hasLabeledEdgeTo reports whether nodeID has an outgoing edge to target carrying
+// the given label.
+func hasLabeledEdgeTo(g *Graph, from, to, label string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && e.Label == label {
+			return true
+		}
+	}
+	return false
+}
+
+// reachesNode reports whether target is reachable from start by following edges
+// (cycle-safe via a visited set). Used to assert every operator edge terminates.
+func reachesNode(g *Graph, start, target string) bool {
+	visited := map[string]bool{}
+	stack := []string{start}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur == target {
+			return true
+		}
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		for _, e := range g.OutgoingEdges(cur) {
+			stack = append(stack, e.To)
+		}
+	}
+	return false
+}
+
+// indexOf returns the position of s in xs, or -1.
+func indexOf(xs []string, s string) int {
+	for i, x := range xs {
+		if x == s {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestBuildProductOperatorDecisionNodeExists pins #318: a steady-progress turn
+// breach routes to a reusable wait.human (freeform) operator-decision node — NOT
+// a new handler. Implement reaches it via a narrow conditional edge keyed on
+// turn_breach_class = operator_decision, ordered so the unconditional
+// EscalateMilestone catch-all still receives a pathological breach.
+func TestBuildProductOperatorDecisionNodeExists(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	n, ok := g.Nodes[operatorNodeID]
+	if !ok {
+		t.Fatalf("%s node missing from build_product.dip (issue #318)", operatorNodeID)
+	}
+	if n.Handler != "wait.human" {
+		t.Errorf("%s handler = %q, want \"wait.human\" (reuse, no new handler — issue #318)", operatorNodeID, n.Handler)
+	}
+	if mode := n.Attrs["mode"]; mode != "freeform" {
+		t.Errorf("%s mode = %q, want \"freeform\" (labeled radio + freeform hybrid — issue #318)", operatorNodeID, mode)
+	}
+
+	// Reached only by the operator_decision class. A narrow condition keeps
+	// pathological breaches (and plain fails) on the catch-all.
+	if !hasEdgeWithCondition(g, "Implement", operatorNodeID, "ctx.turn_breach_class = operator_decision") {
+		t.Errorf("Implement has no `ctx.turn_breach_class = operator_decision` edge to %s (issue #318)", operatorNodeID)
+	}
+}
+
+// TestBuildProductOperatorDecisionSafeDefault pins the CRITICAL hazard 1: the
+// unattended default must deterministically resolve to the safe, non-advancing
+// option ("stop"), never "continue". Two operative mechanisms, asserted here:
+//
+//   - Edge order: the freeform interviewer's unattended path falls back to the
+//     FIRST outgoing edge label (labels[0]); dippin's `default:` keyword maps to
+//     `default_choice`, which freeform's labels[0] fallback does NOT read — so
+//     edge order is what drives --auto-approve / --webhook-url. "stop"/"abandon"
+//     MUST precede "continue" so labels[0] is safe.
+//   - default_choice: dippin maps `default: stop` here; it is the value the gate's
+//     TIMEOUT path resolves (HumanConfig.DefaultChoice) and documents intent.
+//
+// The end-to-end resolution (AutoApprove → "stop") is pinned behaviorally in the
+// handlers package (TestOperatorDecision_UnattendedResolvesToStop).
+func TestBuildProductOperatorDecisionSafeDefault(t *testing.T) {
+	g := loadBuildProduct(t)
+	if g.Nodes[operatorNodeID] == nil {
+		t.Fatalf("%s node missing from build_product.dip (issue #318)", operatorNodeID)
+	}
+
+	// dippin maps the `default:` keyword to default_choice (the timeout-path default).
+	if def := g.Nodes[operatorNodeID].HumanConfig().DefaultChoice; def != "stop" {
+		t.Errorf("%s resolved default = %q, want \"stop\" — unattended/timeout must NOT silently advance unverified work (issue #318 hazard 1)", operatorNodeID, def)
+	}
+
+	labels := outgoingLabels(g, operatorNodeID)
+	iStop, iAbandon, iContinue := indexOf(labels, "stop"), indexOf(labels, "abandon"), indexOf(labels, "continue")
+	if iStop < 0 || iAbandon < 0 || iContinue < 0 {
+		t.Fatalf("%s missing one of stop/abandon/continue labels: %v (issue #318)", operatorNodeID, labels)
+	}
+	// labels[0] is the freeform auto-approve fallback; it must never be "continue".
+	if labels[0] == "continue" {
+		t.Errorf("first edge label is %q — the auto-approve labels[0] fallback must be safe, never \"continue\" (issue #318 hazard 1)", labels[0])
+	}
+	if !(iStop < iContinue && iAbandon < iContinue) {
+		t.Errorf("edge order %v: stop(%d)/abandon(%d) must precede continue(%d) so labels[0] fallback is safe (issue #318 hazard 1)", labels, iStop, iAbandon, iContinue)
+	}
+}
+
+// TestBuildProductOperatorDecisionFourEdges pins the four labeled choices and
+// their safe targets, and that every operator edge reaches the exit (DIP005 —
+// no dangling label). stop escalates (human can still rescue), abandon ends the
+// run without advancing, commit_advance persists the tree via the existing
+// commit-on-success node, continue routes through the capped warm-retry tool.
+func TestBuildProductOperatorDecisionFourEdges(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	wantTargets := map[string]string{
+		"stop":           "EscalateMilestone",
+		"abandon":        g.ExitNode,
+		"commit_advance": "CommitIfDirty",
+		"continue":       "ContinueWithMoreTurns",
+	}
+	for label, target := range wantTargets {
+		if !hasLabeledEdgeTo(g, operatorNodeID, target, label) {
+			t.Errorf("%s missing labeled edge %q -> %s (issue #318)", operatorNodeID, label, target)
+		}
+	}
+	for _, e := range g.OutgoingEdges(operatorNodeID) {
+		if !reachesNode(g, e.To, g.ExitNode) {
+			t.Errorf("%s -> %s (label %q) does not reach exit %q (DIP005, issue #318)", operatorNodeID, e.To, e.Label, g.ExitNode)
+		}
+	}
+}
+
+// TestBuildProductContinueCapLoop pins hazard 3: the continue cap is a TOOL node
+// gating the warm-retry edge (a per-loop disk counter, not the global engine
+// RestartCount). On success it re-enters Implement (restart: true → warm
+// continue+N); on fail (cap exhausted) it escalates instead of looping forever.
+func TestBuildProductContinueCapLoop(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	n, ok := g.Nodes["ContinueWithMoreTurns"]
+	if !ok {
+		t.Fatal("ContinueWithMoreTurns node missing from build_product.dip (issue #318 hazard 3)")
+	}
+	if n.Handler != "tool" {
+		t.Errorf("ContinueWithMoreTurns handler = %q, want \"tool\" (cap circuit-breaker, issue #318)", n.Handler)
+	}
+	if !hasEdgeAttr(g, "ContinueWithMoreTurns", "Implement", "ctx.outcome = success", "restart", "true") {
+		t.Error("ContinueWithMoreTurns -> Implement must be `ctx.outcome = success` with restart: true (warm continue+N, issue #318)")
+	}
+	if !hasEdgeWithCondition(g, "ContinueWithMoreTurns", "EscalateMilestone", "ctx.outcome = fail") {
+		t.Error("ContinueWithMoreTurns -> EscalateMilestone must be the `ctx.outcome = fail` (cap-exhausted) route (issue #318)")
+	}
+}
+
+// TestBuildProductOperatorDecisionPersistsViaCommitNode documents and pins the
+// resolution of #318 hazard 4 (commitWIPBeforeRouting bypass). The engine's WIP
+// preservation runs only inside checkStrictFailure, which early-returns when a
+// node has ANY conditional edge — and Implement already carried conditional edges
+// before this change (the `ctx.outcome = success` rescue), so routing a breach to
+// the operator gate introduces NO new bypass. It is also a no-op in normal runs
+// (WithGitArtifacts is off by default). Green work is therefore persisted the way
+// ALL product persistence works in tracker — through the pipeline's own
+// commit-on-success node, not an engine commit: the operator's work-preserving
+// choices route to CommitIfDirty (commit_advance) or EscalateMilestone (stop,
+// whose "mark done" leads onward), never dropping the tree.
+func TestBuildProductOperatorDecisionPersistsViaCommitNode(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	// commit_advance persists the tree via the existing commit node, then advances.
+	if !hasLabeledEdgeTo(g, operatorNodeID, "CommitIfDirty", "commit_advance") {
+		t.Error("operator commit_advance must route to CommitIfDirty (the commit-on-success node) to persist work (issue #318 hazard 4)")
+	}
+	if !hasEdgeTo(g, "CommitIfDirty", "TestMilestone") {
+		t.Error("CommitIfDirty must continue to TestMilestone so commit_advance advances the milestone (issue #318)")
+	}
+	// stop escalates to a gate that can still preserve/route the work (mark done).
+	if !hasLabeledEdgeTo(g, operatorNodeID, "EscalateMilestone", "stop") {
+		t.Error("operator stop must route to EscalateMilestone, not drop the milestone (issue #318)")
+	}
+}
+
+// TestBuildProductPathologicalStillFallsThrough pins that adding the narrow
+// operator_decision conditional edge does NOT capture a pathological breach: the
+// unconditional Implement -> EscalateMilestone catch-all (and the resolved
+// fallback_target) must remain, so a looping agent still stops (issue #296/#303).
+func TestBuildProductPathologicalStillFallsThrough(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if !hasUnconditionalEdgeTo(g, "Implement", "EscalateMilestone") {
+		t.Error("Implement lost its unconditional catch-all to EscalateMilestone — a pathological breach would no longer fall through (issue #296/#303)")
+	}
+	if got := resolveFallback(g, g.Nodes["Implement"]); got != "EscalateMilestone" {
+		t.Errorf("Implement resolved fallback = %q, want EscalateMilestone (issue #296 regression)", got)
+	}
+	// The green-breach rescue (success edge through CommitIfDirty) is untouched.
+	if !hasEdgeWithCondition(g, "Implement", "CommitIfDirty", "ctx.outcome = success") {
+		t.Error("Implement success edge to CommitIfDirty must remain (issue #297/#303)")
+	}
+}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -623,22 +623,39 @@ func resolveMaxTurns(workingDir, nodeID string, base int) int {
 	return base
 }
 
+// safeNodeFilename reports whether nodeID is usable as a single path element —
+// a bare filename with no separators or parent refs. dippin IDs are identifiers,
+// but readMaxTurnsOverride is a general working-dir file read, so it fails closed
+// against an ID that could traverse out of the override dir. #318.
+func safeNodeFilename(nodeID string) bool {
+	return nodeID != "" && nodeID == filepath.Base(nodeID) && nodeID != "." && nodeID != ".."
+}
+
+// parsePositiveInt returns the positive integer encoded in s (trimmed), or 0.
+func parsePositiveInt(s string) int {
+	if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil && n > 0 {
+		return n
+	}
+	return 0
+}
+
 // readMaxTurnsOverride returns the node-scoped warm-continue MaxTurns override
 // for nodeID under workingDir, or 0 when absent/unreadable/non-positive (a
 // no-op so normal runs keep their statically-configured budget). #318.
 func readMaxTurnsOverride(workingDir, nodeID string) int {
-	if workingDir == "" || nodeID == "" {
+	if workingDir == "" || !safeNodeFilename(nodeID) {
 		return 0
 	}
-	data, err := os.ReadFile(filepath.Join(workingDir, maxTurnsOverrideSubdir, nodeID))
+	path := filepath.Join(workingDir, maxTurnsOverrideSubdir, nodeID)
+	// Only honor a regular file — a symlink planted here must not be followed.
+	if fi, err := os.Lstat(path); err != nil || !fi.Mode().IsRegular() {
+		return 0
+	}
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return 0
 	}
-	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || n <= 0 {
-		return 0
-	}
-	return n
+	return parsePositiveInt(string(data))
 }
 
 // buildTurnLimitMsg returns a non-empty message when the session hit the turn limit,

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -606,6 +608,39 @@ func (h *CodergenHandler) applyEpisodeContextUpdates(updates map[string]string, 
 	updates[pipeline.ContextKeyEpisodeSummaries] = agent.SerializeEpisodeSummaries(summaries)
 }
 
+// maxTurnsOverrideSubdir is the tracker-owned, working-dir-relative directory
+// holding per-node warm-continue MaxTurns overrides (#318). One file per node
+// ID; its integer contents replace the node's static max_turns on re-entry.
+const maxTurnsOverrideSubdir = ".tracker/turn_overrides"
+
+// resolveMaxTurns returns the warm-continue MaxTurns override for nodeID under
+// workingDir when one is present, else base. Keeps the override branch out of
+// buildConfig (which is already a long flat sequence of attr applies). #318.
+func resolveMaxTurns(workingDir, nodeID string, base int) int {
+	if override := readMaxTurnsOverride(workingDir, nodeID); override > 0 {
+		return override
+	}
+	return base
+}
+
+// readMaxTurnsOverride returns the node-scoped warm-continue MaxTurns override
+// for nodeID under workingDir, or 0 when absent/unreadable/non-positive (a
+// no-op so normal runs keep their statically-configured budget). #318.
+func readMaxTurnsOverride(workingDir, nodeID string) int {
+	if workingDir == "" || nodeID == "" {
+		return 0
+	}
+	data, err := os.ReadFile(filepath.Join(workingDir, maxTurnsOverrideSubdir, nodeID))
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
 // buildTurnLimitMsg returns a non-empty message when the session hit the turn limit,
 // and an empty string otherwise.
 func buildTurnLimitMsg(node *pipeline.Node, sessResult agent.SessionResult) string {
@@ -720,6 +755,13 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	if cfg.MaxTurns > 0 {
 		config.MaxTurns = cfg.MaxTurns
 	}
+	// #318 warm continue+N: a node-scoped, disk-driven override bumps MaxTurns
+	// on warm re-entry of this agent node (the operator-decision "continue"
+	// path writes it via a capped tool node). Consulted here because MaxTurns
+	// is otherwise read statically and nothing reads context for it. A missing
+	// or malformed override is a no-op, so normal runs are unaffected. (The
+	// conditional lives in resolveMaxTurns to keep buildConfig's branch count flat.)
+	config.MaxTurns = resolveMaxTurns(config.WorkingDir, node.ID, config.MaxTurns)
 	if cfg.CommandTimeout > 0 {
 		config.CommandTimeout = cfg.CommandTimeout
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -613,14 +613,25 @@ func (h *CodergenHandler) applyEpisodeContextUpdates(updates map[string]string, 
 // ID; its integer contents replace the node's static max_turns on re-entry.
 const maxTurnsOverrideSubdir = ".tracker/turn_overrides"
 
+// maxTurnsOverrideCeiling bounds a warm-continue override so a stale or
+// corrupted file can't inflate runtime/cost. BudgetGuard is the global cost
+// backstop, but a single oversized session can still run long; this caps the
+// blast radius. Generous vs the agent default (80) and build_product's capped
+// bumps (≤170). #318.
+const maxTurnsOverrideCeiling = 1000
+
 // resolveMaxTurns returns the warm-continue MaxTurns override for nodeID under
-// workingDir when one is present, else base. Keeps the override branch out of
-// buildConfig (which is already a long flat sequence of attr applies). #318.
+// workingDir when one is present, else base. A warm continue only ever RAISES
+// the budget, so an override that does not exceed base (stale/smaller, or left
+// by a different workflow that reused the node ID) is ignored, as is one past
+// the ceiling (corruption). Overrides are scoped per working dir + node ID.
+// Keeps the branch out of buildConfig (already a long flat attr sequence). #318.
 func resolveMaxTurns(workingDir, nodeID string, base int) int {
-	if override := readMaxTurnsOverride(workingDir, nodeID); override > 0 {
-		return override
+	override := readMaxTurnsOverride(workingDir, nodeID)
+	if override <= base || override > maxTurnsOverrideCeiling {
+		return base
 	}
-	return base
+	return override
 }
 
 // safeNodeFilename reports whether nodeID is usable as a single path element —

--- a/pipeline/handlers/codergen_warmturns_test.go
+++ b/pipeline/handlers/codergen_warmturns_test.go
@@ -90,6 +90,55 @@ func TestBuildConfig_EmptyWorkingDirNoOverride(t *testing.T) {
 	}
 }
 
+// TestReadMaxTurnsOverride_RejectsPathTraversal pins that a node ID is never
+// used to traverse out of the override directory or read an arbitrary file: a
+// nodeID containing separators or ".." resolves to no override (0), even when a
+// readable integer file sits at the traversed-to location. Defense-in-depth —
+// the helper is a general working-dir file read, so it fails closed.
+func TestReadMaxTurnsOverride_RejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A valid integer file exactly where "../../../secret" would resolve from
+	// <workdir>/.tracker/turn_overrides — i.e. an escape the guard must block.
+	if err := os.WriteFile(filepath.Join(root, "secret"), []byte("999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, nodeID := range []string{
+		"../../../secret",
+		"..",
+		"sub/Implement",
+	} {
+		if got := readMaxTurnsOverride(workdir, nodeID); got != 0 {
+			t.Errorf("readMaxTurnsOverride(workdir, %q) = %d, want 0 (must not traverse/read outside the override dir)", nodeID, got)
+		}
+	}
+}
+
+// TestReadMaxTurnsOverride_SkipsNonRegularFile pins that a symlink planted where
+// the override file is expected is not followed — only a regular file counts.
+func TestReadMaxTurnsOverride_SkipsNonRegularFile(t *testing.T) {
+	workdir := t.TempDir()
+	dir := filepath.Join(workdir, ".tracker", "turn_overrides")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(workdir, "elsewhere")
+	if err := os.WriteFile(target, []byte("999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "Implement")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	if got := readMaxTurnsOverride(workdir, "Implement"); got != 0 {
+		t.Errorf("readMaxTurnsOverride followed a symlink and returned %d, want 0", got)
+	}
+}
+
 // TestWarmContinue_CarriesBumpedTurnsAndEpisodes pins the #318 acceptance
 // criterion for continue+N: the resumed agent run config carries BOTH a bumped
 // MaxTurns (from the disk override) AND non-empty PriorEpisodeSummaries (warm,

--- a/pipeline/handlers/codergen_warmturns_test.go
+++ b/pipeline/handlers/codergen_warmturns_test.go
@@ -13,10 +13,12 @@ import (
 )
 
 // writeTurnOverride writes a node-scoped warm-continue MaxTurns override file
-// under workingDir, matching the path codergen.buildConfig consults.
+// under workingDir, using the same maxTurnsOverrideSubdir constant buildConfig
+// consults so the test follows the override location if it ever moves. (The
+// build_product.dip tool node writes the literal equivalent of this path.)
 func writeTurnOverride(t *testing.T, workingDir, nodeID, value string) {
 	t.Helper()
-	dir := filepath.Join(workingDir, ".tracker", "turn_overrides")
+	dir := filepath.Join(workingDir, maxTurnsOverrideSubdir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir override dir: %v", err)
 	}
@@ -90,6 +92,36 @@ func TestBuildConfig_EmptyWorkingDirNoOverride(t *testing.T) {
 	}
 }
 
+// TestBuildConfig_OverrideIgnoredWhenNotAnIncrease pins that a warm-continue
+// override only ever RAISES the budget: an override that does not exceed the
+// node's base max_turns (e.g. a stale/smaller value, possibly left by a
+// different workflow that reused the node ID) is ignored.
+func TestBuildConfig_OverrideIgnoredWhenNotAnIncrease(t *testing.T) {
+	workdir := t.TempDir()
+	writeTurnOverride(t, workdir, "Implement", "30") // < base 50
+
+	h := &CodergenHandler{workingDir: workdir}
+	node := &pipeline.Node{ID: "Implement", Attrs: map[string]string{"max_turns": "50"}}
+	if got := h.buildConfig(node).MaxTurns; got != 50 {
+		t.Errorf("MaxTurns = %d, want 50 (a non-increasing override must be ignored)", got)
+	}
+}
+
+// TestBuildConfig_OverrideIgnoredWhenImplausiblyLarge pins that a corrupted or
+// runaway override can't inflate runtime/cost: a value past the ceiling is
+// ignored (BudgetGuard is the global backstop, but one oversized session can
+// still run long).
+func TestBuildConfig_OverrideIgnoredWhenImplausiblyLarge(t *testing.T) {
+	workdir := t.TempDir()
+	writeTurnOverride(t, workdir, "Implement", "999999")
+
+	h := &CodergenHandler{workingDir: workdir}
+	node := &pipeline.Node{ID: "Implement", Attrs: map[string]string{"max_turns": "50"}}
+	if got := h.buildConfig(node).MaxTurns; got != 50 {
+		t.Errorf("MaxTurns = %d, want 50 (an implausibly large override must be ignored)", got)
+	}
+}
+
 // TestReadMaxTurnsOverride_RejectsPathTraversal pins that a node ID is never
 // used to traverse out of the override directory or read an arbitrary file: a
 // nodeID containing separators or ".." resolves to no override (0), even when a
@@ -122,7 +154,7 @@ func TestReadMaxTurnsOverride_RejectsPathTraversal(t *testing.T) {
 // the override file is expected is not followed — only a regular file counts.
 func TestReadMaxTurnsOverride_SkipsNonRegularFile(t *testing.T) {
 	workdir := t.TempDir()
-	dir := filepath.Join(workdir, ".tracker", "turn_overrides")
+	dir := filepath.Join(workdir, maxTurnsOverrideSubdir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}

--- a/pipeline/handlers/codergen_warmturns_test.go
+++ b/pipeline/handlers/codergen_warmturns_test.go
@@ -1,0 +1,136 @@
+// ABOUTME: Tests for #318 warm continue+N MaxTurns override plumbing in codergen.
+// ABOUTME: A disk-driven, node-scoped override lets the operator gate re-enter an
+// ABOUTME: agent node with a bumped turn budget while episode summaries carry warm.
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// writeTurnOverride writes a node-scoped warm-continue MaxTurns override file
+// under workingDir, matching the path codergen.buildConfig consults.
+func writeTurnOverride(t *testing.T, workingDir, nodeID, value string) {
+	t.Helper()
+	dir := filepath.Join(workingDir, ".tracker", "turn_overrides")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir override dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, nodeID), []byte(value), 0o644); err != nil {
+		t.Fatalf("write override file: %v", err)
+	}
+}
+
+// TestBuildConfig_HonorsMaxTurnsOverrideFromDisk pins #318 hazard 2: MaxTurns is
+// read statically today; warm continue+N needs a disk-driven override consulted
+// in buildConfig. A node-scoped override file bumps the agent's turn budget.
+func TestBuildConfig_HonorsMaxTurnsOverrideFromDisk(t *testing.T) {
+	workdir := t.TempDir()
+	writeTurnOverride(t, workdir, "Implement", "130")
+
+	h := &CodergenHandler{workingDir: workdir}
+	node := &pipeline.Node{
+		ID:    "Implement",
+		Attrs: map[string]string{"max_turns": "50"},
+	}
+	config := h.buildConfig(node)
+	if config.MaxTurns != 130 {
+		t.Errorf("MaxTurns = %d, want 130 (disk override should bump the static node value)", config.MaxTurns)
+	}
+}
+
+// TestBuildConfig_OverrideIsNodeScoped pins that the override only applies to the
+// node it names — a sibling agent node sharing the working dir must NOT inherit
+// another node's bumped budget (prevents cross-node turn-budget bleed).
+func TestBuildConfig_OverrideIsNodeScoped(t *testing.T) {
+	workdir := t.TempDir()
+	writeTurnOverride(t, workdir, "Implement", "130")
+
+	h := &CodergenHandler{workingDir: workdir}
+	other := &pipeline.Node{
+		ID:    "FixMilestone",
+		Attrs: map[string]string{"max_turns": "50"},
+	}
+	config := h.buildConfig(other)
+	if config.MaxTurns != 50 {
+		t.Errorf("FixMilestone MaxTurns = %d, want 50 (override for Implement must not bleed)", config.MaxTurns)
+	}
+}
+
+// TestBuildConfig_NoOverrideKeepsNodeMaxTurns pins the no-override default: an
+// agent node with no override file keeps its statically-configured max_turns.
+func TestBuildConfig_NoOverrideKeepsNodeMaxTurns(t *testing.T) {
+	workdir := t.TempDir()
+	h := &CodergenHandler{workingDir: workdir}
+	node := &pipeline.Node{
+		ID:    "Implement",
+		Attrs: map[string]string{"max_turns": "50"},
+	}
+	config := h.buildConfig(node)
+	if config.MaxTurns != 50 {
+		t.Errorf("MaxTurns = %d, want 50 (no override file present)", config.MaxTurns)
+	}
+}
+
+// TestBuildConfig_EmptyWorkingDirNoOverride pins that an unset working dir is a
+// safe no-op (no panic, no stray relative-path read), keeping the node value.
+func TestBuildConfig_EmptyWorkingDirNoOverride(t *testing.T) {
+	h := &CodergenHandler{}
+	node := &pipeline.Node{
+		ID:    "Implement",
+		Attrs: map[string]string{"max_turns": "50"},
+	}
+	config := h.buildConfig(node)
+	if config.MaxTurns != 50 {
+		t.Errorf("MaxTurns = %d, want 50 (empty working dir must not read an override)", config.MaxTurns)
+	}
+}
+
+// TestWarmContinue_CarriesBumpedTurnsAndEpisodes pins the #318 acceptance
+// criterion for continue+N: the resumed agent run config carries BOTH a bumped
+// MaxTurns (from the disk override) AND non-empty PriorEpisodeSummaries (warm,
+// carried via ContextKeyEpisodeSummaries) — i.e. it resumes warm, not cold.
+func TestWarmContinue_CarriesBumpedTurnsAndEpisodes(t *testing.T) {
+	workdir := t.TempDir()
+	writeTurnOverride(t, workdir, "Implement", "130")
+
+	h := NewCodergenHandler(&alwaysToolCallCompleter{}, workdir)
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "build it", "max_turns": "50"},
+	}
+
+	backend, err := h.selectBackend(node)
+	if err != nil {
+		t.Fatalf("selectBackend: %v", err)
+	}
+	runCfg, err := h.buildRunConfig(node, "build it", backend)
+	if err != nil {
+		t.Fatalf("buildRunConfig: %v", err)
+	}
+
+	pctx := pipeline.NewPipelineContext()
+	pctx.Set(pipeline.ContextKeyEpisodeSummaries, agent.SerializeEpisodeSummaries([]string{
+		"episode 1: scaffolded the package",
+		"episode 2: wrote the parser",
+	}))
+	episodes := h.injectPriorEpisodes(runCfg, pctx)
+
+	if runCfg.MaxTurns != 130 {
+		t.Errorf("resumed MaxTurns = %d, want 130 (warm continue must bump the budget)", runCfg.MaxTurns)
+	}
+	if len(episodes) == 0 {
+		t.Error("PriorEpisodeSummaries is empty — continue+N must resume warm, not cold")
+	}
+	sc, ok := runCfg.Extra.(*agent.SessionConfig)
+	if !ok || sc == nil {
+		t.Fatalf("runCfg.Extra is not *agent.SessionConfig: %T", runCfg.Extra)
+	}
+	if len(sc.PriorEpisodeSummaries) == 0 {
+		t.Error("SessionConfig.PriorEpisodeSummaries is empty — warm episodes not injected")
+	}
+}

--- a/pipeline/handlers/operator_decision_default_test.go
+++ b/pipeline/handlers/operator_decision_default_test.go
@@ -1,0 +1,85 @@
+// ABOUTME: Behavioral guard for #318 hazard 1 — an unattended (auto-approve /
+// ABOUTME: webhook) operator-decision gate must resolve to the SAFE default
+// ABOUTME: ("stop"), never silently "continue" past unverified work.
+package handlers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// loadBuildProductGraph loads the shipped build_product.dip into a Graph from the
+// handlers package (examples/ is two levels up from pipeline/handlers).
+func loadBuildProductGraph(t *testing.T) *pipeline.Graph {
+	t.Helper()
+	path := filepath.Join("..", "..", "examples", "build_product.dip")
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	g, _, err := pipeline.LoadDippinWorkflow(string(source), "build_product.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	return g
+}
+
+// TestOperatorDecision_UnattendedResolvesToStop pins that a non-interactive run
+// (AutoApproveFreeformInterviewer — the deterministic --auto-approve / --webhook
+// path) on the real OperatorDecision node resolves to "stop", routing to the
+// escalation gate rather than advancing. This is the end-to-end form of the
+// #318 hazard-1 guard: the freeform `default` attr is honored and never lands on
+// "continue".
+func TestOperatorDecision_UnattendedResolvesToStop(t *testing.T) {
+	g := loadBuildProductGraph(t)
+	node := g.Nodes["OperatorDecision"]
+	if node == nil {
+		t.Fatal("OperatorDecision node missing from build_product.dip (issue #318)")
+	}
+
+	h := NewHumanHandler(&AutoApproveFreeformInterviewer{}, g)
+	out, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if out.PreferredLabel != "stop" {
+		t.Errorf("unattended PreferredLabel = %q, want \"stop\" — auto-approve must take the safe default (issue #318 hazard 1)", out.PreferredLabel)
+	}
+	if out.PreferredLabel == "continue" {
+		t.Fatal("unattended run resolved to \"continue\" — the exact unsafe outcome #318 forbids")
+	}
+}
+
+// TestOperatorDecision_DroppedDefaultStillSafe pins the defense-in-depth ordering:
+// if the `default` attr were ever dropped, the freeform interviewer falls back to
+// the FIRST edge label. That fallback must be a non-advancing option, never
+// "continue" — so the edge order (stop/abandon before continue) fails safe.
+func TestOperatorDecision_DroppedDefaultStillSafe(t *testing.T) {
+	g := loadBuildProductGraph(t)
+	if g.Nodes["OperatorDecision"] == nil {
+		t.Fatal("OperatorDecision node missing from build_product.dip (issue #318)")
+	}
+
+	var labels []string
+	for _, e := range g.OutgoingEdges("OperatorDecision") {
+		if e.Label != "" {
+			labels = append(labels, e.Label)
+		}
+	}
+	if len(labels) == 0 {
+		t.Fatal("OperatorDecision has no labeled edges (issue #318)")
+	}
+
+	// Empty default → AskFreeformWithLabels returns labels[0].
+	fallback, err := (&AutoApproveFreeformInterviewer{}).AskFreeformWithLabels("", labels, "")
+	if err != nil {
+		t.Fatalf("AskFreeformWithLabels: %v", err)
+	}
+	if fallback == "continue" {
+		t.Errorf("dropped-default fallback (labels[0]) = %q — must not be the advancing option; reorder so stop/abandon precede continue (issue #318 hazard 1)", fallback)
+	}
+}

--- a/pipeline/handlers/operator_decision_default_test.go
+++ b/pipeline/handlers/operator_decision_default_test.go
@@ -28,12 +28,17 @@ func loadBuildProductGraph(t *testing.T) *pipeline.Graph {
 	return g
 }
 
-// TestOperatorDecision_UnattendedResolvesToStop pins that a non-interactive run
-// (AutoApproveFreeformInterviewer — the deterministic --auto-approve / --webhook
-// path) on the real OperatorDecision node resolves to "stop", routing to the
-// escalation gate rather than advancing. This is the end-to-end form of the
-// #318 hazard-1 guard: the freeform `default` attr is honored and never lands on
-// "continue".
+// TestOperatorDecision_UnattendedResolvesToStop pins that a non-interactive
+// auto-approve run (AutoApproveFreeformInterviewer) on the real OperatorDecision
+// node resolves to "stop", routing to the escalation gate rather than advancing.
+//
+// NOTE on the mechanism: in freeform mode HumanHandler reads node.Attrs["default"]
+// (NOT default_choice, where dippin's `default:` keyword lands), so for a
+// dippin-authored gate that bare attr is empty and the interviewer falls back to
+// the FIRST labeled edge. The safety here therefore comes from EDGE ORDERING
+// (stop is listed first), not from a freeform `default` attr being honored. The
+// --webhook path is a separate interviewer not exercised here; this test pins the
+// deterministic auto-approve path end-to-end.
 func TestOperatorDecision_UnattendedResolvesToStop(t *testing.T) {
 	g := loadBuildProductGraph(t)
 	node := g.Nodes["OperatorDecision"]


### PR DESCRIPTION
Closes #318 — the deferred PR2 of #303 (epic #308, Phase 1 turn-limit track). PR1 (#317) merged the breach-classification core; this delivers the operator-decision node + warm `continue +N` it split off.

## What

When a **native-backend** turn-limit breach classifies to `operator_decision` (PR1: steady progress, verify ran but **not** green, no loop), the operator now gets a real choice instead of a bare escalation — and unattended runs take a deterministically **safe** default.

In `build_product.dip`, `Implement` routes `when ctx.turn_breach_class = operator_decision` to a new **`OperatorDecision`** gate. It **reuses `wait.human`** (freeform) — **no new handler** — with four labeled edges:

| label | route | meaning |
|---|---|---|
| `stop` *(default)* | `EscalateMilestone` | treat as stuck, preserve work, escalate |
| `abandon` | `Done` | end the run, do not advance |
| `commit_advance` | `CommitIfDirty` | persist the tree via the commit-on-success node, then advance |
| `continue` | `ContinueWithMoreTurns` | warm retry with a bumped turn budget (capped) |

## Hazards handled (from the #303 panel review)

1. **Safe unattended default (CRITICAL).** Pin `default: stop` and order `stop`/`abandon` **before** `continue`. `--auto-approve` / `--webhook-url` resolve to the freeform `labels[0]` fallback (= `stop`); the timeout path resolves `default_choice` (= `stop`). Either way an unattended run **never silently advances unverified work**. `--autopilot lax`/`mentor` are not deterministically safe, so the gate prompt frames `continue` as the risky option. A **pathological** breach still narrowly falls through to the `EscalateMilestone` catch-all.
2. **Warm `continue +N` plumbing.** New node-scoped, disk-driven `MaxTurns` override (`.tracker/turn_overrides/<nodeID>`) consulted in `codergen.buildConfig`. `ContinueWithMoreTurns` bumps `Implement`'s budget (50 → 90/130/170) and re-enters it **warm** — `PriorEpisodeSummaries` carry across for free. `resolveMaxTurns` keeps `buildConfig`'s branch count flat (no complexity regression).
3. **Cap circuit-breaker.** A per-loop disk counter (NOT the global engine `RestartCount`); 3 continues max, then escalate. Counters reset at the milestone boundary (`MarkMilestoneDone`) and in `Cleanup`.
4. **`commitWIPBeforeRouting` bypass.** Documented + tested: `Implement` already carried conditional edges, so the operator route introduces **no new** bypass (and it is a no-op while git-artifacts is off by default). Green work is persisted the way all product persistence works — through the pipeline's own commit node.
5. **dippin.** New cycle + 4-way gate; `dippin validate` clean, `doctor` **A/90** (baseline held), `simulate -all-paths` enumerates the operator cycle and **all paths terminate**.
6. **UX.** Relies on the standard `last_response` append (no inlined breach message in the label) so the gate renders via `ReviewHybridContent`.

## TDD

Failing tests written first, then implementation:
- `codergen_warmturns_test.go` — `buildConfig` honors the disk override (+ node-scoping, no-override defaults); warm continue carries bumped `MaxTurns` **and** non-empty `PriorEpisodeSummaries`.
- `build_product_operator_decision_test.go` — node exists / reached by the `operator_decision` condition; safe default + edge order; four labeled edges each terminate; capped warm-retry loop; pathological still falls through; persists via the commit node.
- `operator_decision_default_test.go` — behavioral guard: `AutoApprove` through `HumanHandler.Execute` resolves to `stop`; dropped-default fallback is never `continue`.

## Verification

- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓ · `go test -race -short ./pipeline/ ./agent/` ✓
- `dippin validate examples/build_product.dip` ✓
- `dippin doctor` on the three core pipelines — A/95, A/90, A/100 ✓
- `dippin simulate -all-paths examples/build_product.dip` — 100 paths, all terminate ✓

## Out of scope

#304 (cost/no-progress detector), #310, #301, #305/#306, #313. No new handler/node type (reuses `wait.human`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)