### PR TITLE
fix(build_product): reserve rc=2 for make-missing in run_project_ci_gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **build_product: a failing `make ci`/`check`/`lint` target no longer
+  escalates to a human as "make not installed"** (closes #320). GNU make
+  exits 2 on any recipe error, colliding with the rc=2 code
+  `run_project_ci_gate` reserves for "Makefile present but `make` not
+  installed" — so an ordinary lint/test failure escaped the FixMilestone
+  loop, routed to EscalateMilestone, and reset the fix-attempt circuit
+  breaker. The make-run path now collapses any make failure to rc=1
+  (fixable → fix loop); rc=2 is genuinely sole-sourced to the
+  `command -v make` check. The make invocation is also `|| MAKE_RC=$?`
+  guarded so FinalBuild's bare call under `set -eu` can't abort
+  mid-function.
+
 - **`exec *` denylist no longer false-positives on fd-only redirect
   statements** (closes #333). The built-in tool_command deny pattern `exec *`
   caught both process-replacing exec (intended) and the POSIX fd-redirect

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -52,17 +52,17 @@ workflow BuildProduct
       #   0  — clean: `make <TARGET>` exited 0, OR (no Makefile gate
       #        ran) the language-native gates passed / no toolchain
       #        was detected (issue #299).
+      #   1  — a gate failed (caller should fail / retry): a failing
+      #        `make <TARGET>` run collapses to exactly 1 — make's own
+      #        exit code (including its native exit 2 on ANY recipe
+      #        error) is never propagated (#320) — and a failing
+      #        language-native gate (go vet / golangci-lint / tsc /
+      #        eslint / ruff / mypy / cargo fmt|clippy) likewise
+      #        collapses to exactly 1. Never an arbitrary N, never 2.
       #   2  — Makefile present but `make` not installed (caller
       #        should escalate; LLM fix loop can't install a binary).
-      #        This helper emits an explicit rc=2 ONLY here; the
-      #        language-native block never returns 2. (Caveat: the
-      #        `make <TARGET>` path below can still propagate make's own
-      #        native exit 2 on a recipe error — pre-existing, #320.)
-      #   N  — a gate failed (caller should fail / retry): `make
-      #        <TARGET>` exits with make's own non-zero code, whereas a
-      #        failing language-native gate (go vet / golangci-lint /
-      #        tsc / eslint / ruff / mypy / cargo fmt|clippy) ALWAYS
-      #        collapses to exactly 1 — never an arbitrary N, never 2.
+      #        rc=2 is sole-sourced to the `command -v make` check —
+      #        no other path in this helper can produce it.
       # Sets PROJECT_CI_RAN to the chosen target on a real `make` run,
       # empty string otherwise (incl. the language-native fall-through).
       run_project_ci_gate() {
@@ -101,8 +101,15 @@ workflow BuildProduct
             '; then
             echo "--- running make $TARGET (project CI gate from $MAKEFILE) ---"
             PROJECT_CI_RAN="$TARGET"
-            make "$TARGET" 2>&1
-            return $?
+            # `|| MAKE_RC=$?` keeps a bare set -e caller (FinalBuild) from
+            # aborting mid-function, mirroring the language-gate invariant.
+            MAKE_RC=0
+            make "$TARGET" 2>&1 || MAKE_RC=$?
+            if [ "$MAKE_RC" -eq 0 ]; then return 0; fi
+            # GNU make exits 2 on ANY recipe error; collapse to 1 so a
+            # fixable CI failure routes to the fix loop, not human
+            # escalation — rc=2 stays sole-sourced to make-missing (#320).
+            return 1
           fi
         done
         echo "INFO: no project CI target in $MAKEFILE (looked for: ci, check, lint) — running language-native gates (#299)"

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -85,9 +85,9 @@ func TestQualityGateMakefilePathPreserved(t *testing.T) {
 
 // Test 6 — regression-pin (semantic): the only EXPLICIT `return 2` statement is
 // the make-missing branch. Exactly one `return 2`, adjacent to `command -v make`,
-// and none after any language-native gate marker. (This pins the source code, not
-// runtime rc uniqueness: the `make "$TARGET"` path can still propagate make's own
-// native exit 2 on a recipe error — pre-existing, tracked in #320.)
+// and none after any language-native gate marker. Since #320 the make-run path
+// collapses recipe failures to `return 1`, so rc=2 is genuinely sole-sourced to
+// make-missing at runtime too (pinned by makefile_ci_failure_rc1 below).
 func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
 	cmd := setupCmd(t)
 	if n := strings.Count(cmd, "return 2"); n != 1 {
@@ -408,6 +408,29 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		}
 		if strings.Contains(out, "go vet ./...") {
 			t.Errorf("Makefile ci won but go vet ALSO ran — precedence broken\n%s", out)
+		}
+	})
+
+	// (k) Makefile ci target FAILS (recipe error) → rc 1, NOT 2 (#320). GNU make
+	// exits 2 on any recipe error, which previously collided with the rc=2
+	// "make missing" contract and mis-routed fixable CI failures to human
+	// escalation (resetting the fix-attempt counter). The helper must collapse
+	// a make-run failure to exactly 1 so it routes to the FixMilestone loop.
+	t.Run("makefile_ci_failure_rc1", func(t *testing.T) {
+		if _, err := exec.LookPath("make"); err != nil {
+			t.Skip("make not available")
+		}
+		dir := t.TempDir()
+		// `|| exit 1` forces the recipe through /bin/sh (metacharacter defeats
+		// make's no-shell fast path), so the failure doesn't depend on which
+		// binaries the hermetic PATH carries — false/exit are shell builtins.
+		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@false || exit 1\n")
+		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), true))
+		if ciRan != "ci" {
+			t.Errorf("failing ci target: PROJECT_CI_RAN=%q want ci (make path must have run)\n%s", ciRan, out)
+		}
+		if rc != 1 {
+			t.Errorf("failing ci target: rc=%d want 1 — rc=2 is reserved for make-missing (#320)\n%s", rc, out)
 		}
 	})
 

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -422,8 +422,10 @@ func TestRunProjectCIGateRuntime(t *testing.T) {
 		}
 		dir := t.TempDir()
 		// `|| exit 1` forces the recipe through /bin/sh (metacharacter defeats
