### PR TITLE
feat(handlers): configurable parallel fan-in aggregation policy (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeed; `quorum` requires at least `<n>` successful branches. Both
   aggregation code paths honor the policy — `ParallelHandler`'s
   `aggregateStatus` and `FanInHandler` — so the policy can be declared on
-  either node. Unknown policies and `quorum` without a positive `n` fail
-  fast before any branch is dispatched. A policy-caused failure names the
+  either node. Unknown policies and `quorum` without a positive `n` are
+  hard configuration errors (on a parallel node they fail before any branch
+  is dispatched; on a fan_in node, when it executes). A policy-caused
+  failure names the
   policy and the failed branch IDs in the `EventParallelCompleted` message,
   and the fan-in handler records the same detail under the
   `fan_in.policy_detail` context key for the audit trail. A policy-failed
   parallel node routes through normal `ctx.outcome = fail` edges — no new
   engine special case — and suppresses its join-node suggestion so edge
   selection cannot fall through to the fan-in and mask the failure (the
-  default `any` policy keeps suggesting the join on all-fail, as before). `examples/build_product.dip` opts `ReviewParallel`
+  default `any` policy keeps suggesting the join on all-fail, as before).
+  `examples/build_product.dip` opts `ReviewParallel`
   into `fan_in_policy: all`, so a single failed reviewer (the canonical
   masked-adversarial-review bug) now routes to `EscalateReview` instead of
   silently proceeding with a partial review set; the `CheckReviewsComplete`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Configurable parallel fan-in aggregation policy** (issue #313, defect 1).
+  Parallel and fan-in nodes accept a `params:` block (dippin-lang v0.39.0)
+  with `fan_in_policy: any | all | quorum` (plus `quorum: <n>`). The default
+  stays `any` (success-if-any, back-compat); `all` requires every branch to
+  succeed; `quorum` requires at least `<n>` successful branches. Both
+  aggregation code paths honor the policy — `ParallelHandler`'s
+  `aggregateStatus` and `FanInHandler` — so the policy can be declared on
+  either node. Unknown policies and `quorum` without a positive `n` fail
+  fast before any branch is dispatched. A policy-caused failure names the
+  policy and the failed branch IDs in the `EventParallelCompleted` message,
+  and the fan-in handler records the same detail under the
+  `fan_in.policy_detail` context key for the audit trail. A policy-failed
+  parallel node routes through normal `ctx.outcome = fail` edges — no new
+  engine special case. `examples/build_product.dip` opts `ReviewParallel`
+  into `fan_in_policy: all`, so a single failed reviewer (the canonical
+  masked-adversarial-review bug) now routes to `EscalateReview` instead of
+  silently proceeding with a partial review set; the `CheckReviewsComplete`
+  guard from PR #326 stays as defense in depth. dippin-lang dependency
+  bumped to v0.39.0.
+
 ### Fixed
 
 - **`build_product.dip` runs ALL detected build stacks in `TestMilestone` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the fan-in handler records the same detail under the
   `fan_in.policy_detail` context key for the audit trail. A policy-failed
   parallel node routes through normal `ctx.outcome = fail` edges — no new
-  engine special case. `examples/build_product.dip` opts `ReviewParallel`
+  engine special case — and suppresses its join-node suggestion so edge
+  selection cannot fall through to the fan-in and mask the failure (the
+  default `any` policy keeps suggesting the join on all-fail, as before). `examples/build_product.dip` opts `ReviewParallel`
   into `fan_in_policy: all`, so a single failed reviewer (the canonical
   masked-adversarial-review bug) now routes to `EscalateReview` instead of
   silently proceeding with a partial review set; the `CheckReviewsComplete`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either node. Unknown policies and `quorum` without a positive `n` are
   hard configuration errors (on a parallel node they fail before any branch
   is dispatched; on a fan_in node, when it executes). A policy-caused
-  failure names the
-  policy and the failed branch IDs in the `EventParallelCompleted` message,
+  failure names the policy and the failed branch IDs in the
+  `EventParallelCompleted` message,
   and the fan-in handler records the same detail under the
   `fan_in.policy_detail` context key for the audit trail. A policy-failed
   parallel node routes through normal `ctx.outcome = fail` edges — no new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hard configuration errors (on a parallel node they fail before any branch
   is dispatched; on a fan_in node, when it executes). A policy-caused
   failure names the policy and the failed branch IDs in the
-  `EventParallelCompleted` message,
-  and the fan-in handler records the same detail under the
-  `fan_in.policy_detail` context key for the audit trail. A policy-failed
+  `EventParallelCompleted` message, and both handlers record the same
+  detail under the `fan_in.policy_detail` context key for the audit trail
+  (the parallel handler writes it too, since a policy failure can skip the
+  fan-in node). A policy-failed
   parallel node routes through normal `ctx.outcome = fail` edges — no new
   engine special case — and suppresses its join-node suggestion so edge
   selection cannot fall through to the fan-in and mask the failure (the
   default `any` policy keeps suggesting the join on all-fail, as before).
-  `examples/build_product.dip` opts `ReviewParallel`
-  into `fan_in_policy: all`, so a single failed reviewer (the canonical
+  `examples/build_product.dip` opts `ReviewParallel` into
+  `fan_in_policy: all`, so a single failed reviewer (the canonical
   masked-adversarial-review bug) now routes to `EscalateReview` instead of
   silently proceeding with a partial review set; the `CheckReviewsComplete`
   guard from PR #326 stays as defense in depth. dippin-lang dependency

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1304,10 +1304,12 @@ workflow BuildProduct
     timeout: 5s
     command:
       set -eu
-      # issue #313: the fan-in is success-if-any, so a reviewer that exhausts
-      # max_turns and fails is masked. CheckReviewsComplete (after the join)
-      # keys on review-file presence; clear last round's reports so a reviewer
-      # that fails on a re-review pass can't be satisfied by a stale file from
+      # issue #313: ReviewParallel declares fan_in_policy: all, so a reviewer
+      # that exhausts max_turns and FAILS now routes to EscalateReview — but a
+      # reviewer that reports success without writing its file is invisible to
+      # any aggregation policy. CheckReviewsComplete (after the join) keys on
+      # review-file presence; clear last round's reports so a reviewer that
+      # fails on a re-review pass can't be satisfied by a stale file from
       # the prior pass. Runs on BOTH inbound paths to ReviewParallel (first
       # entry from PickNextMilestone and the capped re-review restart loop).
       mkdir -p .ai/build

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1315,6 +1315,8 @@ workflow BuildProduct
       printf 'cleared stale review reports\n'
 
   parallel ReviewParallel -> ReviewClaude, ReviewCodex, ReviewGemini
+    params:
+      fan_in_policy: all
 
   # Phase 3 reviewers (issue #233 Gap 2). All three carry the same 5-point
   # structured rubric so the synthesis step can compare findings on equal
@@ -1529,10 +1531,12 @@ workflow BuildProduct
     timeout: 5s
     command:
       set -eu
-      # issue #313 defense-in-depth: the parallel fan-in is success-if-any, so
-      # a single reviewer that exhausts max_turns and never writes its report
-      # is silently masked — SynthesizeReviews would synthesize from a partial
-      # set. Require ALL THREE reports present + non-empty; a single missing
+      # issue #313 defense-in-depth: ReviewParallel now declares
+      # fan_in_policy: all, so a failed reviewer routes to EscalateReview
+      # upstream — but a reviewer that "succeeds" without writing its report
+      # is invisible to any aggregation policy, and SynthesizeReviews would
+      # synthesize from a partial set. Require ALL THREE reports present +
+      # non-empty; a single missing
       # review (typically the adversarial ReviewGemini, the one most likely to
       # exhaust turns) fails the gate and routes to EscalateReview rather than
       # masking the gap. A 2-of-3 quorum would not fix this — it would still
@@ -1994,16 +1998,16 @@ workflow BuildProduct
     # The three reviewers run as parallel branches; a branch runs via
     # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
     # path, so a per-branch fallback_target would be inert. Route failure on the
-    # aggregating ReviewParallel node instead: aggregateStatus is success-if-any,
-    # so this fires only when ALL THREE reviewers fail (which would otherwise
-    # dead-stop the pipeline). On success the parallel handler's suggested-next
-    # routes to ReviewJoin.
+    # aggregating ReviewParallel node instead. ReviewParallel declares
+    # fan_in_policy: all (issue #313, dippin-lang v0.39.0), so this fires when
+    # ANY of the three reviewers fails — a single missing adversarial review can
+    # no longer be masked by the default success-if-any aggregation. On success
+    # the parallel handler's suggested-next routes to ReviewJoin.
     #
-    # A SINGLE reviewer failing is NOT caught here (success-if-any masks it) and
-    # cannot be fixed in .dip — dippin v0.35.0 carries no per-node fan-in policy
-    # attribute, so the engine-level configurable-policy fix stays open on #313.
-    # Defense-in-depth lives at CheckReviewsComplete below: it fails loudly if
-    # any of the three review reports is missing/empty and routes to EscalateReview.
+    # Defense-in-depth stays at CheckReviewsComplete below: it fails loudly if
+    # any of the three review reports is missing/empty and routes to
+    # EscalateReview (catches a reviewer that "succeeds" without writing its
+    # report, which no aggregation policy can see).
     ReviewParallel -> EscalateReview  when ctx.outcome = fail
     ReviewClaude -> ReviewJoin
     ReviewCodex -> ReviewJoin

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.38.0
+	github.com/2389-research/dippin-lang v0.39.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/2389-research/dippin-lang v0.38.0 h1:nkmT0abGrAZDRXmSSERDVcXz1AbxPCDMon4uLK1r9ZY=
 github.com/2389-research/dippin-lang v0.38.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.39.0 h1:hEV4wu7ZBkcQTp4YbgokcqVJMgzL17pYkPYWHZS3ioQ=
+github.com/2389-research/dippin-lang v0.39.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pipeline/context.go
+++ b/pipeline/context.go
@@ -44,6 +44,13 @@ const (
 	ContextKeyToolRoute          = "tool_route"
 	ContextKeySuggestedNextNodes = "suggested_next_nodes"
 
+	// ContextKeyFanInPolicyDetail records the most recent fan-in policy
+	// evaluation (#313) — policy name, success tally, and failed branch IDs.
+	// Written by both the parallel and fan-in handlers for non-default
+	// (all/quorum) policies, on success and failure, so the audit trail and
+	// diagnose can explain policy-caused routing.
+	ContextKeyFanInPolicyDetail = "fan_in.policy_detail"
+
 	// ContextKeyResponsePrefix is prepended to a node ID to form a per-node
 	// response key (e.g. "response.mynode"). Downstream nodes can reference
 	// specific upstream outputs without relying on last_response being current.

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -467,11 +467,26 @@ func extractParallelAttrs(cfg ir.ParallelConfig, attrs map[string]string) {
 			attrs[prefix+"fidelity"] = branch.Fidelity
 		}
 	}
+	// Generic params pass-through (dippin-lang v0.39.0, #313) — e.g.
+	// fan_in_policy / quorum. Typed fields above take precedence.
+	spillParams(cfg.Params, attrs)
 }
 
 func extractFanInAttrs(cfg ir.FanInConfig, attrs map[string]string) {
 	if len(cfg.Sources) > 0 {
 		attrs["fan_in_sources"] = strings.Join(cfg.Sources, ",")
+	}
+	// Generic params pass-through (dippin-lang v0.39.0, #313).
+	spillParams(cfg.Params, attrs)
+}
+
+// spillParams copies params into attrs without overwriting keys already set
+// by typed-field extraction (mirrors the AgentConfig.Params convention).
+func spillParams(params, attrs map[string]string) {
+	for k, v := range params {
+		if _, exists := attrs[k]; !exists {
+			attrs[k] = v
+		}
 	}
 }
 

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -387,6 +387,68 @@ func TestFromDippinIR_ParallelConfig(t *testing.T) {
 	}
 }
 
