### PR TITLE
fix(engine): goal-gate retry must re-execute the gate before terminal success (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   persisted `gate_recheck_pending` marker when a goal-gate redirect fires,
   cleared only when the gate node actually re-executes. Pending gates stay
   visible to the exit check even when cleared from the completed set, and
-  while retries remain a still-pending gate re-enters **at the gate itself**
-  so it re-evaluates the current (possibly remediated) tree. Retry budget
-  still flows through `retry_counts`, the one-shot fallback guard is
-  unchanged, the marker is persisted in checkpoint.json for deterministic
-  resume, and retry targets whose path flows back through the gate behave
-  exactly as before. Defect 2 of #348 (human "accept" at an escalation
+  a still-pending gate re-enters **at the gate itself** so it re-evaluates
+  the current (possibly remediated) tree. The re-entry completes the
+  redirect's retry cycle without a fresh budget charge (so it fires even
+  with `max_retries: 1`); new redirects still charge `retry_counts`, the
+  one-shot fallback guard is unchanged, the marker is persisted in
+  checkpoint.json for deterministic resume, and retry targets whose path
+  flows back through the gate behave exactly as before. Defect 2 of #348 (human "accept" at an escalation
   should mark the gate overridden) remains open, blocked on #271 /
   dippin-lang#124.
 - **auto_status no longer fails open on goal gates, and heading-mangled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Goal-gate retry now re-executes the gate instead of replaying the
