### PR TITLE
fix: fresh-eyes review — stream errors, budget gaps, 25 verified findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fresh-eyes review fixes across stream-error surfacing, pipeline core, CLI,
+  handlers, TUI, and examples** (full-project subagent review, each finding
+  individually verified; plan at
+  `docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md`).
+  - LLM stream errors no longer silently swallowed: the Anthropic SSE adapter
+    handles mid-stream `error` events (`overloaded_error`, `rate_limit_error`);
+    the Gemini adapter parses `{"error":...}` chunks (previously unmarshaled
+    into an empty struct and vanished); the OpenAI adapter emits an error even
+    when the SSE error payload is unparseable; the openai-compat adapter fires
+    on error chunks carrying only `code`/`type` without `message`; interleaved
+    tool-call starts (Start(0), Start(1), End(0)) no longer drop the first
+    call's arguments.
+  - Pipeline core: `ExpandGraphVariables` replaces longest names first so
+    `$target` can no longer clobber `$target_name` (map-iteration-order flake);
+    `InjectParamsIntoGraph` clones keep `DippinValidated` and build adjacency
+    via `AddEdge` (edge-index lookups on param-injected graphs were empty);
+    retry-exhaustion fallback routing now runs the same cost-emit + budget
+    check as the in-budget retry path.
+  - CLI/library: the library API treats `.dipx` as an explicit path in bare-name
+    resolution (the CLI already did); `tracker update` uses unique
+    `os.CreateTemp` names for both the write-permission probe and the staged
+    binary (fixed names could truncate real files or race concurrent updates);
+    the post-run update hint no longer delays error output after a failed run;
+    doctor provider probes use the strict gateway resolver so doctor reports
+    the same `ErrGatewayRouteRefused` a run would hard-fail on.
+  - Handlers/agent/TUI: ACP `initSession` failures reap the killed subprocess
+    (zombie + leaked pipe fds); webhook gate `Cancel()` aborts the in-flight
+    POST instead of letting it run to the client timeout; choice-mode human
+    gates error cleanly instead of panicking when constructed without a graph;
+    the empty-API-response session error reports the true count of consecutive
+    empties (N+1, matching observed responses); agent-log search highlighting
+    no longer panics or garbles output when lowercasing changes a rune's UTF-8
+    byte width (e.g. Ⱥ→ⱥ) — match offsets in the lowered string now map back
+    to the original.
+  - Aux binaries/examples: the SWE-bench agent-runner classifies context
+    deadline/cancel as `timeout` instead of `tool_error`; dead handler-name
+    filter loop removed from conformance `list-handlers`;
+    `ask_and_execute.dip` hardens two printfs against format injection
+    (`%b`/`%s`) and drops FinalVerify's `retry_target` into worktrees that
+    ApplyWinner already tore down (exhaustion now escalates to the human
+    gate); `build_product.dip` guards the `TestMilestone` `fix_attempts` read
+    against non-numeric content (same idiom as the warm-continue counter) and
+    adds the missing stdin operand to the SKIP_PATTERN `paste` (BSD/macOS
+    paste requires it — #345 regression).
+  - Test hygiene: claude-code backend env tests use `t.Setenv` (a leaked
+    `PATH=/usr/bin` broke every later subprocess-spawning test in the package
+    on macOS); `agent/exec` jail-hook tests no longer hardcode `/bin/true`
+    (absent on macOS).
+
 - **`build_product.dip` runs ALL detected build stacks in `TestMilestone` and
   `FinalBuild`** (closes #305). Both nodes previously detected the build
   system with a first-match `if go.mod / elif package.json / elif

--- a/agent/exec/env_test.go
+++ b/agent/exec/env_test.go
@@ -246,7 +246,8 @@ func TestLocalEnvironment_CommandWrapperApplied(t *testing.T) {
 		wrapped = true
 		return cmd
 	}
-	_, err := env.ExecCommand(context.Background(), "/bin/true", nil, 5*time.Second)
+	// "sh -c true" rather than /bin/true — macOS has no /bin/true.
+	_, err := env.ExecCommand(context.Background(), "sh", []string{"-c", "true"}, 5*time.Second)
 	if err != nil {
 		t.Fatalf("ExecCommand: %v", err)
 	}
@@ -264,7 +265,7 @@ func TestLocalEnvironment_CommandWrapperAppliedWithLimit(t *testing.T) {
 		wrapped = true
 		return cmd
 	}
-	_, err := env.ExecCommandWithLimit(context.Background(), "/bin/true", nil, 5*time.Second, 1024)
+	_, err := env.ExecCommandWithLimit(context.Background(), "sh", []string{"-c", "true"}, 5*time.Second, 1024)
 	if err != nil {
 		t.Fatalf("ExecCommandWithLimit: %v", err)
 	}
@@ -296,10 +297,10 @@ func TestLocalEnvironment_WriteOpenerApplied(t *testing.T) {
 func TestLocalEnvironment_HooksNilFallsThrough(t *testing.T) {
 	env := NewLocalEnvironment(t.TempDir())
 	// Both function fields nil — must fall through to existing behavior.
-	if _, err := env.ExecCommand(context.Background(), "/bin/true", nil, 5*time.Second); err != nil {
+	if _, err := env.ExecCommand(context.Background(), "sh", []string{"-c", "true"}, 5*time.Second); err != nil {
 		t.Errorf("ExecCommand with nil CommandWrapper = %v, want nil", err)
 	}
-	if _, err := env.ExecCommandWithLimit(context.Background(), "/bin/true", nil, 5*time.Second, 1024); err != nil {
+	if _, err := env.ExecCommandWithLimit(context.Background(), "sh", []string{"-c", "true"}, 5*time.Second, 1024); err != nil {
 		t.Errorf("ExecCommandWithLimit with nil CommandWrapper = %v, want nil", err)
 	}
 	if err := env.WriteFile(context.Background(), "test.txt", "hello"); err != nil {

--- a/agent/session.go
+++ b/agent/session.go
@@ -317,7 +317,9 @@ func (s *Session) handleNoTools(resp *llm.Response, turn int, turnStart time.Tim
 			))
 			return false, false, nil // continue loop
 		}
-		emptyErr := fmt.Errorf("agent session failed: %d consecutive empty API responses", maxEmptyResponseRetries)
+		// maxEmptyResponseRetries counts the retries; the total number of
+		// consecutive empty responses observed is one more than that.
+		emptyErr := fmt.Errorf("agent session failed: %d consecutive empty API responses", maxEmptyResponseRetries+1)
 		result.Error = emptyErr
 		result.Duration = time.Since(start)
 		s.emit(Event{Type: EventError, SessionID: s.id, Err: emptyErr})

--- a/agent/session_test.go
+++ b/agent/session_test.go
@@ -65,6 +65,25 @@ func mustNewSession(t *testing.T, client Completer, cfg SessionConfig, opts ...S
 	return sess
 }
 
+func TestSessionEmptyResponseErrorCountsAllEmpties(t *testing.T) {
+	// Initial empty + 2 retries = 3 consecutive empty responses before the
+	// session gives up; the error message must report what actually happened.
+	empty := &llm.Response{
+		Message:      llm.Message{Role: llm.RoleAssistant},
+		FinishReason: llm.FinishReason{Reason: "stop"},
+	}
+	client := &mockCompleter{responses: []*llm.Response{empty, empty, empty}}
+
+	sess := mustNewSession(t, client, DefaultConfig())
+	_, err := sess.Run(context.Background(), "do something")
+	if err == nil {
+		t.Fatal("expected error after consecutive empty responses")
+	}
+	if !strings.Contains(err.Error(), "3 consecutive empty API responses") {
+		t.Errorf("error should count all 3 empties, got: %v", err)
+	}
+}
+
 func TestSessionTextOnlyResponse(t *testing.T) {
 	client := &mockCompleter{
 		responses: []*llm.Response{

--- a/cmd/tracker-conformance/main.go
+++ b/cmd/tracker-conformance/main.go
@@ -1027,24 +1027,12 @@ func buildRunResultJSON(result *pipeline.EngineResult) map[string]any {
 
 // handleListHandlers writes the names of all registered pipeline handler types.
 func handleListHandlers(stdout, stderr io.Writer) int {
-	// Create a minimal graph to build the default registry.
-	g := pipeline.NewGraph("list-handlers")
-	registry := handlers.NewDefaultRegistry(g)
-
 	// List all handler names that the registry knows about.
 	// Use the shapeHandlerMap as the source of truth for handler names.
 	handlerNames := []string{
 		"start", "exit", "codergen", "conditional",
 		"parallel", "parallel.fan_in", "tool", "wait.human", "subgraph",
 		"stack.manager_loop",
-	}
-
-	// Filter to only those actually registered (some may not be if deps missing).
-	var available []string
-	for _, name := range handlerNames {
-		if registry.Has(name) {
-			available = append(available, name)
-		}
 	}
 
 	// Always include the full list to show what the engine supports.

--- a/cmd/tracker-swebench/agent-runner/main.go
+++ b/cmd/tracker-swebench/agent-runner/main.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -225,6 +226,11 @@ func main() {
 
 func classifyTerminationReason(result agent.SessionResult, err error) string {
 	if err != nil {
+		// A context-deadline/cancel kill is the harness timeout, not a tool
+		// failure — report it distinctly so eval results aren't skewed.
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			return "timeout"
+		}
 		if strings.Contains(strings.ToLower(err.Error()), "empty api responses") {
 			return "empty_response"
 		}

--- a/cmd/tracker-swebench/agent-runner/main_test.go
+++ b/cmd/tracker-swebench/agent-runner/main_test.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -113,6 +115,18 @@ func TestClassifyTerminationReason(t *testing.T) {
 			name: "generic_error",
 			err:  errors.New("tool failed"),
 			want: "tool_error",
+		},
+		{
+			// Session killed by the harness timeout — must not be misreported
+			// as a tool failure. Wrapped to verify errors.Is unwrapping.
+			name: "timeout_deadline",
+			err:  fmt.Errorf("agent session failed: %w", context.DeadlineExceeded),
+			want: "timeout",
+		},
+		{
+			name: "timeout_canceled",
+			err:  context.Canceled,
+			want: "timeout",
 		},
 	}
 

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -135,7 +135,9 @@ func main() {
 
 	err = executeCommand(cfg, commandDeps{})
 
-	if cfg.mode == modeRun {
+	// Only nag about updates after a successful run — on failure the error
+	// (printed below) is the headline, and the hint's ≤2s wait just delays it.
+	if cfg.mode == modeRun && err == nil {
 		printUpdateHint()
 	}
 

--- a/cmd/tracker/update.go
+++ b/cmd/tracker/update.go
@@ -289,11 +289,13 @@ func atomicSwap(exe, tmpBin, tagName string) error {
 
 // checkWritePermission verifies the process can write to the directory.
 func checkWritePermission(dir string) error {
-	tmp := filepath.Join(dir, ".tracker-update-test")
-	f, err := os.Create(tmp)
+	// CreateTemp (not a fixed name) so the probe can never truncate a real
+	// file or race a concurrent update's probe.
+	f, err := os.CreateTemp(dir, ".tracker-update-test-*")
 	if err != nil {
 		return err
 	}
+	tmp := f.Name()
 	f.Close()
 	os.Remove(tmp)
 	return nil
@@ -437,13 +439,16 @@ func findAndExtractBinary(tr *tar.Reader, destDir string) (string, error) {
 	return "", fmt.Errorf("tracker binary not found in archive")
 }
 
-// writeBinaryEntry writes the current tar entry to destDir/.tracker-new.
+// writeBinaryEntry writes the current tar entry to a unique temp file in
+// destDir (the caller chmods and atomically swaps the returned path).
 func writeBinaryEntry(tr *tar.Reader, destDir string) (string, error) {
-	tmpBin := filepath.Join(destDir, ".tracker-new")
-	out, err := os.Create(tmpBin)
+	// Unique name per extraction — a fixed name lets two concurrent updates
+	// interleave writes into the same file and swap in a corrupt binary.
+	out, err := os.CreateTemp(destDir, ".tracker-new-*")
 	if err != nil {
 		return "", err
 	}
+	tmpBin := out.Name()
 	n, err := io.Copy(out, io.LimitReader(tr, maxBinarySize+1))
 	out.Close()
 	if err != nil {

--- a/cmd/tracker/update.go
+++ b/cmd/tracker/update.go
@@ -296,9 +296,13 @@ func checkWritePermission(dir string) error {
 		return err
 	}
 	tmp := f.Name()
-	f.Close()
+	closeErr := f.Close()
+	// Remove stays best-effort: the probe file is empty, and failing an
+	// update over leftover-cleanup would be a false negative.
 	os.Remove(tmp)
-	return nil
+	// A Close error means writes to this directory may not be durable —
+	// report it as a write-permission failure rather than masking it.
+	return closeErr
 }
 
 // downloadToTemp downloads a URL to a temp file in the given directory.
@@ -450,10 +454,16 @@ func writeBinaryEntry(tr *tar.Reader, destDir string) (string, error) {
 	}
 	tmpBin := out.Name()
 	n, err := io.Copy(out, io.LimitReader(tr, maxBinarySize+1))
-	out.Close()
+	closeErr := out.Close()
 	if err != nil {
 		os.Remove(tmpBin)
 		return "", err
+	}
+	// Some filesystems only report a write error on Close — accepting the
+	// binary past a failed Close could swap in a truncated executable.
+	if closeErr != nil {
+		os.Remove(tmpBin)
+		return "", closeErr
 	}
 	if n > maxBinarySize {
 		os.Remove(tmpBin)

--- a/cmd/tracker/update_test.go
+++ b/cmd/tracker/update_test.go
@@ -273,6 +273,58 @@ func TestExtractBinaryFromTar(t *testing.T) {
 	})
 }
 
+func TestExtractBinaryUniqueTempPaths(t *testing.T) {
+	// Two extractions into the same directory must not share a temp path —
+	// a fixed name lets concurrent updates clobber each other's binary
+	// between extraction and the atomic swap.
+	dir := t.TempDir()
+	tarOne := createTestTar(t, dir, "one.tar.gz", "tracker", []byte("binary-one"))
+	tarTwo := createTestTar(t, dir, "two.tar.gz", "tracker", []byte("binary-two"))
+
+	first, err := extractBinaryFromTar(tarOne, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(first)
+	second, err := extractBinaryFromTar(tarTwo, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(second)
+
+	if first == second {
+		t.Fatalf("both extractions returned %q — concurrent updates would corrupt each other", first)
+	}
+	data, _ := os.ReadFile(first)
+	if string(data) != "binary-one" {
+		t.Errorf("first binary content = %q, want %q", data, "binary-one")
+	}
+	data, _ = os.ReadFile(second)
+	if string(data) != "binary-two" {
+		t.Errorf("second binary content = %q, want %q", data, "binary-two")
+	}
+}
+
+func TestCheckWritePermissionPreservesExistingFile(t *testing.T) {
+	// The write probe must not truncate-and-delete a real file that
+	// happens to collide with its probe name.
+	dir := t.TempDir()
+	existing := filepath.Join(dir, ".tracker-update-test")
+	if err := os.WriteFile(existing, []byte("user data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkWritePermission(dir); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("probe deleted pre-existing file: %v", err)
+	}
+	if string(data) != "user data" {
+		t.Errorf("probe clobbered pre-existing file: %q", data)
+	}
+}
+
 func TestAtomicSwap(t *testing.T) {
 	t.Run("successful swap", func(t *testing.T) {
 		dir := t.TempDir()

--- a/docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md
@@ -1,7 +1,7 @@
 # Fresh-Eyes Review Fixes — 2026-06-10
 
 Full-project review (7 parallel subagent reviewers, findings personally verified).
-Branch: `review/fresh-eyes-fixes`. 36 raw findings → 19 confirmed fixes, 3 policy
+Branch: `review/fresh-eyes-fixes`. 36 raw findings → 25 confirmed fixes, 3 policy
 questions held for Doctor Biz, rest documented as skips/false-positives.
 
 ## Phase A — LLM stream errors (CLAUDE.md: never silently swallow errors)
@@ -45,7 +45,7 @@ for Doctor Biz if the warning proves noisy.
 | D3a | `pipeline/handlers/human.go:913` | `executeChoice` lacks nil-graph guard (siblings have it) | add guard |
 | D3b | `agent/session.go:320` | error msg reports N retries, N+1 empties occurred | `maxEmptyResponseRetries+1` |
 | D4 | `tui/search.go:220-250` | `HighlightLine`: byte offsets from `lowerPlain` sliced into `plain`; `ToLower` changes UTF-8 widths → panic/garble | lowered→plain offset map |
-| D5 | `agent/session_run.go:316` | dangling tool_use on restricted-tool early return — VERIFY reachability first; skip if tools stripped from request |
+| D5 | `agent/session_run.go:316` | dangling tool_use on restricted-tool early return | SKIPPED — verified dead-defensive: restricted sessions send no tools, so providers can't emit tool_use |
 
 ## Phase E — aux binaries / examples
 

--- a/docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md
+++ b/docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md
@@ -1,0 +1,78 @@
+# Fresh-Eyes Review Fixes — 2026-06-10
+
+Full-project review (7 parallel subagent reviewers, findings personally verified).
+Branch: `review/fresh-eyes-fixes`. 36 raw findings → 19 confirmed fixes, 3 policy
+questions held for Doctor Biz, rest documented as skips/false-positives.
+
+## Phase A — LLM stream errors (CLAUDE.md: never silently swallow errors)
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| A1 | `llm/anthropic/adapter.go` | `handleSSEData` switch has no `case "error"` — mid-stream `overloaded_error`/`rate_limit_error` events silently dropped | add error case; map error type → HTTP status → `llm.ErrorFromStatusCode` |
+| A2 | `llm/google/adapter.go` + `translate.go` | `geminiResponse` has no `Error` field; `{"error":{...}}` chunks unmarshal to empty struct and vanish | add `Error *geminiAPIError`; emit typed error in `processSSELine` |
+| A3 | `llm/openai/adapter_sse.go` | `handleSSEError` emits only when payload parses; unparseable error payload → nothing | else-branch emits `EventError` with raw payload context |
+| A4 | `llm/openaicompat/adapter.go` | `tryEmitSSEError` requires `Message != ""`; error with only code/type falls through as normal chunk | fire on any of Message/Code/Type; synthesize message |
+| A5 | `llm/stream.go` | `processToolCallStart` overwrites in-flight call — interleaved Start(0),Start(1),End(0),End(1) (openaicompat) loses tool 0 | finalize active call at top of `processToolCallStart` |
+
+## Phase B — pipeline core
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| B1 | `pipeline/transforms.go:41` | `ExpandGraphVariables` map iteration + `ReplaceAll`: `$target` vs `$target_name` prefix collision, nondeterministic | iterate keys sorted by descending length |
+| B2 | `pipeline/expand.go:276` | `InjectParamsIntoGraph` clone drops `DippinValidated` (consulted by validate.go:132, validate_semantic.go:33) and never populates adjacency maps (appends `clone.Edges` directly) | copy flag; build edges via `clone.AddEdge` |
+| B3 | `pipeline/engine_run.go:822` | `handleRetryExhausted` fallback branch skips `emitCostUpdate`+budget check → ceiling overshoot | mirror the retry path's emit+check |
+
+~~B4 (commitWIPBeforeRouting warning on non-git runs)~~ — DROPPED: `TestEngine_CommitWIP_NoGitAdapterWarns`
+encodes this as intentional #302 behavior (graceful skip with actionable message). Not a bug; UX call
+for Doctor Biz if the warning proves noisy.
+
+## Phase C — CLI / library
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| C1 | `tracker_resolve.go:85` | library `isExplicitFilePath` missing `.dipx` (CLI has it) | add extension + test |
+| C2 | `cmd/tracker/update.go:440` | fixed `.tracker-new` temp name + `os.Create` — concurrent updates corrupt | `os.CreateTemp(destDir, ".tracker-new-*")` |
+| C3 | `cmd/tracker/update.go:291` | fixed `.tracker-update-test` probe name, same class | `os.CreateTemp` + remove |
+| C4 | `cmd/tracker/main.go:139` | `printUpdateHint` (≤2s block) runs before error print on failed runs | only hint when `err == nil` |
+| C5 | `tracker_doctor.go:330-379` | doctor probes use lax `ResolveProviderBaseURL` → doctor green where run hard-fails (`ErrGatewayRouteRefused`) | use `ResolveProviderBaseURLStrict`, surface error |
+
+## Phase D — handlers / agent / TUI
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| D1 | `pipeline/handlers/backend_acp.go:277,295` | initSession failure: `killProcess` never `Wait()`s → zombie + leaked pipe fds | `_ = proc.cmd.Wait()` after the two initSession killProcess sites (NOT inside killProcess — waitForProcess has concurrent Wait) |
+| D2 | `pipeline/handlers/webhook_interviewer.go:256` | POST uses `context.Background()` — ignores Cancel() | ctx wired to `w.canceled` |
+| D3a | `pipeline/handlers/human.go:913` | `executeChoice` lacks nil-graph guard (siblings have it) | add guard |
+| D3b | `agent/session.go:320` | error msg reports N retries, N+1 empties occurred | `maxEmptyResponseRetries+1` |
+| D4 | `tui/search.go:220-250` | `HighlightLine`: byte offsets from `lowerPlain` sliced into `plain`; `ToLower` changes UTF-8 widths → panic/garble | lowered→plain offset map |
+| D5 | `agent/session_run.go:316` | dangling tool_use on restricted-tool early return — VERIFY reachability first; skip if tools stripped from request |
+
+## Phase E — aux binaries / examples
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| E1 | `cmd/tracker-conformance/main.go:1030` | dead `available` filter loop (result discarded; comment says full list intended) | remove dead code |
+| E2 | `cmd/tracker-swebench/agent-runner/main.go:226` | `classifyTerminationReason`: DeadlineExceeded → "tool_error" | map to "timeout" |
+| E3 | `examples/ask_and_execute.dip` | `printf "$RESULTS"` format-injection; `printf "applied: $WINNER"`; FinalVerify `retry_target: ImplementClaude` re-enters torn-down worktrees | `printf '%b'` / `'%s'`; drop retry_target (exhaustion → EscalateToHuman) |
+| E4 | `examples/build_product.dip:~875` | TestMilestone reads `fix_attempts` without numeric guard (ContinueWithMoreTurns has it) | add same guard |
+
+## Phase F — discovered during verification
+
+| ID | File | Bug | Fix |
+|----|------|-----|-----|
+| F1 | `pipeline/handlers/backend_claudecode_env_test.go:84` | `TestBuildEnvPreservesNonAPIKeys` leaks `PATH=/usr/bin` + `HOME=/test/home` via raw `os.Setenv` (no restore) — on macOS `sh` is in `/bin`, so every later subprocess-spawning test in the package fails (`TestExecute_BreachGreen_AdvancesAsSuccessWithMarker` flaked suite-wide, passed isolated). Pre-existing on main (confirmed via stash). | convert all `os.Setenv`/bare `os.Unsetenv` in the file to `t.Setenv` (+ register-restore-then-unset idiom for the Noop test) |
+| F2 | `agent/exec/env_test.go:249,267,299,302` | three jail-hook tests hardcode `/bin/true` — absent on macOS (`/usr/bin/true` only), so `agent/exec` fails on every Mac. Pre-existing (shipped with #272; my diff touches nothing in `agent/exec`). | `"sh", []string{"-c", "true"}` — PATH-resolved, matches the file's existing idiom |
+| F3 | `examples/build_product.dip:904` | `paste -sd'\|'` with no file operand — BSD/POSIX paste requires one (GNU defaults to stdin), so TestMilestone's SKIP_PATTERN breaks at runtime on macOS and `TestMilestoneKnownFailuresSkipPreserved` fails. Shipped in 726f7d3 (#345); line 1244 already does it right (`paste -sd, -`). | add the `-` stdin operand |
+
+## Held for Doctor Biz (security policy — 🔴 ask-first)
+
+1. `agent/tool_safety.go` denylist gaps: `bash <(curl …)` process substitution; backtick command-substitution gadgets.
+2. `cmd/tracker/update.go` proceeds with warning when `checksums.txt` missing — hard-fail option.
+
+## Documented skips (verified not-bugs or out-of-scope polish)
+
+- `agent/session.go:309` empty-response trigger includes `TotalToolCalls()==0` — matches CLAUDE.md spec ("0 prior tool calls"), intentional.
+- `manager_loop` pollTimer drain branch — unreachable today, zero behavioral risk.
+- TUI P2 cosmetics: capPartialText wide-rune overflow, HighlightLine ANSI styling loss, modal zero-dim, autopilot flash race, choiceRunner ordering fragility.
+- `dippin_adapter` parenthesized-condition handling — only reachable programmatically, not from `.dip`.
+- Reviewer claims rejected: replaceContextValues dirty-marking (clean), parallel fan-in dup (by design).

--- a/examples/ask_and_execute.dip
+++ b/examples/ask_and_execute.dip
@@ -214,7 +214,9 @@ workflow AskAndExecute
           RESULTS="$RESULTS\n$NAME: TESTS FAIL (exit=$TEST_EXIT), diff=$DIFF_LINES lines"
         fi
       done
-      printf "$RESULTS"
+      # %b expands the \n escapes in RESULTS while keeping it data, not a
+      # format string — test names containing % can't break the printf.
+      printf '%b' "$RESULTS"
 
   # ─── Phase 4: Cross-Critique ───────────────────────────────
 
@@ -323,7 +325,7 @@ workflow AskAndExecute
       # Clean up candidate artifacts (keep decisions)
       rm -rf .ai/worktrees .ai/candidates
 
-      printf "applied: $WINNER"
+      printf 'applied: %s' "$WINNER"
 
   # ─── Phase 6: Verify ───────────────────────────────────────
 
@@ -359,7 +361,6 @@ workflow AskAndExecute
     provider: anthropic
     reasoning_effort: high
     goal_gate: true
-    retry_target: ImplementClaude
     fallback_target: EscalateToHuman
     prompt:
       The winning implementation has been applied. Verify:

--- a/examples/ask_and_execute.dip
+++ b/examples/ask_and_execute.dip
@@ -377,7 +377,7 @@ workflow AskAndExecute
     auto_status: true
 
   human EscalateToHuman
-    label: "Verification failed after retry. Please review."
+    label: "Verification failed. Please review."
     mode: freeform
 
   agent CommitFinal

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -877,8 +877,13 @@ workflow BuildProduct
       ATTEMPT_FILE=".ai/milestones/fix_attempts"
       ATTEMPTS=0
       if [ -f "$ATTEMPT_FILE" ]; then
-        ATTEMPTS=$(cat "$ATTEMPT_FILE")
+        ATTEMPTS=$(cat "$ATTEMPT_FILE" 2>/dev/null || echo 0)
       fi
+      # Reset a corrupted/non-numeric counter so the arithmetic below can't
+      # error under `set -e` (same guard as the warm-continue counter above).
+      case "$ATTEMPTS" in
+        ''|*[!0-9]*) ATTEMPTS=0 ;;
+      esac
       ATTEMPTS=$((ATTEMPTS + 1))
       echo "$ATTEMPTS" > "$ATTEMPT_FILE"
 
@@ -896,7 +901,7 @@ workflow BuildProduct
       # Build the skip pattern from known_failures, stripping comments and blanks.
       SKIP_PATTERN=""
       if [ -f .ai/milestones/known_failures ]; then
-        SKIP_PATTERN=$(grep -v '^#' .ai/milestones/known_failures | grep -v '^$' | paste -sd'|')
+        SKIP_PATTERN=$(grep -v '^#' .ai/milestones/known_failures | grep -v '^$' | paste -sd'|' -)
       fi
 
       # Run EVERY detected stack, not just the first match (issue #305) — a

--- a/llm/anthropic/adapter.go
+++ b/llm/anthropic/adapter.go
@@ -349,8 +349,67 @@ func (a *Adapter) handleSSEData(eventType string, data []byte, ch chan<- llm.Str
 		a.handleSSEBlockStop(data, ch, blockTypes)
 	case "message_delta":
 		a.handleSSEMessageDelta(data, ch, inputUsage)
+	case "error":
+		a.handleSSEErrorEvent(data, ch)
 	case "message_stop", "ping":
 		// No action needed.
+	}
+}
+
+// sseErrorEvent is the payload of an SSE "error" event delivered inside an
+// HTTP-200 stream (overloaded_error, rate_limit_error, api_error, ...).
+type sseErrorEvent struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// handleSSEErrorEvent surfaces a mid-stream error event as a typed EventError.
+// Anthropic reports these inside HTTP-200 streams, so they are invisible to
+// status-code checks; dropping them would surface as a bogus empty response.
+func (a *Adapter) handleSSEErrorEvent(data []byte, ch chan<- llm.StreamEvent) {
+	var evt sseErrorEvent
+	if err := json.Unmarshal(data, &evt); err != nil {
+		ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("anthropic: parse error event: %w", err)}
+		return
+	}
+	errType := evt.Error.Type
+	if errType == "" {
+		errType = "api_error"
+	}
+	msg := evt.Error.Message
+	if msg == "" {
+		msg = "unknown stream error"
+	}
+	ch <- llm.StreamEvent{
+		Type: llm.EventError,
+		Err:  llm.ErrorFromStatusCode(anthropicErrorTypeToStatus(errType), fmt.Sprintf("anthropic: %s: %s", errType, msg), "anthropic"),
+	}
+}
+
+// anthropicErrorTypeToStatus maps Anthropic error type strings to the HTTP
+// status codes they correspond to outside of streams, so stream errors get
+// the same typed-error classification as non-stream errors.
+func anthropicErrorTypeToStatus(errType string) int {
+	switch errType {
+	case "invalid_request_error":
+		return 400
+	case "authentication_error":
+		return 401
+	case "permission_error":
+		return 403
+	case "not_found_error":
+		return 404
+	case "request_too_large":
+		return 413
+	case "rate_limit_error":
+		return 429
+	case "overloaded_error":
+		return 529
+	default:
+		return 500
 	}
 }
 

--- a/llm/anthropic/adapter_test.go
+++ b/llm/anthropic/adapter_test.go
@@ -1292,3 +1292,67 @@ func TestAdapterStreamRedactedThinking(t *testing.T) {
 }
 
 func intPtr(v int) *int { return &v }
+
+func TestAdapterStreamErrorEvent(t *testing.T) {
+	cases := []struct {
+		name      string
+		errType   string
+		errMsg    string
+		wantInMsg string
+		check     func(error) bool
+	}{
+		{
+			name:      "overloaded maps to server error",
+			errType:   "overloaded_error",
+			errMsg:    "Overloaded",
+			wantInMsg: "Overloaded",
+			check:     func(err error) bool { var e *llm.ServerError; return errors.As(err, &e) },
+		},
+		{
+			name:      "rate limit maps to rate limit error",
+			errType:   "rate_limit_error",
+			errMsg:    "Number of requests has exceeded your rate limit",
+			wantInMsg: "rate limit",
+			check:     func(err error) bool { var e *llm.RateLimitError; return errors.As(err, &e) },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				events := []string{
+					`event: message_start` + "\n" + `data: {"type":"message_start","message":{"id":"msg_err","model":"claude-opus-4-6","role":"assistant","content":[],"usage":{"input_tokens":5,"output_tokens":0}}}`,
+					`event: error` + "\n" + fmt.Sprintf(`data: {"type":"error","error":{"type":%q,"message":%q}}`, tc.errType, tc.errMsg),
+				}
+				for _, evt := range events {
+					fmt.Fprintf(w, "%s\n\n", evt)
+				}
+			}))
+			defer server.Close()
+
+			a := New("test-key", WithBaseURL(server.URL))
+			ch := a.Stream(context.Background(), &llm.Request{
+				Model:    "claude-opus-4-6",
+				Messages: []llm.Message{llm.UserMessage("Hi")},
+			})
+
+			var streamErr error
+			for evt := range ch {
+				if evt.Type == llm.EventError && streamErr == nil {
+					streamErr = evt.Err
+				}
+			}
+
+			if streamErr == nil {
+				t.Fatal("expected EventError for SSE error event, got none")
+			}
+			if !strings.Contains(streamErr.Error(), tc.wantInMsg) {
+				t.Errorf("error %q should contain %q", streamErr.Error(), tc.wantInMsg)
+			}
+			if !tc.check(streamErr) {
+				t.Errorf("error has wrong type: %T (%v)", streamErr, streamErr)
+			}
+		})
+	}
+}

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -239,6 +239,21 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 		return true
 	}
 
+	if chunk.Error != nil {
+		// The API reports errors inside HTTP-200 streams; surface them as
+		// typed errors instead of silently dropping the chunk.
+		state.flushPendingFinish(ch)
+		msg := chunk.Error.Message
+		if msg == "" {
+			msg = "unknown stream error"
+		}
+		if chunk.Error.Status != "" {
+			msg = fmt.Sprintf("%s (%s)", msg, chunk.Error.Status)
+		}
+		ch <- llm.StreamEvent{Type: llm.EventError, Err: llm.ErrorFromStatusCode(chunk.Error.Code, "google: "+msg, "gemini")}
+		return true
+	}
+
 	if state.first {
 		ch <- llm.StreamEvent{Type: llm.EventStreamStart, Raw: data}
 		state.first = false

--- a/llm/google/adapter_test.go
+++ b/llm/google/adapter_test.go
@@ -873,3 +873,43 @@ func TestThoughtSignatureRoundTrip(t *testing.T) {
 		t.Errorf("expected 'ABCD1234sig', got %v", sig)
 	}
 }
+
+func TestAdapterStreamErrorChunk(t *testing.T) {
+	sseData := strings.Join([]string{
+		`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"partial"}]},"index":0}]}`,
+		"",
+		`data: {"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gemini-2.5-pro",
+		Messages: []llm.Message{llm.UserMessage("Say ok")},
+	})
+
+	var streamErr error
+	for evt := range ch {
+		if evt.Type == llm.EventError && streamErr == nil {
+			streamErr = evt.Err
+		}
+	}
+
+	if streamErr == nil {
+		t.Fatal("expected EventError for in-stream error chunk, got none")
+	}
+	if !strings.Contains(streamErr.Error(), "Resource has been exhausted") {
+		t.Errorf("error %q should contain the API message", streamErr.Error())
+	}
+	var rl *llm.RateLimitError
+	if !errors.As(streamErr, &rl) {
+		t.Errorf("expected *llm.RateLimitError, got %T (%v)", streamErr, streamErr)
+	}
+}