+// TestFromDippinIR_ParallelFanInParams verifies that generic Params on
+// parallel and fan_in IR nodes (dippin-lang v0.39.0) are forwarded into node
+// attrs, with typed fields taking precedence over Params keys (#313).
+func TestFromDippinIR_ParallelFanInParams(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "ParallelParamsTest",
+		Start: "start",
+		Exit:  "exit",
+		Nodes: []*ir.Node{
+			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{
+				ID:   "parallel",
+				Kind: ir.NodeParallel,
+				Config: ir.ParallelConfig{
+					Targets: []string{"task1", "task2"},
+					Params: map[string]string{
+						"fan_in_policy":    "all",
+						"parallel_targets": "evil_override", // typed field must win
+					},
+				},
+			},
+			{ID: "task1", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{ID: "task2", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+			{
+				ID:   "join",
+				Kind: ir.NodeFanIn,
+				Config: ir.FanInConfig{
+					Sources: []string{"task1", "task2"},
+					Params: map[string]string{
+						"fan_in_policy": "quorum",
+						"quorum":        "2",
+					},
+				},
+			},
+			{ID: "exit", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
+		},
+		Edges: []*ir.Edge{
+			{From: "start", To: "parallel"},
+			{From: "join", To: "exit"},
+		},
+	}
+
+	graph, err := FromDippinIR(workflow)
+	if err != nil {
+		t.Fatalf("FromDippinIR failed: %v", err)
+	}
+
+	par := graph.Nodes["parallel"]
+	if par.Attrs["fan_in_policy"] != "all" {
+		t.Errorf("parallel fan_in_policy = %q, want all", par.Attrs["fan_in_policy"])
+	}
+	if par.Attrs["parallel_targets"] != "task1,task2" {
+		t.Errorf("typed Targets must win over Params, got %q", par.Attrs["parallel_targets"])
+	}
+
+	join := graph.Nodes["join"]
+	if join.Attrs["fan_in_policy"] != "quorum" || join.Attrs["quorum"] != "2" {
+		t.Errorf("fan_in params not forwarded: policy=%q quorum=%q",
+			join.Attrs["fan_in_policy"], join.Attrs["quorum"])
+	}
+}
+
 // TestFromDippinIR_FanInConfig verifies FanInConfig extraction.
 func TestFromDippinIR_FanInConfig(t *testing.T) {
 	workflow := &ir.Workflow{

--- a/pipeline/handlers/fanin.go
+++ b/pipeline/handlers/fanin.go
@@ -58,7 +58,7 @@ func (h *FanInHandler) Execute(_ context.Context, node *pipeline.Node, pctx *pip
 		// write would leave a stale "failed" detail after a later pass
 		// succeeds. Successful-branch context still merges above so
 		// downstream escalation gates can reference partial output.
-		merged["fan_in.policy_detail"] = policy.detail(successes, len(results), failed)
+		merged[pipeline.ContextKeyFanInPolicyDetail] = policy.detail(successes, len(results), failed)
 	}
 
 	return pipeline.Outcome{

--- a/pipeline/handlers/fanin.go
+++ b/pipeline/handlers/fanin.go
@@ -27,8 +27,14 @@ func (h *FanInHandler) Name() string { return "parallel.fan_in" }
 // Execute reads "parallel.results" from the pipeline context, unmarshals the
 // branch results, merges context updates from all successful branches (in
 // order, so later branches overwrite earlier ones for the same key), and
-// returns OutcomeSuccess if any branch succeeded or OutcomeFail if all failed.
+// evaluates the node's fan-in policy (#313) — default "any": OutcomeSuccess
+// if any branch succeeded, OutcomeFail if all failed.
 func (h *FanInHandler) Execute(_ context.Context, node *pipeline.Node, pctx *pipeline.PipelineContext) (pipeline.Outcome, error) {
+	policy, err := resolveFanInPolicy(node.ID, node.ParallelConfig())
+	if err != nil {
+		return pipeline.Outcome{}, err
+	}
+
 	raw, ok := pctx.Get("parallel.results")
 	if !ok {
 		return pipeline.Outcome{}, fmt.Errorf("fan-in node %q: missing parallel.results in context", node.ID)
@@ -39,10 +45,20 @@ func (h *FanInHandler) Execute(_ context.Context, node *pipeline.Node, pctx *pip
 		return pipeline.Outcome{}, fmt.Errorf("fan-in node %q: failed to unmarshal parallel.results: %w", node.ID, err)
 	}
 
-	merged, anySuccess := mergeSuccessfulBranches(results)
+	merged := mergeSuccessfulBranches(results)
+	successes, failed := tallyBranches(results)
 	status := pipeline.OutcomeFail
-	if anySuccess {
+	if policy.satisfied(successes, len(results)) {
 		status = pipeline.OutcomeSuccess
+	}
+	if policy.name != "any" {
+		// Record the policy evaluation in context so the audit trail /
+		// diagnose can explain the routing (#313). Written on success too —
+		// pipeline context persists across re-review loops, so a fail-only
+		// write would leave a stale "failed" detail after a later pass
+		// succeeds. Successful-branch context still merges above so
+		// downstream escalation gates can reference partial output.
+		merged["fan_in.policy_detail"] = policy.detail(successes, len(results), failed)
 	}
 
 	return pipeline.Outcome{
@@ -52,17 +68,14 @@ func (h *FanInHandler) Execute(_ context.Context, node *pipeline.Node, pctx *pip
 }
 
 // mergeSuccessfulBranches collects context updates from successful branches.
-// Returns the merged map and whether any branch succeeded.
-func mergeSuccessfulBranches(results []ParallelResult) (map[string]string, bool) {
+func mergeSuccessfulBranches(results []ParallelResult) map[string]string {
 	merged := make(map[string]string)
-	anySuccess := false
 	for _, r := range results {
 		if r.Status == string(pipeline.OutcomeSuccess) {
-			anySuccess = true
 			for k, v := range r.ContextUpdates {
 				merged[k] = v
 			}
 		}
 	}
-	return merged, anySuccess
+	return merged
 }

--- a/pipeline/handlers/fanin_policy.go
+++ b/pipeline/handlers/fanin_policy.go
@@ -1,5 +1,5 @@
 // ABOUTME: Configurable fan-in aggregation policy shared by the parallel and fan-in handlers (#313).
-// ABOUTME: Supports any (default, success-if-any), all, and quorum:<n> branch-success policies.
+// ABOUTME: Supports fan_in_policy: any (default, success-if-any), all, or quorum (with quorum: <n>).
 package handlers
 
 import (

--- a/pipeline/handlers/fanin_policy.go
+++ b/pipeline/handlers/fanin_policy.go
@@ -1,0 +1,77 @@
+// ABOUTME: Configurable fan-in aggregation policy shared by the parallel and fan-in handlers (#313).
+// ABOUTME: Supports any (default, success-if-any), all, and quorum:<n> branch-success policies.
+package handlers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// fanInPolicy is the resolved branch-aggregation policy for a parallel or
+// fan-in node. Both aggregation code paths (ParallelHandler.aggregateStatus
+// and FanInHandler) evaluate the same policy so a workflow can declare it on
+// either node.
+type fanInPolicy struct {
+	name   string // "any", "all", or "quorum"
+	quorum int    // required successes when name == "quorum"
+}
+
+// resolveFanInPolicy validates the node's fan_in_policy / quorum params and
+// returns the effective policy. Unset means "any" (success-if-any) for
+// back-compat. Unknown policies and quorum without a positive n are
+// configuration errors — fail loudly rather than silently aggregating.
+func resolveFanInPolicy(nodeID string, cfg pipeline.ParallelNodeConfig) (fanInPolicy, error) {
+	switch cfg.FanInPolicy {
+	case "", "any":
+		return fanInPolicy{name: "any"}, nil
+	case "all":
+		return fanInPolicy{name: "all"}, nil
+	case "quorum":
+		if cfg.Quorum < 1 {
+			return fanInPolicy{}, fmt.Errorf("node %q: fan_in_policy=quorum requires a positive quorum param", nodeID)
+		}
+		return fanInPolicy{name: "quorum", quorum: cfg.Quorum}, nil
+	default:
+		return fanInPolicy{}, fmt.Errorf("node %q: unknown fan_in_policy %q (want any, all, or quorum)", nodeID, cfg.FanInPolicy)
+	}
+}
+
+// satisfied reports whether the policy is met by the given branch tally.
+func (p fanInPolicy) satisfied(successes, total int) bool {
+	switch p.name {
+	case "all":
+		return total > 0 && successes == total
+	case "quorum":
+		return successes >= p.quorum
+	default: // any
+		return successes > 0
+	}
+}
+
+// detail renders a human-readable explanation of the policy evaluation for
+// events and audit context, naming any failed branches.
+func (p fanInPolicy) detail(successes, total int, failed []string) string {
+	d := fmt.Sprintf("policy %s: %d/%d branches succeeded", p.name, successes, total)
+	if p.name == "quorum" {
+		d = fmt.Sprintf("policy quorum(%d): %d/%d branches succeeded", p.quorum, successes, total)
+	}
+	if len(failed) > 0 {
+		d += "; failed: " + strings.Join(failed, ", ")
+	}
+	return d
+}
+
+// tallyBranches counts successful branches and collects the IDs of
+// non-successful ones.
+func tallyBranches(results []ParallelResult) (successes int, failed []string) {
+	for _, r := range results {
+		if r.Status == string(pipeline.OutcomeSuccess) {
+			successes++
+		} else {
+			failed = append(failed, r.NodeID)
+		}
+	}
+	return successes, failed
+}

--- a/pipeline/handlers/fanin_policy_test.go
+++ b/pipeline/handlers/fanin_policy_test.go
@@ -1,0 +1,259 @@
+// ABOUTME: Tests for the configurable fan-in aggregation policy (issue #313).
+// ABOUTME: Covers any/all/quorum semantics in both the parallel and fan-in handlers.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// mixedStubHandler returns fail for node IDs in failIDs, success otherwise.
+func mixedStubHandler(name string, failIDs ...string) *stubHandler {
+	failSet := make(map[string]bool, len(failIDs))
+	for _, id := range failIDs {
+		failSet[id] = true
+	}
+	return &stubHandler{
+		name: name,
+		execFunc: func(_ context.Context, node *pipeline.Node, _ *pipeline.PipelineContext) (pipeline.Outcome, error) {
+			if failSet[node.ID] {
+				return pipeline.Outcome{Status: string(pipeline.OutcomeFail)}, nil
+			}
+			return pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)}, nil
+		},
+	}
+}
+
+// runParallelWithPolicy executes a parallel node over the given branches with
+// fan_in_policy attrs applied, returning the outcome.
+func runParallelWithPolicy(t *testing.T, branches []string, policyAttrs map[string]string, stub *stubHandler, eh pipeline.PipelineEventHandler) (pipeline.Outcome, error) {
+	t.Helper()
+	g := buildTestGraph(branches, stub.name)
+	for k, v := range policyAttrs {
+		g.Nodes["parallel_node"].Attrs[k] = v
+	}
+	registry := pipeline.NewHandlerRegistry()
+	registry.Register(stub)
+	h := NewParallelHandler(g, registry, eh)
+	return h.Execute(context.Background(), g.Nodes["parallel_node"], pipeline.NewPipelineContext())
+}
+
+// --- parallel handler (aggregateStatus path) ---
+
+// Default policy (unset) stays success-if-any — back-compat pin for #313.
+func TestParallelHandlerDefaultPolicyIsAny(t *testing.T) {
+	stub := mixedStubHandler("stub_pin_any", "branch_fail")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"}, nil, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("default policy must remain success-if-any, got %q", outcome.Status)
+	}
+}
+
+func TestParallelHandlerPolicyAllFailsOnPartialFailure(t *testing.T) {
+	stub := mixedStubHandler("stub_all_partial", "branch_fail")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"},
+		map[string]string{"fan_in_policy": "all"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("policy=all with a failed branch should aggregate fail, got %q", outcome.Status)
+	}
+}
+
+func TestParallelHandlerPolicyAllSucceedsWhenAllSucceed(t *testing.T) {
+	stub := mixedStubHandler("stub_all_ok")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b"},
+		map[string]string{"fan_in_policy": "all"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("policy=all with all branches succeeding should be success, got %q", outcome.Status)
+	}
+}
+
+func TestParallelHandlerPolicyQuorum(t *testing.T) {
+	cases := []struct {
+		name   string
+		quorum string
+		want   string
+	}{
+		{"met", "2", string(pipeline.OutcomeSuccess)},   // 2/3 succeed, quorum 2
+		{"not_met", "3", string(pipeline.OutcomeFail)},  // 2/3 succeed, quorum 3
+		{"unsatisfiable", "4", string(pipeline.OutcomeFail)}, // quorum > branch count
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := mixedStubHandler("stub_quorum_"+tc.name, "branch_fail")
+			outcome, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b", "branch_fail"},
+				map[string]string{"fan_in_policy": "quorum", "quorum": tc.quorum}, stub, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if outcome.Status != tc.want {
+				t.Errorf("quorum=%s with 2/3 succeeding: got %q, want %q", tc.quorum, outcome.Status, tc.want)
+			}
+		})
+	}
+}
+
+// Invalid policy config errors before any branch executes (fail fast).
+func TestParallelHandlerPolicyInvalidConfig(t *testing.T) {
+	cases := []struct {
+		name  string
+		attrs map[string]string
+	}{
+		{"unknown_policy", map[string]string{"fan_in_policy": "bogus"}},
+		{"quorum_missing_n", map[string]string{"fan_in_policy": "quorum"}},
+		{"quorum_non_positive", map[string]string{"fan_in_policy": "quorum", "quorum": "0"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := mixedStubHandler("stub_invalid_" + tc.name)
+			_, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b"}, tc.attrs, stub, nil)
+			if err == nil {
+				t.Fatal("expected error for invalid policy config")
+			}
+			if stub.called.Load() != 0 {
+				t.Errorf("branches must not execute on invalid policy config, got %d calls", stub.called.Load())
+			}
+		})
+	}
+}
+
+// A policy-caused failure must be visible in the EventParallelCompleted
+// message (policy name + failed branch IDs) so the TUI / diagnose see it.
+func TestParallelHandlerPolicyFailureSurfacesInEvent(t *testing.T) {
+	stub := mixedStubHandler("stub_event_policy", "branch_fail")
+	eh := &collectingEventHandler{}
+	outcome, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"},
+		map[string]string{"fan_in_policy": "all"}, stub, eh)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Fatalf("expected fail, got %q", outcome.Status)
+	}
+	var completed *pipeline.PipelineEvent
+	for i := range eh.events {
+		if eh.events[i].Type == pipeline.EventParallelCompleted {
+			completed = &eh.events[i]
+		}
+	}
+	if completed == nil {
+		t.Fatal("no EventParallelCompleted emitted")
+	}
+	if !strings.Contains(completed.Message, "all") || !strings.Contains(completed.Message, "branch_fail") {
+		t.Errorf("EventParallelCompleted message should name the policy and failed branches, got %q", completed.Message)
+	}
+}
+
+// --- fan-in handler (mergeSuccessfulBranches path) ---
+
+func runFanInWithPolicy(t *testing.T, results []ParallelResult, policyAttrs map[string]string) (pipeline.Outcome, error) {
+	t.Helper()
+	node := &pipeline.Node{ID: "fan_in_node", Handler: "parallel.fan_in", Attrs: policyAttrs}
+	pctx := pipeline.NewPipelineContext()
+	data, err := json.Marshal(results)
+	if err != nil {
+		t.Fatalf("marshal results: %v", err)
+	}
+	pctx.Set("parallel.results", string(data))
+	return NewFanInHandler().Execute(context.Background(), node, pctx)
+}
+
+func TestFanInHandlerPolicyAllFailsOnPartialFailure(t *testing.T) {
+	results := []ParallelResult{
+		{NodeID: "branch_ok", Status: string(pipeline.OutcomeSuccess), ContextUpdates: map[string]string{"from_ok": "yes"}},
+		{NodeID: "branch_fail", Status: string(pipeline.OutcomeFail), Error: "boom"},
+	}
+	outcome, err := runFanInWithPolicy(t, results, map[string]string{"fan_in_policy": "all"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("policy=all with a failed branch should be fail, got %q", outcome.Status)
+	}
+	// Successful-branch context still merges so downstream escalation gates
+	// can reference partial output.
+	if outcome.ContextUpdates["from_ok"] != "yes" {
+		t.Errorf("successful branch context should still merge, got %v", outcome.ContextUpdates)
+	}
+}
+
+func TestFanInHandlerPolicyQuorum(t *testing.T) {
+	results := []ParallelResult{
+		{NodeID: "a", Status: string(pipeline.OutcomeSuccess)},
+		{NodeID: "b", Status: string(pipeline.OutcomeSuccess)},
+		{NodeID: "c", Status: string(pipeline.OutcomeFail)},
+	}
+	met, err := runFanInWithPolicy(t, results, map[string]string{"fan_in_policy": "quorum", "quorum": "2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if met.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("quorum=2 with 2/3 succeeding should be success, got %q", met.Status)
+	}
+	notMet, err := runFanInWithPolicy(t, results, map[string]string{"fan_in_policy": "quorum", "quorum": "3"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if notMet.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("quorum=3 with 2/3 succeeding should be fail, got %q", notMet.Status)
+	}
+}
+
+func TestFanInHandlerPolicyInvalidConfig(t *testing.T) {
+	results := []ParallelResult{{NodeID: "a", Status: string(pipeline.OutcomeSuccess)}}
+	for name, attrs := range map[string]map[string]string{
+		"unknown_policy":   {"fan_in_policy": "bogus"},
+		"quorum_missing_n": {"fan_in_policy": "quorum"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := runFanInWithPolicy(t, results, attrs); err == nil {
+				t.Fatal("expected error for invalid policy config")
+			}
+		})
+	}
+}
+
+// Policy-caused fan-in failure records a human-readable detail in context so
+// the audit trail / diagnose can explain why a partially-successful parallel
+// block routed to fail.
+func TestFanInHandlerPolicyFailureDetailInContext(t *testing.T) {
+	results := []ParallelResult{
+		{NodeID: "branch_ok", Status: string(pipeline.OutcomeSuccess)},
+		{NodeID: "branch_fail", Status: string(pipeline.OutcomeFail), Error: "boom"},
+	}
+	outcome, err := runFanInWithPolicy(t, results, map[string]string{"fan_in_policy": "all"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	detail := outcome.ContextUpdates["fan_in.policy_detail"]
+	if !strings.Contains(detail, "all") || !strings.Contains(detail, "branch_fail") {
+		t.Errorf("fan_in.policy_detail should name the policy and failed branches, got %q", detail)
+	}
+}
+
+// Default (unset) fan-in policy stays success-if-any — back-compat pin for #313.
+func TestFanInHandlerDefaultPolicyIsAny(t *testing.T) {
+	results := []ParallelResult{
+		{NodeID: "branch_ok", Status: string(pipeline.OutcomeSuccess)},
+		{NodeID: "branch_fail", Status: string(pipeline.OutcomeFail)},
+	}
+	outcome, err := runFanInWithPolicy(t, results, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("default policy must remain success-if-any, got %q", outcome.Status)
+	}
+}

--- a/pipeline/handlers/fanin_policy_test.go
+++ b/pipeline/handlers/fanin_policy_test.go
@@ -167,7 +167,7 @@ func TestParallelHandlerPolicyDetailInContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	detail := failOut.ContextUpdates["fan_in.policy_detail"]
+	detail := failOut.ContextUpdates[pipeline.ContextKeyFanInPolicyDetail]
 	if !strings.Contains(detail, "all") || !strings.Contains(detail, "branch_fail") {
 		t.Errorf("policy-failed parallel node should record fan_in.policy_detail, got %q", detail)
 	}
@@ -178,7 +178,7 @@ func TestParallelHandlerPolicyDetailInContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if d := okOut.ContextUpdates["fan_in.policy_detail"]; !strings.Contains(d, "2/2") {
+	if d := okOut.ContextUpdates[pipeline.ContextKeyFanInPolicyDetail]; !strings.Contains(d, "2/2") {
 		t.Errorf("satisfied policy should also record detail, got %q", d)
 	}
 
@@ -188,7 +188,7 @@ func TestParallelHandlerPolicyDetailInContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, exists := anyOut.ContextUpdates["fan_in.policy_detail"]; exists {
+	if _, exists := anyOut.ContextUpdates[pipeline.ContextKeyFanInPolicyDetail]; exists {
 		t.Error("default any policy must not write fan_in.policy_detail")
 	}
 }
@@ -324,7 +324,7 @@ func TestFanInHandlerPolicyFailureDetailInContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	detail := outcome.ContextUpdates["fan_in.policy_detail"]
+	detail := outcome.ContextUpdates[pipeline.ContextKeyFanInPolicyDetail]
 	if !strings.Contains(detail, "all") || !strings.Contains(detail, "branch_fail") {
 		t.Errorf("fan_in.policy_detail should name the policy and failed branches, got %q", detail)
 	}

--- a/pipeline/handlers/fanin_policy_test.go
+++ b/pipeline/handlers/fanin_policy_test.go
@@ -156,6 +156,43 @@ func TestParallelHandlerPolicyFailureSurfacesInEvent(t *testing.T) {
 	}
 }
 
+// The PARALLEL handler also records fan_in.policy_detail for non-default
+// policies — a policy failure suppresses the join suggestion, so the fan-in
+// node (the other detail writer) may never run (Copilot, PR #344). Written
+// on success too so a later pass can't leave a stale "failed" detail.
+func TestParallelHandlerPolicyDetailInContext(t *testing.T) {
+	stub := mixedStubHandler("stub_par_detail", "branch_fail")
+	failOut, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"},
+		map[string]string{"fan_in_policy": "all"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	detail := failOut.ContextUpdates["fan_in.policy_detail"]
+	if !strings.Contains(detail, "all") || !strings.Contains(detail, "branch_fail") {
+		t.Errorf("policy-failed parallel node should record fan_in.policy_detail, got %q", detail)
+	}
+
+	okStub := mixedStubHandler("stub_par_detail_ok")
+	okOut, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b"},
+		map[string]string{"fan_in_policy": "all"}, okStub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d := okOut.ContextUpdates["fan_in.policy_detail"]; !strings.Contains(d, "2/2") {
+		t.Errorf("satisfied policy should also record detail, got %q", d)
+	}
+
+	// Default any policy: no detail key (back-compat).
+	anyStub := mixedStubHandler("stub_par_detail_any", "branch_fail")
+	anyOut, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"}, nil, anyStub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, exists := anyOut.ContextUpdates["fan_in.policy_detail"]; exists {
+		t.Error("default any policy must not write fan_in.policy_detail")
+	}
+}
+
 // A policy-caused failure must NOT suggest the join node — otherwise a
 // workflow with (say) only a success conditional on the parallel node falls
 // through selectBySuggested to the join and the fan-in (default any) masks

--- a/pipeline/handlers/fanin_policy_test.go
+++ b/pipeline/handlers/fanin_policy_test.go
@@ -86,8 +86,8 @@ func TestParallelHandlerPolicyQuorum(t *testing.T) {
 		quorum string
 		want   string
 	}{
-		{"met", "2", string(pipeline.OutcomeSuccess)},   // 2/3 succeed, quorum 2
-		{"not_met", "3", string(pipeline.OutcomeFail)},  // 2/3 succeed, quorum 3
+		{"met", "2", string(pipeline.OutcomeSuccess)},        // 2/3 succeed, quorum 2
+		{"not_met", "3", string(pipeline.OutcomeFail)},       // 2/3 succeed, quorum 3
 		{"unsatisfiable", "4", string(pipeline.OutcomeFail)}, // quorum > branch count
 	}
 	for _, tc := range cases {

--- a/pipeline/handlers/fanin_policy_test.go
+++ b/pipeline/handlers/fanin_policy_test.go
@@ -156,6 +156,56 @@ func TestParallelHandlerPolicyFailureSurfacesInEvent(t *testing.T) {
 	}
 }
 
+// A policy-caused failure must NOT suggest the join node — otherwise a
+// workflow with (say) only a success conditional on the parallel node falls
+// through selectBySuggested to the join and the fan-in (default any) masks
+// the failure the policy was meant to surface (Codex review, PR #344).
+func TestParallelHandlerPolicyFailureSuppressesJoinSuggestion(t *testing.T) {
+	stub := mixedStubHandler("stub_policy_join", "branch_fail")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_ok", "branch_fail"},
+		map[string]string{"fan_in_policy": "all", "parallel_join": "join_node"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Fatalf("expected fail, got %q", outcome.Status)
+	}
+	if v := outcome.ContextUpdates[pipeline.ContextKeySuggestedNextNodes]; v != "" {
+		t.Errorf("policy failure must not suggest the join, got %q", v)
+	}
+}
+
+// Back-compat pin: under the default any policy, an all-branches-failed
+// parallel node STILL suggests the join — existing workflows route that
+// failure at the fan-in node downstream.
+func TestParallelHandlerDefaultPolicyAllFailStillSuggestsJoin(t *testing.T) {
+	stub := mixedStubHandler("stub_anyfail_join", "branch_a", "branch_b")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b"},
+		map[string]string{"parallel_join": "join_node"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Fatalf("expected fail, got %q", outcome.Status)
+	}
+	if v := outcome.ContextUpdates[pipeline.ContextKeySuggestedNextNodes]; v != "join_node" {
+		t.Errorf("default-policy all-fail should keep suggesting the join, got %q", v)
+	}
+}
+
+// A satisfied non-default policy keeps the join suggestion.
+func TestParallelHandlerPolicySuccessKeepsJoinSuggestion(t *testing.T) {
+	stub := mixedStubHandler("stub_policy_ok_join")
+	outcome, err := runParallelWithPolicy(t, []string{"branch_a", "branch_b"},
+		map[string]string{"fan_in_policy": "all", "parallel_join": "join_node"}, stub, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v := outcome.ContextUpdates[pipeline.ContextKeySuggestedNextNodes]; v != "join_node" {
+		t.Errorf("satisfied policy should suggest the join, got %q", v)
+	}
+}
+
 // --- fan-in handler (mergeSuccessfulBranches path) ---
 
 func runFanInWithPolicy(t *testing.T, results []ParallelResult, policyAttrs map[string]string) (pipeline.Outcome, error) {

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -54,6 +54,13 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 		return pipeline.Outcome{}, err
 	}
 
+	// Validate the aggregation policy before dispatching any branch — a
+	// misconfigured policy must fail fast, not after burning branch work.
+	policy, err := resolveFanInPolicy(node.ID, node.ParallelConfig())
+	if err != nil {
+		return pipeline.Outcome{}, err
+	}
+
 	branchOverrides := parseBranchOverrides(node.Attrs)
 
 	branchIDs := make([]string, len(edges))
@@ -75,13 +82,19 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	}
 	pctx.Set("parallel.results", string(resultsJSON))
 
-	status := aggregateStatus(collected)
+	status, policyDetail := aggregateStatus(collected, policy)
 
+	msg := fmt.Sprintf("fan-in complete, aggregate status: %s", status)
+	if policy.name != "any" {
+		// Surface the policy evaluation (incl. failed branch IDs) so the TUI
+		// and `tracker diagnose` can explain a policy-caused failure (#313).
+		msg += " (" + policyDetail + ")"
+	}
 	h.eventHandler.HandlePipelineEvent(pipeline.PipelineEvent{
 		Type:      pipeline.EventParallelCompleted,
 		Timestamp: time.Now(),
 		NodeID:    node.ID,
-		Message:   fmt.Sprintf("fan-in complete, aggregate status: %s", status),
+		Message:   msg,
 	})
 
 	outcome := pipeline.Outcome{
@@ -320,14 +333,16 @@ func (h *ParallelHandler) emitBranchComplete(nodeID string, pr ParallelResult) {
 	}
 }
 
-// aggregateStatus returns success if at least one branch succeeded, fail otherwise.
-func aggregateStatus(results []ParallelResult) string {
-	for _, r := range results {
-		if r.Status == string(pipeline.OutcomeSuccess) {
-			return string(pipeline.OutcomeSuccess)
-		}
+// aggregateStatus evaluates the branch results against the fan-in policy
+// (default "any": success if at least one branch succeeded) and returns the
+// aggregate status plus a human-readable policy detail string.
+func aggregateStatus(results []ParallelResult, policy fanInPolicy) (string, string) {
+	successes, failed := tallyBranches(results)
+	status := string(pipeline.OutcomeFail)
+	if policy.satisfied(successes, len(results)) {
+		status = string(pipeline.OutcomeSuccess)
 	}
-	return string(pipeline.OutcomeFail)
+	return status, policy.detail(successes, len(results), failed)
 }
 
 // aggregateBranchStats sums SessionStats from all parallel branch results.

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -124,7 +124,7 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 		// otherwise lose the structured breadcrumb (Copilot, PR #344). Written
 		// on success as well so a later pass can't leave a stale "failed"
 		// detail in context.
-		outcome.ContextUpdates["fan_in.policy_detail"] = policyDetail
+		outcome.ContextUpdates[pipeline.ContextKeyFanInPolicyDetail] = policyDetail
 	}
 	return outcome, nil
 }

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -102,7 +102,15 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 		Stats:         aggregateBranchStats(collected),
 		ChildOverride: aggregateChildOverrides(branchOverridesOut),
 	}
-	if joinID := node.ParallelConfig().JoinID; joinID != "" {
+	// Suggest the join — EXCEPT when a non-default policy is unsatisfied.
+	// Leaving the suggestion in place would let edge selection fall through
+	// selectBySuggested to the join (bypassing strict-failure because
+	// conditional edges exist), and a default-any fan-in downstream would
+	// mask the very failure the policy surfaced (Codex review, PR #344).
+	// Under the default any policy the suggestion is kept even on all-fail —
+	// existing workflows route that failure at the fan-in node.
+	policyBlocked := policy.name != "any" && status != string(pipeline.OutcomeSuccess)
+	if joinID := node.ParallelConfig().JoinID; joinID != "" && !policyBlocked {
 		outcome.ContextUpdates = map[string]string{pipeline.ContextKeySuggestedNextNodes: joinID}
 	}
 	return outcome, nil

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -44,8 +44,11 @@ func NewParallelHandler(graph *pipeline.Graph, registry *pipeline.HandlerRegistr
 // Name returns the handler name used for registry lookup.
 func (h *ParallelHandler) Name() string { return "parallel" }
 
-// Execute fans out to all outgoing edge targets concurrently, collects results,
-// and returns OutcomeSuccess if at least one branch succeeded, OutcomeFail if all failed.
+// Execute fans out to all outgoing edge targets concurrently, collects
+// results, and aggregates them per the node's fan_in_policy (#313): the
+// default "any" returns OutcomeSuccess if at least one branch succeeded,
+// "all" requires every branch, and "quorum" requires at least `quorum`
+// successful branches.
 // If the parallel node has branch.N.* attributes, those override the target node's
 // attrs (e.g., llm_model, llm_provider, fidelity) for that specific branch.
 func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx *pipeline.PipelineContext) (pipeline.Outcome, error) {
@@ -110,8 +113,18 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	// Under the default any policy the suggestion is kept even on all-fail —
 	// existing workflows route that failure at the fan-in node.
 	policyBlocked := policy.name != "any" && status != string(pipeline.OutcomeSuccess)
+	outcome.ContextUpdates = make(map[string]string)
 	if joinID := node.ParallelConfig().JoinID; joinID != "" && !policyBlocked {
-		outcome.ContextUpdates = map[string]string{pipeline.ContextKeySuggestedNextNodes: joinID}
+		outcome.ContextUpdates[pipeline.ContextKeySuggestedNextNodes] = joinID
+	}
+	if policy.name != "any" {
+		// Record the policy evaluation in context here too — a policy failure
+		// suppresses the join suggestion, so the fan-in node (the other
+		// fan_in.policy_detail writer) may never run, and diagnose/audit would
+		// otherwise lose the structured breadcrumb (Copilot, PR #344). Written
+		// on success as well so a later pass can't leave a stale "failed"
+		// detail in context.
+		outcome.ContextUpdates["fan_in.policy_detail"] = policyDetail
 	}
 	return outcome, nil
 }

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -385,6 +385,11 @@ type ParallelNodeConfig struct {
 	JoinID          string
 	MaxConcurrency  int
 	BranchTimeout   time.Duration
+	// FanInPolicy selects the branch-aggregation policy (#313): "" / "any"
+	// (success-if-any, the default), "all", or "quorum" (requires Quorum).
+	// The accessor is lenient — handlers validate strictly at execution time.
+	FanInPolicy string
+	Quorum      int
 }
 
 // ParallelConfig returns the typed parallel/fan-in config for the node.
@@ -393,6 +398,12 @@ func (n *Node) ParallelConfig() ParallelNodeConfig {
 		ParallelTargets: n.Attrs["parallel_targets"],
 		FanInSources:    n.Attrs["fan_in_sources"],
 		JoinID:          n.Attrs["parallel_join"],
+		FanInPolicy:     n.Attrs["fan_in_policy"],
+	}
+	if v := n.Attrs["quorum"]; v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			cfg.Quorum = i
+		}
 	}
 	if v := n.Attrs["max_concurrency"]; v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {

--- a/pipeline/node_config_test.go
+++ b/pipeline/node_config_test.go
@@ -275,6 +275,29 @@ func TestHumanConfig_TimeoutParsing(t *testing.T) {
 	}
 }
 
+// fan_in_policy / quorum attrs parse into the typed config (#313). The
+// accessor is lenient (bad quorum stays 0); the handlers validate strictly.
+func TestParallelConfig_FanInPolicy(t *testing.T) {
+	n := &Node{Attrs: map[string]string{
+		"fan_in_policy": "quorum",
+		"quorum":        "2",
+	}}
+	cfg := n.ParallelConfig()
+	if cfg.FanInPolicy != "quorum" || cfg.Quorum != 2 {
+		t.Errorf("fan-in policy mismatch: %+v", cfg)
+	}
+
+	def := (&Node{Attrs: map[string]string{}}).ParallelConfig()
+	if def.FanInPolicy != "" || def.Quorum != 0 {
+		t.Errorf("unset policy should be zero-valued, got %+v", def)
+	}
+
+	bad := (&Node{Attrs: map[string]string{"quorum": "-1"}}).ParallelConfig()
+	if bad.Quorum != 0 {
+		t.Errorf("non-positive quorum should stay 0, got %d", bad.Quorum)
+	}
+}
+
 func TestParallelConfig_StraightThrough(t *testing.T) {
 	n := &Node{Attrs: map[string]string{
 		"parallel_targets": "A,B,C",

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -23,7 +23,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod. Kept in sync
 // with go.mod by TestPinnedDippinVersionMatchesGoMod.
-const PinnedDippinVersion = "v0.38.0"
+const PinnedDippinVersion = "v0.39.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
## Summary

Engine half of #313 (defect 1): the parallel fan-in aggregation is no longer hardwired to success-if-any. Unblocked by dippin-lang v0.39.0, which carries `params:` on `parallel` / `fan_in` nodes (dippin-lang#110).

- **New policy params** on parallel and fan_in nodes: `fan_in_policy: any | all | quorum` plus `quorum: <n>`. Param names match the upstream dippin-lang v0.39.0 fixtures.
- **Default stays `any`** (success-if-any) — pinned by `TestParallelHandlerDefaultPolicyIsAny` / `TestFanInHandlerDefaultPolicyIsAny`, so workflows that set no policy see zero behavior change.
- **One policy, two code paths**: `ParallelHandler.aggregateStatus` and `FanInHandler` both evaluate the same `fanInPolicy` (shared in `pipeline/handlers/fanin_policy.go`), so the policy can be declared on either node.
- **Fail fast on misconfiguration**: unknown policy or `quorum` without a positive `n` errors before any branch is dispatched (no silent fallback — per CLAUDE.md error rules).
- **Observability**: a non-default policy's evaluation (success count + failed branch IDs) lands in the `EventParallelCompleted` message and in the `fan_in.policy_detail` context key (written on success too, so a re-review loop can't leave a stale "failed" detail).
- **Routing**: a policy-failed parallel node returns `OutcomeFail` and routes via normal `ctx.outcome = fail` edges — no engine special case, checkpoint resume unaffected (the engine still doesn't know about parallel/fan-in).
- **build_product.dip**: `ReviewParallel` opts into `fan_in_policy: all`, closing the canonical masked-adversarial-review hole — a single failed reviewer now routes to `EscalateReview` (the fail edge shipped in PR #312). The `CheckReviewsComplete` / `ClearStaleReviews` guard from PR #326 **stays** as defense in depth (it catches a reviewer that "succeeds" without writing its report, which no aggregation policy can see).
- dippin-lang bumped to v0.39.0 (`go get`, `PinnedDippinVersion` kept in sync).

## Scope decisions (please read)

- **Policy set**: shipped `any` / `all` / `quorum:<n>`; no required-branches variant. `all` covers build_product's adversarial-reviewer case directly, and quorum covers the lossy-majority case. Required-branches can be added later if a workflow needs it.
- **Defect 2 of #313 (per-branch `fallback_target` runtime-inert) is NOT fixed here.** The policy makes branch failure observable and routable at the aggregating node, which subsumes the practical cases, but a per-branch `fallback_target` is still inert. `build_product_with_superspec.dip`'s `ReviewParallel` was deliberately NOT flipped — it has no fail edge, so `all` would dead-stop it; needs its own escalation routing first. I'll comment on #313 with what remains and keep it open.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` — clean
- `go test ./... -short` — all packages pass
- `go test -race -short ./pipeline/...` — pass
- `dippin doctor` — ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 (baselines held)

Part of #313 (engine defect 1); leaves #313 open for defect 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783718107&installation_id=131176874&pr_number=344&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F344&signature=b256852a0c84b425a7f5369fa52654e2c2ab378a1db7a168619106b9e264fa78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable fan-in aggregation for parallel workflows: any (default), all, quorum; policy outcomes include human-readable policy detail and failed branch IDs; context key "fan_in.policy_detail" added for diagnostics.

* **Bug Fixes**
  * Hardened example cross-review flow so a single reviewer failure now triggers escalation and prevents masked/silent failures.

* **Tests**
  * Added unit tests covering fan-in policy behaviors and edge cases.

* **Chores**
  * Bumped dippin language requirement to v0.39.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->