### PR TITLE
fix(handlers): fail closed on missing auto_status verdict for goal gates (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **auto_status no longer fails open on goal gates, and heading-mangled
+  STATUS lines parse** (issue #346). Two defects from the same case-study
+  run: (1) `parseStatusLine` now strips leading markdown heading markers
+  (`#`+space, any count) the same way it strips emphasis (#233 Gap 5.1), so
+  `## STATUS:fail` and `### **STATUS: fail**` register instead of being
+  silently missed; (2) when an `auto_status` node completes normally with
+  NO parseable STATUS line, nodes marked `goal_gate: true` now resolve to
+  `fail` (fail-closed — an unparseable verdict on a gate is an anomaly, not
+  a pass) instead of the legacy success default. Plain `auto_status` nodes
+  keep the success default for back-compat. Either way the anomaly is
+  observable: the handler reports it via `Outcome.MissingStatus`, the
+  engine emits a new `auto_status_missing` audit event to activity.jsonl,
+  and `tracker diagnose` surfaces a per-node suggestion distinguishing the
+  fail-closed flip from the silent default. Last-line-wins and
+  code-fence-skipping semantics are unchanged.
+
 ## [0.38.0] - 2026-06-11
 
 ### Added

--- a/pipeline/engine_autostatus_event_test.go
+++ b/pipeline/engine_autostatus_event_test.go
@@ -1,0 +1,60 @@
+// ABOUTME: Tests for EventAutoStatusMissing emission (#346) — the engine must
+// ABOUTME: surface a handler-reported missing-STATUS anomaly as a typed audit event.
+package pipeline
+
+import (
+	"context"
+	"testing"
+)
+
+// TestEngineEmitsAutoStatusMissingEvent verifies the engine emits
+// EventAutoStatusMissing when a handler outcome carries a MissingStatus
+// detail — same pattern as EventToolMarkerMissing (#210): the handler decides
+// the status, the engine provides the audit-trail companion.
+func TestEngineEmitsAutoStatusMissingEvent(t *testing.T) {
+	g := NewGraph("auto-status-missing")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "verify", Shape: "box", Attrs: map[string]string{"goal_gate": "true"}})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+	g.AddEdge(&Edge{From: "start", To: "verify"})
+	g.AddEdge(&Edge{From: "verify", To: "done", Condition: "ctx.outcome = success"})
+	g.AddEdge(&Edge{From: "verify", To: "done", Condition: "ctx.outcome = fail"})
+
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "verify" {
+				return Outcome{
+					Status:        string(OutcomeFail),
+					MissingStatus: &AutoStatusDetail{ResponseTail: "no marker here", FailClosed: true},
+				}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+
+	var got *PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		if evt.Type == EventAutoStatusMissing {
+			e := evt
+			got = &e
+		}
+	})
+
+	engine := NewEngine(g, reg, WithPipelineEventHandler(handler))
+	_, _ = engine.Run(context.Background())
+
+	if got == nil {
+		t.Fatal("expected an EventAutoStatusMissing event, got none")
+	}
+	if got.NodeID != "verify" {
+		t.Errorf("event NodeID = %q, want %q", got.NodeID, "verify")
+	}
+	if got.AutoStatus == nil || got.AutoStatus.ResponseTail != "no marker here" {
+		t.Errorf("event AutoStatus payload = %+v, want ResponseTail %q", got.AutoStatus, "no marker here")
+	}
+	if !got.AutoStatus.FailClosed {
+		t.Error("event AutoStatus.FailClosed = false, want true")
+	}
+}

