### PR TITLE
fix(examples): commit nodes must be commit-only — scope-guard FinalCommit (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   attribute. Mirrors #323, which exposed the same identity to tool
   subprocess environments.
 
+### Fixed
+
+- **FinalCommit is now explicitly commit-only in both build_product
+  workflows** (issue #349, items 1–2). In case-study run b68b532619c3,
+  FinalCommit's "ensure all changes are committed" prompt plus a failure
+  report in context led the agent to author an entire missing milestone
+  (~700 lines across 8 files) inside the commit node — shipping through
+  zero quality gates; an independent audit traced essentially all shipped
+  defects to that one ungated write path. Both `build_product.dip` and
+  `build_product_with_superspec.dip` now give FinalCommit the
+  #346-hardened early-`STATUS:fail` contract (`auto_status: true`,
+  last-line-wins, fails closed on truncation) and a commit-only scope
+  guard: stage and commit existing work and report the hash; if
+  completing the task would require ANY new implementation, do not write
+  it — fail with the reason so the pipeline escalates
+  (`fallback_target: EscalateReview` / `EscalateToHuman`; the superspec
+  variant gains the explicit `fallback_target`). No `goal_gate` was
+  added: a failing commit gate re-entering itself (#360/#361
+  `gate_recheck_pending`) cannot produce the missing implementation —
+  escalation is the correct route. Items 3 (stale "Previous Node Output"
+  injection) and 4 (accept ⇒ override semantics) are tracked separately
+  as #352 and #348/#271.
+
 ## [0.38.1] - 2026-06-11
 
 ### Fixed

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1933,10 +1933,40 @@ workflow BuildProduct
     model: claude-sonnet-4-6
     provider: anthropic
     reasoning_effort: low
+    auto_status: true
     fallback_target: EscalateReview
     prompt:
-      Ensure all changes are committed. If there are uncommitted changes from
-      the cleanup or final fixes, commit them. Include the commit hash.
+      FINAL COMMIT — COMMIT-ONLY SCOPE (issue #349):
+
+      STATUS contract — emit `STATUS:fail` as the FIRST line of your
+      response, before any other text. Then do the work below. Only
+      at the very end, after the commit (or clean-tree check) has
+      succeeded, emit a final `STATUS:success` line — alone on its
+      line, outside any code fence — to override the early fail. The
+      workflow's `auto_status` parser is last-line-wins; if your
+      response is truncated for any reason the early `STATUS:fail`
+      remains and the node fails closed. The STATUS value must be
+      exactly `fail` or `success`, with no trailing prose on that
+      line. Never emit STATUS:retry (this node has no retry route).
+
+      You are a commit-only node. Your ONLY job is to stage and commit
+      work that already exists in the tree, then report the commit hash.
+
+      - If the tree is clean: report the current HEAD hash, emit
+        STATUS:success.
+      - If there are uncommitted changes from the cleanup or final
+        fixes: `git add` and commit them, report the commit hash, emit
+        STATUS:success.
+
+      You MUST NOT author new implementation here: no new files, no new
+      functions, no behavior changes, no fixes — even if upstream
+      context (failure reports, spec violations, missing milestones)
+      says something is broken or missing. Anything written in this
+      node ships through zero quality gates (no tests, no review, no
+      verification). If completing this task would require ANY new
+      implementation, do NOT write it — leave the early STATUS:fail in
+      place and name exactly what is missing, so the pipeline escalates
+      for a human decision instead.
 
   # ─── Edges ─────────────────────────────────────────────────
 

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -1017,10 +1017,41 @@ workflow BuildProductWithSuperspec
     model: claude-sonnet-4-6
     provider: anthropic
     reasoning_effort: low
+    auto_status: true
+    fallback_target: EscalateToHuman
     prompt:
-      Ensure everything is committed. If there are uncommitted changes from
-      cleanup or final fixes, commit them. Include the commit hash.
-      This is the ship commit.
+      FINAL COMMIT — COMMIT-ONLY SCOPE (issue #349):
+
+      STATUS contract — emit `STATUS:fail` as the FIRST line of your
+      response, before any other text. Then do the work below. Only
+      at the very end, after the commit (or clean-tree check) has
+      succeeded, emit a final `STATUS:success` line — alone on its
+      line, outside any code fence — to override the early fail. The
+      workflow's `auto_status` parser is last-line-wins; if your
+      response is truncated for any reason the early `STATUS:fail`
+      remains and the node fails closed. The STATUS value must be
+      exactly `fail` or `success`, with no trailing prose on that
+      line. Never emit STATUS:retry (this node has no retry route).
+
+      You are a commit-only node. Your ONLY job is to stage and commit
+      work that already exists in the tree, then report the commit
+      hash. This is the ship commit.
+
+      - If the tree is clean: report the current HEAD hash, emit
+        STATUS:success.
+      - If there are uncommitted changes from cleanup or final fixes:
+        `git add` and commit them, report the commit hash, emit
+        STATUS:success.
+
+      You MUST NOT author new implementation here: no new files, no new
+      functions, no behavior changes, no fixes — even if upstream
+      context (failure reports, spec violations, missing milestones)
+      says something is broken or missing. Anything written in this
+      node ships through zero quality gates (no tests, no review, no
+      verification). If completing this task would require ANY new
+      implementation, do NOT write it — leave the early STATUS:fail in
+      place and name exactly what is missing, so the pipeline escalates
+      for a human decision instead.
 
   # ═══════════════════════════════════════════════════════════════
   # Edges


### PR DESCRIPTION
## Summary

Addresses items 1 and 2 of #349 (case-study run `b68b532619c3`: `FinalCommit`'s "ensure all changes are committed" prompt plus a stale failure report in context led the agent to author an entire unreviewed milestone inside the commit node — ~700 lines across 8 files, shipped through zero quality gates, containing the run's worst defects).

`FinalCommit` in both `build_product.dip` and `build_product_with_superspec.dip` is rewritten as **explicitly commit-only** with the #346-hardened STATUS contract:

- `auto_status: true` + the early-`STATUS:fail` convention used by SpecLint/FinalSpecCheck (last-line-wins; truncation fails closed).
- ONLY job: stage/commit existing work, report the commit hash.
- If completing the task would require ANY new implementation (new files, new functions, behavior changes) — including anything upstream context claims is broken or missing — do NOT write it: leave the early `STATUS:fail` and name what's missing, so the pipeline escalates for a human decision.

## Design decisions

- **Fail routing**: `build_product` keeps the existing `fallback_target: EscalateReview` node attr (a direct `FinalCommit -> EscalateReview` edge would close an unconditional cycle via the accept path — DIP005, per the comment at the edge block). The superspec variant gains an explicit `fallback_target: EscalateToHuman`, matching its `FinalGates`/`TraceabilityAudit` convention (previously it relied solely on the graph-level `on_failure`). Verified: the engine consults node-level `fallback_target` before dead-stopping on a fail with all-unconditional edges (`pipeline/engine.go:546`).
- **No `goal_gate` on FinalCommit** (item 2 decision): under #360/#361, a failing goal gate re-enters **at the gate itself** after the escalation tail (`gate_recheck_pending`). For a commit-only node, failure means "implementation is missing" — re-running the commit node can never produce it, so a gate re-check buys nothing and risks a charge-free re-entry loop. Escalation via `fallback_target` is the correct route.
- **Scope trigger is "would I have to author code," not "is the spec satisfied"**: a clean tree + an accepted-with-known-violations context still commits and succeeds (accept semantics) — the guard fires only when the node would have to write implementation to complete its task. Accept ⇒ override semantics remain #348 defect 2 / #271.
- `CommitIfDirty` is a scripted tool node — already safe, untouched.

## Out of scope

- Item 3 (stale "Previous Node Output" injection, `pipeline/transforms.go:96`) → #352.
- Item 4 (accept ⇒ override semantics) → #348 defect 2 / #271, blocked on dippin-lang#124.
- `writable_paths` jail as mechanical enforcement: noted only — `tool_access` is all-or-nothing (a commit node needs git), and the jail is Linux-Landlock-only and refuses claude-code/acp backends, which build_product is routinely run with. The portable fix is the prompt contract + STATUS gate above.

## Verification

No Go-side changes — the contract is `.dip` prose + existing engine features, pinned by:

- `dippin doctor` — ask_and_execute **A/95**, build_product **A/90**, build_product_with_superspec **A/100** (unchanged)
- `dippin simulate -all-paths` — both variants terminate on all 100 enumerated paths
- `go build ./...`, `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- `go test ./... -short` — pass; `go test -race -short ./pipeline/...` — pass
- CHANGELOG.md updated under [Unreleased]

Part of #349 (items 1–2; items 3–4 tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783870286&installation_id=131176874&pr_number=365&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F365&signature=ff31bf2f6c80d147be18630aed923bc44471d61c9930570a35fb06ab02f38d46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->