### PR TITLE
fix(build_product): run ALL detected stacks in TestMilestone & FinalBuild (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`build_product.dip` runs ALL detected build stacks in `TestMilestone` and
+  `FinalBuild`** (closes #305). Both nodes previously detected the build
+  system with a first-match `if go.mod / elif package.json / elif
+  pyproject.toml / elif Cargo.toml` chain, so a polyglot repo (e.g. Go
+  backend + JS frontend) never ran `npm test`. The chains are now
+  independent `if` blocks: every detected stack runs, failures accumulate
+  (`|| TEST_EXIT=$?` / `|| STACK_EXIT=$?` under `set -eu`), and a failure in
+  any stack fails the milestone / final build. The `known_failures` skip
+  pattern, `tests-pass` / `escalate` sentinels, no-build-system notice, and
+  single-language behavior are unchanged (pinned by a stub-toolchain test
+  harness). `build_product_with_superspec.dip` has no equivalent test-runner
+  chain — its phase-gate `if/elif` blocks are coverage-oriented quality
+  gates with a different shape, out of scope here.
+
 ## [0.37.0] - 2026-06-10
 
 ### Added

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -899,6 +899,12 @@ workflow BuildProduct
         SKIP_PATTERN=$(grep -v '^#' .ai/milestones/known_failures | grep -v '^$' | paste -sd'|')
       fi
 
+      # Run EVERY detected stack, not just the first match (issue #305) — a
+      # polyglot repo (e.g. Go backend + JS frontend) must exercise all of its
+      # test suites. Failures accumulate into TEST_EXIT so a later passing
+      # stack can't mask an earlier failing one. `go build` stays unguarded:
+      # under set -eu a Go compile failure aborts immediately (exit 1, normal
+      # fix-loop failure), same as before #305.
       if [ -f go.mod ]; then
         go build ./... 2>&1
         if [ -n "$SKIP_PATTERN" ]; then
@@ -908,13 +914,17 @@ workflow BuildProduct
         else
           go test ./... 2>&1 || TEST_EXIT=$?
         fi
-      elif [ -f package.json ]; then
+      fi
+      if [ -f package.json ]; then
         npm test 2>&1 || TEST_EXIT=$?
-      elif [ -f pyproject.toml ]; then
+      fi
+      if [ -f pyproject.toml ]; then
         uv run pytest 2>&1 || TEST_EXIT=$?
-      elif [ -f Cargo.toml ]; then
+      fi
+      if [ -f Cargo.toml ]; then
         cargo test 2>&1 || TEST_EXIT=$?
-      else
+      fi
+      if [ ! -f go.mod ] && [ ! -f package.json ] && [ ! -f pyproject.toml ] && [ ! -f Cargo.toml ]; then
         echo "no known build system — skipping tests"
       fi
 
@@ -1635,16 +1645,28 @@ workflow BuildProduct
     timeout: 600s
     command:
       set -eu
+      # Run EVERY detected stack, not just the first match (issue #305).
+      # Test failures accumulate into STACK_EXIT (the `|| STACK_EXIT=$?`
+      # guards keep set -eu from aborting mid-sweep) so every stack's
+      # results are visible in one pass; the [ ... ] check below then
+      # propagates any failure as a node-level failure via set -e. `go
+      # build` stays unguarded: a compile failure aborts immediately, as
+      # before #305.
+      STACK_EXIT=0
       if [ -f go.mod ]; then
         go build ./... 2>&1
-        go test ./... 2>&1
-      elif [ -f package.json ]; then
-        npm test 2>&1
-      elif [ -f pyproject.toml ]; then
-        uv run pytest 2>&1
-      elif [ -f Cargo.toml ]; then
-        cargo test 2>&1
+        go test ./... 2>&1 || STACK_EXIT=$?
       fi
+      if [ -f package.json ]; then
+        npm test 2>&1 || STACK_EXIT=$?
+      fi
+      if [ -f pyproject.toml ]; then
+        uv run pytest 2>&1 || STACK_EXIT=$?
+      fi
+      if [ -f Cargo.toml ]; then
+        cargo test 2>&1 || STACK_EXIT=$?
+      fi
+      [ "$STACK_EXIT" -eq 0 ]
 
       # Project CI gate (issue #233 Gap 1). Sources the same shared
       # helper as TestMilestone — written by Setup; lives in exactly

--- a/pipeline/build_product_test_runner_test.go
+++ b/pipeline/build_product_test_runner_test.go
@@ -51,8 +51,11 @@ func stackEnv(t *testing.T, stubLog string, extra ...string) []string {
 	for _, name := range []string{"go", "npm", "uv", "cargo"} {
 		writeStub(t, binDir, name)
 	}
+	// Prepend the stub bin to the host PATH: the stubs still shadow any real
+	// toolchain (first match wins) while coreutils (grep/paste/cat) stay
+	// reachable wherever the host keeps them (Copilot, PR #345).
 	env := []string{
-		"PATH=" + binDir + ":/usr/bin:/bin",
+		"PATH=" + binDir + ":" + os.Getenv("PATH"),
 		"STUB_LOG=" + stubLog,
 		"HOME=" + t.TempDir(),
 	}
@@ -213,6 +216,26 @@ func TestMilestoneKnownFailuresSkipPreserved(t *testing.T) {
 	}
 	if !strings.Contains(log, "npm test") {
 		t.Errorf("npm test not invoked alongside skip-patterned go test:\n%s", log)
+	}
+}
+
+// A FIRST-stack test failure (go test fails, go build passes) must not
+// abort before later stacks run, and must still fail the milestone —
+// symmetric with the FinalBuild accumulate case (Copilot, PR #345).
+func TestMilestoneFirstStackFailureStillRunsLater(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	env := stackEnv(t, stubLog, "STUB_GO_TEST_EXIT=7")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, env)
+	if code == 0 {
+		t.Fatalf("go test failed but TestMilestone exited 0:\n%s", out)
+	}
+	if strings.Contains(out, "tests-pass") {
+		t.Errorf("tests-pass sentinel emitted despite go test failure:\n%s", out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "npm test") {
+		t.Errorf("npm test should still run after go test failure (#305 accumulate):\n%s", log)
 	}
 }
 

--- a/pipeline/build_product_test_runner_test.go
+++ b/pipeline/build_product_test_runner_test.go
@@ -19,7 +19,11 @@ func toolCmd(t *testing.T, nodeID string) string {
 	if !ok {
 		t.Fatalf("%s node missing from build_product graph", nodeID)
 	}
-	return n.Attrs["tool_command"]
+	cmd := n.Attrs["tool_command"]
+	if cmd == "" {
+		t.Fatalf("%s node has an empty tool_command attr (schema change? not a tool node?)", nodeID)
+	}
+	return cmd
 }
 
 // writeStub writes a fake toolchain binary that logs its invocation to

--- a/pipeline/build_product_test_runner_test.go
+++ b/pipeline/build_product_test_runner_test.go
@@ -1,0 +1,288 @@
+// ABOUTME: Regression guard for issue #305 — TestMilestone and FinalBuild must run
+// ABOUTME: EVERY detected build stack (polyglot repos), not just the first match.
+package pipeline
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// toolCmd returns the named tool node's tool_command from the loaded
+// build_product graph (the exact bytes tracker executes at runtime).
+func toolCmd(t *testing.T, nodeID string) string {
+	t.Helper()
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes[nodeID]
+	if !ok {
+		t.Fatalf("%s node missing from build_product graph", nodeID)
+	}
+	return n.Attrs["tool_command"]
+}
+
+// writeStub writes a fake toolchain binary that logs its invocation to
+// $STUB_LOG and exits with $STUB_<NAME>_EXIT (default 0). Stubs shadow any
+// real toolchain via PATH ordering, so `go test` / `npm test` etc. are
+// deterministic and offline.
+// The go stub additionally honors $STUB_GO_TEST_EXIT for `go test` only, so
+// a case can fail the test sweep while `go build` still passes.
+func writeStub(t *testing.T, binDir, name string) {
+	t.Helper()
+	upper := strings.ToUpper(name)
+	script := "#!/bin/sh\n" +
+		"echo \"" + name + " $*\" >> \"$STUB_LOG\"\n"
+	if name == "go" {
+		script += "case \"${1:-}\" in test) exit \"${STUB_GO_TEST_EXIT:-${STUB_GO_EXIT:-0}}\";; esac\n"
+	}
+	script += "exit \"${STUB_" + upper + "_EXIT:-0}\"\n"
+	if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// stackEnv builds an env with stubbed go/npm/uv/cargo first on PATH (real
+// coreutils stay reachable for cat/grep/paste), plus the stub log path and
+// any extra STUB_*_EXIT overrides.
+func stackEnv(t *testing.T, stubLog string, extra ...string) []string {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range []string{"go", "npm", "uv", "cargo"} {
+		writeStub(t, binDir, name)
+	}
+	env := []string{
+		"PATH=" + binDir + ":/usr/bin:/bin",
+		"STUB_LOG=" + stubLog,
+		"HOME=" + t.TempDir(),
+	}
+	return append(env, extra...)
+}
+
+// setupRunDir creates a workdir with the .ai scaffolding both tool nodes
+// expect: a no-op ci-probe.sh (the #299 gate is covered by its own suite)
+// and the milestones dir TestMilestone writes its attempt counter into.
+func setupRunDir(t *testing.T, stackFiles ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, sub := range []string{".ai/build", ".ai/milestones"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite(t, filepath.Join(dir, ".ai/build/ci-probe.sh"),
+		"run_project_ci_gate() { return \"${STUB_CI_RC:-0}\"; }\n")
+	for _, f := range stackFiles {
+		mustWrite(t, filepath.Join(dir, f), "{}\n")
+	}
+	return dir
+}
+
+// runToolCmd executes a tool_command body in dir and returns combined output
+// + exit code (the same sh semantics the tool handler uses).
+func runToolCmd(t *testing.T, cmd, dir string, env []string) (string, int) {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping runtime tool-command test")
+	}
+	scriptPath := filepath.Join(t.TempDir(), "cmd.sh")
+	if err := os.WriteFile(scriptPath, []byte(cmd), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	c := exec.Command("sh", scriptPath)
+	c.Dir = dir
+	c.Env = env
+	b, err := c.CombinedOutput()
+	code := 0
+	if err != nil {
+		ee, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("exec failed: %v\n%s", err, string(b))
+		}
+		code = ee.ExitCode()
+	}
+	return string(b), code
+}
+
+// readLog returns the stub invocation log ("" when no stub ran).
+func readLog(t *testing.T, stubLog string) string {
+	t.Helper()
+	b, err := os.ReadFile(stubLog)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// --- TestMilestone ---
+
+// A Go+JS repo must run BOTH `go test` and `npm test` (#305 — the pre-fix
+// first-match elif chain never reaches npm).
+func TestMilestoneRunsAllDetectedStacks(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("all stacks pass but exit=%d:\n%s", code, out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "go test") {
+		t.Errorf("go test not invoked in Go+JS repo:\n%s", log)
+	}
+	if !strings.Contains(log, "npm test") {
+		t.Errorf("npm test not invoked in Go+JS repo (#305 first-match bug):\n%s", log)
+	}
+	if !strings.Contains(out, "tests-pass") {
+		t.Errorf("missing tests-pass sentinel:\n%s", out)
+	}
+}
+
+// A failure in the SECOND detected stack must fail the milestone.
+func TestMilestoneSecondStackFailureFails(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	env := stackEnv(t, stubLog, "STUB_NPM_EXIT=7")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, env)
+	if code == 0 {
+		t.Fatalf("npm test failed but TestMilestone exited 0 (#305 masking):\n%s", out)
+	}
+	if strings.Contains(out, "tests-pass") {
+		t.Errorf("tests-pass sentinel emitted despite npm failure:\n%s", out)
+	}
+	// First attempt — normal failure for the fix loop, not escalation.
+	if strings.Contains(out, "escalate") {
+		t.Errorf("first failure should not escalate:\n%s", out)
+	}
+}
+
+// All four stacks present → all four runners invoked.
+func TestMilestoneRunsAllFourStacks(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json", "pyproject.toml", "Cargo.toml")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("all stacks pass but exit=%d:\n%s", code, out)
+	}
+	log := readLog(t, stubLog)
+	for _, want := range []string{"go test", "npm test", "uv run pytest", "cargo test"} {
+		if !strings.Contains(log, want) {
+			t.Errorf("%q not invoked with all four stack files present:\n%s", want, log)
+		}
+	}
+}
+
+// Single-stack repos behave exactly as before (regression pin): only the
+// matching runner is invoked.
+func TestMilestoneSingleStackUnchanged(t *testing.T) {
+	dir := setupRunDir(t, "go.mod")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("single-stack pass but exit=%d:\n%s", code, out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "go test") {
+		t.Errorf("go test not invoked:\n%s", log)
+	}
+	for _, notWant := range []string{"npm", "uv", "cargo"} {
+		if strings.Contains(log, notWant) {
+			t.Errorf("%q invoked in a Go-only repo:\n%s", notWant, log)
+		}
+	}
+	if !strings.Contains(out, "tests-pass") {
+		t.Errorf("missing tests-pass sentinel:\n%s", out)
+	}
+}
+
+// The known_failures skip pattern is still applied to the Go runner.
+func TestMilestoneKnownFailuresSkipPreserved(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	mustWrite(t, filepath.Join(dir, ".ai/milestones/known_failures"),
+		"# a comment\nTestFlaky\n\nTestAlsoFlaky\n")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("exit=%d:\n%s", code, out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "-skip TestFlaky|TestAlsoFlaky") {
+		t.Errorf("go test missing -skip pattern:\n%s", log)
+	}
+	if !strings.Contains(log, "npm test") {
+		t.Errorf("npm test not invoked alongside skip-patterned go test:\n%s", log)
+	}
+}
+
+// No stack files → the no-build-system notice still prints and the node passes.
+func TestMilestoneNoStackNoticePreserved(t *testing.T) {
+	dir := setupRunDir(t)
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("no-stack repo should pass, exit=%d:\n%s", code, out)
+	}
+	if !strings.Contains(out, "no known build system") {
+		t.Errorf("missing no-build-system notice:\n%s", out)
+	}
+}
+
+// --- FinalBuild ---
+
+// A Go+JS repo must run BOTH stacks in FinalBuild.
+func TestFinalBuildRunsAllDetectedStacks(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, toolCmd(t, "FinalBuild"), dir, stackEnv(t, stubLog))
+	if code != 0 {
+		t.Fatalf("all stacks pass but exit=%d:\n%s", code, out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "go test") {
+		t.Errorf("go test not invoked in Go+JS repo:\n%s", log)
+	}
+	if !strings.Contains(log, "npm test") {
+		t.Errorf("npm test not invoked in Go+JS repo (#305 first-match bug):\n%s", log)
+	}
+	if !strings.Contains(out, "final-build-pass") {
+		t.Errorf("missing final-build-pass sentinel:\n%s", out)
+	}
+}
+
+// A failing stack fails FinalBuild AND the remaining stacks still run
+// (failures accumulate; no early abort that would hide later-stack results).
+func TestFinalBuildStackFailureFailsButRunsRemaining(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	env := stackEnv(t, stubLog, "STUB_NPM_EXIT=7")
+	out, code := runToolCmd(t, toolCmd(t, "FinalBuild"), dir, env)
+	if code == 0 {
+		t.Fatalf("npm test failed but FinalBuild exited 0 (#305 masking):\n%s", out)
+	}
+	if strings.Contains(out, "final-build-pass") {
+		t.Errorf("final-build-pass emitted despite npm failure:\n%s", out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "go test") || !strings.Contains(log, "npm test") {
+		t.Errorf("both stacks should have run:\n%s", log)
+	}
+}
+
+// A FIRST-stack test failure must not abort before later stacks run, and
+// must still fail the node.
+func TestFinalBuildFirstStackFailureStillRunsLater(t *testing.T) {
+	dir := setupRunDir(t, "go.mod", "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	// Fail only `go test` (build passes) so the sweep reaches npm.
+	env := stackEnv(t, stubLog, "STUB_GO_TEST_EXIT=7")
+	out, code := runToolCmd(t, toolCmd(t, "FinalBuild"), dir, env)
+	if code == 0 {
+		t.Fatalf("go test failed but FinalBuild exited 0:\n%s", out)
+	}
+	log := readLog(t, stubLog)
+	if !strings.Contains(log, "npm test") {
+		t.Errorf("npm test should still run after go test failure (#305 accumulate):\n%s", log)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #305. `TestMilestone` and `FinalBuild` used a first-match `if go.mod / elif package.json / elif pyproject.toml / elif Cargo.toml` chain, so a polyglot repo only ever exercised its first-matched stack. Both blocks are now independent `if`s, mirroring #299's polyglot philosophy: run every detected stack, accumulate failures.

- **TestMilestone**: per-stack `|| TEST_EXIT=$?` folds into the existing `TEST_EXIT` logic — the `known_failures` `-skip` pattern (Go), `tests-pass`/`escalate` sentinels, and fix-attempt counter behave exactly as before. The `else` no-build-system notice became an explicit none-of-the-four guard.
- **FinalBuild**: per-stack `|| STACK_EXIT=$?` guards keep `set -eu` from aborting mid-sweep (so a Go test failure no longer hides the npm result); `[ "$STACK_EXIT" -eq 0 ]` then propagates any failure as a node-level failure via `set -e`, before the CI gate — same abort point as the old bare calls.
- **`go build` stays unguarded** in both (matching the issue's proposed shape): a compile failure aborts immediately, exactly as pre-#305.

## Findings on superspec

`build_product_with_superspec.dip` does NOT duplicate the test-runner chain. Its `if/elif` blocks (Phase gates, ~:306/​:459) are coverage-oriented quality gates (Go-or-Python only, `--coverprofile`/`--cov` shapes, report-file plumbing) — a different mechanism with different scope, so they're out of scope for #305 (same situation as the #320 ci-probe heredoc, which was also never duplicated there).

## Tests (TDD)

New `pipeline/build_product_test_runner_test.go` extends the #299 extract-and-run harness: stub `go`/`npm`/`uv`/`cargo` binaries on PATH log invocations and exit per `STUB_*_EXIT` env, so the sweeps are asserted offline. RED-first on: Go+JS runs both stacks (both nodes), second-stack failure fails the node, first-stack `go test` failure still runs npm (FinalBuild accumulate), all-four-stacks sweep, `-skip` pattern preserved. Regression pins (green before and after): single-stack repos unchanged, no-build-system notice.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` — clean
- `go test ./... -short` — all packages pass
- `dippin doctor` — ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 (baselines held)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783718562&installation_id=131176874&pr_number=345&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F345&signature=25ee457babbb6223fd93b5d6e2a38b368031cc6bde7ef8243c8dea4ef1d675e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->