+  escalation tail** (issue #348, defect 1). When a goal-gate retry redirected
+  to the gate's fallback/escalation path and that path reached the exit
+  without flowing back through the gate, the redirect's `clearDownstream`
+  removed the gate from the checkpoint's completed set — and since the
+  exit-time goal-gate check only scanned completed nodes, the gate vanished
+  from the check and the run completed **plain success with the gate still
+  at `outcome: fail`** (case-study run b68b532619c3: FinalSpecCheck never
+  re-ran after FinalCommit's remediation). The engine now records a
+  persisted `gate_recheck_pending` marker when a goal-gate redirect fires,
+  cleared only when the gate node actually re-executes. Pending gates stay
+  visible to the exit check even when cleared from the completed set, and
+  while retries remain a still-pending gate re-enters **at the gate itself**
+  so it re-evaluates the current (possibly remediated) tree. Retry budget
+  still flows through `retry_counts`, the one-shot fallback guard is
+  unchanged, the marker is persisted in checkpoint.json for deterministic
+  resume, and retry targets whose path flows back through the gate behave
+  exactly as before. Defect 2 of #348 (human "accept" at an escalation
+  should mark the gate overridden) remains open, blocked on #271 /
+  dippin-lang#124.
 - **auto_status no longer fails open on goal gates, and heading-mangled
   STATUS lines parse** (issue #346). Two defects from the same case-study
   run: (1) `parseStatusLine` now strips leading markdown heading markers

--- a/pipeline/checkpoint.go
+++ b/pipeline/checkpoint.go
@@ -30,6 +30,17 @@ type Checkpoint struct {
 	// the guard survives checkpoint save/restore cycles.
 	FallbackTaken map[string]bool `json:"fallback_taken,omitempty"`
 
+	// GateRecheckPending tracks goal-gate nodes whose retry/fallback
+	// redirect has fired but which have not re-executed since (#348
+	// defect 1). Set when handleExitNode redirects away from an
+	// unsatisfied gate; cleared when the gate node executes again. While
+	// pending, the gate stays visible to the exit-time goal-gate check
+	// even after clearDownstream removed it from CompletedNodes, and a
+	// retry re-enters AT the gate so it re-evaluates the current tree
+	// instead of replaying an escalation tail that routes around it.
+	// Persisted so a resumed run replays the re-entry deterministically.
+	GateRecheckPending map[string]bool `json:"gate_recheck_pending,omitempty"`
+
 	// WIPRefs maps a failed/exhausted node ID to the recoverable git ref
 	// (a tag tracker/wip/<runID>/<nodeID>) where its uncommitted work was
 	// preserved before the engine routed away from it (#302). Additive;
@@ -95,6 +106,27 @@ func (cp *Checkpoint) MarkCompleted(nodeID string) {
 	}
 	cp.completedSet[nodeID] = true
 	cp.CompletedNodes = append(cp.CompletedNodes, nodeID)
+}
+
+// SetGateRecheckPending marks a goal-gate node as awaiting re-execution
+// after a retry/fallback redirect (#348 defect 1).
+func (cp *Checkpoint) SetGateRecheckPending(nodeID string) {
+	if cp.GateRecheckPending == nil {
+		cp.GateRecheckPending = make(map[string]bool)
+	}
+	cp.GateRecheckPending[nodeID] = true
+}
+
+// ClearGateRecheckPending records that a goal-gate node has re-executed,
+// clearing its pending recheck (#348 defect 1).
+func (cp *Checkpoint) ClearGateRecheckPending(nodeID string) {
+	delete(cp.GateRecheckPending, nodeID)
+}
+
+// IsGateRecheckPending reports whether a goal-gate node is awaiting
+// re-execution after a retry/fallback redirect (#348 defect 1).
+func (cp *Checkpoint) IsGateRecheckPending(nodeID string) bool {
+	return cp.GateRecheckPending[nodeID]
 }
 
 // SetEdgeSelection records the selected outgoing edge for a completed node.

--- a/pipeline/checkpoint_test.go
+++ b/pipeline/checkpoint_test.go
@@ -253,3 +253,35 @@ func TestCheckpoint_WIPRefsRoundTrip(t *testing.T) {
 		t.Errorf("expected empty WIPRefs on legacy checkpoint, got %v", old.WIPRefs)
 	}
 }
+
+func TestCheckpoint_GateRecheckPending_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "checkpoint.json")
+
+	cp := &Checkpoint{RunID: "run-348"}
+	cp.SetGateRecheckPending("FinalSpecCheck")
+	if !cp.IsGateRecheckPending("FinalSpecCheck") {
+		t.Fatal("expected FinalSpecCheck to be recheck-pending after Set")
+	}
+	if err := SaveCheckpoint(cp, path); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	loaded, err := LoadCheckpoint(path)
+	if err != nil {
+		t.Fatalf("LoadCheckpoint: %v", err)
+	}
+	if !loaded.IsGateRecheckPending("FinalSpecCheck") {
+		t.Fatal("gate_recheck_pending must survive a save/load cycle so resume replays the re-entry")
+	}
+
+	loaded.ClearGateRecheckPending("FinalSpecCheck")
+	if loaded.IsGateRecheckPending("FinalSpecCheck") {
+		t.Fatal("expected pending recheck to clear")
+	}
+	// Clearing on a nil map must not panic (pre-#348 checkpoints).
+	(&Checkpoint{}).ClearGateRecheckPending("anything")
+	if (&Checkpoint{}).IsGateRecheckPending("anything") {
+		t.Fatal("empty checkpoint should report no pending rechecks")
+	}
+}

--- a/pipeline/engine_checkpoint.go
+++ b/pipeline/engine_checkpoint.go
@@ -207,12 +207,23 @@ func (e *Engine) checkGoalGateNode(cp *Checkpoint, nodeID string, nodeOutcomes m
 		return goalGateCheckResult{}, false
 	}
 
+	// A pending recheck wins over the budget branch (#348 defect 1, codex
+	// P2 on #360): the prior redirect already charged the retry budget but
+	// never re-ran the gate, so re-entering AT the gate is the COMPLETION
+	// of that retry cycle, not a new retry — it must fire even when the
+	// redirect consumed the last unit (max_retries=1), and handleExitNode
+	// does not charge for it. No loop risk: the re-entry executes the gate
+	// next, which clears the pending flag (applyOutcome).
+	if cp.IsGateRecheckPending(nodeID) {
+		return goalGateCheckResult{target: nodeID, nodeID: nodeID, shouldRetry: true, unsatisfied: true}, true
+	}
+
 	var t, n string
 	var retry, unsat bool
 	if cp.RetryCount(nodeID) >= e.maxRetries(node) {
 		t, n, retry, unsat = e.goalGateExhaustedPath(cp, node, nodeID)
 	} else {
-		t, n, retry, unsat = e.goalGateRemainingPath(cp, node, nodeID)
+		t, n, retry, unsat = e.goalGateRemainingPath(node, nodeID)
 	}
 	return goalGateCheckResult{target: t, nodeID: n, shouldRetry: retry, unsatisfied: unsat}, true
 }
