### PR TITLE
feat(handlers): inject TRACKER_RUN_ID / TRACKER_RUN_DIR / TRACKER_WORKDIR into tool subprocesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tool subprocesses receive run identity via `TRACKER_RUN_ID` /
+  `TRACKER_RUN_DIR` / `TRACKER_WORKDIR` env vars** (closes #323). Every tool
+  subprocess now gets the run identifier, the absolute per-run artifact
+  directory (the same root `WriteStageArtifacts` uses), and the absolute
+  workdir, so a tool node can read an upstream agent's output with
+  `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` instead of an `ls -dt` mtime
+  heuristic that breaks under concurrent runs in the same workdir. The vars
+  are appended after sensitive-env filtering (and on the `TRACKER_PASS_ENV=1`
+  path) so they are always present; operator-exported values of the same
+  names are removed, never duplicated. When the run has no artifact dir
+  (bare library engines), `TRACKER_RUN_ID`/`TRACKER_RUN_DIR` are omitted and
+  `TRACKER_WORKDIR` is still set. Env-only — no new `${ctx.*}` expansion keys.
+
 - **`graph.workflow_dir` is seeded from the pipeline file's parent directory**
   (closes #332). When a pipeline loads from a real on-disk path — `.dip` or
   legacy `.dot` — (via `tracker run` / `validate`, including subgraph refs;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Tool subprocesses receive run identity via `TRACKER_RUN_ID` /
-  `TRACKER_RUN_DIR` / `TRACKER_WORKDIR` env vars** (closes #323). Every tool
-  subprocess now gets the run identifier, the absolute per-run artifact
-  directory (the same root `WriteStageArtifacts` uses), and the absolute
-  workdir, so a tool node can read an upstream agent's output with
-  `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` instead of an `ls -dt` mtime
-  heuristic that breaks under concurrent runs in the same workdir. The vars
-  are appended after sensitive-env filtering (and on the `TRACKER_PASS_ENV=1`
-  path) so they are always present; operator-exported values of the same
-  names are removed, never duplicated. When the run has no artifact dir
-  (bare library engines), `TRACKER_RUN_ID`/`TRACKER_RUN_DIR` are omitted and
-  `TRACKER_WORKDIR` is still set. Env-only — no new `${ctx.*}` expansion keys.
+  `TRACKER_RUN_DIR` / `TRACKER_WORKDIR` env vars** (closes #323). Locally-
+  executed tool subprocesses (the default `LocalEnvironment` path — the same
+  one that applies sensitive-env filtering) now get the run identifier, the
+  absolute per-run artifact directory (the same root `WriteStageArtifacts`
+  uses), and the absolute workdir, so a tool node can read an upstream
+  agent's output with `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` instead
+  of an `ls -dt` mtime heuristic that breaks under concurrent runs in the
+  same workdir. The vars are appended after sensitive-env filtering (and on
+  the `TRACKER_PASS_ENV=1` path) so they are always present on that path;
+  operator-exported values of the same names are removed, never duplicated.
+  When the run has no artifact dir (bare library engines),
+  `TRACKER_RUN_ID`/`TRACKER_RUN_DIR` are omitted and `TRACKER_WORKDIR` is
+  still set. Env-only — no new `${ctx.*}` expansion keys.
 
 - **`graph.workflow_dir` is seeded from the pipeline file's parent directory**
   (closes #332). When a pipeline loads from a real on-disk path — `.dip` or

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -36,6 +36,29 @@ Everything about a run — prompts, responses, event stream, per-node outcomes, 
 
 Subdirectory names are node IDs verbatim. Subgraph children appear under the parent's node ID (e.g. `<parent>/<child>/`) — see [tui.md §Node list](./tui.md) for how the TUI mirrors this structure.
 
+## Run identity env vars for tool subprocesses
+
+Every tool subprocess receives the active run's identity in its environment (#323):
+
+- `TRACKER_RUN_ID` — the run identifier; matches the `.tracker/runs/<runID>/` directory name.
+- `TRACKER_RUN_DIR` — absolute path to the per-run artifact directory (the same root `WriteStageArtifacts` writes to).
+- `TRACKER_WORKDIR` — absolute path to the workflow's workdir, so scripts resolve paths unambiguously regardless of CWD.
+
+This lets a tool node read a specific upstream node's output directly:
+
+```bash
+cat "$TRACKER_RUN_DIR/PlanAgent/response.md"
+```
+
+without an `ls -dt .tracker/runs/ | head -1` mtime heuristic, which is unsafe under concurrent runs in the same workdir (a second invocation creates a newer run dir and the first run's tools pick up the wrong artifacts).
+
+Semantics:
+
+- The vars are injected after sensitive-env filtering and also on the `TRACKER_PASS_ENV=1` path, so they are always present.
+- Operator-exported values of these three names are removed from the inherited environment — a stale export can never masquerade as run identity.
+- When the run has no artifact directory (bare library engines without `WithArtifactDir`), `TRACKER_RUN_ID` and `TRACKER_RUN_DIR` are omitted entirely; `TRACKER_WORKDIR` is always set.
+- Env-only: the values are not exposed as `${ctx.*}` expansion keys in `tool_command`.
+
 ## Files written per node
 
 [pipeline/artifacts.go](../../pipeline/artifacts.go) is the single writer:

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -38,7 +38,7 @@ Subdirectory names are node IDs verbatim. Subgraph children appear under the par
 
 ## Run identity env vars for tool subprocesses
 
-Every tool subprocess receives the active run's identity in its environment (#323):
+Tool subprocesses executed locally (the default `LocalEnvironment` exec path — the same path that applies sensitive-env filtering) receive the active run's identity in their environment (#323):
 
 - `TRACKER_RUN_ID` — the run identifier; matches the `.tracker/runs/<runID>/` directory name.
 - `TRACKER_RUN_DIR` — absolute path to the per-run artifact directory (the same root `WriteStageArtifacts` writes to).
@@ -54,7 +54,7 @@ without an `ls -dt .tracker/runs/ | head -1` mtime heuristic, which is unsafe un
 
 Semantics:
 
-- The vars are injected after sensitive-env filtering and also on the `TRACKER_PASS_ENV=1` path, so they are always present.
+- The vars are injected after sensitive-env filtering and also on the `TRACKER_PASS_ENV=1` path, so they are always present on the local exec path. Non-local `ExecutionEnvironment` implementations run via `ExecCommand`, which passes no custom environment — they get neither the filtering nor these vars.
 - Operator-exported values of these three names are removed from the inherited environment — a stale export can never masquerade as run identity.
 - When the run has no artifact directory (bare library engines without `WithArtifactDir`), `TRACKER_RUN_ID` and `TRACKER_RUN_DIR` are omitted entirely; `TRACKER_WORKDIR` is always set.
 - Env-only: the values are not exposed as `${ctx.*}` expansion keys in `tool_command`.

--- a/docs/architecture/context-flow.md
+++ b/docs/architecture/context-flow.md
@@ -122,7 +122,7 @@ Runtime contract:
 For human interview mode, `writes:` extraction uses the collected interview answers object (question IDs and normalized question-text keys mapped to answers).
 For other human modes (`freeform`, `choice`, `yes_no`), `writes:` extraction is not applied automatically; rely on built-in human response keys unless handler behavior is extended.
 
-**Tool-side complement:** every tool subprocess also receives `TRACKER_RUN_ID`, `TRACKER_RUN_DIR`, and `TRACKER_WORKDIR` in its environment (#323), so a tool node can read an upstream node's artifact directly — `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` — even when that agent has `tool_access: none` and cannot write files itself. These are env vars only, not `${ctx.*}` expansion keys; see [artifacts.md §Run identity env vars](./artifacts.md#run-identity-env-vars-for-tool-subprocesses).
+**Tool-side complement:** locally-executed tool subprocesses (the default `LocalEnvironment` exec path) also receive `TRACKER_RUN_ID`, `TRACKER_RUN_DIR`, and `TRACKER_WORKDIR` in their environment (#323), so a tool node can read an upstream node's artifact directly — `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` — even when that agent has `tool_access: none` and cannot write files itself. These are env vars only, not `${ctx.*}` expansion keys; see [artifacts.md §Run identity env vars](./artifacts.md#run-identity-env-vars-for-tool-subprocesses).
 
 ## Fidelity levels
 

--- a/docs/architecture/context-flow.md
+++ b/docs/architecture/context-flow.md
@@ -122,6 +122,8 @@ Runtime contract:
 For human interview mode, `writes:` extraction uses the collected interview answers object (question IDs and normalized question-text keys mapped to answers).
 For other human modes (`freeform`, `choice`, `yes_no`), `writes:` extraction is not applied automatically; rely on built-in human response keys unless handler behavior is extended.
 
+**Tool-side complement:** every tool subprocess also receives `TRACKER_RUN_ID`, `TRACKER_RUN_DIR`, and `TRACKER_WORKDIR` in its environment (#323), so a tool node can read an upstream node's artifact directly — `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` — even when that agent has `tool_access: none` and cannot write files itself. These are env vars only, not `${ctx.*}` expansion keys; see [artifacts.md §Run identity env vars](./artifacts.md#run-identity-env-vars-for-tool-subprocesses).
+
 ## Fidelity levels
 
 An agent node receives a compacted view of the pipeline context as part of its prompt construction. The amount of context injected is controlled by the `fidelity` attribute.

--- a/pipeline/handlers/tool.go
+++ b/pipeline/handlers/tool.go
@@ -45,14 +45,54 @@ var sensitiveEnvPatterns = []string{
 	"_PASSWORD",
 }
 
+// runIdentity carries the per-invocation run identity injected into every
+// tool subprocess environment (#323): TRACKER_RUN_ID, TRACKER_RUN_DIR,
+// TRACKER_WORKDIR. RunDir is the same directory WriteStageArtifacts uses,
+// so a tool subprocess can read an upstream agent's response.md without an
+// `ls -dt` mtime heuristic (unsafe under concurrent runs). Empty fields are
+// omitted from the env — e.g. RunID/RunDir when the run has no artifact dir.
+type runIdentity struct {
+	RunID   string
+	RunDir  string
+	WorkDir string
+}
+
 // buildToolEnv constructs a filtered environment for tool command execution.
 // Strips environment variables matching sensitive patterns to prevent
 // exfiltration via malicious tool commands. Override with TRACKER_PASS_ENV=1.
-func buildToolEnv() []string {
-	if os.Getenv("TRACKER_PASS_ENV") == "1" {
-		return os.Environ()
+// The run-identity vars are appended after filtering (and on the
+// TRACKER_PASS_ENV=1 path) so they are always present.
+func buildToolEnv(id runIdentity) []string {
+	env := os.Environ()
+	if os.Getenv("TRACKER_PASS_ENV") != "1" {
+		env = filterSensitiveEnv(env)
 	}
-	return filterSensitiveEnv(os.Environ())
+	return appendRunIdentityEnv(env, id)
+}
+
+// appendRunIdentityEnv removes any inherited TRACKER_RUN_ID / TRACKER_RUN_DIR /
+// TRACKER_WORKDIR entries — an operator export must never masquerade as run
+// identity, so stale values are dropped rather than duplicated — and appends
+// the non-empty fields of id.
+func appendRunIdentityEnv(env []string, id runIdentity) []string {
+	out := make([]string, 0, len(env)+3)
+	for _, e := range env {
+		switch strings.SplitN(e, "=", 2)[0] {
+		case "TRACKER_RUN_ID", "TRACKER_RUN_DIR", "TRACKER_WORKDIR":
+			continue
+		}
+		out = append(out, e)
+	}
+	if id.RunID != "" {
+		out = append(out, "TRACKER_RUN_ID="+id.RunID)
+	}
+	if id.RunDir != "" {
+		out = append(out, "TRACKER_RUN_DIR="+id.RunDir)
+	}
+	if id.WorkDir != "" {
+		out = append(out, "TRACKER_WORKDIR="+id.WorkDir)
+	}
+	return out
 }
 
 // filterSensitiveEnv returns a copy of env with sensitive vars removed.
@@ -255,8 +295,11 @@ func (h *ToolHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *pi
 	}
 
 	artifactRoot := h.env.WorkingDir()
+	identity := runIdentity{WorkDir: absPathOrSelf(h.env.WorkingDir())}
 	if dir, ok := pctx.GetInternal(pipeline.InternalKeyArtifactDir); ok && dir != "" {
 		artifactRoot = dir
+		identity.RunDir = absPathOrSelf(dir)
+		identity.RunID = filepath.Base(identity.RunDir)
 	}
 
 	command, err = h.applyWorkingDir(node, command)
@@ -274,7 +317,16 @@ func (h *ToolHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *pi
 		return pipeline.Outcome{}, err
 	}
 
-	return h.execAndBuildOutcome(ctx, node, command, artifactRoot, timeout, outputLimit)
+	return h.execAndBuildOutcome(ctx, node, command, artifactRoot, identity, timeout, outputLimit)
+}
+
+// absPathOrSelf returns the absolute form of p, or p unchanged if it cannot
+// be resolved (filepath.Abs fails only when the working directory is gone).
+func absPathOrSelf(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
 }
 
 // expandAndValidateCommand expands variables in the tool_command attribute and
@@ -402,11 +454,11 @@ func (h *ToolHandler) parseOutputLimit(node *pipeline.Node) (int, error) {
 
 // execAndBuildOutcome runs the command and builds the pipeline outcome from the result.
 // Layer 4: uses ExecCommandWithLimit on LocalEnvironment, ExecCommand otherwise.
-func (h *ToolHandler) execAndBuildOutcome(ctx context.Context, node *pipeline.Node, command, artifactRoot string, timeout time.Duration, outputLimit int) (pipeline.Outcome, error) {
+func (h *ToolHandler) execAndBuildOutcome(ctx context.Context, node *pipeline.Node, command, artifactRoot string, identity runIdentity, timeout time.Duration, outputLimit int) (pipeline.Outcome, error) {
 	var result exec.CommandResult
 	var err error
 	if le, ok := h.env.(*exec.LocalEnvironment); ok {
-		result, err = le.ExecCommandWithLimit(ctx, "sh", []string{"-c", command}, timeout, outputLimit, buildToolEnv())
+		result, err = le.ExecCommandWithLimit(ctx, "sh", []string{"-c", command}, timeout, outputLimit, buildToolEnv(identity))
 	} else {
 		result, err = h.env.ExecCommand(ctx, "sh", []string{"-c", command}, timeout)
 	}

--- a/pipeline/handlers/tool.go
+++ b/pipeline/handlers/tool.go
@@ -321,7 +321,8 @@ func (h *ToolHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *pi
 }
 
 // absPathOrSelf returns the absolute form of p, or p unchanged if it cannot
-// be resolved (filepath.Abs fails only when the working directory is gone).
+// be resolved (filepath.Abs fails when the current working directory cannot
+// be determined — deleted, permission-denied, or other os.Getwd failures).
 func absPathOrSelf(p string) string {
 	if abs, err := filepath.Abs(p); err == nil {
 		return abs

--- a/pipeline/handlers/tool.go
+++ b/pipeline/handlers/tool.go
@@ -45,12 +45,15 @@ var sensitiveEnvPatterns = []string{
 	"_PASSWORD",
 }
 
-// runIdentity carries the per-invocation run identity injected into every
-// tool subprocess environment (#323): TRACKER_RUN_ID, TRACKER_RUN_DIR,
+// runIdentity carries the per-invocation run identity injected into tool
+// subprocess environments (#323): TRACKER_RUN_ID, TRACKER_RUN_DIR,
 // TRACKER_WORKDIR. RunDir is the same directory WriteStageArtifacts uses,
 // so a tool subprocess can read an upstream agent's response.md without an
 // `ls -dt` mtime heuristic (unsafe under concurrent runs). Empty fields are
 // omitted from the env — e.g. RunID/RunDir when the run has no artifact dir.
+// Injection happens on the LocalEnvironment exec path only — the same path
+// that applies sensitive-env filtering; non-local ExecutionEnvironments run
+// via ExecCommand, which passes no environment at all.
 type runIdentity struct {
 	RunID   string
 	RunDir  string

--- a/pipeline/handlers/tool_env_e2e_test.go
+++ b/pipeline/handlers/tool_env_e2e_test.go
@@ -1,0 +1,71 @@
+// ABOUTME: Engine-level test for run-identity env vars in tool subprocesses (#323).
+// ABOUTME: A codergen node (fake backend) writes response.md; a tool node reads it via $TRACKER_RUN_DIR.
+package handlers
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	agentexec "github.com/2389-research/tracker/agent/exec"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// TestToolReadsUpstreamResponseViaRunDir runs a two-node pipeline: a codergen
+// node backed by a fake completer, then a tool node that cats the upstream
+// node's response.md using $TRACKER_RUN_DIR. This is the acceptance test for
+// issue #323 — the tool_access:none agent → tool data flow without any
+// ls -dt mtime heuristic.
+func TestToolReadsUpstreamResponseViaRunDir(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	workdir := t.TempDir()
+	artifactDir := filepath.Join(workdir, ".tracker", "runs")
+	if err := os.MkdirAll(artifactDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dot := `digraph t {
+		Start [shape=Mdiamond];
+		Agent [shape=box, prompt="say the magic word"];
+		ReadBack [shape=parallelogram, tool_command="cat \"$TRACKER_RUN_DIR/Agent/response.md\""];
+		Exit [shape=Msquare];
+		Start -> Agent;
+		Agent -> ReadBack;
+		ReadBack -> Exit;
+	}`
+	graph, err := pipeline.ParseDOT(dot)
+	if err != nil {
+		t.Fatalf("ParseDOT: %v", err)
+	}
+
+	codergen := NewCodergenHandler(&fakeCompleter{responseText: "magic-word-xyzzy"}, workdir)
+	codergen.env = agentexec.NewLocalEnvironment(workdir)
+
+	registry := pipeline.NewHandlerRegistry()
+	registry.Register(NewStartHandler())
+	registry.Register(NewExitHandler())
+	registry.Register(codergen)
+	registry.Register(NewToolHandler(agentexec.NewLocalEnvironment(workdir)))
+
+	engine := pipeline.NewEngine(graph, registry, pipeline.WithArtifactDir(artifactDir))
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine.Run: %v", err)
+	}
+	if result.Status != pipeline.OutcomeSuccess {
+		t.Fatalf("pipeline status = %q, want success", result.Status)
+	}
+
+	stdout, ok := result.Context[pipeline.ContextKeyToolStdout]
+	if !ok {
+		t.Fatal("tool_stdout missing from final context")
+	}
+	if !strings.Contains(stdout, "magic-word-xyzzy") {
+		t.Errorf("tool_stdout = %q, want it to contain the upstream agent's response", stdout)
+	}
+}

--- a/pipeline/handlers/tool_test.go
+++ b/pipeline/handlers/tool_test.go
@@ -385,7 +385,7 @@ func TestBuildToolEnv_StripsAPIKeys(t *testing.T) {
 	t.Setenv("SAFE_VAR", "keep-me")
 	t.Setenv("TRACKER_PASS_ENV", "")
 
-	env := buildToolEnv()
+	env := buildToolEnv(runIdentity{})
 	envMap := make(map[string]string)
 	for _, e := range env {
 		parts := strings.SplitN(e, "=", 2)
@@ -415,7 +415,7 @@ func TestBuildToolEnv_PassEnvOverride(t *testing.T) {
 	t.Setenv("ANTHROPIC_API_KEY", "sk-secret")
 	t.Setenv("TRACKER_PASS_ENV", "1")
 
-	env := buildToolEnv()
+	env := buildToolEnv(runIdentity{})
 	envMap := make(map[string]string)
 	for _, e := range env {
 		parts := strings.SplitN(e, "=", 2)
@@ -426,6 +426,156 @@ func TestBuildToolEnv_PassEnvOverride(t *testing.T) {
 
 	if _, ok := envMap["ANTHROPIC_API_KEY"]; !ok {
 		t.Error("TRACKER_PASS_ENV=1 should preserve API keys")
+	}
+}
+
+// envToMap splits KEY=VALUE entries into a map and also returns a count of
+// occurrences per key so duplicate-injection bugs are visible.
+func envToMap(env []string) (map[string]string, map[string]int) {
+	m := make(map[string]string)
+	counts := make(map[string]int)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			m[parts[0]] = parts[1]
+			counts[parts[0]]++
+		}
+	}
+	return m, counts
+}
+
+func TestBuildToolEnv_RunIdentityVars(t *testing.T) {
+	t.Setenv("TRACKER_PASS_ENV", "")
+
+	id := runIdentity{RunID: "run-abc", RunDir: "/work/.tracker/runs/run-abc", WorkDir: "/work"}
+	envMap, _ := envToMap(buildToolEnv(id))
+
+	if got := envMap["TRACKER_RUN_ID"]; got != "run-abc" {
+		t.Errorf("TRACKER_RUN_ID = %q, want %q", got, "run-abc")
+	}
+	if got := envMap["TRACKER_RUN_DIR"]; got != "/work/.tracker/runs/run-abc" {
+		t.Errorf("TRACKER_RUN_DIR = %q, want %q", got, "/work/.tracker/runs/run-abc")
+	}
+	if got := envMap["TRACKER_WORKDIR"]; got != "/work" {
+		t.Errorf("TRACKER_WORKDIR = %q, want %q", got, "/work")
+	}
+}
+
+func TestBuildToolEnv_RunIdentitySurvivesSensitiveStripping(t *testing.T) {
+	// The three identity vars must never match the sensitive patterns —
+	// pin that so a future pattern addition can't silently strip them.
+	for _, name := range []string{"TRACKER_RUN_ID", "TRACKER_RUN_DIR", "TRACKER_WORKDIR"} {
+		if hasSensitivePattern(name + "=x") {
+			t.Errorf("%s matches a sensitive pattern and would be stripped", name)
+		}
+	}
+
+	// And with stripping active, the vars are present alongside stripped secrets.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-secret")
+	t.Setenv("TRACKER_PASS_ENV", "")
+	envMap, _ := envToMap(buildToolEnv(runIdentity{RunID: "r1", RunDir: "/d/r1", WorkDir: "/d"}))
+	if _, ok := envMap["ANTHROPIC_API_KEY"]; ok {
+		t.Error("ANTHROPIC_API_KEY should be stripped")
+	}
+	if envMap["TRACKER_RUN_ID"] != "r1" {
+		t.Errorf("TRACKER_RUN_ID = %q, want %q", envMap["TRACKER_RUN_ID"], "r1")
+	}
+}
+
+func TestBuildToolEnv_RunIdentityOverridesOperatorExports(t *testing.T) {
+	t.Setenv("TRACKER_RUN_ID", "stale-id")
+	t.Setenv("TRACKER_RUN_DIR", "/stale/dir")
+	t.Setenv("TRACKER_WORKDIR", "/stale/wd")
+	t.Setenv("TRACKER_PASS_ENV", "")
+
+	id := runIdentity{RunID: "fresh", RunDir: "/runs/fresh", WorkDir: "/wd"}
+	envMap, counts := envToMap(buildToolEnv(id))
+
+	for name, want := range map[string]string{
+		"TRACKER_RUN_ID":  "fresh",
+		"TRACKER_RUN_DIR": "/runs/fresh",
+		"TRACKER_WORKDIR": "/wd",
+	} {
+		if got := envMap[name]; got != want {
+			t.Errorf("%s = %q, want %q (operator export must be overridden)", name, got, want)
+		}
+		if counts[name] != 1 {
+			t.Errorf("%s appears %d times, want exactly 1 (no duplicates)", name, counts[name])
+		}
+	}
+}
+
+func TestBuildToolEnv_PassEnvCarriesRunIdentity(t *testing.T) {
+	t.Setenv("TRACKER_PASS_ENV", "1")
+	t.Setenv("TRACKER_RUN_ID", "stale-id")
+
+	id := runIdentity{RunID: "fresh", RunDir: "/runs/fresh", WorkDir: "/wd"}
+	envMap, counts := envToMap(buildToolEnv(id))
+
+	if got := envMap["TRACKER_RUN_ID"]; got != "fresh" {
+		t.Errorf("TRACKER_RUN_ID = %q, want %q under TRACKER_PASS_ENV=1", got, "fresh")
+	}
+	if counts["TRACKER_RUN_ID"] != 1 {
+		t.Errorf("TRACKER_RUN_ID appears %d times, want exactly 1", counts["TRACKER_RUN_ID"])
+	}
+	if got := envMap["TRACKER_RUN_DIR"]; got != "/runs/fresh" {
+		t.Errorf("TRACKER_RUN_DIR = %q, want %q under TRACKER_PASS_ENV=1", got, "/runs/fresh")
+	}
+	if got := envMap["TRACKER_WORKDIR"]; got != "/wd" {
+		t.Errorf("TRACKER_WORKDIR = %q, want %q under TRACKER_PASS_ENV=1", got, "/wd")
+	}
+}
+
+func TestBuildToolEnv_NoRunIdentityOmitsVars(t *testing.T) {
+	// When no run-scoped artifact dir exists (bare engine, no-artifact run),
+	// RUN_ID/RUN_DIR are omitted — and stale operator exports are removed,
+	// not passed through.
+	t.Setenv("TRACKER_RUN_ID", "stale-id")
+	t.Setenv("TRACKER_RUN_DIR", "/stale/dir")
+	t.Setenv("TRACKER_PASS_ENV", "")
+
+	envMap, _ := envToMap(buildToolEnv(runIdentity{WorkDir: "/wd"}))
+
+	if v, ok := envMap["TRACKER_RUN_ID"]; ok {
+		t.Errorf("TRACKER_RUN_ID should be absent, got %q", v)
+	}
+	if v, ok := envMap["TRACKER_RUN_DIR"]; ok {
+		t.Errorf("TRACKER_RUN_DIR should be absent, got %q", v)
+	}
+	if got := envMap["TRACKER_WORKDIR"]; got != "/wd" {
+		t.Errorf("TRACKER_WORKDIR = %q, want %q", got, "/wd")
+	}
+}
+
+func TestToolHandlerInjectsRunIdentityEnv(t *testing.T) {
+	if _, err := osexec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	workdir := t.TempDir()
+	runDir := filepath.Join(t.TempDir(), "run-xyz")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	env := exec.NewLocalEnvironment(workdir)
+	h := NewToolHandler(env)
+	node := &pipeline.Node{
+		ID:    "envprobe",
+		Shape: "parallelogram",
+		Attrs: map[string]string{
+			"tool_command": `printf '%s|%s|%s' "$TRACKER_RUN_ID" "$TRACKER_RUN_DIR" "$TRACKER_WORKDIR"`,
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	pctx.SetInternal(pipeline.InternalKeyArtifactDir, runDir)
+
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "run-xyz|" + runDir + "|" + workdir
+	if got := outcome.ContextUpdates[pipeline.ContextKeyToolStdout]; got != want {
+		t.Errorf("tool_stdout = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes #323.

## What

Every tool subprocess now receives the active run's identity in its environment:

- `TRACKER_RUN_ID` — the run identifier (matches the `.tracker/runs/<runID>/` dir name)
- `TRACKER_RUN_DIR` — absolute per-run artifact dir, the same root `WriteStageArtifacts` uses
- `TRACKER_WORKDIR` — absolute workdir

This closes the `tool_access: none` agent → tool data-flow gap: a downstream tool node can `cat "$TRACKER_RUN_DIR/<NodeID>/response.md"` instead of an `ls -dt | head -1` mtime heuristic that is unsafe under concurrent runs in the same workdir.

## Design decisions

- **Seam**: extended `buildToolEnv()`'s signature to `buildToolEnv(id runIdentity)` (rather than appending at the call site) — the identity handling lives next to the sensitive-env filtering it must compose with, and the unit-test seam stays a single function.
- **Always present**: identity vars are appended *after* sensitive filtering, and also on the `TRACKER_PASS_ENV=1` path.
- **Override, never duplicate**: any inherited `TRACKER_RUN_ID`/`TRACKER_RUN_DIR`/`TRACKER_WORKDIR` (operator exports) are removed from the env before appending, so a stale export can't masquerade as run identity — including on runs with no artifact dir.
- **No-artifact-dir semantics**: when `InternalKeyArtifactDir` is unset (bare library engines without `WithArtifactDir`), `TRACKER_RUN_ID`/`TRACKER_RUN_DIR` are omitted entirely; `TRACKER_WORKDIR` is always set. Documented in `docs/architecture/artifacts.md`.
- **Env-only**: no new `${ctx.*}` expansion keys; the tool_command safe-key allowlist is untouched.
- **Non-LocalEnvironment backends** don't get the vars — environment injection (like sensitive stripping) was already LocalEnvironment-only; unchanged.

## Tests (TDD)

- Unit: three vars present with correct values; survive sensitive stripping (pins that the names match no sensitive pattern); operator exports overridden with exactly one occurrence each; `TRACKER_PASS_ENV=1` path carries them; no-run-dir case omits RUN_ID/RUN_DIR and strips stale exports.
- Handler: real `LocalEnvironment` tool node prints `$TRACKER_RUN_ID|$TRACKER_RUN_DIR|$TRACKER_WORKDIR`.
- Engine-level (issue acceptance): codergen node (fake completer) → tool node `cat "$TRACKER_RUN_DIR/Agent/response.md"` returns the upstream agent's response.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓
- `go test -race -short ./pipeline/...` ✓
- `dippin doctor` baselines hold: ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713198&installation_id=131176874&pr_number=340&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F340&signature=79ff7029623a5aa18d018448654dbf139a78e2160aafed0e0e882cd67f82545a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool subprocesses now get run-identity env vars (TRACKER_RUN_ID, TRACKER_RUN_DIR, TRACKER_WORKDIR) so tools can read upstream artifacts; vars are appended after sensitive-env filtering, avoid duplicating operator-exported values, and are omitted when no per-run artifact dir exists (WORKDIR remains set).

* **Documentation**
  * Docs updated to describe these env vars, their filtering behavior, and that they are not available as ctx expansion keys.

* **Tests**
  * Added unit and end-to-end tests validating env injection and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->