--- a/pipeline/engine_checkpoint.go
+++ b/pipeline/engine_checkpoint.go
@@ -141,7 +141,7 @@ func (e *Engine) maxRetries(node *Node) int {
 
 // isGoalGate checks whether a node is marked as a goal gate.
 func isGoalGate(node *Node) bool {
-	return node.Attrs["goal_gate"] == "true"
+	return node.IsGoalGate()
 }
 
 // goalGateRetryTarget checks if any completed goal gate node is unsatisfied and

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -264,7 +264,7 @@ type runState struct {
 	//
 	// Stored as a shallow copy via `s.lastOutcome = *outcome`: value-type fields
 	// (Status, OverrideActor, PreferredLabel) are safely snapshotted, but slice
-	// and pointer fields (Truncations, ChildOverride, ChildUsage, MissingMarker,
+	// and pointer fields (Truncations, ChildOverride, ChildUsage, MissingMarker, MissingStatus,
 	// MissingRoute) share backing storage with the original outcome — treat them
 	// as read-only here. Mutating those fields through s.lastOutcome would
 	// silently corrupt the handler's outcome value (and vice versa).
@@ -651,6 +651,30 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 			Message: fmt.Sprintf("tool node %q: route_required is set but no _TRACKER_ROUTE= sentinel line was emitted to stdout — failing node to avoid silent fallback",
 				currentNodeID),
 			Route: outcome.MissingRoute,
+		})
+	}
+
+	// Same shape again for auto_status (#346): the agent completed normally
+	// but emitted no parseable STATUS line. The handler already chose the
+	// status (fail-closed on goal gates, legacy success default otherwise);
+	// this is the audit-trail companion so the TUI and `tracker diagnose`
+	// can surface the anomaly instead of it registering as a silent verdict.
+	if outcome.MissingStatus != nil {
+		var msg string
+		if outcome.MissingStatus.FailClosed {
+			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
+				currentNodeID)
+		} else {
+			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — keeping legacy success default (mark the node goal_gate: true to fail closed)",
+				currentNodeID)
+		}
+		e.emit(PipelineEvent{
+			Type:       EventAutoStatusMissing,
+			Timestamp:  time.Now(),
+			RunID:      s.runID,
+			NodeID:     currentNodeID,
+			Message:    msg,
+			AutoStatus: outcome.MissingStatus,
 		})
 	}
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -665,7 +665,7 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
 				currentNodeID)
 		} else {
-			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — keeping legacy success default (mark the node goal_gate: true to fail closed)",
+			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — the STATUS verdict defaulted to success (legacy behavior; the node's final status may still differ, e.g. on a declared-writes failure; mark the node goal_gate: true to fail closed)",
 				currentNodeID)
 		}
 		e.emit(PipelineEvent{

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -75,6 +75,14 @@ const (
 	// channel. Carries RouteDetail with the captured stdout tail.
 	EventToolRouteMissing PipelineEventType = "tool_route_missing"
 
+	// EventAutoStatusMissing fires when an auto_status agent node completed
+	// normally but its response contained no parseable STATUS line (#346).
+	// On goal_gate nodes the handler fails closed (an unparseable verdict on
+	// a gate is an anomaly, not a pass); on plain auto_status nodes the
+	// legacy success default is kept — either way this event makes the
+	// anomaly observable instead of a silent flip. Carries AutoStatusDetail.
+	EventAutoStatusMissing PipelineEventType = "auto_status_missing"
+
 	// EventValidationOverridden fires when the engine traverses an
 	// Edge.Override-marked edge at advanceToNextNode. Carries an
 	// OverrideDetail payload via PipelineEvent.Override. Stage-level
@@ -117,6 +125,16 @@ type MarkerDetail struct {
 // is no Pattern field — just the captured stdout tail for diagnosis.
 type RouteDetail struct {
 	CapturedTail string `json:"captured_tail,omitempty"`
+}
+
+// AutoStatusDetail is the payload for EventAutoStatusMissing (#346).
+// ResponseTail is up to 256 bytes from the end of the agent's response text
+// (where the STATUS line was expected) for diagnostic context. FailClosed is
+// true when the missing line failed the node (goal_gate nodes), false when
+// the legacy success default was kept (plain auto_status nodes).
+type AutoStatusDetail struct {
+	ResponseTail string `json:"response_tail,omitempty"`
+	FailClosed   bool   `json:"fail_closed,omitempty"`
 }
 
 // CostSnapshot is the payload for EventCostUpdated and EventBudgetExceeded events.
@@ -202,6 +220,7 @@ type PipelineEvent struct {
 	Truncation *TruncationDetail // non-nil for EventToolOutputTruncated
 	Marker     *MarkerDetail     // non-nil for EventToolMarkerMissing
 	Route      *RouteDetail      // non-nil for EventToolRouteMissing
+	AutoStatus *AutoStatusDetail // non-nil for EventAutoStatusMissing
 	// Override is non-nil on EventValidationOverridden events. Carries the
 	// gate, label, actor, and subgraph_path of the traversed override edge.
 	Override *OverrideDetail

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -85,6 +85,13 @@ type jsonlLogEntry struct {
 	// captured stdout tail for diagnosis.
 	RouteTail string `json:"route_tail,omitempty"`
 
+	// Auto-status fields — populated for auto_status_missing events
+	// (#346). Tail is up to 256 bytes from the end of the agent's
+	// response text (where the STATUS line was expected); FailClosed is
+	// true when the missing line failed a goal gate closed.
+	AutoStatusTail       string `json:"auto_status_tail,omitempty"`
+	AutoStatusFailClosed bool   `json:"auto_status_fail_closed,omitempty"`
+
 	// Override fields — populated for validation_overridden events.
 	// Identify the gate that produced the override, the edge label that
 	// selected it, who acted, and the subgraph_path when the override
@@ -238,6 +245,10 @@ func buildLogEntry(evt PipelineEvent) jsonlLogEntry {
 	}
 	if evt.Route != nil {
 		entry.RouteTail = evt.Route.CapturedTail
+	}
+	if evt.AutoStatus != nil {
+		entry.AutoStatusTail = evt.AutoStatus.ResponseTail
+		entry.AutoStatusFailClosed = evt.AutoStatus.FailClosed
 	}
 	if evt.Override != nil {
 		entry.OverrideGate = evt.Override.GateNodeID

--- a/pipeline/handler.go
+++ b/pipeline/handler.go
@@ -46,6 +46,14 @@ type Outcome struct {
 	// runs unconditionally; this field is populated only when the
 	// missing-sentinel + route_required combination triggers a fail.
 	MissingRoute *RouteDetail
+	// MissingStatus records an auto_status node that completed normally but
+	// produced no parseable STATUS line (#346). When non-nil the engine emits
+	// EventAutoStatusMissing. On goal_gate nodes the handler also sets
+	// Status = OutcomeFail (fail-closed: an unparseable verdict on a gate is
+	// an anomaly, not a pass); on plain auto_status nodes the legacy success
+	// default is kept and this field is the only signal. Populated only by
+	// the codergen handler.
+	MissingStatus *AutoStatusDetail
 	// OverrideActor is the Actor classification of the interviewer that produced
 	// this outcome. Populated by HumanHandler from its bound interviewer's
 	// Actor() method (via actorOf helper). The engine reads this at edge-selection

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -553,7 +553,7 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 	// else→operator) rather than unconditionally failed; auto_status is honored
 	// only on normal completion, never to rescue a breach. See
 	// resolveTerminalStatus / classifyBreach.
-	status, turnLimitMsg, breachClass := h.resolveTerminalStatus(node, responseText, sessResult, native)
+	status, turnLimitMsg, breachClass, statusMissing := h.resolveTerminalStatus(node, responseText, sessResult, native)
 
 	outcome := pipeline.Outcome{
 		Status: string(status),
@@ -562,6 +562,12 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 			pipeline.ContextKeyResponsePrefix + node.ID: responseText,
 		},
 		Stats: buildSessionStats(sessResult),
+	}
+	if statusMissing {
+		outcome.MissingStatus = &pipeline.AutoStatusDetail{
+			ResponseTail: tailForDiag(responseText, 256),
+			FailClosed:   node.IsGoalGate(),
+		}
 	}
 	h.applyEpisodeContextUpdates(outcome.ContextUpdates, sessResult, priorEpisodes)
 	if applyDeclaredWrites(node, outcome.ContextUpdates, responseText, "Response JSON") {
@@ -682,23 +688,41 @@ func buildTurnLimitMsg(node *pipeline.Node, sessResult agent.SessionResult) stri
 }
 
 // resolveTerminalStatus determines the node's terminal status, the turn-limit
-// message, and the #303 breach class. On a breach it classifies via the
-// turn_breach_policy; auto_status (an explicit STATUS line) is authoritative on
-// NORMAL completion only — it must NOT manufacture success on a breach, since a
-// missing/early STATUS line defaults parseAutoStatus to success and would
-// silently advance unverified work (#303 decision #5).
-func (h *CodergenHandler) resolveTerminalStatus(node *pipeline.Node, responseText string, sessResult agent.SessionResult, native bool) (pipeline.TerminalStatus, string, string) {
+// message, the #303 breach class, and whether the STATUS line was missing
+// (#346). On a breach it classifies via the turn_breach_policy; auto_status
+// (an explicit STATUS line) is authoritative on NORMAL completion only — it
+// must NOT manufacture success on a breach, since a missing/early STATUS line
+// defaults parseAutoStatus to success and would silently advance unverified
+// work (#303 decision #5).
+//
+// Missing-STATUS semantics (#346): when auto_status is set and no parseable
+// STATUS line is found on normal completion, goal_gate nodes fail closed —
+// an unparseable verdict on a gate is an anomaly, not a pass. Plain
+// auto_status nodes keep the legacy success default for back-compat. Either
+// way statusMissing is returned true so the anomaly is observable
+// (Outcome.MissingStatus → EventAutoStatusMissing), never a silent flip.
+func (h *CodergenHandler) resolveTerminalStatus(node *pipeline.Node, responseText string, sessResult agent.SessionResult, native bool) (pipeline.TerminalStatus, string, string, bool) {
 	status := pipeline.OutcomeSuccess
 	turnLimitMsg := buildTurnLimitMsg(node, sessResult)
 	var breachClass string
+	var statusMissing bool
 	if turnLimitMsg != "" {
 		policy := node.AgentConfig(h.graphAttrs).TurnBreachPolicy
 		status, breachClass = classifyBreach(policy, sessResult, native)
 	}
 	if node.Attrs["auto_status"] == "true" && turnLimitMsg == "" {
-		status = parseAutoStatus(responseText)
+		parsed, found := parseAutoStatus(responseText)
+		switch {
+		case found:
+			status = parsed
+		case node.IsGoalGate():
+			status = pipeline.OutcomeFail
+			statusMissing = true
+		default:
+			statusMissing = true // keep the success default, but observable
+		}
 	}
-	return status, turnLimitMsg, breachClass
+	return status, turnLimitMsg, breachClass, statusMissing
 }
 
 // applyBreachMarker writes the #303 turn_breach_class to the context updates,
@@ -861,9 +885,13 @@ func applyTypedCompaction(config *agent.SessionConfig, cfg pipeline.AgentNodeCon
 // parseAutoStatus scans the response text for STATUS: directives and returns
 // the last one found. Case-insensitive matching. Lines inside code fences
 // (``` blocks) are skipped to avoid matching hallucinated STATUS lines.
-// Falls back to success if no valid STATUS line is found.
-func parseAutoStatus(text string) pipeline.TerminalStatus {
+// The second return reports whether any valid STATUS line was found (#346);
+// when it is false the status falls back to the legacy success default and
+// the caller decides whether that default is acceptable (it is not on a
+// goal gate — see resolveTerminalStatus).
+func parseAutoStatus(text string) (pipeline.TerminalStatus, bool) {
 	result := pipeline.OutcomeSuccess
+	found := false
 	inCodeBlock := false
 	for _, line := range strings.Split(text, "\n") {
 		trimmed := strings.TrimSpace(line)
@@ -876,9 +904,10 @@ func parseAutoStatus(text string) pipeline.TerminalStatus {
 		}
 		if s := parseStatusLine(trimmed); s != "" {
 			result = s
+			found = true
 		}
 	}
-	return result
+	return result, found
 }
 
 // parseStatusLine extracts the status value from a "STATUS: ..." line.
@@ -891,7 +920,14 @@ func parseAutoStatus(text string) pipeline.TerminalStatus {
 // italic `*`, underscore-bold `__`, underscore-italic `_`) from both
 // the full line and the value portion, so the prefix check and value
 // switch see the bare token.
+//
+// Markdown-heading tolerance (issue #346): LLMs also emit the verdict as a
+// heading (`## STATUS:fail`) when they want it to draw the eye — at least as
+// natural as bold. The leading run of '#' (any count, with or without the
+// following space) is stripped before the emphasis strip, so heading-wrapped
+// directives parse like plain ones.
 func parseStatusLine(trimmed string) pipeline.TerminalStatus {
+	trimmed = strings.TrimSpace(strings.TrimLeft(trimmed, "#"))
 	trimmed = strings.Trim(trimmed, "*_")
 	if !strings.HasPrefix(strings.ToUpper(trimmed), "STATUS:") {
 		return ""

--- a/pipeline/handlers/codergen_autostatus_test.go
+++ b/pipeline/handlers/codergen_autostatus_test.go
@@ -1,0 +1,219 @@
+// ABOUTME: Tests for #346 — auto_status heading tolerance and fail-closed
+// ABOUTME: missing-STATUS handling on goal-gate nodes.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// TestParseAutoStatus_HeadingMarkers covers #346 defect 2: LLMs emit the
+// verdict as a markdown heading (`## STATUS:fail`) to make it draw the eye,
+// exactly like the bold shapes #233 Gap 5.1 already tolerates. Leading
+// heading markers must be stripped before the prefix check.
+func TestParseAutoStatus_HeadingMarkers(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		expect pipeline.TerminalStatus
+	}{
+		{
+			name:   "h2 heading no space after colon: ## STATUS:fail",
+			input:  "## STATUS:fail",
+			expect: pipeline.OutcomeFail,
+		},
+		{
+			name:   "h1 heading: # STATUS: success",
+			input:  "# STATUS: success",
+			expect: pipeline.OutcomeSuccess,
+		},
+		{
+			name:   "h3 heading wrapping bold: ### **STATUS: fail**",
+			input:  "### **STATUS: fail**",
+			expect: pipeline.OutcomeFail,
+		},
+		{
+			name:   "heading without space after hashes: ##STATUS:fail",
+			input:  "##STATUS:fail",
+			expect: pipeline.OutcomeFail,
+		},
+		{
+			name: "case study b68b532619c3: heading verdict at end of report",
+			input: "## Verification Report\n" +
+				"cmd/goblin/ does not exist. 0 of 8 criteria met.\n" +
+				"## STATUS:fail",
+			expect: pipeline.OutcomeFail,
+		},
+		{
+			name: "last-wins survives heading shapes",
+			input: "## STATUS:fail\n" +
+				"...recovered...\n" +
+				"## STATUS:success",
+			expect: pipeline.OutcomeSuccess,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := parseAutoStatus(tc.input)
+			if !found {
+				t.Fatalf("parseAutoStatus(%q) found = false, want true", tc.input)
+			}
+			if got != tc.expect {
+				t.Errorf("parseAutoStatus(%q) = %q, want %q", tc.input, got, tc.expect)
+			}
+		})
+	}
+}
+
+// TestParseAutoStatus_FoundFlag pins the new found return: false when no
+// parseable STATUS line exists (including fence-only), true when one does.
+// The status value on found=false stays OutcomeSuccess (legacy default) so
+// non-gate callers keep back-compat behavior.
+func TestParseAutoStatus_FoundFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantFound bool
+	}{
+		{"no STATUS at all", "Some narrative without any marker.", false},
+		{"STATUS only inside code fence", "```\nSTATUS:fail\n```\ndone", false},
+		{"heading STATUS with invalid value", "## STATUS: of the project is unclear", false},
+		{"plain STATUS present", "STATUS:fail", true},
+		{"heading STATUS present", "## STATUS:fail", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, found := parseAutoStatus(tc.input)
+			if found != tc.wantFound {
+				t.Fatalf("parseAutoStatus(%q) found = %v, want %v", tc.input, found, tc.wantFound)
+			}
+			if !found && got != pipeline.OutcomeSuccess {
+				t.Errorf("parseAutoStatus(%q) status on not-found = %q, want legacy default %q", tc.input, got, pipeline.OutcomeSuccess)
+			}
+		})
+	}
+}
+
+// TestCodergenHandler_AutoStatusMissing_GoalGateFailsClosed is the #346
+// defect-1 core: a goal-gate node whose agent never emitted a parseable
+// STATUS line must resolve to fail, not success — an unparseable verdict on
+// a gate is an anomaly, not a pass. The anomaly is surfaced via
+// Outcome.MissingStatus so the engine can emit an audit event.
+func TestCodergenHandler_AutoStatusMissing_GoalGateFailsClosed(t *testing.T) {
+	client := &fakeCompleter{responseText: "Verification report: 0 of 8 criteria met, but no marker."}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{ID: "verify", Shape: "box", Handler: "codergen", Attrs: map[string]string{
+		"prompt":      "verify the milestone",
+		"auto_status": "true",
+		"goal_gate":   "true",
+	}}
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("goal-gate node with no STATUS line = %q, want fail (fail-closed)", outcome.Status)
+	}
+	if outcome.MissingStatus == nil {
+		t.Fatal("expected MissingStatus detail to be populated for observability")
+	}
+	if !outcome.MissingStatus.FailClosed {
+		t.Error("MissingStatus.FailClosed = false, want true on a goal gate")
+	}
+	if outcome.MissingStatus.ResponseTail == "" {
+		t.Error("MissingStatus.ResponseTail is empty, want response tail for diagnosis")
+	}
+}
+
+// TestCodergenHandler_AutoStatusMissing_PlainNodeKeepsSuccessDefault pins
+// back-compat: a plain auto_status node (no goal_gate) with no STATUS line
+// keeps the legacy success default — but the anomaly is still observable
+// via MissingStatus.
+func TestCodergenHandler_AutoStatusMissing_PlainNodeKeepsSuccessDefault(t *testing.T) {
+	client := &fakeCompleter{responseText: "Narrative with no marker."}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{ID: "gen", Shape: "box", Handler: "codergen", Attrs: map[string]string{
+		"prompt":      "run tests",
+		"auto_status": "true",
+	}}
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("plain auto_status node with no STATUS line = %q, want success (back-compat)", outcome.Status)
+	}
+	if outcome.MissingStatus == nil {
+		t.Fatal("expected MissingStatus detail to be populated even when defaulting to success")
+	}
+	if outcome.MissingStatus.FailClosed {
+		t.Error("MissingStatus.FailClosed = true, want false on a non-gate node")
+	}
+}
+
+// TestCodergenHandler_AutoStatusHeading_GoalGateParsesFail is the end-to-end
+// case-study shape: the gate's verdict arrives as a `## STATUS:fail` heading
+// and must register as fail with no missing-status anomaly.
+func TestCodergenHandler_AutoStatusHeading_GoalGateParsesFail(t *testing.T) {
+	client := &fakeCompleter{responseText: "cmd/goblin/ does not exist. 0 of 8 criteria met.\n## STATUS:fail"}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{ID: "verify", Shape: "box", Handler: "codergen", Attrs: map[string]string{
+		"prompt":      "verify the milestone",
+		"auto_status": "true",
+		"goal_gate":   "true",
+	}}
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeFail) {
+		t.Errorf("heading STATUS:fail on goal gate = %q, want fail", outcome.Status)
+	}
+	if outcome.MissingStatus != nil {
+		t.Error("MissingStatus should be nil when a STATUS line parsed")
+	}
+}
+
+// TestCodergenHandler_AutoStatusPresent_NoMissingDetail pins that a normal
+// parsed STATUS line never produces a MissingStatus anomaly.
+func TestCodergenHandler_AutoStatusPresent_NoMissingDetail(t *testing.T) {
+	client := &fakeCompleter{responseText: "STATUS:success\nAll good."}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{ID: "gen", Shape: "box", Handler: "codergen", Attrs: map[string]string{
+		"prompt":      "run tests",
+		"auto_status": "true",
+	}}
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("status = %q, want success", outcome.Status)
+	}
+	if outcome.MissingStatus != nil {
+		t.Error("MissingStatus should be nil when a STATUS line parsed")
+	}
+}
+
+// TestCodergenHandler_NoAutoStatus_NoMissingDetail pins that nodes without
+// auto_status are completely unaffected by #346 — no detail, no flip.
+func TestCodergenHandler_NoAutoStatus_NoMissingDetail(t *testing.T) {
+	client := &fakeCompleter{responseText: "Narrative with no marker."}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{ID: "gen", Shape: "box", Handler: "codergen", Attrs: map[string]string{
+		"prompt":    "run tests",
+		"goal_gate": "true", // even on a gate: without auto_status there is no STATUS contract
+	}}
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("status = %q, want success", outcome.Status)
+	}
+	if outcome.MissingStatus != nil {
+		t.Error("MissingStatus must be nil for nodes without auto_status")
+	}
+}

--- a/pipeline/handlers/codergen_test.go
+++ b/pipeline/handlers/codergen_test.go
@@ -964,7 +964,7 @@ func TestParseAutoStatus_CaseInsensitive(t *testing.T) {
 		{"STATUS: SUCCESS\nAll good.", pipeline.OutcomeSuccess},
 	}
 	for _, tt := range tests {
-		got := parseAutoStatus(tt.input)
+		got, _ := parseAutoStatus(tt.input)
 		if got != tt.want {
 			t.Errorf("parseAutoStatus(%q) = %q, want %q", tt.input, got, tt.want)
 		}
@@ -973,7 +973,7 @@ func TestParseAutoStatus_CaseInsensitive(t *testing.T) {
 
 func TestParseAutoStatus_SkipsCodeBlock(t *testing.T) {
 	input := "Here is how to set status:\n```\nSTATUS:fail\n```\nSTATUS:success\nDone."
-	got := parseAutoStatus(input)
+	got, _ := parseAutoStatus(input)
 	if got != pipeline.OutcomeSuccess {
 		t.Errorf("parseAutoStatus with code block = %q, want %q", got, pipeline.OutcomeSuccess)
 	}
@@ -981,7 +981,7 @@ func TestParseAutoStatus_SkipsCodeBlock(t *testing.T) {
 
 func TestParseAutoStatus_OnlyCodeBlockDefaultsToSuccess(t *testing.T) {
 	input := "Some output.\n```\nSTATUS:fail\n```\nNo real status here."
-	got := parseAutoStatus(input)
+	got, _ := parseAutoStatus(input)
 	if got != pipeline.OutcomeSuccess {
 		t.Errorf("parseAutoStatus code-block-only = %q, want %q", got, pipeline.OutcomeSuccess)
 	}
@@ -1271,7 +1271,7 @@ func TestParseAutoStatus_V3FailFirstContract(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseAutoStatus(tc.input)
+			got, _ := parseAutoStatus(tc.input)
 			if got != tc.expect {
 				t.Fatalf("parseAutoStatus = %v, want %v", got, tc.expect)
 			}
@@ -1391,7 +1391,7 @@ func TestParseAutoStatus_Gap5_1_AuditedShapes(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseAutoStatus(tc.input)
+			got, _ := parseAutoStatus(tc.input)
 			if got != tc.expect {
 				t.Errorf("parseAutoStatus(%q) = %q; want %q\n  note: %s", tc.input, got, tc.expect, tc.note)
 			}

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -92,6 +92,13 @@ type AgentNodeConfig struct {
 	CompactionThreshold  float64
 }
 
+// IsGoalGate reports whether the node is marked `goal_gate: true`. Shared by
+// the engine's goal-gate retry logic and the codergen handler's fail-closed
+// missing-STATUS rule (#346).
+func (n *Node) IsGoalGate() bool {
+	return n.Attrs["goal_gate"] == "true"
+}
+
 // AgentConfig returns the typed agent config for the node, merging graphAttrs
 // defaults with node.Attrs overrides. Graph-level values apply to all agent
 // nodes unless a node explicitly overrides the same attr. Unparseable numeric

--- a/testdata/runs/auto_status_missing/activity.jsonl
+++ b/testdata/runs/auto_status_missing/activity.jsonl
@@ -1,0 +1,5 @@
+{"ts":"2026-06-10T15:58:00Z","type":"pipeline_started"}
+{"ts":"2026-06-10T15:58:01Z","type":"stage_started","node_id":"VerifyMilestone"}
+{"ts":"2026-06-10T15:58:08Z","type":"auto_status_missing","node_id":"VerifyMilestone","message":"node \"VerifyMilestone\": auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)","auto_status_tail":"0 of 8 criteria met but no marker\n","auto_status_fail_closed":true}
+{"ts":"2026-06-10T15:58:09Z","type":"stage_started","node_id":"Summarize"}
+{"ts":"2026-06-10T15:58:10Z","type":"auto_status_missing","node_id":"Summarize","message":"node \"Summarize\": auto_status is set but no parseable STATUS line was found — keeping legacy success default (mark the node goal_gate: true to fail closed)","auto_status_tail":"narrative summary text\n"}

--- a/testdata/runs/auto_status_missing/checkpoint.json
+++ b/testdata/runs/auto_status_missing/checkpoint.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "auto-status-missing-run",
+  "completed_nodes": ["Start"],
+  "current_node": "",
+  "retry_counts": {},
+  "restart_count": 0,
+  "timestamp": "2026-06-10T15:58:00Z"
+}

--- a/tracker_diagnose.go
+++ b/tracker_diagnose.go
@@ -118,6 +118,12 @@ const (
 	// emitted to stdout. Surfaces the captured stdout tail and the
 	// recommended author pattern. Issue #212.
 	SuggestionToolRouteMissing SuggestionKind = "tool_route_missing"
+	// SuggestionAutoStatusMissing fires when an auto_status agent node
+	// completed normally but its response contained no parseable STATUS
+	// line (#346). Goal-gate nodes fail closed; plain auto_status nodes
+	// keep the legacy success default — the suggestion copy distinguishes
+	// the two so a silently-defaulted verdict is visible post-run.
+	SuggestionAutoStatusMissing SuggestionKind = "auto_status_missing"
 	// SuggestionAuditLogInjection fires when the integrity-protected
 	// activity log has one or more lines missing the runtime sentinel
 	// prefix (#213). Detection-only — the suggestion text is explicit
@@ -212,6 +218,7 @@ type runtimeAnomalies struct {
 	Fallthroughs   []fallthroughObservation
 	MarkerMissings []markerMissingObservation
 	RouteMissings  []routeMissingObservation
+	StatusMissings []statusMissingObservation
 	// VisitStarts records per-node stage_started events so the
 	// suggestion builder can flush stale pending truncations from a
 	// prior visit as orphans before pairing within the new visit.
@@ -242,6 +249,13 @@ type routeMissingObservation struct {
 	Seq          int
 	NodeID       string
 	CapturedTail string
+}
+
+type statusMissingObservation struct {
+	Seq          int
+	NodeID       string
+	ResponseTail string
+	FailClosed   bool
 }
 
 // Seq is a monotonically-increasing scan position shared across all
@@ -378,6 +392,10 @@ type diagnoseEntry struct {
 
 	// Tool-route-missing event fields (#212).
 	RouteTail string `json:"route_tail"`
+
+	// Auto-status-missing event fields (#346).
+	AutoStatusTail       string `json:"auto_status_tail"`
+	AutoStatusFailClosed bool   `json:"auto_status_fail_closed"`
 }
 
 // enrichFromActivity streams the activity log (preferring the secure
@@ -489,6 +507,14 @@ func enrichFromActivity(ctx context.Context, runDir string, failures map[string]
 				Seq:          anomalySeq,
 				NodeID:       entry.NodeID,
 				CapturedTail: entry.RouteTail,
+			})
+		case pipeline.EventAutoStatusMissing:
+			anomalySeq++
+			anomalies.StatusMissings = append(anomalies.StatusMissings, statusMissingObservation{
+				Seq:          anomalySeq,
+				NodeID:       entry.NodeID,
+				ResponseTail: entry.AutoStatusTail,
+				FailClosed:   entry.AutoStatusFailClosed,
 			})
 		}
 		enrichFromEntry(entry, failures, stageStarts, failSignatures)
@@ -787,6 +813,43 @@ func buildSuggestions(failures []NodeFailure, halt *BudgetHalt, anomalies runtim
 		}
 		out = append(out, Suggestion{
 			NodeID: latest.NodeID, Kind: SuggestionToolMarkerMissing, Message: msg,
+		})
+	}
+
+	// Emit at most one suggestion per node for missing auto_status
+	// STATUS lines (#346). Same de-dupe shape as marker_grep above;
+	// the copy distinguishes the fail-closed goal-gate flip from the
+	// legacy success default so a silently-defaulted verdict is
+	// visible post-run.
+	lastStatusByNode := map[string]statusMissingObservation{}
+	statusCountByNode := map[string]int{}
+	for _, sm := range anomalies.StatusMissings {
+		statusCountByNode[sm.NodeID]++
+		if prev, ok := lastStatusByNode[sm.NodeID]; !ok || sm.Seq > prev.Seq {
+			lastStatusByNode[sm.NodeID] = sm
+		}
+	}
+	emittedStatus := map[string]bool{}
+	for _, sm := range anomalies.StatusMissings {
+		if emittedStatus[sm.NodeID] {
+			continue
+		}
+		emittedStatus[sm.NodeID] = true
+		latest := lastStatusByNode[sm.NodeID]
+		count := statusCountByNode[sm.NodeID]
+		var msg string
+		if latest.FailClosed {
+			msg = fmt.Sprintf("%s: auto_status is set but the agent emitted no parseable STATUS line, so the goal gate failed closed (response tail: %q). The agent likely phrased the verdict in a shape the parser rejects, or never emitted one — tighten the prompt's STATUS contract or inspect the node's response.md.",
+				latest.NodeID, latest.ResponseTail)
+		} else {
+			msg = fmt.Sprintf("%s: auto_status is set but the agent emitted no parseable STATUS line, so the node defaulted to success (response tail: %q). If this node is a verification gate, mark it goal_gate: true so a missing verdict fails closed instead.",
+				latest.NodeID, latest.ResponseTail)
+		}
+		if count > 1 {
+			msg += fmt.Sprintf(" (%d occurrences across retries/loop; showing the most recent)", count)
+		}
+		out = append(out, Suggestion{
+			NodeID: latest.NodeID, Kind: SuggestionAutoStatusMissing, Message: msg,
 		})
 	}
 	return out

--- a/tracker_diagnose.go
+++ b/tracker_diagnose.go
@@ -842,7 +842,7 @@ func buildSuggestions(failures []NodeFailure, halt *BudgetHalt, anomalies runtim
 			msg = fmt.Sprintf("%s: auto_status is set but the agent emitted no parseable STATUS line, so the goal gate failed closed (response tail: %q). The agent likely phrased the verdict in a shape the parser rejects, or never emitted one — tighten the prompt's STATUS contract or inspect the node's response.md.",
 				latest.NodeID, latest.ResponseTail)
 		} else {
-			msg = fmt.Sprintf("%s: auto_status is set but the agent emitted no parseable STATUS line, so the node defaulted to success (response tail: %q). If this node is a verification gate, mark it goal_gate: true so a missing verdict fails closed instead.",
+			msg = fmt.Sprintf("%s: auto_status is set but the agent emitted no parseable STATUS line, so the STATUS verdict defaulted to success (response tail: %q). If this node is a verification gate, mark it goal_gate: true so a missing verdict fails closed instead.",
 				latest.NodeID, latest.ResponseTail)
 		}
 		if count > 1 {

--- a/tracker_diagnose_test.go
+++ b/tracker_diagnose_test.go
@@ -468,3 +468,49 @@ func writeCheckpoint(t *testing.T, runDir, runID string) {
 		t.Fatalf("write checkpoint: %v", err)
 	}
 }
+
+// TestDiagnose_AutoStatusMissing pins activity.jsonl parsing and the
+// SuggestionAutoStatusMissing emission for #346: an auto_status agent node
+// that completed normally without a parseable STATUS line. The fixture has
+// a fail-closed goal gate (VerifyMilestone) and a default-success plain node
+// (Summarize) — the suggestion copy must distinguish the two.
+func TestDiagnose_AutoStatusMissing(t *testing.T) {
+	r, err := Diagnose(context.Background(), "testdata/runs/auto_status_missing")
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+
+	var suggestions []Suggestion
+	for _, s := range r.Suggestions {
+		if s.Kind == SuggestionAutoStatusMissing {
+			suggestions = append(suggestions, s)
+		}
+	}
+	if len(suggestions) != 2 {
+		t.Fatalf("got %d auto-status-missing suggestions, want 2", len(suggestions))
+	}
+
+	byNode := map[string]Suggestion{}
+	for _, s := range suggestions {
+		byNode[s.NodeID] = s
+	}
+
+	gate, ok := byNode["VerifyMilestone"]
+	if !ok {
+		t.Fatal("missing suggestion for VerifyMilestone (fail-closed gate path)")
+	}
+	if !strings.Contains(gate.Message, "failed closed") {
+		t.Errorf("gate suggestion should explain the fail-closed flip: %q", gate.Message)
+	}
+	if !strings.Contains(gate.Message, "0 of 8 criteria met") {
+		t.Errorf("gate suggestion should include the response tail: %q", gate.Message)
+	}
+
+	plain, ok := byNode["Summarize"]
+	if !ok {
+		t.Fatal("missing suggestion for Summarize (default-success path)")
+	}
+	if !strings.Contains(plain.Message, "defaulted to success") {
+		t.Errorf("plain suggestion should warn about the success default: %q", plain.Message)
+	}
+}


### PR DESCRIPTION
Closes #346.

## What happened (case study b68b532619c3)

`VerifyMilestone` emitted a correct FAIL verdict as `## STATUS:fail`. `parseAutoStatus` missed the heading shape, fell back to its success default, and the failed milestone was marked complete — ~32 minutes and ~$10 of downstream work re-discovered what the gate already knew.

## Changes

1. **Heading tolerance** (`parseStatusLine`): leading markdown heading markers (`#` run, with or without the following space) are stripped before the existing #233 Gap 5.1 emphasis strip — unconditional, pure robustness. `## STATUS:fail` and `### **STATUS: fail**` now parse.
2. **Fail closed where it matters** (`parseAutoStatus` → `(status, found)`): on normal completion with `auto_status` set and NO parseable STATUS line:
   - `goal_gate: true` nodes resolve to **`fail`** — an unparseable verdict on a gate is an anomaly, not a pass.
   - Plain `auto_status` nodes **keep the legacy success default** (back-compat, pinned by `TestCodergenHandler_AutoStatusMissing_PlainNodeKeepsSuccessDefault`). Design choice: rather than a new opt-in attr, `goal_gate` is the existing, semantically-correct signal for "a missing verdict must not pass" — no new .dip surface needed, and non-gate nodes are bitwise unaffected.
3. **Observable, never silent**: the handler populates `Outcome.MissingStatus` (same pattern as `MissingMarker`/#210), the engine emits a new `auto_status_missing` event to activity.jsonl/NDJSON, and `tracker diagnose` surfaces a per-node suggestion distinguishing the fail-closed flip from the silent default.

## Explicitly preserved (pinned by existing tests)

- Last-line-wins (`TestParseAutoStatus_V3FailFirstContract` — the early-`STATUS:fail` convention in `build_product.dip` still works as designed).
- Code-fence skipping.
- #303 interplay: `auto_status` is still never consulted on a turn-limit breach; `resolveTerminalStatus`'s breach classification path is untouched.
- Nodes without `auto_status` (even gates) are unaffected.

`build_product.dip`'s STATUS-contract prose was reviewed and left as-is: the early-fail convention remains load-bearing for mid-response truncation on non-gate nodes (e.g. VerifyMilestone is not `goal_gate`), so nothing there is provably redundant.

## Out of scope (noted per issue)

The issue's longer-term **structural status channel** (forced tool call / structured output instead of text scanning) is not attempted here.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓; `go test -race -short ./pipeline/...` ✓
- `dippin doctor`: ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 (baselines held) ✓
- gofmt clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783803618&installation_id=131176874&pr_number=359&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F359&signature=ec2d850007ecd9199a8b5ef5752e71cbb4af53e43889320f0a92e1f946934648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->