### PR TITLE
feat(engine): seed graph.workflow_dir from .dip parent path (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`graph.workflow_dir` is seeded from the `.dip` file's parent directory**
-  (closes #332). When a pipeline loads from a real on-disk `.dip` path (via
-  `tracker run` / `validate`, including subgraph refs — each subgraph gets its
-  own dir), the loader sets `graph.Attrs["workflow_dir"]` to the absolute
+- **`graph.workflow_dir` is seeded from the pipeline file's parent directory**
+  (closes #332). When a pipeline loads from a real on-disk path — `.dip` or
+  legacy `.dot` — (via `tracker run` / `validate`, including subgraph refs;
+  each subgraph gets its own dir), the loader sets
+  `graph.Attrs["workflow_dir"]` to the absolute
   parent directory, so authors can reference sibling files from any cwd:
   `command: bash ${graph.workflow_dir}/scripts/setup.sh`. `graph.*` is
   author-controlled and already allowlisted in tool_command interpolation; the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`graph.workflow_dir` is seeded from the `.dip` file's parent directory**
+  (closes #332). When a pipeline loads from a real on-disk `.dip` path (via
+  `tracker run` / `validate`, including subgraph refs — each subgraph gets its
+  own dir), the loader sets `graph.Attrs["workflow_dir"]` to the absolute
+  parent directory, so authors can reference sibling files from any cwd:
+  `command: bash ${graph.workflow_dir}/scripts/setup.sh`. `graph.*` is
+  author-controlled and already allowlisted in tool_command interpolation; the
+  seeded value is a literal path and is never re-scanned (single-pass
+  expansion). Not seeded for embedded built-ins, `.dipx` bundles
+  (content-addressed, no stable dir), or library callers passing synthetic
+  sources — there the absent attr expands to empty string under the existing
+  lenient-expansion semantics. An author-declared `workflow_dir` attr is never
+  clobbered.
+
 ### Fixed
 
 - **`exec *` denylist no longer false-positives on fd-only redirect

--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -45,14 +45,43 @@ func loadPipeline(filename, formatOverride string) (*pipeline.Graph, error) {
 		return nil, fmt.Errorf("read pipeline file: %w", err)
 	}
 
+	var graph *pipeline.Graph
 	switch format {
 	case "dip":
-		return loadDippinPipeline(string(fileBytes), filename)
+		graph, err = loadDippinPipeline(string(fileBytes), filename)
 	case "dot":
-		return pipeline.ParseDOT(string(fileBytes))
+		graph, err = pipeline.ParseDOT(string(fileBytes))
 	default:
 		return nil, fmt.Errorf("unknown pipeline format: %q (valid: dip, dot)", format)
 	}
+	if err != nil {
+		return nil, err
+	}
+	seedWorkflowDir(graph, filename)
+	return graph, nil
+}
+
+// seedWorkflowDir sets graph.Attrs["workflow_dir"] to the absolute parent
+// directory of the pipeline file, so authors can reference sibling files via
+// ${graph.workflow_dir} in prompts and tool_commands (#332). The seeded value
+// is a literal path — variable expansion is single-pass, so it is never
+// re-scanned. No-op if the attr is already set (an author-declared value
+// wins) or if the path can't be made absolute.
+//
+// Only the raw on-disk load path (loadPipeline) seeds this: embedded
+// built-ins, .dipx bundles (content-addressed, no stable dir), and library
+// callers passing synthetic sources have no real workflow directory, and an
+// absent attr expands to empty string under the existing lenient-expansion
+// semantics.
+func seedWorkflowDir(graph *pipeline.Graph, filename string) {
+	if graph.Attrs["workflow_dir"] != "" {
+		return
+	}
+	abs, err := filepath.Abs(filename)
+	if err != nil {
+		return
+	}
+	graph.Attrs["workflow_dir"] = filepath.Dir(abs)
 }
 
 // emitDOTDeprecationWarning prints a one-line warning that DOT is deprecated.

--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -65,8 +65,9 @@ func loadPipeline(filename, formatOverride string) (*pipeline.Graph, error) {
 // directory of the pipeline file, so authors can reference sibling files via
 // ${graph.workflow_dir} in prompts and tool_commands (#332). The seeded value
 // is a literal path — variable expansion is single-pass, so it is never
-// re-scanned. No-op if the attr is already set (an author-declared value
-// wins) or if the path can't be made absolute.
+// re-scanned. No-op if the attr is already present (an author-declared value
+// wins — including an explicit empty one, which ParseDOT can carry from a
+// .dot graph attr) or if the path can't be made absolute.
 //
 // Only the raw on-disk load path (loadPipeline) seeds this: embedded
 // built-ins, .dipx bundles (content-addressed, no stable dir), and library
@@ -74,7 +75,7 @@ func loadPipeline(filename, formatOverride string) (*pipeline.Graph, error) {
 // absent attr expands to empty string under the existing lenient-expansion
 // semantics.
 func seedWorkflowDir(graph *pipeline.Graph, filename string) {
-	if graph.Attrs["workflow_dir"] != "" {
+	if _, ok := graph.Attrs["workflow_dir"]; ok {
 		return
 	}
 	abs, err := filepath.Abs(filename)

--- a/cmd/tracker/loading_workflow_dir_test.go
+++ b/cmd/tracker/loading_workflow_dir_test.go
@@ -87,6 +87,19 @@ func TestSeedWorkflowDir_PreservesExistingValue(t *testing.T) {
 	}
 }
 
+func TestSeedWorkflowDir_PreservesExplicitEmptyValue(t *testing.T) {
+	// ParseDOT copies arbitrary graph attrs, so a .dot author can declare
+	// workflow_dir="" to opt out — presence wins, not non-emptiness.
+	graph := pipeline.NewGraph("test")
+	graph.Attrs["workflow_dir"] = ""
+
+	seedWorkflowDir(graph, "/some/other/place/fixture.dot")
+
+	if got := graph.Attrs["workflow_dir"]; got != "" {
+		t.Errorf("explicit empty workflow_dir clobbered: got %q, want \"\"", got)
+	}
+}
+
 func TestLoadEmbeddedPipeline_DoesNotSeedWorkflowDir(t *testing.T) {
 	_, _, info, err := resolvePipelineSource("build_product")
 	if err != nil {

--- a/cmd/tracker/loading_workflow_dir_test.go
+++ b/cmd/tracker/loading_workflow_dir_test.go
@@ -1,0 +1,102 @@
+// ABOUTME: Tests for graph.workflow_dir seeding when loading raw .dip files.
+// ABOUTME: Embedded built-ins and pre-set values must not be touched.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+const workflowDirFixture = `workflow WorkflowDirFixture
+  start: Start
+  exit: Done
+
+  agent Start
+    label: Start
+
+  tool Echo
+    label: "Echo"
+    command: printf 'dir=${graph.workflow_dir}'
+
+  agent Done
+    label: Done
+
+  edges
+    Start -> Echo
+    Echo -> Done
+`
+
+// writeWorkflowDirFixture writes the fixture .dip into a temp dir and returns
+// its absolute path.
+func writeWorkflowDirFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.dip")
+	if err := os.WriteFile(path, []byte(workflowDirFixture), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return path
+}
+
+func TestLoadPipeline_SeedsWorkflowDirFromForeignCwd(t *testing.T) {
+	path := writeWorkflowDirFixture(t)
+
+	// Load from an unrelated cwd: the attr must be the .dip's parent dir.
+	t.Chdir(t.TempDir())
+
+	graph, err := loadPipeline(path, "")
+	if err != nil {
+		t.Fatalf("loadPipeline: %v", err)
+	}
+	want := filepath.Dir(path)
+	if got := graph.Attrs["workflow_dir"]; got != want {
+		t.Errorf("workflow_dir = %q, want %q", got, want)
+	}
+}
+
+func TestLoadPipeline_SeedsAbsoluteWorkflowDirFromRelativePath(t *testing.T) {
+	path := writeWorkflowDirFixture(t)
+
+	// Load via a relative path: the attr must still be absolute.
+	t.Chdir(filepath.Dir(path))
+
+	graph, err := loadPipeline("fixture.dip", "")
+	if err != nil {
+		t.Fatalf("loadPipeline: %v", err)
+	}
+	got := graph.Attrs["workflow_dir"]
+	if !filepath.IsAbs(got) {
+		t.Errorf("workflow_dir = %q, want an absolute path", got)
+	}
+	if want := filepath.Dir(path); got != want {
+		t.Errorf("workflow_dir = %q, want %q", got, want)
+	}
+}
+
+func TestSeedWorkflowDir_PreservesExistingValue(t *testing.T) {
+	graph := pipeline.NewGraph("test")
+	graph.Attrs["workflow_dir"] = "/author/declared"
+
+	seedWorkflowDir(graph, "/some/other/place/fixture.dip")
+
+	if got := graph.Attrs["workflow_dir"]; got != "/author/declared" {
+		t.Errorf("workflow_dir clobbered: got %q, want %q", got, "/author/declared")
+	}
+}
+
+func TestLoadEmbeddedPipeline_DoesNotSeedWorkflowDir(t *testing.T) {
+	_, _, info, err := resolvePipelineSource("build_product")
+	if err != nil {
+		t.Fatalf("resolvePipelineSource: %v", err)
+	}
+	graph, err := loadEmbeddedPipeline(info)
+	if err != nil {
+		t.Fatalf("loadEmbeddedPipeline: %v", err)
+	}
+	if got, ok := graph.Attrs["workflow_dir"]; ok {
+		t.Errorf("embedded workflow should not carry workflow_dir, got %q", got)
+	}
+}

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -620,6 +620,31 @@ func TestExpandVariables_ToolCommandMode_AllowsGraphAndParams(t *testing.T) {
 	}
 }
 
+func TestExpandVariables_ToolCommandMode_WorkflowDir(t *testing.T) {
+	ctx := NewPipelineContext()
+
+	// Seeded: ${graph.workflow_dir} expands in tool_command mode (graph.* is
+	// author/operator-controlled, on the allowlist).
+	graphAttrs := map[string]string{"workflow_dir": "/abs/path/to/dev_loop"}
+	result, err := ExpandVariables("bash ${graph.workflow_dir}/scripts/setup.sh", ctx, nil, graphAttrs, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "bash /abs/path/to/dev_loop/scripts/setup.sh" {
+		t.Errorf("result = %q", result)
+	}
+
+	// Not seeded (embedded built-in, .dipx, library source): lenient mode
+	// expands the absent key to empty string — pin that semantic.
+	result, err = ExpandVariables("bash ${graph.workflow_dir}/scripts/setup.sh", ctx, nil, map[string]string{}, false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "bash /scripts/setup.sh" {
+		t.Errorf("absent workflow_dir: result = %q, want %q", result, "bash /scripts/setup.sh")
+	}
+}
+
 func TestExpandVariables_NormalMode_AllowsEverything(t *testing.T) {
 	ctx := NewPipelineContext()
 	ctx.Set("last_response", "hello world")

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -631,7 +631,7 @@ func TestExpandVariables_ToolCommandMode_WorkflowDir(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if result != "bash /abs/path/to/dev_loop/scripts/setup.sh" {
-		t.Errorf("result = %q", result)
+		t.Errorf("result = %q, want %q", result, "bash /abs/path/to/dev_loop/scripts/setup.sh")
 	}
 
 	// Not seeded (embedded built-in, .dipx, library source): lenient mode


### PR DESCRIPTION
## Summary

- `loadPipeline` (cmd/tracker/loading.go) now seeds `graph.Attrs["workflow_dir"]` with the absolute parent directory of the pipeline file after a successful raw-file load, so workflow trees with sibling config/scripts/prompts (e.g. dev_loop) can reference them from any cwd: `command: bash ${graph.workflow_dir}/scripts/setup.sh`.
- **Seam choice** (deviation from the issue's `cmd/tracker/run.go` suggestion, as anticipated): `loadPipeline` is the single chokepoint where a raw on-disk pipeline file is read — it covers `tracker run`, `tracker validate`, and recursive subgraph loads (each subgraph gets its own dir, which is the sensible semantic for nested trees). `tracker simulate`'s source-string path (`tracker.ValidateSource`) bypasses it, but simulation never executes tools so the attr has no consumer there.
- Not seeded: embedded built-ins, `.dipx` bundles (content-addressed, no stable dir), library callers with synthetic sources. Absent attr expands to empty string under existing lenient expansion — pinned in a test.
- Author-declared `workflow_dir` is never clobbered (seed only if unset). Seeded value is a literal path, never re-scanned (single-pass expansion). `graph.*` is already on the tool_command interpolation allowlist (author/operator-controlled).

Closes #332.

## Test plan

- [x] TDD: seeding tests watched fail first (undefined `seedWorkflowDir` / attr empty), then GREEN
  - load from a foreign cwd → attr is the .dip's absolute parent dir
  - load via relative path → attr is still absolute
  - pre-set attr survives (author wins)
  - embedded built-in → attr absent
  - `${graph.workflow_dir}` expands in tool_command mode; absent key → empty (lenient semantics pinned)
- [x] `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go test ./... -short` — all pass
- [x] `go test -race -short ./pipeline/...` — pass
- [x] `dippin doctor` baselines held: A/95, A/90, A/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783703334&installation_id=131176874&pr_number=338&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F338&signature=83e87a616f2815e1f8e7ea951156940e6eb3424d46c2fe0f0a09a1a684dda325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pipeline files can now automatically reference sibling files using `${graph.workflow_dir}` interpolation, which resolves to the pipeline file's parent directory regardless of the working directory. Explicit declarations are preserved.

* **Tests**
  * Added tests to verify workflow directory seeding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->