### PR TITLE
feat(build_product): spec-coherence preflight gate before decomposition (#301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Spec-coherence preflight (`SpecLint`) in both build_product workflows** (closes
+  #301, completing Phase 2 of epic #308). `build_product.dip` and
+  `build_product_with_superspec.dip` previously read SPEC.md and went straight into
+  decomposition — every miss in the audited code-goblin run traced to a SPEC defect
+  the workflow never checked. A new `SpecLint` agent gate now runs ONCE, strictly
+  before any spec read or decomposition (`Setup -> SpecLint`; success continues to
+  `ReadSpec`/`AnalyzeSpec`, fail routes to the existing `EscalateReview`/
+  `EscalateToHuman` human gate — never silently to Done). Critical rules hard-fail
+  the gate: (a) dangling doc/section/file references, (b) the same constant stated
+  two ways ("max 2 retries" vs "max 2 attempts"), (c) interface contracts naming
+  values their signatures never receive, (f) mandated tests too vague for any
+  milestone to own. Rules (d) uncheckable guarantees and (e) example code
+  contradicting declared signatures are warnings. Findings (with grep/file:line
+  evidence) land in `.ai/decisions/spec-quality.md`; the rule-(f) mandated-test list
+  feeds the Decompose requirement-coverage table (#300). The gate fails closed via
+  the `auto_status` last-line-wins STATUS contract (truncation leaves the early
+  `STATUS:fail` standing). Structural regression tests pin the routing
+  (`pipeline/spec_lint_preflight_test.go`); a deliberately-broken SPEC fixture +
+  manual verification procedure live in `pipeline/testdata/spec_lint_broken/`. The
+  node is intentionally duplicated across the two workflows (not a shared subgraph:
+  built-in delivery — embedded runs, library `tracker.Run`, `tracker init` — cannot
+  resolve subgraph file refs); dedup is tracked in #307.
+
 - **`reasoning_effort` wired through to Anthropic and Gemini** (closes #329). The
   unified `reasoning_effort` knob (`.dip` node attr) was only consumed by the OpenAI
   provider; the Anthropic and Gemini translate layers silently dropped it, so

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -422,6 +422,96 @@ workflow BuildProduct
 
       printf 'setup-ready'
 
+  # ─── SpecLint: spec-coherence preflight (issue #301, epic #308 Phase 2) ──
+  #
+  # Runs ONCE, strictly before any spec read or decomposition. Hard-fails the
+  # critical coherence classes (dangling refs, contradictory constants,
+  # contract/signature mismatch, unassignable mandated tests) so no agent
+  # builds on a broken spec. NOTE: this node is intentionally duplicated (not
+  # a shared subgraph) in build_product_with_superspec.dip — built-in delivery
+  # (embedded `tracker run build_product` outside the repo, library
+  # tracker.Run, `tracker init`) cannot resolve subgraph file refs; dedup of
+  # the two copies is tracked in issue #307.
+
+  agent SpecLint
+    label: "Spec Coherence Preflight"
+    model: claude-opus-4-6
+    provider: anthropic
+    reasoning_effort: high
+    auto_status: true
+    prompt:
+      SPEC COHERENCE PREFLIGHT (issue #301):
+
+      STATUS contract — emit `STATUS:fail` as the FIRST line of your
+      response, before any other text. Then run the checks below. Only
+      at the very end, after every CRITICAL check passes, emit a final
+      `STATUS:success` line — alone on its line, outside any code
+      fence — to override the early fail. The workflow's `auto_status`
+      parser is last-line-wins; if your response is truncated for any
+      reason the early `STATUS:fail` remains and the gate fails closed.
+      The STATUS value must be exactly `fail` or `success`, with no
+      trailing prose on that line. Never emit STATUS:retry (this node
+      has no retry route).
+
+      You are a coherence linter for SPEC.md. You are NOT judging
+      whether the spec is good — only whether it is self-consistent
+      and buildable. Do not propose fixes; report findings. Every
+      finding must cite evidence: the SPEC.md line/section PLUS the
+      grep/ls/file check that produced it (file:line where relevant).
+
+      Run these checks across the entire SPEC.md:
+
+      CRITICAL — any finding fails the gate:
+      (a) Self-contained: every doc, file, or section SPEC.md
+          references must exist. For each reference (a "see PLAN.md",
+          a named section, a file path), verify with ls/grep that the
+          target exists in the repo or within SPEC.md itself. A
+          dangling reference means downstream agents will INVENT the
+          missing content.
+      (b) Single-source constants: every numeric or named parameter
+          must be stated exactly one way. grep SPEC.md for each
+          constant it declares (retry counts, timeouts, limits,
+          sizes) and flag any restatement that differs — "max 2
+          retries" in one section vs "max 2 attempts" in another is
+          how an off-by-one ships.
+      (c) Contract/signature coherence: for every interface or
+          function whose contract names a value (an input it derives
+          from, a header it computes, an error it returns), check
+          that the declared signature actually receives/produces that
+          value. A contract like "Idempotency-Key derived from
+          review_id+sha" on a signature receiving neither is
+          unimplementable as written.
+      (f) Mandated tests enumerated and assignable: list every test
+          SPEC.md mandates by name or by concrete behavior. This list
+          feeds the Decompose requirement-coverage table (issue
+          #300); a mandated test so vague no milestone could own it
+          is a finding.
+
+      WARN — report in the artifact, do NOT fail the gate:
+      (d) Checkable guarantees: behavioral guarantees phrased so they
+          can never become an assertion or a named test.
+      (e) Example code coherence: example code that does not parse
+          against the signatures the spec itself declares (e.g. shown
+          returning `string` where declared `(string, error)`),
+          unless explicitly marked illustrative.
+
+      Write .ai/decisions/spec-quality.md with exactly these sections:
+      ## Critical findings
+      One entry per finding: rule letter, SPEC.md line/section,
+      evidence, one line on why it blocks the build — or "none".
+      ## Warnings
+      Rule (d)/(e) findings, same evidence shape — or "none".
+      ## Mandated tests
+      Every rule-(f) test, one per line, each with its SPEC.md
+      source — or the single line "SPEC mandates no named tests".
+
+      Then your terminal STATUS line:
+      - zero critical findings -> STATUS:success (warnings alone never
+        fail the gate)
+      - any critical finding -> leave the early STATUS:fail standing
+        as the last line. The fail edge routes to a human who fixes
+        the spec — never paper over a finding to keep the build going.
+
   agent ReadSpec
     label: "Read & Analyze Spec"
     model: claude-opus-4-6
@@ -507,7 +597,10 @@ workflow BuildProduct
          threshold are NOT mandated — do not list them. State how many you
          found; if none, write the line: SPEC mandates no named
          verifications (never leave the table silently empty — a silent
-         empty table hides under-extraction). Table columns:
+         empty table hides under-extraction). Cross-check against the
+         "Mandated tests" section of .ai/decisions/spec-quality.md
+         (written by the SpecLint preflight, issue #301): every test
+         listed there must appear in this table. Table columns:
            | Mandated verification | SPEC.md source (line/section) | Owning milestone |
 
       2. THEN decompose into milestones as the rules above describe.
@@ -1809,7 +1902,11 @@ workflow BuildProduct
 
   edges
     Start -> Setup
-    Setup -> ReadSpec
+    Setup -> SpecLint
+    # Spec-coherence preflight (#301): success/fail conditions are exhaustive —
+    # no unconditional fallback (it would race the conditional edges).
+    SpecLint -> ReadSpec  when ctx.outcome = success
+    SpecLint -> EscalateReview  when ctx.outcome = fail
     ReadSpec -> Decompose  when ctx.outcome = success
     ReadSpec -> EscalateReview  when ctx.outcome = fail
     Decompose -> ApprovePlan  when ctx.outcome = success

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -39,6 +39,96 @@ workflow BuildProductWithSuperspec
       fi
       printf 'setup-ready'
 
+  # ─── SpecLint: spec-coherence preflight (issue #301, epic #308 Phase 2) ──
+  #
+  # Runs ONCE, strictly before any spec read or decomposition. Hard-fails the
+  # critical coherence classes (dangling refs, contradictory constants,
+  # contract/signature mismatch, unassignable mandated tests) so no agent
+  # builds on a broken spec. NOTE: this node is an intentional duplicate of
+  # the SpecLint node in build_product.dip (not a shared subgraph) — built-in delivery
+  # (embedded `tracker run build_product` outside the repo, library
+  # tracker.Run, `tracker init`) cannot resolve subgraph file refs; dedup of
+  # the two copies is tracked in issue #307.
+
+  agent SpecLint
+    label: "Spec Coherence Preflight"
+    model: claude-opus-4-6
+    provider: anthropic
+    reasoning_effort: high
+    auto_status: true
+    prompt:
+      SPEC COHERENCE PREFLIGHT (issue #301):
+
+      STATUS contract — emit `STATUS:fail` as the FIRST line of your
+      response, before any other text. Then run the checks below. Only
+      at the very end, after every CRITICAL check passes, emit a final
+      `STATUS:success` line — alone on its line, outside any code
+      fence — to override the early fail. The workflow's `auto_status`
+      parser is last-line-wins; if your response is truncated for any
+      reason the early `STATUS:fail` remains and the gate fails closed.
+      The STATUS value must be exactly `fail` or `success`, with no
+      trailing prose on that line. Never emit STATUS:retry (this node
+      has no retry route).
+
+      You are a coherence linter for SPEC.md. You are NOT judging
+      whether the spec is good — only whether it is self-consistent
+      and buildable. Do not propose fixes; report findings. Every
+      finding must cite evidence: the SPEC.md line/section PLUS the
+      grep/ls/file check that produced it (file:line where relevant).
+
+      Run these checks across the entire SPEC.md:
+
+      CRITICAL — any finding fails the gate:
+      (a) Self-contained: every doc, file, or section SPEC.md
+          references must exist. For each reference (a "see PLAN.md",
+          a named section, a file path), verify with ls/grep that the
+          target exists in the repo or within SPEC.md itself. A
+          dangling reference means downstream agents will INVENT the
+          missing content.
+      (b) Single-source constants: every numeric or named parameter
+          must be stated exactly one way. grep SPEC.md for each
+          constant it declares (retry counts, timeouts, limits,
+          sizes) and flag any restatement that differs — "max 2
+          retries" in one section vs "max 2 attempts" in another is
+          how an off-by-one ships.
+      (c) Contract/signature coherence: for every interface or
+          function whose contract names a value (an input it derives
+          from, a header it computes, an error it returns), check
+          that the declared signature actually receives/produces that
+          value. A contract like "Idempotency-Key derived from
+          review_id+sha" on a signature receiving neither is
+          unimplementable as written.
+      (f) Mandated tests enumerated and assignable: list every test
+          SPEC.md mandates by name or by concrete behavior. This list
+          feeds the Decompose requirement-coverage table (issue
+          #300); a mandated test so vague no milestone could own it
+          is a finding.
+
+      WARN — report in the artifact, do NOT fail the gate:
+      (d) Checkable guarantees: behavioral guarantees phrased so they
+          can never become an assertion or a named test.
+      (e) Example code coherence: example code that does not parse
+          against the signatures the spec itself declares (e.g. shown
+          returning `string` where declared `(string, error)`),
+          unless explicitly marked illustrative.
+
+      Write .ai/decisions/spec-quality.md with exactly these sections:
+      ## Critical findings
+      One entry per finding: rule letter, SPEC.md line/section,
+      evidence, one line on why it blocks the build — or "none".
+      ## Warnings
+      Rule (d)/(e) findings, same evidence shape — or "none".
+      ## Mandated tests
+      Every rule-(f) test, one per line, each with its SPEC.md
+      source — or the single line "SPEC mandates no named tests".
+
+      Then your terminal STATUS line:
+      - zero critical findings -> STATUS:success (warnings alone never
+        fail the gate)
+      - any critical finding -> leave the early STATUS:fail standing
+        as the last line. The fail edge routes to a human who fixes
+        the spec — never paper over a finding to keep the build going.
+
   agent AnalyzeSpec
     label: "Analyze Spec Structure"
     model: claude-opus-4-6
@@ -938,7 +1028,13 @@ workflow BuildProductWithSuperspec
 
   edges
     Start -> Setup
-    Setup -> AnalyzeSpec
+    Setup -> SpecLint
+    # Spec-coherence preflight (#301): the fail edge is explicit — a node with a
+    # conditional success edge does NOT fall through to the graph-level
+    # on_failure cascade for an unmatched fail outcome. Conditions are
+    # exhaustive; no unconditional fallback (it would race the conditionals).
+    SpecLint -> AnalyzeSpec  when ctx.outcome = success
+    SpecLint -> EscalateToHuman  when ctx.outcome = fail
     AnalyzeSpec -> BuildPlan
     BuildPlan -> ApprovePlan
     ApprovePlan -> SetupPhase1Worktrees  label: "approve"

--- a/pipeline/spec_lint_preflight_test.go
+++ b/pipeline/spec_lint_preflight_test.go
@@ -1,0 +1,133 @@
+// ABOUTME: Regression guard for issue #301 — both shipped build_product workflows must
+// ABOUTME: run the SpecLint coherence preflight strictly before any decomposition node.
+package pipeline
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// loadBuildProductSuperspec loads examples/build_product_with_superspec.dip the
+// same way the binary embeds it. Mirrors loadBuildProduct.
+func loadBuildProductSuperspec(t *testing.T) *Graph {
+	t.Helper()
+	path := filepath.Join("..", "examples", "build_product_with_superspec.dip")
+	source, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	g, _, err := LoadDippinWorkflow(string(source), "build_product_with_superspec.dip")
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+	return g
+}
+
+// reachesNodeAvoiding reports whether target is reachable from start without
+// traversing the blocked node. Used to assert SpecLint is an unavoidable gate:
+// if decomposition is reachable while SpecLint is blocked, a bypass path exists.
+func reachesNodeAvoiding(g *Graph, start, target, blocked string) bool {
+	visited := map[string]bool{}
+	stack := []string{start}
+	for len(stack) > 0 {
+		cur := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if cur == blocked {
+			continue
+		}
+		if cur == target {
+			return true
+		}
+		if visited[cur] {
+			continue
+		}
+		visited[cur] = true
+		for _, e := range g.OutgoingEdges(cur) {
+			stack = append(stack, e.To)
+		}
+	}
+	return false
+}
+
+// assertSpecLintGate pins the issue #301 invariants shared by both workflows:
+// the SpecLint agent node sits on the Setup edge, routes success/fail
+// exhaustively (no unconditional fallback — see CLAUDE.md edge-routing rules),
+// fails closed via auto_status, and writes the spec-quality decision artifact.
+func assertSpecLintGate(t *testing.T, g *Graph, successTarget, escalateTarget string) {
+	t.Helper()
+
+	n, ok := g.Nodes["SpecLint"]
+	if !ok {
+		t.Fatal("SpecLint node missing (issue #301 spec-coherence preflight)")
+	}
+	if n.Handler != "codergen" {
+		t.Errorf("SpecLint handler = %q, want codergen (LLM agent gate, not a shell linter)", n.Handler)
+	}
+	if n.Attrs["auto_status"] != "true" {
+		t.Error("SpecLint must set auto_status: true — without it the fail edge is dead (agent outcome is always success)")
+	}
+	if !strings.Contains(n.Attrs["prompt"], ".ai/decisions/spec-quality.md") {
+		t.Error("SpecLint prompt must write the .ai/decisions/spec-quality.md artifact (issue #301 AC)")
+	}
+	if !strings.Contains(n.Attrs["prompt"], "STATUS:fail") {
+		t.Error("SpecLint prompt must carry the fail-closed STATUS contract (STATUS:fail first line, last-line-wins override)")
+	}
+
+	if !hasUnconditionalEdgeTo(g, "Setup", "SpecLint") {
+		t.Error("Setup must route to SpecLint (the preflight runs before any spec read/decomposition)")
+	}
+	if hasEdgeTo(g, "Setup", successTarget) {
+		t.Errorf("Setup still routes directly to %s, bypassing SpecLint", successTarget)
+	}
+	if !hasEdgeWithCondition(g, "SpecLint", successTarget, "ctx.outcome = success") {
+		t.Errorf("SpecLint must continue to %s only when ctx.outcome = success", successTarget)
+	}
+	if !hasEdgeWithCondition(g, "SpecLint", escalateTarget, "ctx.outcome = fail") {
+		t.Errorf("SpecLint must route ctx.outcome = fail to %s (human fixes the spec; never silently to Done)", escalateTarget)
+	}
+	for _, e := range g.OutgoingEdges("SpecLint") {
+		if e.Condition == "" {
+			t.Errorf("SpecLint has an unconditional edge to %q — success/fail conditions are exhaustive, a fallback risks loops", e.To)
+		}
+	}
+}
+
+// TestBuildProductSpecLintPreflight pins SpecLint's placement and routing in
+// build_product.dip: Setup -> SpecLint -> ReadSpec (success) / EscalateReview (fail).
+func TestBuildProductSpecLintPreflight(t *testing.T) {
+	g := loadBuildProduct(t)
+	assertSpecLintGate(t, g, "ReadSpec", "EscalateReview")
+}
+
+// TestBuildProductSpecLintGatesDecomposition asserts ReadSpec and Decompose are
+// unreachable from Setup without traversing SpecLint — no bypass path may let
+// an agent build on an unchecked spec.
+func TestBuildProductSpecLintGatesDecomposition(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, target := range []string{"ReadSpec", "Decompose"} {
+		if reachesNodeAvoiding(g, "Setup", target, "SpecLint") {
+			t.Errorf("%s is reachable from Setup without passing SpecLint (issue #301: preflight must gate all decomposition)", target)
+		}
+	}
+}
+
+// TestSuperspecSpecLintPreflight pins the same gate in
+// build_product_with_superspec.dip: Setup -> SpecLint -> AnalyzeSpec (success) /
+// EscalateToHuman (fail). The fail edge must be explicit — a node with a
+// conditional success edge does not fall through to the graph-level on_failure
+// cascade for an unmatched fail outcome.
+func TestSuperspecSpecLintPreflight(t *testing.T) {
+	g := loadBuildProductSuperspec(t)
+	assertSpecLintGate(t, g, "AnalyzeSpec", "EscalateToHuman")
+}
+
+// TestSuperspecSpecLintGatesDecomposition asserts AnalyzeSpec is unreachable
+// from Setup without traversing SpecLint in the superspec workflow.
+func TestSuperspecSpecLintGatesDecomposition(t *testing.T) {
+	g := loadBuildProductSuperspec(t)
+	if reachesNodeAvoiding(g, "Setup", "AnalyzeSpec", "SpecLint") {
+		t.Error("AnalyzeSpec is reachable from Setup without passing SpecLint (issue #301: preflight must gate all decomposition)")
+	}
+}

--- a/pipeline/testdata/spec_lint_broken/README.md
+++ b/pipeline/testdata/spec_lint_broken/README.md
@@ -1,0 +1,43 @@
+# SpecLint manual verification fixture (issue #301)
+
+`SPEC.md` in this directory is deliberately broken — one defect per
+SpecLint rule. The Go tests (`pipeline/spec_lint_preflight_test.go`)
+pin the graph structure and routing only; the LLM's judgment (does it
+actually catch these defects?) is non-deterministic and cannot be a
+`go test`. Verify it manually after any change to the SpecLint prompt:
+
+## Path enumeration (deterministic, no LLM)
+
+```sh
+dippin simulate -all-paths examples/build_product.dip
+dippin simulate -all-paths examples/build_product_with_superspec.dip
+```
+
+Both must enumerate a `SpecLint -> EscalateReview` (or
+`-> EscalateToHuman`) fail path and a success path toward
+ReadSpec/AnalyzeSpec, and every path must terminate.
+
+## Judgment check (LLM, manual)
+
+```sh
+repo=$(mktemp -d) && cd "$repo" && git init -q
+cp <tracker>/pipeline/testdata/spec_lint_broken/SPEC.md .
+tracker run build_product --auto-approve
+```
+
+Expected: the run stops at the EscalateReview gate without ever
+reaching Decompose, and `.ai/decisions/spec-quality.md` contains:
+
+- **Critical findings**: rule (a) — dangling `PLAN.md` + missing
+  "Shared Contracts" section; rule (b) — "max 2 retries" vs "maximum
+  of 2 attempts total"; rule (c) — Idempotency-Key derived from
+  `review_id + commit_sha` but `Review(ctx, model, envelope)` receives
+  neither.
+- **Warnings**: rule (d) — "fast and robust under load"; rule (e) —
+  `BuildEnvelope` example dropping the `error` return.
+- **Mandated tests**: the synthetic-429 test and the
+  cancel-within-100ms test, each with its SPEC.md source.
+
+Counter-check: run the same command against a repo with a coherent
+SPEC.md — the run must pass straight through SpecLint into ReadSpec
+with `## Critical findings` = none.

--- a/pipeline/testdata/spec_lint_broken/SPEC.md
+++ b/pipeline/testdata/spec_lint_broken/SPEC.md
@@ -1,0 +1,76 @@
+# SPEC: Review Envelope Service
+
+A deliberately-broken spec fixture for the SpecLint coherence preflight
+(issue #301). Each defect below maps to a SpecLint rule; see README.md
+for the manual verification procedure. Do NOT fix these defects.
+
+## Overview
+
+Build a service that wraps code-review results in signed envelopes and
+submits them to the upstream API. The milestone breakdown lives in
+PLAN.md, and the field layouts are defined in the Shared Contracts
+section below.
+
+<!-- Rule (a) violations: PLAN.md does not exist, and there is no
+     "Shared Contracts" section anywhere in this file. -->
+
+## Retry policy
+
+Submission uses max 2 retries with exponential backoff starting at
+250ms.
+
+If the upstream returns 429, the client backs off and tries again, up
+to a maximum of 2 attempts total.
+
+<!-- Rule (b) violation: "max 2 retries" (3 calls) vs "maximum of 2
+     attempts total" (2 calls) — the same constant stated two ways. -->
+
+## Idempotency
+
+Every submission MUST carry an `Idempotency-Key` header derived from
+`review_id + commit_sha`.
+
+```go
+// Declared interface
+type Submitter interface {
+    Review(ctx context.Context, model string, envelope Envelope) error
+}
+```
+
+<!-- Rule (c) violation: the contract derives the key from review_id +
+     commit_sha, but Review's signature receives neither. -->
+
+## Envelope construction
+
+```go
+// Example usage — BuildEnvelope is declared in the API section below as:
+//   func BuildEnvelope(payload []byte) (string, error)
+key := BuildEnvelope(payload)
+submit(key)
+```
+
+<!-- Rule (e) violation (warn): example calls BuildEnvelope as if it
+     returned a single string; the declared signature is (string, error). -->
+
+## API
+
+```go
+func BuildEnvelope(payload []byte) (string, error)
+```
+
+## Quality requirements
+
+The service must be fast and robust under load.
+
+<!-- Rule (d) violation (warn): no checkable threshold — can never
+     become an assertion or a named test. -->
+
+## Mandated tests
+
+- A synthetic-429 test MUST verify the retry/backoff path.
+- A cancellation test MUST verify the client aborts within 100ms of
+  context cancellation.
+
+<!-- Rule (f): these two tests must be enumerated in the "Mandated
+     tests" section of .ai/decisions/spec-quality.md so the Decompose
+     requirement-coverage table (issue #300) can own them. -->


### PR DESCRIPTION
## Summary

Adds a `SpecLint` agent gate to **both** `build_product.dip` and `build_product_with_superspec.dip` that runs once, strictly before any spec read or decomposition (closes #301 — the last Phase-2 item of epic #308).

- **Routing**: `Setup -> SpecLint`; `SpecLint -> ReadSpec`/`AnalyzeSpec when ctx.outcome = success`; `SpecLint -> EscalateReview`/`EscalateToHuman when ctx.outcome = fail`. Conditions are exhaustive — no unconditional fallback. The superspec fail edge is explicit (a conditional-success node does not fall through to the graph `on_failure` cascade).
- **Rules** (from #301): (a) dangling doc/section/file references, (b) same constant stated two ways, (c) contracts naming values their signatures never receive, (f) mandated tests unenumerable/unassignable → **critical fail**; (d) uncheckable guarantees, (e) example code contradicting declared signatures → **warn**. Findings with grep/file:line evidence go to `.ai/decisions/spec-quality.md`; the rule-(f) list feeds the Decompose requirement-coverage table (#300 pairing — Decompose's coverage step now cross-checks it).
- **Fails closed**: `auto_status` last-line-wins STATUS contract (early `STATUS:fail`, terminal `STATUS:success` override), mirroring `FinalSpecCheck`.

## Design decision surfaced: per-file node, not a shared subgraph (AC deviation)

#301's AC asks for the preflight to be "reused (not copy-pasted) by both workflows" — i.e. a shared subgraph. I spiked that (single-node child with `start`/`exit` = SpecLint propagates child `EngineResult.Status = fail` to the parent fail outcome cleanly; `dippin validate/simulate/doctor` all handle it), **but a subgraph ref breaks build_product's built-in delivery**:

1. **Embedded runs**: `cmd/tracker/run.go` resolves subgraph refs via `resolveSubgraphPath` (filesystem `os.Stat` only) — `tracker run build_product` from any CWD outside this repo would fail at load.
2. **Library API**: the `tracker.Run`/`NewEngine` path has no subgraph wiring at all (no `WithSubgraphs` anywhere in `tracker.go`).
3. **`tracker init build_product`** copies exactly one file — the copied parent would reference a child that wasn't copied.

Fixing all three (embed-FS resolution, library subgraph loading, multi-file init) is loader infrastructure work well beyond #301's ".dip edits" scope. The node is therefore an **intentional byte-identical duplicate** in both files, each copy carrying a comment cross-referencing #307 (whose scope already includes "backport preflight" + examples dedup) as the dedup home.

## Tests

- `pipeline/spec_lint_preflight_test.go` (TDD, red-first): node existence/`auto_status`/artifact+STATUS contract in the prompt; exact edge conditions; **no bypass** — `ReadSpec`/`Decompose`/`AnalyzeSpec` unreachable from `Setup` without traversing SpecLint (BFS with the gate blocked).
- LLM judgment is non-deterministic and can't be a `go test`: `pipeline/testdata/spec_lint_broken/` has a deliberately-broken SPEC fixture (dangling `PLAN.md`, "max 2 retries" vs "maximum of 2 attempts", Idempotency-Key contract vs `Review(ctx, model, envelope)`, `BuildEnvelope` example dropping `error`, two mandated tests) plus the documented manual `tracker run` procedure and expected findings.

## Verification

- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓ · `go test -race -short ./pipeline/` ✓
- `dippin validate` both workflows ✓
- `dippin doctor`: ask_and_execute A/95, build_product **A/90** (baseline held), superspec **A/100** (baseline held); 0 errors, all nodes reachable, all paths terminate ✓
- `dippin simulate -all-paths` both workflows: SpecLint on every enumerated path, every path terminates ✓
- CHANGELOG.md updated under [Unreleased]/Added ✓

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783698136&installation_id=131176874&pr_number=334&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F334&signature=05086869ca60ee3db10e8deda45240c7b7627b5c7585bcb5292acbf646d401cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced SpecLint, a preflight quality gate that validates SPEC document coherence before processing, checking for dangling references, contract mismatches, and test consistency.
  * SpecLint generates a spec-quality report and routes workflows conditionally based on pass/fail status.

* **Tests**
  * Added regression tests to verify SpecLint placement and workflow routing.
  * Added test fixture with intentionally broken SPEC documentation for gate validation.

* **Documentation**
  * Updated CHANGELOG and added fixture documentation for manual verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->