--- a/llm/google/translate.go
+++ b/llm/google/translate.go
@@ -359,6 +359,15 @@ type geminiResponse struct {
 	Candidates    []geminiCandidate `json:"candidates"`
 	UsageMetadata *geminiUsageMeta  `json:"usageMetadata,omitempty"`
 	ModelVersion  string            `json:"modelVersion,omitempty"`
+	Error         *geminiAPIError   `json:"error,omitempty"`
+}
+
+// geminiAPIError is the error object Gemini embeds in HTTP-200 responses,
+// notably inside SSE streams (e.g. RESOURCE_EXHAUSTED mid-stream).
+type geminiAPIError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Status  string `json:"status"`
 }
 
 type geminiCandidate struct {

--- a/llm/openai/adapter_sse.go
+++ b/llm/openai/adapter_sse.go
@@ -235,20 +235,28 @@ func (a *Adapter) handleSSEError(eventType string, data []byte, ch chan<- llm.St
 			} `json:"status_details"`
 		} `json:"response"`
 	}
-	if err := json.Unmarshal(data, &errEvt); err == nil {
-		msg := errEvt.Error.Message
-		code := errEvt.Error.Code
-		if msg == "" {
-			msg = errEvt.Response.StatusDetails.Error.Message
-			code = errEvt.Response.StatusDetails.Error.Code
-		}
-		if msg == "" {
-			msg = fmt.Sprintf("unknown API error (event type: %s)", eventType)
-		}
+	if err := json.Unmarshal(data, &errEvt); err != nil {
+		// An error event whose payload cannot be parsed must still surface
+		// as an error — swallowing it would turn a failed request into a
+		// bogus empty response.
 		ch <- llm.StreamEvent{
 			Type: llm.EventError,
-			Err:  sseErrorToTyped(code, msg),
+			Err:  fmt.Errorf("openai: %s event with unparseable payload: %w", eventType, err),
 		}
+		return
+	}
+	msg := errEvt.Error.Message
+	code := errEvt.Error.Code
+	if msg == "" {
+		msg = errEvt.Response.StatusDetails.Error.Message
+		code = errEvt.Response.StatusDetails.Error.Code
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("unknown API error (event type: %s)", eventType)
+	}
+	ch <- llm.StreamEvent{
+		Type: llm.EventError,
+		Err:  sseErrorToTyped(code, msg),
 	}
 }
 