-		// make's no-shell fast path), so the failure doesn't depend on which
-		// binaries the hermetic PATH carries — false/exit are shell builtins.
+		// make's no-shell fast path) and makes the failure independent of the
+		// hermetic PATH: `exit` is a builtin everywhere, and if this sh resolves
+		// `false` externally (POSIX doesn't require it builtin) the not-found
+		// failure (127) still trips `|| exit 1` — the recipe exits 1 either way.
 		mustWrite(t, filepath.Join(dir, "Makefile"), "ci:\n\t@false || exit 1\n")
 		out, rc, ciRan := runGate(t, probe, dir, hermeticEnv(t, t.TempDir(), t.TempDir(), true))
 		if ciRan != "ci" {


### PR DESCRIPTION
Closes #320.

## What

`run_project_ci_gate`'s make-run path did `make "$TARGET" 2>&1; return $?` — but GNU make exits **2 on any recipe error**, the exact code the helper reserves for "Makefile present but `make` not installed". A normal `make ci` lint/test failure therefore:

- routed to `EscalateMilestone` (human) instead of the `FixMilestone` loop, and
- reset the fix-attempt counter, defeating the circuit breaker.

Per the settled design in the issue: capture make's rc; return 0 on success, else **return 1** (fixable → fix loop). rc=2 is now sole-sourced to the `command -v make` check.

## Details

- The make invocation is `|| MAKE_RC=$?` guarded — FinalBuild calls the gate **bare** under `set -eu`, so an unguarded failing `make` would abort mid-function (same invariant as the #299 language-native gates). Net caller-visible behavior for FinalBuild is unchanged (non-zero either way).
- Helper header comment rewritten to the new 0/1/2 contract; the stale "(pre-existing, #320)" caveats removed from the header and from `TestQualityGateRc2OnlyMakeMissing`'s comment.
- `VerifyMilestone`'s prose (`CI_RC==2` = make binary missing) already described the intended contract — this change makes it true; no prose edit needed there.
- **Not touched**: the #299 language-native fallback block (already collapses to rc=1), TestMilestone's routing.
- **Checked**: `build_product_with_superspec.dip` carries no copy of the heredoc (`run_project_ci_gate` / `ci-probe` appear only in `build_product.dip`), so only one file is fixed.

## Tests (TDD)

Extended the existing runtime heredoc-extraction harness in `pipeline/build_product_quality_gate_test.go` (extract probe → run under hermetic PATH):

- **New** `makefile_ci_failure_rc1`: a `ci:` target that fails → rc=1, not 2 (RED before the fix with `RC=2`, GREEN after). The recipe uses `|| exit 1` to force the shell path so it doesn't depend on hermetic-bin contents.
- Existing `make_missing_rc2` (no make on PATH → rc=2) and `makefile_ci_target_wins` (passing target → rc=0) pin the other two cases.
- Pins `TestQualityGateMakefilePathPreserved` (the `make "$TARGET" 2>&1` invocation + awk parser) and `TestQualityGateRc2OnlyMakeMissing` (exactly one `return 2`, anchored to `command -v make`) stay green.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓ (19 packages)
- `dippin doctor` baselines hold: ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783713580&installation_id=131176874&pr_number=341&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F341&signature=4e4d82b8379d250c5cc475552756abcb2e304d9af3ebcdabb7c88c05b37f2142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->