### PR TITLE
fix(engine): clear gate recheck-pending on any gate execution, even empty status (#348)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   at `outcome: fail`** (case-study run b68b532619c3: FinalSpecCheck never
   re-ran after FinalCommit's remediation). The engine now records a
   persisted `gate_recheck_pending` marker when a goal-gate redirect fires,
-  cleared only when the gate node actually re-executes. Pending gates stay
+  cleared only when the gate node actually re-executes (on any execution,
+  even one reporting an empty status — uncharged re-entries must never
+  loop). Pending gates stay
   visible to the exit check even when cleared from the completed set, and
   a still-pending gate re-enters **at the gate itself** so it re-evaluates
   the current (possibly remediated) tree. The re-entry completes the

--- a/pipeline/engine_goal_gate_recheck_test.go
+++ b/pipeline/engine_goal_gate_recheck_test.go
@@ -306,3 +306,31 @@ func TestGoalGateRecheckWithSingleRetryBudget(t *testing.T) {
 		t.Errorf("status = %q, want %q (gate satisfied on re-run)", result.Status, OutcomeSuccess)
 	}
 }
+
+// TestApplyOutcomeClearsPendingRecheckOnEmptyStatus covers the Copilot
+// review finding on #360: the pending clear must fire whenever the gate
+// node executes, NOT only when the handler returned a non-empty status.
+// An empty/unknown status leaves the gate unsatisfied at the exit check,
+// and since pending re-entries are budget-free, a still-pending flag
+// would re-enter the gate without ever charging retry budget — an
+// unbounded loop for a misbehaving handler.
+func TestApplyOutcomeClearsPendingRecheckOnEmptyStatus(t *testing.T) {
+	g := NewGraph("pending-clear-empty")
+	g.AddNode(&Node{ID: "gate", Shape: "box", Attrs: map[string]string{"goal_gate": "true"}})
+	e := NewEngine(g, newTestRegistry())
+
+	s := &runState{
+		runID:        "t",
+		pctx:         NewPipelineContext(),
+		cp:           &Checkpoint{},
+		trace:        &Trace{},
+		nodeOutcomes: map[string]string{},
+	}
+	s.cp.SetGateRecheckPending("gate")
+
+	e.applyOutcome(s, "gate", &Outcome{Status: ""})
+
+	if s.cp.IsGateRecheckPending("gate") {
+		t.Fatal("gate executed (empty status) but recheck-pending was not cleared — uncharged re-entry loop hazard")
+	}
+}

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -692,15 +692,19 @@ func (e *Engine) applyOutcome(s *runState, currentNodeID string, outcome *Outcom
 
 	s.pctx.Merge(outcome.ContextUpdates)
 
+	// #348 defect 1: a goal gate that executes has, by definition,
+	// re-evaluated — clear any pending recheck regardless of outcome,
+	// INCLUDING an empty/unknown status (a fresh fail re-arms via the
+	// normal exit-time gate check). This must not be gated on
+	// outcome.Status != "": pending re-entries are budget-free, so a
+	// still-pending flag after an empty-status execution would re-enter
+	// the gate without ever charging retry budget.
+	if isGoalGate(e.nodeOrDefault(currentNodeID)) {
+		s.cp.ClearGateRecheckPending(currentNodeID)
+	}
 	if outcome.Status != "" {
 		s.pctx.Set(ContextKeyOutcome, outcome.Status)
 		s.nodeOutcomes[currentNodeID] = outcome.Status
-		// #348 defect 1: a goal gate that executes has, by definition,
-		// re-evaluated — clear any pending recheck regardless of outcome
-		// (a fresh fail re-arms via the normal exit-time gate check).
-		if isGoalGate(e.nodeOrDefault(currentNodeID)) {
-			s.cp.ClearGateRecheckPending(currentNodeID)
-		}
 	}
 	if outcome.PreferredLabel != "" {
 		s.pctx.Set(ContextKeyPreferredLabel, outcome.PreferredLabel)


### PR DESCRIPTION
Follow-up to #360, fixing the Copilot review finding that landed just after merge (comment on `pipeline/engine_run.go`): the `GateRecheckPending` clear in `applyOutcome` sat inside `if outcome.Status != ""`, so a gate handler returning an empty/unknown status would execute without clearing the flag.

That mattered because pending re-entries are budget-free (#360's codex P2 fix): a still-pending gate after an empty-status execution would re-enter the gate without ever charging `retry_counts` — an unbounded loop for a misbehaving handler. The clear now fires whenever the executed node is a goal gate, independent of outcome status. An empty-status gate then behaves exactly as pre-#348: not completed, not in `nodeOutcomes`, invisible to the exit check.

TDD: `TestApplyOutcomeClearsPendingRecheckOnEmptyStatus` went RED on the old code, GREEN after the move.

## Verification
- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./pipeline/... -short` ✓; `go test -race -short ./pipeline/...` ✓
- gofmt clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783806084&installation_id=131176874&pr_number=361&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F361&signature=888039589f23cae4a694a8e3041a940aa740d4d8cfa984e3040415da4c920873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->