--- a/llm/openai/adapter_test.go
+++ b/llm/openai/adapter_test.go
@@ -943,3 +943,41 @@ func TestAdapterProviderOptions(t *testing.T) {
 		t.Errorf("expected store=true from provider options, got %v", raw["store"])
 	}
 }
+
+func TestAdapterStreamUnparseableErrorPayload(t *testing.T) {
+	sseData := strings.Join([]string{
+		"event: response.created",
+		`data: {"type":"response.created","response":{"id":"resp_e1","model":"gpt-4.1"}}`,
+		"",
+		"event: error",
+		`data: {malformed`,
+		"",
+	}, "\n")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, sseData)
+	}))
+	defer server.Close()
+
+	a := New("test-key", WithBaseURL(server.URL))
+	ch := a.Stream(context.Background(), &llm.Request{
+		Model:    "gpt-4.1",
+		Messages: []llm.Message{llm.UserMessage("Hello")},
+	})
+
+	var streamErr error
+	for evt := range ch {
+		if evt.Type == llm.EventError && streamErr == nil {
+			streamErr = evt.Err
+		}
+	}
+
+	if streamErr == nil {
+		t.Fatal("expected EventError for unparseable error payload, got none")
+	}
+	if !strings.Contains(streamErr.Error(), "unparseable payload") {
+		t.Errorf("error %q should mention the unparseable payload", streamErr.Error())
+	}
+}

