### PR TITLE
fix(engine): resolve file directives when loading raw .dip files (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Raw `.dip` load path now resolves `command_file:` / `prompt_file:` /
+  `system_prompt_file:` directives** (closes #331). `LoadDippinWorkflow` parsed
+  the source but never called dippin's `parser.ResolveFileDirectives`, so any
+  tool node using `command_file:` arrived with an empty command and the run
+  failed at that node with `missing required attribute 'tool_command'` — while
+  the same workflow packed to `.dipx` worked. Directive paths now resolve
+  relative to the `.dip` file's own directory (matching the dippin CLI), so
+  multi-file workflow trees like dev_loop run via `tracker /path/to/foo.dip`
+  from any cwd. Resolution failures are fatal and name the node ID and the
+  referenced path. A guard test keeps embedded built-ins free of file
+  directives (no sibling files ship in the binary).
+
 ## [0.36.0] - 2026-06-10
 
 ### Added

--- a/pipeline/dippin_load.go
+++ b/pipeline/dippin_load.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/2389-research/dippin-lang/ir"
 	"github.com/2389-research/dippin-lang/parser"
@@ -12,13 +13,26 @@ import (
 // LoadDippinWorkflowFromIR for validation, lint, and conversion to a Graph.
 // This ensures all .dip entry points apply consistent validation semantics.
 //
-// filename is used for error messages (e.g., "inline.dip" or "/path/to/file.dip").
+// filename is used for error messages (e.g., "inline.dip" or "/path/to/file.dip")
+// and as the anchor for file directives: command_file / prompt_file /
+// system_prompt_file paths resolve relative to filepath.Dir(filename), matching
+// the dippin CLI. For synthetic filenames like "inline.dip" the anchor is "."
+// (cwd-relative) — the same semantics as `dippin check inline.dip` run from cwd.
+// A directive resolution failure (missing/unreadable file, path escape) is fatal.
+//
 // Returns the graph and any validation/lint diagnostics (warnings only).
 // Validation errors are returned as fatal errors.
 func LoadDippinWorkflow(source, filename string) (*Graph, []validator.Diagnostic, error) {
 	workflow, err := parser.NewParser(source, filename).Parse()
 	if err != nil {
 		return nil, nil, fmt.Errorf("parse Dippin file: %w", err)
+	}
+	// Parser entry points deliberately do not resolve file directives
+	// ("CLI entry points call it after parsing") — tracker is a CLI entry
+	// point, so resolve here. dippin's error already names the node ID,
+	// directive, and user-written path.
+	if err := parser.ResolveFileDirectives(workflow, filepath.Dir(filename)); err != nil {
+		return nil, nil, fmt.Errorf("resolve file directives in %s: %w", filename, err)
 	}
 	return LoadDippinWorkflowFromIR(workflow, filename)
 }

--- a/pipeline/dippin_load_test.go
+++ b/pipeline/dippin_load_test.go
@@ -3,6 +3,8 @@
 package pipeline
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -45,6 +47,77 @@ func TestLoadDippinWorkflowFromIR_ProducesSameGraphAsLoadDippinWorkflow(t *testi
 	}
 	if !graphViaIR.DippinValidated {
 		t.Errorf("IR path did not mark DippinValidated")
+	}
+}
+
+// loadFileDirectivesFixture reads a fixture .dip under testdata/filedirectives
+// and returns (source, absolute filename). Absolute so resolution must anchor
+// on the .dip's own directory, never the test process cwd.
+func loadFileDirectivesFixture(t *testing.T, name string) (string, string) {
+	t.Helper()
+	abs, err := filepath.Abs(filepath.Join("testdata", "filedirectives", name))
+	if err != nil {
+		t.Fatalf("Abs: %v", err)
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	return string(data), abs
+}
+
+func TestLoadDippinWorkflow_ResolvesCommandFileAndPromptFile(t *testing.T) {
+	source, filename := loadFileDirectivesFixture(t, "workflow.dip")
+
+	graph, _, err := LoadDippinWorkflow(source, filename)
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow: %v", err)
+	}
+
+	tool := graph.Nodes["RunScript"]
+	if tool == nil {
+		t.Fatal("node RunScript missing from graph")
+	}
+	if got := tool.Attrs["tool_command"]; !strings.Contains(got, "command from file directive fixture") {
+		t.Errorf("tool_command not resolved from command_file; got %q", got)
+	}
+
+	start := graph.Nodes["Start"]
+	if start == nil {
+		t.Fatal("node Start missing from graph")
+	}
+	if got := start.Attrs["prompt"]; !strings.Contains(got, "prompt from file directive fixture") {
+		t.Errorf("prompt not resolved from prompt_file; got %q", got)
+	}
+}
+
+func TestLoadDippinWorkflow_ResolvesRelativeToFileDirNotCwd(t *testing.T) {
+	source, filename := loadFileDirectivesFixture(t, "workflow.dip")
+
+	// Change to an unrelated cwd: resolution must anchor on the .dip's dir.
+	t.Chdir(t.TempDir())
+
+	graph, _, err := LoadDippinWorkflow(source, filename)
+	if err != nil {
+		t.Fatalf("LoadDippinWorkflow from foreign cwd: %v", err)
+	}
+	if got := graph.Nodes["RunScript"].Attrs["tool_command"]; !strings.Contains(got, "command from file directive fixture") {
+		t.Errorf("tool_command not resolved from foreign cwd; got %q", got)
+	}
+}
+
+func TestLoadDippinWorkflow_MissingDirectiveFileFailsLoudly(t *testing.T) {
+	source, filename := loadFileDirectivesFixture(t, "workflow_missing.dip")
+
+	_, _, err := LoadDippinWorkflow(source, filename)
+	if err == nil {
+		t.Fatal("expected error for missing command_file target")
+	}
+	if !strings.Contains(err.Error(), "RunScript") {
+		t.Errorf("error should name the node ID RunScript: %v", err)
+	}
+	if !strings.Contains(err.Error(), "scripts/does_not_exist.sh") {
+		t.Errorf("error should name the referenced path: %v", err)
 	}
 }
 

--- a/pipeline/testdata/filedirectives/prompts/start.md
+++ b/pipeline/testdata/filedirectives/prompts/start.md
@@ -1,0 +1,1 @@
+prompt from file directive fixture

--- a/pipeline/testdata/filedirectives/scripts/cmd.sh
+++ b/pipeline/testdata/filedirectives/scripts/cmd.sh
@@ -1,0 +1,1 @@
+printf 'command from file directive fixture'

--- a/pipeline/testdata/filedirectives/workflow.dip
+++ b/pipeline/testdata/filedirectives/workflow.dip
@@ -1,0 +1,19 @@
+workflow FileDirectives
+  goal: "Fixture for command_file/prompt_file resolution in LoadDippinWorkflow."
+  start: Start
+  exit: Done
+
+  agent Start
+    label: Start
+    prompt_file: prompts/start.md
+
+  tool RunScript
+    label: "Run Script"
+    command_file: scripts/cmd.sh
+
+  agent Done
+    label: Done
+
+  edges
+    Start -> RunScript
+    RunScript -> Done

--- a/pipeline/testdata/filedirectives/workflow_missing.dip
+++ b/pipeline/testdata/filedirectives/workflow_missing.dip
@@ -1,0 +1,18 @@
+workflow FileDirectivesMissing
+  goal: "Fixture: command_file points at a file that does not exist."
+  start: Start
+  exit: Done
+
+  agent Start
+    label: Start
+
+  tool RunScript
+    label: "Run Script"
+    command_file: scripts/does_not_exist.sh
+
+  agent Done
+    label: Done
+
+  edges
+    Start -> RunScript
+    RunScript -> Done

--- a/tracker_workflows_directives_test.go
+++ b/tracker_workflows_directives_test.go
@@ -1,0 +1,48 @@
+// ABOUTME: Guard test — embedded built-in workflows must not use file
+// ABOUTME: directives (command_file etc.); sibling files don't ship in the binary.
+package tracker
+
+import (
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/dippin-lang/parser"
+)
+
+// TestEmbeddedWorkflows_NoFileDirectives keeps embedded built-ins free of
+// command_file / prompt_file / system_prompt_file directives. Embedded
+// workflows have no sibling files at runtime, so a directive would make the
+// built-in unloadable (LoadDippinWorkflow resolves directives relative to the
+// .dip's directory — the same delivery gap as embedded subgraph refs, see the
+// design notes in PR #334). If a built-in needs file content, inline it.
+func TestEmbeddedWorkflows_NoFileDirectives(t *testing.T) {
+	workflows := Workflows()
+	if len(workflows) == 0 {
+		t.Fatal("no embedded workflows found")
+	}
+	for _, info := range workflows {
+		data, _, err := OpenWorkflow(info.Name)
+		if err != nil {
+			t.Fatalf("OpenWorkflow(%q): %v", info.Name, err)
+		}
+		wf, err := parser.NewParser(string(data), info.File).Parse()
+		if err != nil {
+			t.Fatalf("parse embedded workflow %q: %v", info.Name, err)
+		}
+		for _, n := range wf.Nodes {
+			switch cfg := n.Config.(type) {
+			case ir.ToolConfig:
+				if cfg.CommandFile != "" {
+					t.Errorf("workflow %q node %q uses command_file: %q — embedded built-ins must inline content", info.Name, n.ID, cfg.CommandFile)
+				}
+			case ir.AgentConfig:
+				if cfg.PromptFile != "" {
+					t.Errorf("workflow %q node %q uses prompt_file: %q — embedded built-ins must inline content", info.Name, n.ID, cfg.PromptFile)
+				}
+				if cfg.SystemPromptFile != "" {
+					t.Errorf("workflow %q node %q uses system_prompt_file: %q — embedded built-ins must inline content", info.Name, n.ID, cfg.SystemPromptFile)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `LoadDippinWorkflow` now calls `parser.ResolveFileDirectives(workflow, filepath.Dir(filename))` between `Parse` and `LoadDippinWorkflowFromIR`, so `command_file:` / `prompt_file:` / `system_prompt_file:` directives are inlined exactly as the dippin CLI does. Previously any raw `.dip` using `command_file:` failed at the first such node with `missing required attribute 'tool_command'` (the `.dipx` pack path was unaffected and remains untouched — no double resolution).
- Resolution failures are fatal and name the node ID + user-written path (dippin's error carries both; tracker wraps with the filename).
- Synthetic filenames (library API `inline.dip`) anchor on `.` (cwd-relative), matching `dippin check` semantics — documented on the function.
- Guard test: iterates all embedded built-ins and asserts none carry `*_file` directives, since embedded workflows have no sibling files at runtime (same delivery gap as embedded subgraph refs, PR #334 design notes).

Closes #331.

## Test plan

- [x] TDD: all three new tests watched RED first (`tool_command`/`prompt` empty, missing-file load succeeded), then GREEN after the fix
  - resolves `command_file:` + `prompt_file:` from a testdata workflow tree
  - resolves from a foreign cwd (anchor is the `.dip`'s dir, not cwd)
  - missing referenced file fails loudly with node ID + attempted path
- [x] `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go test ./... -short` — all pass
- [x] `go test -race -short ./pipeline/...` — pass
- [x] `dippin doctor` baselines held: ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783702952&installation_id=131176874&pr_number=337&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F337&signature=6cdf886a1d4aecad9d64491233f885259affdf70e565da3eaef4116392f7badb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->