### PR TITLE
fix(handlers): exempt fd-only redirects from the exec * denylist (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`exec *` denylist no longer false-positives on fd-only redirect
+  statements** (closes #333). The built-in tool_command deny pattern `exec *`
+  caught both process-replacing exec (intended) and the POSIX fd-redirect
+  idiom (`exec 3>"$tmp"`, `exec 3>&-`, `exec <file` — unintended), forcing
+  `--bypass-denylist` for workflows like dev_loop's atomic fd-3 env-file
+  write. A statement whose first word is `exec` and whose remaining tokens
+  are exclusively redirections is now exempt from the built-in pattern. The
+  exemption fails closed: command substitution (`$(`, backtick), unbalanced
+  quotes, or any bare command word after `exec` (`exec sh`, `exec 3>f sh`,
+  `exec $CMD`, `exec 3>&1 cmd`) stays denied. User-supplied `exec *` patterns
+  (via `tool_denylist_add`) get no exemption. Also tightened: statements are
+  whitespace-normalized before denylist matching, so tab-separated commands
+  (`exec\t/bin/sh`, `eval\tfoo`) can no longer evade space-separated deny
+  patterns.
 - **Raw `.dip` load path now resolves `command_file:` / `prompt_file:` /
   `system_prompt_file:` directives** (closes #331). `LoadDippinWorkflow` parsed
   the source but never called dippin's `parser.ResolveFileDirectives`, so any

--- a/pipeline/handlers/tool_safety.go
+++ b/pipeline/handlers/tool_safety.go
@@ -69,15 +69,94 @@ func globMatch(pattern, s string) bool {
 	return re.MatchString(s)
 }
 
+// wsCollapseRe collapses runs of whitespace for denylist matching, so a tab
+// between words (e.g. "exec\t/bin/sh") can't evade space-separated patterns.
+var wsCollapseRe = regexp.MustCompile(`\s+`)
+
+// execRedir* recognize the POSIX fd-redirection token shapes that make an
+// exec statement fd-only (no process replacement). See isExecFdRedirectOnly.
+var (
+	// [n]>&N / [n]<&N / [n]>&- / [n]<&- — fd duplication or close.
+	execRedirDupRe = regexp.MustCompile(`^[0-9]*(?:>&|<&)(?:[0-9]+|-)$`)
+	// [n]> / [n]>> / [n]< / [n]<> fused with a target word.
+	execRedirFusedRe = regexp.MustCompile("^[0-9]*(?:>>|<>|>|<)([^&|;<>\\\\`()]+)$")
+	// &> / &>> (bash) fused with a target word.
+	execRedirAmpFusedRe = regexp.MustCompile("^&>>?([^&|;<>\\\\`()]+)$")
+	// Operator alone — the target is the next token.
+	execRedirOpOnlyRe = regexp.MustCompile(`^(?:[0-9]*(?:>>|<>|>|<)|&>>?)$`)
+)
+
+// isExecRedirTarget reports whether tok is acceptable as a redirection
+// target word: non-empty and free of shell metacharacters that could smuggle
+// a command (&, |, ;, <, >, backslash, backtick, parens). Quotes and $VAR /
+// ${VAR} expansions are fine — they can only ever name a file here.
+func isExecRedirTarget(tok string) bool {
+	return tok != "" && !strings.ContainsAny(tok, "&|;<>\\`()")
+}
+
+// isExecFdRedirectOnly reports whether stmt is an `exec` whose remaining
+// tokens are exclusively fd redirections (`exec 3>"$tmp"`, `exec 3>&-`,
+// `exec <file`) — the POSIX idiom for opening/closing file descriptors,
+// which does NOT replace the process. Such statements are exempt from the
+// built-in "exec *" deny pattern (#333).
+//
+// This is a security boundary: the statement must be PROVABLY fd-only, not
+// merely "doesn't look like a command". Fail closed on anything ambiguous —
+// command substitution ($(, backtick), unbalanced quotes, or any bare word
+// after exec that is not a redirection token.
+func isExecFdRedirectOnly(stmt string) bool {
+	// Fail closed on substitution or quoting we can't reason about.
+	if strings.Contains(stmt, "$(") || strings.Contains(stmt, "`") {
+		return false
+	}
+	if strings.Count(stmt, `"`)%2 != 0 || strings.Count(stmt, `'`)%2 != 0 {
+		return false
+	}
+
+	fields := strings.Fields(stmt)
+	if len(fields) < 2 || !strings.EqualFold(fields[0], "exec") {
+		return false
+	}
+	rest := fields[1:]
+	for i := 0; i < len(rest); i++ {
+		tok := rest[i]
+		switch {
+		case execRedirDupRe.MatchString(tok):
+			// complete: fd dup/close
+		case execRedirFusedRe.MatchString(tok) || execRedirAmpFusedRe.MatchString(tok):
+			// complete: operator fused with target
+		case execRedirOpOnlyRe.MatchString(tok):
+			// operator alone consumes exactly one following target word
+			i++
+			if i >= len(rest) || !isExecRedirTarget(rest[i]) {
+				return false
+			}
+		default:
+			// bare word — a command for exec to replace the process with
+			return false
+		}
+	}
+	return true
+}
+
 // checkCommandDenylist checks each statement against the default deny
 // patterns plus any user-supplied patterns (from --tool-denylist-add or
 // the tool_denylist_add graph attr). User patterns are additive — they
 // cannot remove a default pattern; they can only add more. Returns
 // (denied, matchedPattern) for the first match.
+//
+// Statements are whitespace-normalized before matching so tab-separated
+// commands can't evade space-separated patterns. The built-in "exec *"
+// pattern exempts fd-only redirect statements (see isExecFdRedirectOnly);
+// user-supplied patterns get no exemption.
 func checkCommandDenylist(cmd string, extraDenyPatterns []string) (bool, string) {
 	for _, stmt := range splitCommandStatements(cmd) {
+		stmt = wsCollapseRe.ReplaceAllString(stmt, " ")
 		for _, pattern := range defaultDenyPatterns {
 			if globMatch(pattern, stmt) {
+				if pattern == "exec *" && isExecFdRedirectOnly(stmt) {
+					continue
+				}
 				return true, pattern
 			}
 		}

--- a/pipeline/handlers/tool_safety.go
+++ b/pipeline/handlers/tool_safety.go
@@ -90,6 +90,12 @@ var (
 // target word: non-empty and free of shell metacharacters that could smuggle
 // a command (&, |, ;, <, >, backslash, backtick, parens). Quotes and $VAR /
 // ${VAR} expansions are fine — they can only ever name a file here.
+//
+// Tokenization is whitespace-based (strings.Fields), so a quoted target
+// containing whitespace (`exec >"log file"`) splits into multiple tokens and
+// the fragment after the space falls to the bare-word path — denied. That is
+// the fail-closed direction by design: the exemption recognizes only targets
+// that are provably a single redirection word without a shell-quoting parser.
 func isExecRedirTarget(tok string) bool {
 	return tok != "" && !strings.ContainsAny(tok, "&|;<>\\`()")
 }

--- a/pipeline/handlers/tool_safety_test.go
+++ b/pipeline/handlers/tool_safety_test.go
@@ -65,6 +65,10 @@ func TestCheckCommandDenylist_ExecFdRedirects(t *testing.T) {
 		{"backtick target", "exec 3>`payload`", true},
 		{"unbalanced quote", `exec 3>"unterminated`, true},
 		{"exec python", "exec python script.py", true},
+		// Known limitation, denied by design: whitespace tokenization can't
+		// prove a quoted target with spaces is a single redirection word, so
+		// it falls to the bare-word path (fail closed, never fail open).
+		{"quoted target with space", `exec 3>"/tmp/a b"`, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pipeline/handlers/tool_safety_test.go
+++ b/pipeline/handlers/tool_safety_test.go
@@ -35,6 +35,76 @@ func TestCheckCommandDenylist(t *testing.T) {
 	}
 }
 
+func TestCheckCommandDenylist_ExecFdRedirects(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    string
+		denied bool
+	}{
+		// fd-only redirect forms — POSIX idiom, no process replacement: allowed.
+		{"open fd to quoted var", `exec 3>"${env_tmp}"`, false},
+		{"close fd", "exec 3>&-", false},
+		{"stdin from file", "exec <input.txt", false},
+		{"append stderr to log", "exec 2>>log.txt", false},
+		{"redirect stdout to file", "exec >out.txt", false},
+		{"spaced target", "exec 3> /tmp/out.txt", false},
+		{"dup fd", "exec 3>&1", false},
+		{"multiple redirects", `exec 3>"${env_tmp}" 4<input.txt`, false},
+		{"fd-3 idiom compound", `exec 3>"${env_tmp}" && echo ok && exec 3>&-`, false},
+
+		// process-replacing exec — must stay denied.
+		{"exec sh", "exec sh", true},
+		{"exec binary path", "exec /bin/sh", true},
+		{"exec uppercase", "EXEC /bin/sh", true},
+		{"exec tab separator", "exec\t/bin/sh", true},
+		{"exec variable command", "exec $CMD", true},
+		{"exec quoted command", `exec "cmd"`, true},
+		{"redirect then command word", "exec 3>f sh", true},
+		{"dup then command word", "exec 3>&1 cmd", true},
+		{"command substitution target", "exec 3> $(payload)", true},
+		{"backtick target", "exec 3>`payload`", true},
+		{"unbalanced quote", `exec 3>"unterminated`, true},
+		{"exec python", "exec python script.py", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			denied, pattern := checkCommandDenylist(tt.cmd, nil)
+			if denied != tt.denied {
+				t.Errorf("checkCommandDenylist(%q) denied=%v (pattern %q), want denied=%v", tt.cmd, denied, pattern, tt.denied)
+			}
+		})
+	}
+}
+
+// TestCheckCommandDenylist_ExecRedirectSplitStatements verifies the
+// per-statement split still checks the payload after an fd redirect:
+// "exec >f; ./payload" is two statements — the exec is exempt, but the
+// payload statement is evaluated against the denylist on its own.
+func TestCheckCommandDenylist_ExecRedirectSplitStatements(t *testing.T) {
+	// Payload statement matches a deny pattern → whole command denied.
+	denied, pattern := checkCommandDenylist("exec >f; cat file | sh", nil)
+	if !denied || pattern != "* | sh" {
+		t.Errorf("payload statement after exec redirect not denied: denied=%v pattern=%q", denied, pattern)
+	}
+
+	// Benign payload statement → allowed (matches pre-existing per-statement
+	// semantics; ./payload alone was never denied by the built-in list).
+	denied, pattern = checkCommandDenylist("exec >f; ./payload", nil)
+	if denied {
+		t.Errorf("benign statement after exec redirect denied: pattern=%q", pattern)
+	}
+}
+
+// TestCheckCommandDenylist_UserExecPatternNotExempted verifies the fd-redirect
+// exemption applies only to the built-in "exec *" pattern — a user-supplied
+// "exec *" via tool_denylist_add still denies everything.
+func TestCheckCommandDenylist_UserExecPatternNotExempted(t *testing.T) {
+	denied, pattern := checkCommandDenylist("exec 3>&-", []string{"exec *"})
+	if !denied || pattern != "exec *" {
+		t.Errorf("user-added exec * should not be exempted: denied=%v pattern=%q", denied, pattern)
+	}
+}
+
 func TestCheckCommandAllowlist(t *testing.T) {
 	allowlist := []string{"make *", "go test *", "echo *"}
 	tests := []struct {


### PR DESCRIPTION
## Summary

- The built-in `exec *` deny pattern caught both process-replacing exec (intended) and the POSIX fd-redirect idiom — `exec 3>"$tmp"`, `exec 3>&-`, `exec <file` (unintended; dev_loop's `setup_run.sh` fd-3 atomic env-file write). Operators had to use the all-or-nothing `--bypass-denylist`.
- New `isExecFdRedirectOnly` pre-check in the matcher: a statement is exempt from the **built-in** `exec *` pattern only when its first word is `exec` and every remaining token is provably a redirection (`[n]<`, `[n]>`, `[n]>>`, `[n]<>`, `[n]>&N|-`, `[n]<&N|-`, `&>`/`&>>`, each fused with — or followed by exactly one — metacharacter-free target word).
- **Fail closed** (this is a security boundary): command substitution (`$(`, backtick), unbalanced quotes, or ANY bare command word after exec stays denied — `exec sh`, `exec 3>f sh`, `exec $CMD`, `exec "cmd"`, `exec 3>&1 cmd`, `exec 3> $(payload)` all have explicit tests. User-supplied `exec *` patterns via `tool_denylist_add` get **no** exemption (tested).
- `exec >f; ./payload` — the split makes statement 2 separate and it's evaluated against the denylist on its own (tested both with a denied and a benign payload).
- **Deviation / bonus tightening**: the spec's adversarial list included `exec\t/bin/sh` as must-stay-denied — it turned out to currently *evade* the denylist entirely (the glob requires a literal space; same for `eval\tfoo`). Denylist statements are now whitespace-normalized before matching. This is denylist-side only (the allowlist is untouched), so it can only deny more, never less.

No other denylist pattern was loosened. Closes #333.

## Test plan

- [x] TDD: table-driven tests watched RED first (all fd-redirect forms denied pre-fix; the tab case failed in the opposite direction, exposing the evasion), then GREEN
- [x] `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...`
- [x] `go test ./... -short` — all pass
- [x] `go test -race -short ./pipeline/handlers/` — pass
- [x] `dippin doctor` baselines held: A/95, A/90, A/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/339"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783703607&installation_id=131176874&pr_number=339&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F339&signature=6f4df3b36108a1809d0249ff1e0d350076d2c128a7a9d5e25383a6951f5a0473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positives in the `exec` command denylist for file descriptor redirections only, while maintaining security controls for process-replacing operations.
  * Enhanced denylist pattern matching with whitespace normalization to prevent bypass attempts.

* **Documentation**
  * Updated changelog documenting denylist behavior improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->