@@ -256,18 +267,9 @@ func (e *Engine) findFallbackTarget(node *Node) string {
 // goalGateRemainingPath handles the retries-still-available case for a goal gate.
 // Returns (target, nodeID, shouldRetry=true, unsatisfied=true) when a target is found,
 // or (empty, nodeID, false, true) if no valid retry target exists.
-//
-// When the gate has a pending recheck (#348 defect 1) — a prior redirect
-// fired but the executed path reached the exit without re-running the gate —
-// the retry re-enters AT the gate itself so it re-evaluates the current
-// tree. Redirecting to the same retry/fallback target again would just
-// replay the tail that already routed around the gate; remediation that
-// happened on that tail (the case study's FinalCommit) is exactly what the
-// gate needs to re-judge. Budget still flows through cp.RetryCounts.
-func (e *Engine) goalGateRemainingPath(cp *Checkpoint, node *Node, nodeID string) (string, string, bool, bool) {
-	if cp.IsGateRecheckPending(nodeID) {
-		return nodeID, nodeID, true, true
-	}
+// (The pending-recheck re-entry is handled upstream in checkGoalGateNode,
+// before the budget branch — see #348 defect 1.)
+func (e *Engine) goalGateRemainingPath(node *Node, nodeID string) (string, string, bool, bool) {
 	retryTargets := []string{
 		node.Attrs["retry_target"],
 		node.Attrs["fallback_target"],

--- a/pipeline/engine_checkpoint.go
+++ b/pipeline/engine_checkpoint.go
@@ -208,12 +208,13 @@ func (e *Engine) checkGoalGateNode(cp *Checkpoint, nodeID string, nodeOutcomes m
 	}
 
 	// A pending recheck wins over the budget branch (#348 defect 1, codex
-	// P2 on #360): the prior redirect already charged the retry budget but
-	// never re-ran the gate, so re-entering AT the gate is the COMPLETION
-	// of that retry cycle, not a new retry — it must fire even when the
-	// redirect consumed the last unit (max_retries=1), and handleExitNode
-	// does not charge for it. No loop risk: the re-entry executes the gate
-	// next, which clears the pending flag (applyOutcome).
+	// P2 on #360): the prior redirect — a charged retry or the uncharged
+	// one-shot fallback — routed away without re-running the gate, so
+	// re-entering AT the gate is the COMPLETION of that redirect cycle,
+	// not a new retry. It must fire even when a retry redirect consumed
+	// the last budget unit (max_retries=1), and handleExitNode does not
+	// charge for it. No loop risk: the re-entry executes the gate next,
+	// which clears the pending flag (applyOutcome).
 	if cp.IsGateRecheckPending(nodeID) {
 		return goalGateCheckResult{target: nodeID, nodeID: nodeID, shouldRetry: true, unsatisfied: true}, true
 	}

--- a/pipeline/engine_checkpoint.go
+++ b/pipeline/engine_checkpoint.go
@@ -5,6 +5,7 @@ package pipeline
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 	"time"
 )
@@ -155,14 +156,35 @@ func isGoalGate(node *Node) bool {
 // and fallback_retry_target are used for one-shot escalation routing
 // (guarded by cp.FallbackTaken to prevent infinite loops).
 //
+// Gates with a pending recheck (#348 defect 1) are considered even when a
+// prior redirect's clearDownstream removed them from CompletedNodes — that
+// removal is what let a retry path that routes AROUND the gate complete the
+// run in plain success with the gate still failed.
+//
 // Returns (target, goalGateNodeID, shouldRetry, unsatisfied).
 func (e *Engine) goalGateRetryTarget(cp *Checkpoint, nodeOutcomes map[string]string) (string, string, bool, bool) {
-	for _, nodeID := range cp.CompletedNodes {
+	for _, nodeID := range e.goalGateCandidates(cp) {
 		if result, found := e.checkGoalGateNode(cp, nodeID, nodeOutcomes); found {
 			return result.target, result.nodeID, result.shouldRetry, result.unsatisfied
 		}
 	}
 	return "", "", false, false
+}
+
+// goalGateCandidates returns the node IDs to evaluate as potential
+// unsatisfied goal gates: the completed nodes (in completion order, the
+// pre-#348 behavior) plus any recheck-pending gates that a redirect's
+// clearDownstream removed from the completed set (sorted for determinism).
+func (e *Engine) goalGateCandidates(cp *Checkpoint) []string {
+	candidates := append([]string(nil), cp.CompletedNodes...)
+	var pending []string
+	for nodeID, isPending := range cp.GateRecheckPending {
+		if isPending && !cp.IsCompleted(nodeID) {
+			pending = append(pending, nodeID)
+		}
+	}
+	sort.Strings(pending)
+	return append(candidates, pending...)
 }
 
 // goalGateCheckResult holds the output of checkGoalGateNode.
@@ -190,7 +212,7 @@ func (e *Engine) checkGoalGateNode(cp *Checkpoint, nodeID string, nodeOutcomes m
 	if cp.RetryCount(nodeID) >= e.maxRetries(node) {
 		t, n, retry, unsat = e.goalGateExhaustedPath(cp, node, nodeID)
 	} else {
-		t, n, retry, unsat = e.goalGateRemainingPath(node, nodeID)
+		t, n, retry, unsat = e.goalGateRemainingPath(cp, node, nodeID)
 	}
 	return goalGateCheckResult{target: t, nodeID: n, shouldRetry: retry, unsatisfied: unsat}, true
 }
@@ -234,7 +256,18 @@ func (e *Engine) findFallbackTarget(node *Node) string {
 // goalGateRemainingPath handles the retries-still-available case for a goal gate.
 // Returns (target, nodeID, shouldRetry=true, unsatisfied=true) when a target is found,
 // or (empty, nodeID, false, true) if no valid retry target exists.
-func (e *Engine) goalGateRemainingPath(node *Node, nodeID string) (string, string, bool, bool) {
+//
+// When the gate has a pending recheck (#348 defect 1) — a prior redirect
+// fired but the executed path reached the exit without re-running the gate —
+// the retry re-enters AT the gate itself so it re-evaluates the current
+// tree. Redirecting to the same retry/fallback target again would just
+// replay the tail that already routed around the gate; remediation that
+// happened on that tail (the case study's FinalCommit) is exactly what the
+// gate needs to re-judge. Budget still flows through cp.RetryCounts.
+func (e *Engine) goalGateRemainingPath(cp *Checkpoint, node *Node, nodeID string) (string, string, bool, bool) {
+	if cp.IsGateRecheckPending(nodeID) {
+		return nodeID, nodeID, true, true
+	}
 	retryTargets := []string{
 		node.Attrs["retry_target"],
 		node.Attrs["fallback_target"],

--- a/pipeline/engine_goal_gate_recheck_test.go
+++ b/pipeline/engine_goal_gate_recheck_test.go
@@ -257,3 +257,52 @@ func TestGoalGateRecheckPendingSurvivesResume(t *testing.T) {
 		t.Errorf("status = %q, want %q", result.Status, OutcomeSuccess)
 	}
 }
+
+// TestGoalGateRecheckWithSingleRetryBudget covers the codex P2 review
+// finding on #360: with max_retries=1, the tail redirect consumes the whole
+// retry budget, and an exhausted-branch-first check would route to fallback
+// before the pending re-entry could fire — the gate would still never
+// re-judge the remediated tree. The pending re-entry is the COMPLETION of
+// the redirect's retry cycle (budget was charged when the redirect fired),
+// so it must run before the exhausted branch and without a fresh charge.
+func TestGoalGateRecheckWithSingleRetryBudget(t *testing.T) {
+	g := recheckTestGraph("1")
+
+	reg := newTestRegistry()
+	gateAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "gate":
+				gateAttempts++
+				if gateAttempts == 1 {
+					return Outcome{Status: string(OutcomeFail)}, nil
+				}
+				return Outcome{Status: string(OutcomeSuccess)}, nil // remediated in the tail
+			case "escalate":
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{"route": "accept"},
+				}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+
+	if gateAttempts < 2 {
+		t.Errorf("gate ran %d times, want >= 2 — the re-entry must fire even with max_retries=1", gateAttempts)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Errorf("status = %q, want %q (gate satisfied on re-run)", result.Status, OutcomeSuccess)
+	}
+}

--- a/pipeline/engine_goal_gate_recheck_test.go
+++ b/pipeline/engine_goal_gate_recheck_test.go
@@ -1,0 +1,259 @@
+// ABOUTME: Tests for goal-gate recheck on retry (issue #348 defect 1).
+// ABOUTME: A goal-gate retry must cause the gate to re-execute before the run can end in plain success.
+package pipeline
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// recheckTestGraph builds the case-study shape (code-goblin b68b532619c3):
+//
+//	start → gate(goal_gate, fallback_target: escalate)
+//	gate -success→ done; gate -fail→ escalate
+//	escalate -route=accept→ cleanup → done   (the "accept" tail)
+//	escalate -route=fix→ fix → gate          (makes the gate REACHABLE from
+//	                                          escalate, so clearDownstream
+//	                                          on retry clears the gate)
+//
+// The escalate handler always picks "accept", so the executed path routes
+// AROUND the gate to done while the gate was cleared from the completed set
+// — the exact mechanism that let the case-study run complete "success"
+// with FinalSpecCheck still at outcome=fail.
+func recheckTestGraph(maxRetries string) *Graph {
+	g := NewGraph("goal-gate-recheck")
+	gateAttrs := map[string]string{
+		"goal_gate":       "true",
+		"fallback_target": "escalate",
+	}
+	if maxRetries != "" {
+		gateAttrs["max_retries"] = maxRetries
+	}
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond"})
+	g.AddNode(&Node{ID: "gate", Shape: "box", Attrs: gateAttrs})
+	g.AddNode(&Node{ID: "escalate", Shape: "box"})
+	g.AddNode(&Node{ID: "fix", Shape: "box"})
+	g.AddNode(&Node{ID: "cleanup", Shape: "box"})
+	g.AddNode(&Node{ID: "done", Shape: "Msquare"})
+
+	g.AddEdge(&Edge{From: "start", To: "gate"})
+	g.AddEdge(&Edge{From: "gate", To: "done", Condition: "ctx.outcome = success"})
+	g.AddEdge(&Edge{From: "gate", To: "escalate", Condition: "ctx.outcome = fail"})
+	g.AddEdge(&Edge{From: "escalate", To: "cleanup", Condition: "ctx.route = accept"})
+	g.AddEdge(&Edge{From: "escalate", To: "fix", Condition: "ctx.route = fix"})
+	g.AddEdge(&Edge{From: "fix", To: "gate"})
+	g.AddEdge(&Edge{From: "cleanup", To: "done"})
+	return g
+}
+
+// TestGoalGateRetryReRunsGateAfterEscalationTail reproduces #348 defect 1:
+// the gate fails once, the goal-gate retry redirects to the escalation tail
+// (escalate → cleanup → done) which performs remediation but never flows
+// back through the gate. The retry must cause the GATE to re-execute so it
+// re-evaluates the remediated tree — here it passes on re-run and the run
+// completes success with the gate genuinely satisfied.
+//
+// Pre-fix behavior: clearDownstream(escalate) removed the gate from the
+// completed set, the accept tail routed around it, and goalGateRetryTarget
+// (which only scanned CompletedNodes) lost track of the gate entirely — the
+// run completed plain success with the gate at outcome=fail and exactly one
+// gate execution.
+func TestGoalGateRetryReRunsGateAfterEscalationTail(t *testing.T) {
+	g := recheckTestGraph("")
+
+	reg := newTestRegistry()
+	gateAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "gate":
+				gateAttempts++
+				if gateAttempts == 1 {
+					return Outcome{Status: string(OutcomeFail)}, nil
+				}
+				// Remediation happened in the tail (cleanup); re-run passes.
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			case "escalate":
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{"route": "accept"},
+				}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+
+	if gateAttempts < 2 {
+		t.Errorf("gate ran %d times, want >= 2 — a goal-gate retry must re-execute the gate", gateAttempts)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Errorf("status = %q, want %q (gate satisfied on re-run)", result.Status, OutcomeSuccess)
+	}
+}
+
+// TestGoalGateNeverSatisfiedCannotEndInPlainSuccess pins the terminal
+// invariant: when the gate fails on every evaluation and the escalation
+// tail keeps routing around it, the run must NOT report plain success —
+// the retry budget drains, the one-shot fallback fires, and the run fails.
+//
+// Pre-fix behavior: the first retry's clearDownstream dropped the gate from
+// the completed set and the run completed success on the next pass.
+func TestGoalGateNeverSatisfiedCannotEndInPlainSuccess(t *testing.T) {
+	g := recheckTestGraph("2")
+
+	reg := newTestRegistry()
+	gateAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "gate":
+				gateAttempts++
+				return Outcome{Status: string(OutcomeFail)}, nil // never satisfied
+			case "escalate":
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{"route": "accept"},
+				}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+
+	if result.Status == OutcomeSuccess {
+		t.Fatalf("run completed plain success with the goal gate never satisfied (gate ran %d times)", gateAttempts)
+	}
+}
+
+// TestGoalGateRetryViaFixPathStillWorks pins the existing behavior that must
+// not regress: when the retry target's path flows BACK through the gate
+// (escalate routes to fix → gate), the gate re-executes on the normal pass
+// and no extra re-entry fires. The gate fails once, the fix runs, and the
+// gate passes on the second evaluation.
+func TestGoalGateRetryViaFixPathStillWorks(t *testing.T) {
+	g := recheckTestGraph("")
+
+	reg := newTestRegistry()
+	gateAttempts := 0
+	fixRuns := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "gate":
+				gateAttempts++
+				if gateAttempts == 1 {
+					return Outcome{Status: string(OutcomeFail)}, nil
+				}
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			case "escalate":
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{"route": "fix"},
+				}, nil
+			case "fix":
+				fixRuns++
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+
+	if result.Status != OutcomeSuccess {
+		t.Fatalf("status = %q, want %q", result.Status, OutcomeSuccess)
+	}
+	if gateAttempts != 2 {
+		t.Errorf("gate ran %d times, want exactly 2 (initial fail + fix-path re-run)", gateAttempts)
+	}
+	if fixRuns != 1 {
+		t.Errorf("fix ran %d times, want 1", fixRuns)
+	}
+}
+
+// TestGoalGateRecheckPendingSurvivesResume pins resume determinism: a run
+// killed mid-escalation-tail after a goal-gate retry redirect (checkpoint
+// has gate_recheck_pending set, the gate cleared from completed_nodes, and
+// CurrentNode on the tail) must still re-execute the gate after resume —
+// the pending flag is the durable record that the redirect fired.
+func TestGoalGateRecheckPendingSurvivesResume(t *testing.T) {
+	g := recheckTestGraph("")
+
+	dir := t.TempDir()
+	cpPath := filepath.Join(dir, "checkpoint.json")
+	cp := &Checkpoint{
+		RunID:          "resume-348",
+		CurrentNode:    "escalate",
+		CompletedNodes: []string{"start"},
+		RetryCounts:    map[string]int{"gate": 1},
+		Context:        map[string]string{},
+	}
+	cp.SetGateRecheckPending("gate")
+	if err := SaveCheckpoint(cp, cpPath); err != nil {
+		t.Fatalf("SaveCheckpoint: %v", err)
+	}
+
+	reg := newTestRegistry()
+	gateAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "gate":
+				gateAttempts++
+				return Outcome{Status: string(OutcomeSuccess)}, nil // remediated pre-kill
+			case "escalate":
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{"route": "accept"},
+				}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	engine := NewEngine(g, reg, WithCheckpointPath(cpPath))
+	result, err := engine.Run(ctx)
+	if err != nil {
+		t.Fatalf("engine.Run error: %v", err)
+	}
+
+	if gateAttempts < 1 {
+		t.Error("gate never re-executed after resume despite a pending recheck")
+	}
+	if result.Status != OutcomeSuccess {
+		t.Errorf("status = %q, want %q", result.Status, OutcomeSuccess)
+	}
+}

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -695,6 +695,12 @@ func (e *Engine) applyOutcome(s *runState, currentNodeID string, outcome *Outcom
 	if outcome.Status != "" {
 		s.pctx.Set(ContextKeyOutcome, outcome.Status)
 		s.nodeOutcomes[currentNodeID] = outcome.Status
+		// #348 defect 1: a goal gate that executes has, by definition,
+		// re-evaluated — clear any pending recheck regardless of outcome
+		// (a fresh fail re-arms via the normal exit-time gate check).
+		if isGoalGate(e.nodeOrDefault(currentNodeID)) {
+			s.cp.ClearGateRecheckPending(currentNodeID)
+		}
 	}
 	if outcome.PreferredLabel != "" {
 		s.pctx.Set(ContextKeyPreferredLabel, outcome.PreferredLabel)
@@ -928,6 +934,12 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 		traceEntry.EdgeTo = target
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
+		// #348 defect 1: the redirect's clearDownstream below may remove the
+		// gate from CompletedNodes while the executed path routes around it
+		// to the exit. Mark the gate recheck-pending so it stays visible to
+		// this check and the next retry re-enters at the gate itself; the
+		// flag clears when the gate actually re-executes (applyOutcome).
+		s.cp.SetGateRecheckPending(gateNodeID)
 		e.clearDownstream(target, s.cp)
 		s.cp.CurrentNode = target
 		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
@@ -945,6 +957,9 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 		})
 		traceEntry.EdgeTo = target
 		s.trace.AddEntry(*traceEntry)
+		// Same #348 marking as the retry path above: the one-shot fallback's
+		// clearDownstream must not let the gate vanish from the exit check.
+		s.cp.SetGateRecheckPending(gateNodeID)
 		e.clearDownstream(target, s.cp)
 		s.cp.CurrentNode = target
 		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -920,16 +920,26 @@ func (e *Engine) handleOutcomeStatus(s *runState, currentNodeID string, status s
 func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus string, traceEntry *TraceEntry) (bool, string, *EngineResult) {
 	target, gateNodeID, retry, unsatisfied := e.goalGateRetryTarget(s.cp, s.nodeOutcomes)
 	if retry {
-		s.cp.IncrementRetry(gateNodeID)
+		// A pending re-entry (target == the gate itself, flagged by a prior
+		// redirect) completes that redirect's retry cycle — the budget was
+		// charged when the redirect fired, so it is not charged again here.
+		// It cannot loop: the gate executes next, clearing the pending flag.
+		reentry := s.cp.IsGateRecheckPending(gateNodeID) && target == gateNodeID
 		gateNode := e.nodeOrDefault(gateNodeID)
+		msg := fmt.Sprintf("goal-gate recheck: re-entering %q so the gate re-judges the current tree (attempt %d/%d)",
+			gateNodeID, s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+		if !reentry {
+			s.cp.IncrementRetry(gateNodeID)
+			msg = fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
+				gateNodeID, target,
+				s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+		}
 		e.emit(PipelineEvent{
 			Type:      EventStageRetrying,
 			Timestamp: time.Now(),
 			RunID:     s.runID,
 			NodeID:    gateNodeID,
-			Message: fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
-				gateNodeID, target,
-				s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode)),
+			Message:   msg,
 		})
 		traceEntry.EdgeTo = target
 		s.trace.AddEntry(*traceEntry)


### PR DESCRIPTION
Part of #348 — fixes **defect 1 only** (see scope note below; the issue stays open).

## What happened (case study b68b532619c3)

`FinalSpecCheck` (`goal_gate: true`, `fallback_target: EscalateReview`) failed correctly. The human chose **accept**, remediation happened inside `FinalCommit` on the escalation tail, and the goal-gate retry then replayed `EscalateReview → Cleanup → FinalCommit → Done` — the gate **never re-ran**, and the pipeline reported completed with its final quality gate at `outcome: fail`.

## Root cause (verified in code)

`handleExitNode`'s retry path does `clearDownstream(target)`. When the gate is reachable from the redirect target (it was, via the fix path), that removes the gate from `cp.CompletedNodes`. The executed path then routes *around* the gate to Done — and `goalGateRetryTarget` only iterated `cp.CompletedNodes`, so the gate vanished from the exit check entirely and the next pass terminated in plain success.

## Mechanism (settled after reading the code)

A persisted `cp.GateRecheckPending` map:

- **Set** when a goal-gate redirect fires (both the retry path and the one-shot fallback path in `handleExitNode` — both call `clearDownstream` and have the same vanishing hazard).
- **Cleared** only when the gate node actually re-executes (`applyOutcome`) — a gate that ran has by definition re-evaluated; a fresh fail re-arms via the normal exit-time check.
- **Exit check** (`goalGateCandidates`): pending gates stay visible even when cleared from the completed set (sorted for determinism, appended after the existing completion-order scan).
- **Re-entry at the gate**: while retries remain, a still-pending gate's retry target is the gate node itself — re-redirecting to the same fallback would just replay the tail that already routed around it, and remediation on that tail (the case study's `FinalCommit`) is exactly what the gate needs to re-judge.

This enforces the required invariant: a goal-gate retry causes the gate to re-execute before the run can terminate successfully — and when the gate is never satisfied, the run **fails** rather than reporting plain success.

## Hazards addressed (all pinned by tests)

- **Fix-loop regression**: retry targets whose path flows back through the gate behave exactly as before (existing `engine_goal_gate_test.go` suite untouched and green; new `TestGoalGateRetryViaFixPathStillWorks` pin).
- **No infinite loop**: budget still flows through `cp.RetryCounts`; `FallbackTaken` stays one-shot; `TestGoalGateNeverSatisfiedCannotEndInPlainSuccess` shows the always-failing gate drains its budget and the run fails, terminating.
- **Checkpoint resume**: `gate_recheck_pending` is persisted (`omitempty`, pre-#348 checkpoints load cleanly); `TestGoalGateRecheckPendingSurvivesResume` resumes from a mid-tail kill and the gate still re-runs. Roundtrip covered in `checkpoint_test.go`.
- **RED-first case-study repro**: `TestGoalGateRetryReRunsGateAfterEscalationTail` failed pre-fix with exactly the case-study shape (gate ran once, run reported success).

## Scope: defect 2 stays open

Defect 2 of #348 — human "accept" at an escalation should mark the gate overridden (terminal `validation_overridden`) — is **not built here**. It is blocked on #271 / dippin-lang#124 (no `.dip` input path for override edges; see the 2026-06-10 comment on #271). #348 should remain open for that defect after this merges; I'll comment on the issue with what remains.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓; `go test -race -short ./pipeline/...` ✓
- `dippin doctor`: ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 (baselines held) ✓
- gofmt clean ✓

Note: will conflict with #359 in CHANGELOG.md; I'll rebase and resolve by hand after #359 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783804210&installation_id=131176874&pr_number=360&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F360&signature=0a4f6a2cc966bd360c9d8c02d1d8f4edc2136f6247a51fabe61c7a6f33ecf1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->