--- a/llm/openaicompat/adapter.go
+++ b/llm/openaicompat/adapter.go
@@ -265,14 +265,24 @@ func (a *Adapter) handleSSEDone(st *sseState, ch chan<- llm.StreamEvent) {
 // Returns true if an error was found and emitted.
 func (a *Adapter) tryEmitSSEError(data string, ch chan<- llm.StreamEvent) bool {
 	var errChunk chatStreamError
-	if err := json.Unmarshal([]byte(data), &errChunk); err == nil && errChunk.Error.Message != "" {
-		ch <- llm.StreamEvent{
-			Type: llm.EventError,
-			Err:  sseErrorToTyped(errChunk.Error.Code, errChunk.Error.Message),
-		}
-		return true
+	if err := json.Unmarshal([]byte(data), &errChunk); err != nil {
+		return false
 	}
-	return false
+	e := errChunk.Error
+	if e.Message == "" && e.Type == "" && e.Code == "" {
+		return false
+	}
+	msg := e.Message
+	if msg == "" {
+		// Some providers omit the message; synthesize one from code/type so
+		// the error is not silently dropped as a normal chunk.
+		msg = fmt.Sprintf("stream error (code=%q, type=%q)", e.Code, e.Type)
+	}
+	ch <- llm.StreamEvent{
+		Type: llm.EventError,
+		Err:  sseErrorToTyped(e.Code, msg),
+	}
+	return true
 }
 
 // handleSSEChoice processes a chunk that contains choices (text or tool call deltas).

--- a/llm/openaicompat/adapter_test.go
+++ b/llm/openaicompat/adapter_test.go
@@ -760,3 +760,41 @@ func TestNew_BaseURLNormalization(t *testing.T) {
 		}
 	}
 }
