### PR TITLE
feat(handlers): inject runtime facts into every codergen prompt (#347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Runtime-facts block injected into every codergen prompt** (issue #347).
+  Every agent prompt is now prefixed with a machine-written `# Runtime`
+  section stating the absolute working directory ("all commands already run
+  here; never cd elsewhere. A failed cd is a hard error, never evidence of
+  completion"), the current date (YYYY-MM-DD, host clock), and the run/node
+  identity. In case-study run b68b532619c3 the absence of these facts let an
+  agent `cd` to a hallucinated path, read the resulting clean tree as "the
+  milestone is already complete," and ship an empty milestone — and stamped
+  three of three dated decision-log artifacts with wrong dates. The block
+  reflects the per-node `working_dir` override when set, covers all three
+  backends (native / claude-code / acp) uniformly, and applies to codergen
+  nodes only — tool and human nodes are unchanged. There is no opt-out
+  attribute. Mirrors #323, which exposed the same identity to tool
+  subprocess environments.
+
 ## [0.38.1] - 2026-06-11
 
 ### Fixed

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -796,15 +796,13 @@ func classifyBreach(policy string, r agent.SessionResult, native bool) (pipeline
 func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	config := agent.DefaultConfig()
 
-	if h.workingDir != "" {
-		config.WorkingDir = h.workingDir
+	// Single resolver shared with the #347 runtime-facts block, so the prompt
+	// can never claim a different directory than the session actually uses.
+	if wd := h.effectiveWorkingDir(node); wd != "" {
+		config.WorkingDir = wd
 	}
 
 	cfg := node.AgentConfig(h.graphAttrs)
-
-	if cfg.WorkingDir != "" {
-		config.WorkingDir = cfg.WorkingDir
-	}
 
 	if cfg.Backend != "" {
 		// Normalize the documented "codergen" alias to "native" before the

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/agent/exec"
@@ -72,6 +73,12 @@ func (h *CodergenHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	if err != nil {
 		return pipeline.Outcome{}, err
 	}
+	// #347: prepend runtime facts (working dir, date, run/node identity) so
+	// the agent never fills them with priors. Applied here — after all other
+	// prompt assembly, before buildRunConfig — so the block is outermost and
+	// covers all three backends uniformly. Codergen only: tool/human nodes
+	// are untouched.
+	prompt = prependRuntimeFacts(prompt, h.effectiveWorkingDir(node), runIDFromContext(pctx), node.ID, time.Now())
 
 	backend, backendErr := h.selectBackend(node)
 	if backendErr != nil {
@@ -440,6 +447,27 @@ func (h *CodergenHandler) resolvePrompt(node *pipeline.Node, pctx *pipeline.Pipe
 		artifactDir = dir
 	}
 	return ResolvePrompt(node, pctx, h.graphAttrs, artifactDir)
+}
+
+// effectiveWorkingDir returns the directory this node's session actually runs
+// in: the per-node working_dir override when set, otherwise the handler
+// default. Mirrors buildConfig's WorkingDir resolution (#347 — the runtime
+// block must name THIS node's dir, and resolvePrompt runs before buildConfig).
+func (h *CodergenHandler) effectiveWorkingDir(node *pipeline.Node) string {
+	if wd := node.AgentConfig(h.graphAttrs).WorkingDir; wd != "" {
+		return wd
+	}
+	return h.workingDir
+}
+
+// runIDFromContext derives the run ID from the engine-seeded artifact dir
+// (basename of <artifactDir>/<runID>), mirroring the #323 tool-env pattern.
+// Empty when the run has no artifact dir (library callers).
+func runIDFromContext(pctx *pipeline.PipelineContext) string {
+	if dir, ok := pctx.GetInternal(pipeline.InternalKeyArtifactDir); ok && dir != "" {
+		return filepath.Base(absPathOrSelf(dir))
+	}
+	return ""
 }
 
 // resolveArtifactRoot returns the artifact directory from pipeline context or working dir.

--- a/pipeline/handlers/codergen_runtime_facts_test.go
+++ b/pipeline/handlers/codergen_runtime_facts_test.go
@@ -1,0 +1,168 @@
+// ABOUTME: Tests for the #347 runtime-facts block injected into every codergen prompt.
+// ABOUTME: Verifies working dir, date, run/node identity, ordering, and codergen-only scope.
+package handlers
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestPrependRuntimeFacts_FullBlock(t *testing.T) {
+	now := time.Date(2026, 6, 10, 15, 4, 5, 0, time.UTC)
+	got := prependRuntimeFacts("do the task", "/home/clint/code/code-goblin", "b68b532619c3", "Implement", now)
+
+	if !strings.HasPrefix(got, "# Runtime\n") {
+		t.Fatalf("runtime block must be the outermost (first) section, got:\n%s", got)
+	}
+	for _, want := range []string{
+		"/home/clint/code/code-goblin",
+		"all commands already run here; never cd elsewhere",
+		"A failed cd is a hard error, never evidence of completion",
+		"Current date: 2026-06-10",
+		"Run: b68b532619c3, node: Implement",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if !strings.HasSuffix(got, "do the task") {
+		t.Fatalf("original prompt must be preserved at the end, got:\n%s", got)
+	}
+}
+
+func TestPrependRuntimeFacts_EmptyWorkingDirOmitsLine(t *testing.T) {
+	now := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	got := prependRuntimeFacts("p", "", "run1", "N", now)
+
+	if strings.Contains(got, "Working directory") {
+		t.Fatalf("empty working dir must omit the line entirely, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Current date: 2026-06-10") {
+		t.Fatalf("date line must remain, got:\n%s", got)
+	}
+}
+
+func TestPrependRuntimeFacts_EmptyRunIDOmitsRunKeepsNode(t *testing.T) {
+	now := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	got := prependRuntimeFacts("p", "/tmp", "", "MyNode", now)
+
+	if strings.Contains(got, "Run:") {
+		t.Fatalf("empty run ID must omit the Run label, got:\n%s", got)
+	}
+	if !strings.Contains(got, "Node: MyNode") {
+		t.Fatalf("node ID must still be present, got:\n%s", got)
+	}
+}
+
+func TestPrependRuntimeFacts_RelativeWorkingDirMadeAbsolute(t *testing.T) {
+	now := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	got := prependRuntimeFacts("p", ".", "", "N", now)
+
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(got, abs) {
+		t.Fatalf("working dir must be printed absolute (%s), got:\n%s", abs, got)
+	}
+}
+
+// capturePromptCompleter returns a completer that records the user prompt of
+// the first request it sees.
+func capturePromptCompleter(prompt *string) *scriptedCompleter {
+	return &scriptedCompleter{
+		responses: []*llm.Response{
+			{
+				Message:      llm.AssistantMessage("done"),
+				FinishReason: llm.FinishReason{Reason: "stop"},
+			},
+		},
+		onComplete: func(req *llm.Request) {
+			for _, m := range req.Messages {
+				if m.Role == llm.RoleUser && *prompt == "" {
+					*prompt = m.Text()
+				}
+			}
+		},
+	}
+}
+
+func TestCodergenHandler_InjectsRuntimeFacts(t *testing.T) {
+	workdir := t.TempDir()
+	var sent string
+	h := NewCodergenHandler(capturePromptCompleter(&sent), workdir)
+	node := &pipeline.Node{
+		ID:      "Implement",
+		Shape:   "box",
+		Handler: "codergen",
+		Attrs:   map[string]string{"prompt": "build the thing"},
+	}
+	pctx := pipeline.NewPipelineContext()
+	pctx.SetInternal(pipeline.InternalKeyArtifactDir, filepath.Join(workdir, ".tracker", "runs", "run42"))
+
+	if _, err := h.Execute(context.Background(), node, pctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(sent, "# Runtime\n") {
+		t.Fatalf("prompt sent to backend must start with the runtime block, got:\n%s", sent)
+	}
+	if !strings.Contains(sent, workdir) {
+		t.Errorf("runtime block must name the handler working dir %s, got:\n%s", workdir, sent)
+	}
+	if !regexp.MustCompile(`Current date: \d{4}-\d{2}-\d{2}\n`).MatchString(sent) {
+		t.Errorf("runtime block must carry a YYYY-MM-DD date, got:\n%s", sent)
+	}
+	if !strings.Contains(sent, "Run: run42, node: Implement") {
+		t.Errorf("runtime block must carry run and node identity, got:\n%s", sent)
+	}
+	if !strings.HasSuffix(strings.TrimSpace(sent), "build the thing") {
+		t.Errorf("original prompt must survive at the end, got:\n%s", sent)
+	}
+}
+
+func TestCodergenHandler_RuntimeFactsHonorPerNodeWorkingDir(t *testing.T) {
+	workdir := t.TempDir()
+	override := t.TempDir()
+	var sent string
+	h := NewCodergenHandler(capturePromptCompleter(&sent), workdir)
+	node := &pipeline.Node{
+		ID:      "gen",
+		Shape:   "box",
+		Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":      "build",
+			"working_dir": override,
+		},
+	}
+
+	if _, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(sent, override) {
+		t.Errorf("runtime block must reflect the per-node working_dir override %s, got:\n%s", override, sent)
+	}
+}
+
+func TestResolvePrompt_DoesNotInjectRuntimeFacts(t *testing.T) {
+	// Pins codergen-only scope (#347): the shared ResolvePrompt used by other
+	// handlers must stay free of the runtime block — injection happens only in
+	// CodergenHandler.Execute.
+	node := &pipeline.Node{
+		ID:    "n",
+		Attrs: map[string]string{"prompt": "hello"},
+	}
+	got, err := ResolvePrompt(node, pipeline.NewPipelineContext(), nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "# Runtime") {
+		t.Fatalf("ResolvePrompt must not inject the runtime block, got:\n%s", got)
+	}
+}

--- a/pipeline/handlers/codergen_test.go
+++ b/pipeline/handlers/codergen_test.go
@@ -426,7 +426,8 @@ func TestCodergenHandlerWritesArtifacts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected prompt artifact: %v", err)
 	}
-	if string(promptBytes) != "Write hello world" {
+	// #347: the runtime block is prepended; the authored prompt follows it.
+	if !strings.HasPrefix(string(promptBytes), "# Runtime\n") || !strings.HasSuffix(string(promptBytes), "Write hello world") {
 		t.Fatalf("prompt artifact = %q", string(promptBytes))
 	}
 
@@ -536,7 +537,8 @@ func TestCodergenHandlerExpandsGoalFromContext(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected prompt artifact: %v", err)
 	}
-	if string(promptBytes) != "Plan for ship a hello world script" {
+	// #347: the runtime block is prepended; the expanded prompt follows it.
+	if !strings.HasSuffix(string(promptBytes), "Plan for ship a hello world script") {
 		t.Fatalf("expanded prompt = %q", string(promptBytes))
 	}
 }

--- a/pipeline/handlers/runtime_facts.go
+++ b/pipeline/handlers/runtime_facts.go
@@ -1,0 +1,31 @@
+// ABOUTME: Runtime-facts block prepended to every codergen prompt (#347).
+// ABOUTME: Surfaces working dir, current date, and run/node identity so agents never fill them with priors.
+package handlers
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// prependRuntimeFacts prepends a machine-written "# Runtime" block to a
+// codergen prompt (#347). It states the absolute working directory, the
+// current date, and the run/node identity — facts an LLM will otherwise fill
+// with priors (a hallucinated `cd` + clean tree once shipped an empty
+// milestone). Empty workDir omits the line; empty runID omits the Run label.
+// The block is always outermost: callers apply it after all other prompt
+// assembly (context summary, variable expansion).
+func prependRuntimeFacts(prompt, workDir, runID, nodeID string, now time.Time) string {
+	var b strings.Builder
+	b.WriteString("# Runtime\n")
+	if workDir != "" {
+		fmt.Fprintf(&b, "- Working directory (absolute): %s — all commands already run here; never cd elsewhere. A failed cd is a hard error, never evidence of completion.\n", absPathOrSelf(workDir))
+	}
+	fmt.Fprintf(&b, "- Current date: %s\n", now.Format("2006-01-02"))
+	if runID != "" {
+		fmt.Fprintf(&b, "- Run: %s, node: %s\n", runID, nodeID)
+	} else {
+		fmt.Fprintf(&b, "- Node: %s\n", nodeID)
+	}
+	return b.String() + "\n" + prompt
+}


### PR DESCRIPTION
## Summary

Closes #347 (case-study run `b68b532619c3`: an agent began with `cd /home/user/repos/goblin` — a hallucinated path — read the resulting clean tree as "the milestone is already complete," and shipped an empty milestone in 13 seconds; three of three dated artifacts carried wrong dates).

Every codergen prompt is now prefixed with a machine-written runtime block:

```
# Runtime
- Working directory (absolute): /home/clint/code/code-goblin — all commands already run here; never cd elsewhere. A failed cd is a hard error, never evidence of completion.
- Current date: 2026-06-12
- Run: b68b532619c3, node: Implement
```

## Design decisions

- **Injection point**: `CodergenHandler.Execute`, after `resolvePrompt` and before `buildRunConfig` — the block is outermost (precedes any context summary) and covers all three backends (native / claude-code / acp) uniformly. **Codergen only** — tool/human nodes untouched, pinned by `TestResolvePrompt_DoesNotInjectRuntimeFacts`.
- **Working dir** reflects the per-node `working_dir` override when set (`effectiveWorkingDir` mirrors `buildConfig`'s resolution), printed absolute; empty working dir (library callers) omits the line entirely.
- **Run ID** derived as basename of the engine-seeded artifact dir, mirroring the #323 tool-env pattern (`TRACKER_RUN_ID`); empty run ID degrades to a plain `Node:` line.
- **No opt-out attribute**: the block is ~a dozen tokens, and an opt-out is speculative config. Pinned by tests asserting unconditional injection.
- **Iteration count skipped** — not trivially available; no plumbing built for it.
- **Date determinism in tests**: the pure function takes `time.Time` (fixed in unit tests); the Execute-path test asserts `YYYY-MM-DD` format, not value.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- `go test ./... -short` — pass; `go test -race -short ./pipeline/...` — pass
- `dippin doctor` — ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 (unchanged)
- Two existing tests asserting exact `prompt.md` content updated to expect the block (the artifact now includes it by design)
- CHANGELOG.md updated under [Unreleased]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783869936&installation_id=131176874&pr_number=364&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F364&signature=47c4a9090cadf7046315059453834ddb1464d46eaa044eeba6a4bf623df25071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Codergen prompts now automatically include runtime context information: absolute working directory, current date (YYYY-MM-DD format), and run/node identity. This applies uniformly across all backends and respects per-node working directory configuration overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->