+
+func TestStream_SSEInStreamErrorWithoutMessage(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		lines := []string{
+			`data: {"error":{"type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+			"",
+			`data: [DONE]`,
+			"",
+		}
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	ch := adapter.Stream(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	var streamErr error
+	for evt := range ch {
+		if evt.Type == llm.EventError && streamErr == nil {
+			streamErr = evt.Err
+		}
+	}
+
+	if streamErr == nil {
+		t.Fatal("expected EventError for message-less in-stream error, got none")
+	}
+	if !strings.Contains(streamErr.Error(), "rate_limit") {
+		t.Errorf("error %q should reference the error code/type", streamErr.Error())
+	}
+}

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -143,6 +143,10 @@ func (a *StreamAccumulator) processToolCallStart(event StreamEvent) {
 	if event.ToolCall == nil {
 		return
 	}
+	// Chat Completions-style providers can start the next tool call before
+	// the prior one's End event arrives (all Ends batched at [DONE]); finalize
+	// the in-flight call so it isn't lost. The leftover End events are no-ops.
+	a.processToolCallEnd()
 	a.activeToolCall = &ToolCallData{
 		ID:             event.ToolCall.ID,
 		Name:           event.ToolCall.Name,

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -169,3 +169,29 @@ func TestStreamAccumulatorPreservesToolCallThoughtSignature(t *testing.T) {
 		t.Fatalf("ThoughtSigData = %q, want %q", calls[0].ThoughtSigData, "sig-123")
 	}
 }
+
+func TestStreamAccumulatorInterleavedToolCalls(t *testing.T) {
+	acc := NewStreamAccumulator()
+
+	// Chat Completions-style providers start the next tool call before the
+	// prior one's End event arrives, then emit all Ends at [DONE].
+	acc.Process(StreamEvent{Type: EventStreamStart})
+	acc.Process(StreamEvent{Type: EventToolCallStart, ToolCall: &ToolCallData{ID: "call_a", Name: "alpha"}})
+	acc.Process(StreamEvent{Type: EventToolCallDelta, Delta: `{"a":1}`})
+	acc.Process(StreamEvent{Type: EventToolCallStart, ToolCall: &ToolCallData{ID: "call_b", Name: "beta"}})
+	acc.Process(StreamEvent{Type: EventToolCallDelta, Delta: `{"b":2}`})
+	acc.Process(StreamEvent{Type: EventToolCallEnd})
+	acc.Process(StreamEvent{Type: EventToolCallEnd})
+	acc.Process(StreamEvent{Type: EventFinish, FinishReason: &FinishReason{Reason: "tool_use"}})
+
+	calls := acc.Response().ToolCalls()
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].ID != "call_a" || string(calls[0].Arguments) != `{"a":1}` {
+		t.Errorf("first call corrupted: %+v", calls[0])
+	}
+	if calls[1].ID != "call_b" || string(calls[1].Arguments) != `{"b":2}` {
+		t.Errorf("second call corrupted: %+v", calls[1])
+	}
+}

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -823,6 +823,10 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
+		e.emitCostUpdate(s)
+		if lr := e.checkBudgetAfterEmit(s); lr != nil {
+			return "", false, lr.result, nil
+		}
 		e.clearDownstream(fallback, s.cp)
 		s.cp.CurrentNode = fallback
 		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)

--- a/pipeline/engine_test.go
+++ b/pipeline/engine_test.go
@@ -1974,3 +1974,67 @@ func TestEngine_OverrideEdge_DecisionPriorityIsOverride(t *testing.T) {
 		t.Errorf("EdgePriority = %q, want %q", observedPriority, EdgePriorityOverride)
 	}
 }
+
+func TestEngine_BudgetCheckedOnFallbackRetryTarget(t *testing.T) {
+	// A node that exhausts its retry budget (OutcomeRetry attempts) and routes
+	// to fallback_retry_target must hit the budget guard at the fallback
+	// transition — not after the fallback node has already run (ceiling
+	// overshoot by one node). The within-budget retry path and the strict
+	// failure fallback (#311) already check; exhaustion must match.
+	g := NewGraph("budget_fallback_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "flaky", Shape: "box", Label: "Flaky", Attrs: map[string]string{
+		"max_retries":           "1",
+		"base_delay":            "0s",
+		"fallback_retry_target": "recovery",
+	}})
+	g.AddNode(&Node{ID: "recovery", Shape: "box", Label: "Recovery"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "flaky"})
+	g.AddEdge(&Edge{From: "flaky", To: "end"})
+	g.AddEdge(&Edge{From: "recovery", To: "end"})
+
+	heavyStats := &SessionStats{InputTokens: 200, OutputTokens: 100, TotalTokens: 300, Provider: "test-provider"}
+
+	var mu sync.Mutex
+	recoveryRan := false
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		n := name
+		reg.Register(&testHandler{name: n, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "flaky":
+				// Transient-style failure: routes through the retry machinery.
+				return Outcome{Status: string(OutcomeRetry), Stats: heavyStats}, nil
+			case "recovery":
+				mu.Lock()
+				recoveryRan = true
+				mu.Unlock()
+				return Outcome{Status: string(OutcomeSuccess), Stats: heavyStats}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		}})
+	}
+
+	// Attempt 1 lands at 300 tokens (under 450, retry proceeds); the final
+	// attempt lands at 600 — breached by the time exhaustion routes away.
+	guard := NewBudgetGuard(BudgetLimits{MaxTotalTokens: 450})
+	engine := NewEngine(g, reg, WithBudgetGuard(guard))
+
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine.Run returned unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Status != OutcomeBudgetExceeded {
+		t.Errorf("result.Status = %q, want %q", result.Status, OutcomeBudgetExceeded)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if recoveryRan {
+		t.Error("fallback target executed after budget breach — budget must be checked at the fallback transition")
+	}
+}

--- a/pipeline/expand.go
+++ b/pipeline/expand.go
@@ -282,6 +282,9 @@ func InjectParamsIntoGraph(g *Graph, params map[string]string) (*Graph, error) {
 		NodeOrder: append([]string(nil), g.NodeOrder...),
 		StartNode: g.StartNode,
 		ExitNode:  g.ExitNode,
+		// Param injection only rewrites attribute values; the dippin
+		// shape-level validation verdict still applies to the clone.
+		DippinValidated: g.DippinValidated,
 	}
 
 	for id, node := range g.Nodes {
@@ -292,8 +295,9 @@ func InjectParamsIntoGraph(g *Graph, params map[string]string) (*Graph, error) {
 		clone.Nodes[id] = cloned
 	}
 
+	// AddEdge (not a bare append) so the clone's adjacency indexes are built.
 	for _, e := range g.Edges {
-		clone.Edges = append(clone.Edges, &Edge{
+		clone.AddEdge(&Edge{
 			From:      e.From,
 			To:        e.To,
 			Label:     e.Label,

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -657,3 +657,29 @@ func TestExpandVariables_NormalMode_AllowsEverything(t *testing.T) {
 		t.Errorf("result = %q, want %q", result, "echo hello world")
 	}
 }
+
+func TestInjectParamsIntoGraphPreservesValidationAndIndexes(t *testing.T) {
+	g := NewGraph("sub")
+	g.AddNode(&Node{ID: "a", Shape: "box"})
+	g.AddNode(&Node{ID: "b", Shape: "box"})
+	g.AddEdge(&Edge{From: "a", To: "b"})
+	g.DippinValidated = true
+
+	clone, err := InjectParamsIntoGraph(g, map[string]string{})
+	if err != nil {
+		t.Fatalf("InjectParamsIntoGraph: %v", err)
+	}
+	if !clone.DippinValidated {
+		t.Error("clone lost DippinValidated flag")
+	}
+	if len(clone.outgoing["a"]) != 1 || len(clone.incoming["b"]) != 1 {
+		t.Errorf("clone adjacency indexes not populated: outgoing[a]=%d incoming[b]=%d",
+			len(clone.outgoing["a"]), len(clone.incoming["b"]))
+	}
+	if len(clone.Edges) != 1 {
+		t.Fatalf("expected 1 cloned edge, got %d", len(clone.Edges))
+	}
+	if clone.Edges[0] == g.Edges[0] {
+		t.Error("clone shares edge pointers with source graph")
+	}
+}

--- a/pipeline/handlers/backend_acp.go
+++ b/pipeline/handlers/backend_acp.go
@@ -275,6 +275,7 @@ func (b *ACPBackend) initSession(ctx context.Context, conn *acp.ClientSideConnec
 	})
 	if initErr != nil {
 		killProcess(proc.cmd)
+		_ = proc.cmd.Wait() // reap the killed process; releases pipes and avoids a zombie
 		logStderr(agentName, "initialize", &proc.stderr)
 		return "", fmt.Errorf("acp: initialize failed for %s: %w", agentName, initErr)
 	}
@@ -293,6 +294,7 @@ func (b *ACPBackend) initSession(ctx context.Context, conn *acp.ClientSideConnec
 	})
 	if sessErr != nil {
 		killProcess(proc.cmd)
+		_ = proc.cmd.Wait() // reap the killed process; releases pipes and avoids a zombie
 		logStderr(agentName, "new session", &proc.stderr)
 		return "", fmt.Errorf("acp: new session failed for %s: %w", agentName, sessErr)
 	}

--- a/pipeline/handlers/backend_claudecode_env_test.go
+++ b/pipeline/handlers/backend_claudecode_env_test.go
@@ -58,17 +58,11 @@ func TestClassifyErrorUnknown(t *testing.T) {
 }
 
 func TestBuildEnvStripsAPIKeys(t *testing.T) {
-	// Set test API keys.
-	os.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	os.Setenv("OPENAI_API_KEY", "sk-test")
-	os.Setenv("GEMINI_API_KEY", "gem-test")
-	os.Setenv("GOOGLE_API_KEY", "goog-test")
-	defer func() {
-		os.Unsetenv("ANTHROPIC_API_KEY")
-		os.Unsetenv("OPENAI_API_KEY")
-		os.Unsetenv("GEMINI_API_KEY")
-		os.Unsetenv("GOOGLE_API_KEY")
-	}()
+	// Set test API keys. t.Setenv restores the prior values on cleanup.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("OPENAI_API_KEY", "sk-test")
+	t.Setenv("GEMINI_API_KEY", "gem-test")
+	t.Setenv("GOOGLE_API_KEY", "goog-test")
 
 	env := buildEnv()
 
@@ -82,10 +76,11 @@ func TestBuildEnvStripsAPIKeys(t *testing.T) {
 }
 
 func TestBuildEnvPreservesNonAPIKeys(t *testing.T) {
-	os.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	os.Setenv("HOME", "/test/home")
-	os.Setenv("PATH", "/usr/bin")
-	defer os.Unsetenv("ANTHROPIC_API_KEY")
+	// t.Setenv (not os.Setenv) — a leaked PATH=/usr/bin breaks every later
+	// test in the package that spawns a subprocess (sh lives in /bin on macOS).
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("HOME", "/test/home")
+	t.Setenv("PATH", "/usr/bin")
 
 	env := buildEnv()
 
@@ -108,12 +103,8 @@ func TestBuildEnvPreservesNonAPIKeys(t *testing.T) {
 }
 
 func TestBuildEnvPassthroughWithOverride(t *testing.T) {
-	os.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-	os.Setenv("TRACKER_PASS_API_KEYS", "1")
-	defer func() {
-		os.Unsetenv("ANTHROPIC_API_KEY")
-		os.Unsetenv("TRACKER_PASS_API_KEYS")
-	}()
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	t.Setenv("TRACKER_PASS_API_KEYS", "1")
 
 	env := buildEnv()
 
@@ -155,12 +146,12 @@ func TestBuildEnv_PassAPIKeysFalseDoesNotPassthrough(t *testing.T) {
 }
 
 func TestBuildEnvNoKeysNoop(t *testing.T) {
-	// Ensure no API keys are set.
-	os.Unsetenv("ANTHROPIC_API_KEY")
-	os.Unsetenv("OPENAI_API_KEY")
-	os.Unsetenv("GEMINI_API_KEY")
-	os.Unsetenv("GOOGLE_API_KEY")
-	os.Unsetenv("TRACKER_PASS_API_KEYS")
+	// Ensure no API keys are set. t.Setenv first so cleanup restores the
+	// caller's real values after the unset.
+	for _, k := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "TRACKER_PASS_API_KEYS"} {
+		t.Setenv(k, os.Getenv(k))
+		os.Unsetenv(k)
+	}
 
 	env := buildEnv()
 	if len(env) == 0 {

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -912,6 +912,9 @@ func normalizeInterviewQuestionKey(text string) string {
 
 // executeChoice handles choice mode: presents outgoing edge labels as options.
 func (h *HumanHandler) executeChoice(node *pipeline.Node, prompt string) (pipeline.Outcome, error) {
+	if h.graph == nil {
+		return pipeline.Outcome{}, fmt.Errorf("human gate node %q: choice mode requires graph edges but handler has no graph", node.ID)
+	}
 	edges := h.graph.OutgoingEdges(node.ID)
 	if len(edges) == 0 {
 		return pipeline.Outcome{}, fmt.Errorf("human gate node %q has no outgoing edges to derive choices from", node.ID)

--- a/pipeline/handlers/human_test.go
+++ b/pipeline/handlers/human_test.go
@@ -49,6 +49,17 @@ func TestHumanHandlerName(t *testing.T) {
 	}
 }
 
+func TestHumanHandlerChoiceNilGraphErrors(t *testing.T) {
+	// Choice mode derives options from outgoing graph edges; a handler
+	// constructed without a graph must error, not nil-deref.
+	h := NewHumanHandler(&AutoApproveInterviewer{}, nil)
+	node := &pipeline.Node{ID: "gate", Shape: "hexagon", Attrs: map[string]string{"prompt": "pick"}}
+	_, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err == nil {
+		t.Fatal("expected error for choice mode without graph")
+	}
+}
+
 func TestHumanHandlerWithAutoApprove(t *testing.T) {
 	graph := pipeline.NewGraph("test")
 	graph.AddNode(&pipeline.Node{ID: "gate", Shape: "hexagon"})

--- a/pipeline/handlers/webhook_interviewer.go
+++ b/pipeline/handlers/webhook_interviewer.go
@@ -253,7 +253,18 @@ func (w *WebhookInterviewer) postWebhook(payload WebhookGatePayload) error {
 		return fmt.Errorf("marshal webhook payload: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, w.WebhookURL, bytes.NewReader(body))
+	// Tie the POST to gate cancellation so Cancel() aborts an in-flight
+	// request instead of letting it run to the client timeout.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		select {
+		case <-w.canceled:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.WebhookURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("create webhook request: %w", err)
 	}

--- a/pipeline/handlers/webhook_interviewer_test.go
+++ b/pipeline/handlers/webhook_interviewer_test.go
@@ -19,7 +19,12 @@ func TestWebhookInterviewer_CancelAbortsInflightPost(t *testing.T) {
 	// Cancel() must abort an in-flight outbound POST — otherwise a hung
 	// webhook endpoint pins the gate goroutine until the 30s client timeout.
 	release := make(chan struct{})
+	reached := make(chan struct{}, 1)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select { // signal the POST arrived (non-blocking: safe on retry)
+		case reached <- struct{}{}:
+		default:
+		}
 		<-release // hang until test cleanup
 	}))
 	defer srv.Close()
@@ -29,7 +34,13 @@ func TestWebhookInterviewer_CancelAbortsInflightPost(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- w.postWebhook(WebhookGatePayload{GateID: "g1"}) }()
 
-	time.Sleep(50 * time.Millisecond) // let the POST reach the hung server
+	// Synchronize on the handler actually receiving the POST — a fixed
+	// sleep is timing-dependent and flaky under CI load.
+	select {
+	case <-reached:
+	case <-time.After(3 * time.Second):
+		t.Fatal("POST never reached the test server")
+	}
 	w.Cancel()
 
 	select {

--- a/pipeline/handlers/webhook_interviewer_test.go
+++ b/pipeline/handlers/webhook_interviewer_test.go
@@ -15,6 +15,33 @@ import (
 	"github.com/2389-research/tracker/pipeline"
 )
 
+func TestWebhookInterviewer_CancelAbortsInflightPost(t *testing.T) {
+	// Cancel() must abort an in-flight outbound POST — otherwise a hung
+	// webhook endpoint pins the gate goroutine until the 30s client timeout.
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release // hang until test cleanup
+	}))
+	defer srv.Close()
+	defer close(release)
+
+	w := NewWebhookInterviewer(srv.URL, "127.0.0.1:0")
+	done := make(chan error, 1)
+	go func() { done <- w.postWebhook(WebhookGatePayload{GateID: "g1"}) }()
+
+	time.Sleep(50 * time.Millisecond) // let the POST reach the hung server
+	w.Cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected error from canceled POST")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("postWebhook did not return after Cancel — POST not tied to cancellation")
+	}
+}
+
 // postCallback posts a WebhookGateResponse to the interviewer's callback server.
 // It is safe to call from goroutines: it uses t.Errorf (not t.Fatalf) so it
 // never panics when called outside the test goroutine.

--- a/pipeline/transforms.go
+++ b/pipeline/transforms.go
@@ -43,8 +43,9 @@ func ExpandGraphVariables(text string, vars map[string]string) string {
 	if text == "" || len(vars) == 0 || !strings.Contains(text, "$") {
 		return text
 	}
-	// Replace longest names first so $target never clobbers $target_name —
-	// map iteration order is random, which made prefix collisions flaky.
+	// Try longest names first at each position so $target never clobbers
+	// $target_name — map iteration order is random, which made prefix
+	// collisions flaky.
 	names := make([]string, 0, len(vars))
 	for varName := range vars {
 		names = append(names, varName)
@@ -55,12 +56,34 @@ func ExpandGraphVariables(text string, vars map[string]string) string {
 		}
 		return names[i] < names[j]
 	})
-	for _, varName := range names {
-		if strings.Contains(text, varName) {
-			text = strings.ReplaceAll(text, varName, vars[varName])
+	// Single left-to-right pass: substituted values are appended to the
+	// output and never re-scanned, so a value containing a $name literal
+	// can't be expanded a second time (CLAUDE.md: variable expansion is
+	// single-pass — never re-scan resolved values). The previous
+	// sequential ReplaceAll loop re-scanned earlier substitutions.
+	var b strings.Builder
+	b.Grow(len(text))
+	for i := 0; i < len(text); {
+		if text[i] != '$' {
+			b.WriteByte(text[i])
+			i++
+			continue
+		}
+		matched := false
+		for _, varName := range names {
+			if strings.HasPrefix(text[i:], varName) {
+				b.WriteString(vars[varName])
+				i += len(varName)
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			b.WriteByte(text[i])
+			i++
 		}
 	}
-	return text
+	return b.String()
 }
 
 // contextKeysForInjection lists the pipeline context keys whose values should

--- a/pipeline/transforms.go
+++ b/pipeline/transforms.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -42,9 +43,21 @@ func ExpandGraphVariables(text string, vars map[string]string) string {
 	if text == "" || len(vars) == 0 || !strings.Contains(text, "$") {
 		return text
 	}
-	for varName, val := range vars {
+	// Replace longest names first so $target never clobbers $target_name —
+	// map iteration order is random, which made prefix collisions flaky.
+	names := make([]string, 0, len(vars))
+	for varName := range vars {
+		names = append(names, varName)
+	}
+	sort.Slice(names, func(i, j int) bool {
+		if len(names[i]) != len(names[j]) {
+			return len(names[i]) > len(names[j])
+		}
+		return names[i] < names[j]
+	})
+	for _, varName := range names {
 		if strings.Contains(text, varName) {
-			text = strings.ReplaceAll(text, varName, val)
+			text = strings.ReplaceAll(text, varName, vars[varName])
 		}
 	}
 	return text

--- a/pipeline/transforms_test.go
+++ b/pipeline/transforms_test.go
@@ -147,3 +147,19 @@ func TestGraphVarMap_NilContext(t *testing.T) {
 		t.Fatalf("expected nil for nil context, got %v", vars)
 	}
 }
+
+func TestExpandGraphVariablesPrefixCollision(t *testing.T) {
+	// $target must never clobber the prefix of $target_name; map iteration
+	// order is random, so run repeatedly to defeat lucky orderings.
+	vars := map[string]string{
+		"$target":      "prod",
+		"$target_name": "api-service",
+	}
+	want := "deploy api-service to prod"
+	for i := 0; i < 100; i++ {
+		got := ExpandGraphVariables("deploy $target_name to $target", vars)
+		if got != want {
+			t.Fatalf("iteration %d: got %q, want %q", i, got, want)
+		}
+	}
+}

--- a/pipeline/transforms_test.go
+++ b/pipeline/transforms_test.go
@@ -163,3 +163,21 @@ func TestExpandGraphVariablesPrefixCollision(t *testing.T) {
 		}
 	}
 }
+
+func TestExpandGraphVariablesSinglePass(t *testing.T) {
+	// Expansion is single-pass — a variable reference appearing inside a
+	// substituted VALUE must never be re-expanded (CLAUDE.md: "Variable
+	// expansion is single-pass — never re-scan resolved values"). Before
+	// the single-pass rewrite this depended on replacement order: the
+	// longest-first sequential ReplaceAll deterministically re-scanned
+	// $long's substituted value for $a.
+	vars := map[string]string{
+		"$long": "literal $a inside",
+		"$a":    "EXPANDED",
+	}
+	got := ExpandGraphVariables("value=$long flag=$a", vars)
+	want := "value=literal $a inside flag=EXPANDED"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -333,8 +333,14 @@ var knownProviders = []providerDef{
 		envVars:      []string{"ANTHROPIC_API_KEY"},
 		defaultModel: "claude-haiku-4-5",
 		buildAdapter: func(key string) (llm.ProviderAdapter, error) {
+			// Strict resolver so doctor reports the same gateway-route
+			// refusal that `tracker run` would hard-fail on.
+			base, err := ResolveProviderBaseURLStrict("anthropic")
+			if err != nil {
+				return nil, err
+			}
 			var opts []anthropic.Option
-			if base := ResolveProviderBaseURL("anthropic"); base != "" {
+			if base != "" {
 				opts = append(opts, anthropic.WithBaseURL(base))
 			}
 			return anthropic.New(key, opts...), nil
@@ -345,8 +351,12 @@ var knownProviders = []providerDef{
 		envVars:      []string{"OPENAI_API_KEY"},
 		defaultModel: "gpt-4o-mini",
 		buildAdapter: func(key string) (llm.ProviderAdapter, error) {
+			base, err := ResolveProviderBaseURLStrict("openai")
+			if err != nil {
+				return nil, err
+			}
 			var opts []openai.Option
-			if base := ResolveProviderBaseURL("openai"); base != "" {
+			if base != "" {
 				opts = append(opts, openai.WithBaseURL(base))
 			}
 			return openai.New(key, opts...), nil
@@ -357,8 +367,12 @@ var knownProviders = []providerDef{
 		envVars:      []string{"OPENAI_COMPAT_API_KEY"},
 		defaultModel: "gpt-4o-mini",
 		buildAdapter: func(key string) (llm.ProviderAdapter, error) {
+			base, err := ResolveProviderBaseURLStrict("openai-compat")
+			if err != nil {
+				return nil, err
+			}
 			var opts []openaicompat.Option
-			if base := ResolveProviderBaseURL("openai-compat"); base != "" {
+			if base != "" {
 				opts = append(opts, openaicompat.WithBaseURL(base))
 			}
 			return openaicompat.New(key, opts...), nil
@@ -369,8 +383,12 @@ var knownProviders = []providerDef{
 		envVars:      []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"},
 		defaultModel: "gemini-2.0-flash",
 		buildAdapter: func(key string) (llm.ProviderAdapter, error) {
+			base, err := ResolveProviderBaseURLStrict("gemini")
+			if err != nil {
+				return nil, err
+			}
 			var opts []google.Option
-			if base := ResolveProviderBaseURL("gemini"); base != "" {
+			if base != "" {
 				opts = append(opts, google.WithBaseURL(base))
 			}
 			return google.New(key, opts...), nil

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -229,6 +229,18 @@ var gatewayBaseURLEnvVars = []struct {
 	{"gemini", "GEMINI_BASE_URL"},
 }
 
+// providerBaseURLEnvVar returns the canonical *_BASE_URL env var name for a
+// provider label via gatewayBaseURLEnvVars — naive ToUpper(name) renders
+// invalid names for dashed labels (OPENAI-COMPAT_BASE_URL).
+func providerBaseURLEnvVar(name string) string {
+	for _, e := range gatewayBaseURLEnvVars {
+		if e.provider == name {
+			return e.envVar
+		}
+	}
+	return strings.ReplaceAll(strings.ToUpper(name), "-", "_") + "_BASE_URL"
+}
+
 // checkGatewayRouting surfaces non-fatal gateway routing caveats (#277). It
 // runs only when TRACKER_GATEWAY_URL or TRACKER_GATEWAY_KIND is set (see
 // Doctor) and emits informational notes — never warnings or errors, since
@@ -433,7 +445,7 @@ func checkProviders(ctx context.Context, probe bool) CheckResult {
 					// DNS, timeout, transport, context cancel, or other non-auth failure.
 					// Do NOT tell the user to rotate a working key.
 					detail.Message = fmt.Sprintf("%-15s %s=%s (probe failed: %s)", p.name, envName, masked, probeMsg)
-					detail.Hint = fmt.Sprintf("probe for %s failed on network/transport — verify connectivity and %s_BASE_URL before rotating keys", p.name, strings.ToUpper(p.name))
+					detail.Hint = fmt.Sprintf("probe for %s failed on network/transport — verify connectivity and %s before rotating keys", p.name, providerBaseURLEnvVar(p.name))
 				}
 				out.Details = append(out.Details, detail)
 				hasProviderErrors = true

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -5,6 +5,7 @@ package tracker
 import (
 	"bufio"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,34 @@ import (
 
 	"github.com/2389-research/tracker/internal/dipxtest"
 )
+
+func TestKnownProvidersGatewayRefusalSurfaces(t *testing.T) {
+	// Doctor's adapter probes must use the strict resolver: a refused
+	// gateway route (bedrock kind defines no openai-compat suffix) must
+	// surface as an error, not silently fall back to the public SDK
+	// default endpoint while `tracker run` hard-fails on the same config.
+	t.Setenv("OPENAI_COMPAT_BASE_URL", "")
+	t.Setenv("TRACKER_GATEWAY_URL", "https://gw.example.com")
+	t.Setenv("TRACKER_GATEWAY_KIND", "bedrock")
+
+	var def *providerDef
+	for i := range knownProviders {
+		if knownProviders[i].name == "OpenAI-Compat" {
+			def = &knownProviders[i]
+			break
+		}
+	}
+	if def == nil {
+		t.Fatal("OpenAI-Compat provider def not found")
+	}
+	_, err := def.buildAdapter("test-key")
+	if err == nil {
+		t.Fatal("expected gateway-route-refused error, got working adapter")
+	}
+	if !errors.Is(err, ErrGatewayRouteRefused) {
+		t.Errorf("error = %v, want ErrGatewayRouteRefused", err)
+	}
+}
 
 func TestDoctor_NoProbe_KeyPresent(t *testing.T) {
 	workdir := t.TempDir()

--- a/tracker_resolve.go
+++ b/tracker_resolve.go
@@ -83,7 +83,7 @@ func ResolveSource(name, workDir string) (source string, info WorkflowInfo, err 
 // isExplicitFilePath returns true if name looks like a filesystem path rather
 // than a bare workflow name.
 func isExplicitFilePath(name string) bool {
-	return strings.ContainsAny(name, "/\\") || strings.HasSuffix(name, ".dip") || strings.HasSuffix(name, ".dot")
+	return strings.ContainsAny(name, "/\\") || strings.HasSuffix(name, ".dip") || strings.HasSuffix(name, ".dipx") || strings.HasSuffix(name, ".dot")
 }
 
 // buildPipelineNotFoundError returns a diagnostic listing all available

--- a/tracker_resolve_test.go
+++ b/tracker_resolve_test.go
@@ -187,6 +187,19 @@ func TestResolveCheckpoint_NotFound(t *testing.T) {
 	}
 }
 
+func TestResolveSource_DipxExplicitPath(t *testing.T) {
+	// A name ending in .dipx must be treated as an explicit file path
+	// (matching the CLI resolver in cmd/tracker/resolve.go), not fall
+	// through to bare-name built-in lookup.
+	_, _, err := ResolveSource("missing-bundle.dipx", "")
+	if err == nil {
+		t.Fatal("expected error for non-existent .dipx path")
+	}
+	if strings.Contains(err.Error(), "Available built-in workflows") {
+		t.Errorf(".dipx name was treated as a bare name; expected file-not-found error, got: %v", err)
+	}
+}
+
 func TestResolveCheckpoint_CheckpointFileMissing(t *testing.T) {
 	tmp := t.TempDir()
 	runDir := filepath.Join(tmp, ".tracker", "runs", "halfrun")

--- a/tui/search.go
+++ b/tui/search.go
@@ -5,6 +5,8 @@ package tui
 import (
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -215,6 +217,27 @@ func isAnsiTerminator(r rune) bool {
 	return (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '~'
 }
 
+// lowerWithOffsets lowercases s rune-by-rune and returns the lowered string
+// plus a map from each byte position in the lowered string back to the byte
+// position of the corresponding rune in s (with one extra entry mapping
+// len(lower) to len(s)). Lowercasing can change a rune's UTF-8 byte length
+// (e.g. Ⱥ U+023A is 2 bytes, ⱥ U+2C65 is 3), so lowered offsets cannot be
+// used to slice s directly.
+func lowerWithOffsets(s string) (string, []int) {
+	var b strings.Builder
+	offsets := make([]int, 0, len(s)+1)
+	for i, r := range s {
+		lr := unicode.ToLower(r)
+		n := utf8.RuneLen(lr)
+		for j := 0; j < n; j++ {
+			offsets = append(offsets, i)
+		}
+		b.WriteRune(lr)
+	}
+	offsets = append(offsets, len(s))
+	return b.String(), offsets
+}
+
 // HighlightLine highlights all occurrences of the search term in a styled line.
 // Uses rune-aware operations for correct multi-byte character handling.
 func HighlightLine(line, term string) string {
@@ -222,7 +245,7 @@ func HighlightLine(line, term string) string {
 		return line
 	}
 	plain := stripAnsi(line)
-	lowerPlain := strings.ToLower(plain)
+	lowerPlain, offsets := lowerWithOffsets(plain)
 	lowerTerm := strings.ToLower(term)
 
 	// If no match in the plain text, return original.
@@ -230,20 +253,25 @@ func HighlightLine(line, term string) string {
 		return line
 	}
 
-	// Rebuild with highlights on the plain text.
+	// Rebuild with highlights on the plain text. Matching runs on the lowered
+	// string; offsets translate match boundaries back into plain. A UTF-8
+	// substring match always lands on rune boundaries (self-synchronization),
+	// so every boundary has an offsets entry.
 	var result strings.Builder
 	pos := 0
-	termLen := len(lowerTerm) // byte length matches since ToLower preserves byte count for ASCII
+	termLen := len(lowerTerm) // byte length in the lowered domain
 	for {
 		idx := strings.Index(lowerPlain[pos:], lowerTerm)
 		if idx < 0 {
-			result.WriteString(Styles.PrimaryText.Render(plain[pos:]))
+			result.WriteString(Styles.PrimaryText.Render(plain[offsets[pos]:]))
 			break
 		}
-		if idx > 0 {
-			result.WriteString(Styles.PrimaryText.Render(plain[pos : pos+idx]))
+		start := offsets[pos+idx]
+		end := offsets[pos+idx+termLen]
+		if start > offsets[pos] {
+			result.WriteString(Styles.PrimaryText.Render(plain[offsets[pos]:start]))
 		}
-		result.WriteString(Styles.SearchMatch.Render(plain[pos+idx : pos+idx+termLen]))
+		result.WriteString(Styles.SearchMatch.Render(plain[start:end]))
 		pos += idx + termLen
 	}
 	return result.String()

--- a/tui/search_test.go
+++ b/tui/search_test.go
@@ -156,6 +156,19 @@ func TestStripAnsi(t *testing.T) {
 	}
 }
 
+func TestHighlightLineUnicodeWidthChange(t *testing.T) {
+	// Ⱥ (U+023A, 2 bytes) lowers to ⱥ (U+2C65, 3 bytes), so byte offsets in
+	// the lowered string diverge from the original — slicing the original
+	// with lowered offsets panicked or garbled the output.
+	result := HighlightLine("ȺȺ error", "error")
+	if !strings.Contains(result, "error") {
+		t.Errorf("highlighted line lost the match: %q", result)
+	}
+	if !strings.Contains(result, "ȺȺ") {
+		t.Errorf("highlighted line lost the prefix: %q", result)
+	}
+}
+
 func TestHighlightLineNoMatch(t *testing.T) {
 	result := HighlightLine("hello world", "xyz")
 	if !strings.Contains(stripAnsi(result), "hello world") {


### PR DESCRIPTION
## Summary

Full-project fresh-eyes review: 7 parallel subagent reviewers produced 36 raw findings; each was personally verified against the code before fixing (11 rejected as false-positives/by-design or documented as skips). 25 confirmed fixes, each TDD red→green. Plan artifact with the complete finding table: `docs/superpowers/plans/2026-06-10-fresh-eyes-review-fixes.md`.

### LLM stream-error surfacing (CLAUDE.md: never silently swallow errors)
- **anthropic**: handle mid-stream SSE `error` events (`overloaded_error`, `rate_limit_error`) — previously dropped by the event switch
- **gemini**: parse `{"error":...}` SSE chunks (unmarshaled into an empty struct and vanished)
- **openai**: emit an error even when the SSE error payload is unparseable
- **openaicompat**: fire on error chunks carrying only `code`/`type` with no `message`
- **stream.go**: finalize the in-flight tool call on interleaved `Start(0), Start(1), End(0)` sequences instead of overwriting it

### Pipeline core
- `ExpandGraphVariables`: replace longest names first — `$target` could clobber `$target_name` depending on map iteration order
- `InjectParamsIntoGraph`: clone keeps `DippinValidated` and builds adjacency via `AddEdge` (edge-index lookups on injected graphs were empty)
- `handleRetryExhausted` fallback routing now runs the same cost-emit + budget check as the in-budget retry path

### CLI / library
- `.dipx` treated as explicit path in library bare-name resolution (CLI parity)
- `tracker update`: `os.CreateTemp` for the write probe and staged binary — fixed names could truncate real files or race concurrent updates
- update hint only prints after successful runs (its ≤2s wait delayed error output)
- doctor provider probes use `ResolveProviderBaseURLStrict` — doctor now reports the same `ErrGatewayRouteRefused` a run would hard-fail on

### Handlers / agent / TUI
- ACP `initSession` failure paths reap the killed subprocess (zombie + leaked pipe fds)
- webhook gate `Cancel()` aborts the in-flight POST (was `context.Background()`)
- choice-mode human gate errors cleanly instead of panicking with a nil graph
- empty-response session error reports the true consecutive count (N+1)
- search highlighting survives runes whose lowercase form changes UTF-8 width (Ⱥ→ⱥ, 2→3 bytes) via a lowered→original offset map

### Aux binaries / examples
- swebench agent-runner: context deadline/cancel classified `timeout`, not `tool_error` (`errors.Is`)
- conformance `list-handlers`: dead filter loop removed
- `ask_and_execute.dip`: printf format-injection hardening (`%b`/`%s`); FinalVerify `retry_target` into torn-down worktrees removed (exhaustion → EscalateToHuman)
- `build_product.dip`: numeric guard on `fix_attempts` read; missing stdin operand added to SKIP_PATTERN `paste` (BSD/macOS breakage, #345 regression)

### Test hygiene (pre-existing failures found during verification)
- claude-code env tests: `t.Setenv` conversion — a leaked `PATH=/usr/bin` broke every later subprocess-spawning test in the package on macOS (suite-wide flake, confirmed pre-existing via stash)
- `agent/exec` jail-hook tests: `sh -c true` instead of `/bin/true` (absent on macOS)

## Verification
- `go build ./...` clean, `go vet ./...` clean
- `go test ./... -short` — zero failures across the suite
- `dippin doctor` (pinned v0.38.0 via `go run`): ask_and_execute **A 95**, build_product **A 90**, build_product_with_superspec **A 100**
- All pre-commit hooks passed (gofmt, goimports, make test)

## Notes for review
- **C4** (update-hint gating in `main()`) has no unit test — `main()` isn't testable without a refactor; verified by inspection
- **D1** (ACP reap) ships without a dedicated test — exercising `initSession` failure needs a heavy ACP harness; the change is two `_ = proc.cmd.Wait()` lines after existing kill sites
- **D5** (restricted-mode dangling tool_use) intentionally skipped — verified dead-defensive: restricted sessions send no tools, so providers can't emit tool_use
- Two security-policy items deliberately **not** included pending sign-off: tool-safety denylist gaps (`bash <(curl …)` process substitution, backtick gadgets) and updater hard-fail on missing `checksums.txt`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783744344&installation_id=131176874&pr_number=356&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F356&signature=af9a2bb8b30ca5e9425b59d910a79c08f91e485f6029698585e8382ebd7f6ece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognize .dipx as explicit workflow paths
  * More robust LLM streaming error detection across providers

* **Bug Fixes**
  * Correct empty-API-response retry/error reporting
  * Preserve tool-call arguments for interleaved streams
  * Enforce budget checks before fallback retry transitions
  * Abort in-flight webhook requests on cancel
  * Reap failed subprocesses to avoid zombies/fd leaks
  * Fix Unicode-aware search highlighting
  * Guard choice mode when no graph is provided
  * Stable list-handlers output; suppress update nags after failures

* **Chores**
  * Safer temp-file handling during self-update
  * Improved test hygiene and cross-platform fixes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->