### PR TITLE
fix(adapter): propagate top-level tool_access IR field to node attrs (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Item 3 (refreshing the architecture section at MarkMilestoneDone) is
   not included.
 
+- **Top-level `tool_access:` on agent nodes is no longer silently dropped**
+  (issue #366). The dippin parser populates the typed IR field
+  `AgentConfig.ToolAccess`, but the adapter only read the `params:` form, so
+  the documented top-level spelling — the one DIP139 steers authors toward —
+  ran agents with full tool access. `extractAgentAttrs` now copies the typed
+  field (same shape as `backend` / `working_dir`), and it takes precedence
+  over a conflicting `params: tool_access`. Downstream enforcement
+  (`IsToolAccessRestricted` fail-closes on any non-empty value) was already
+  correct; only the adapter wire was missing.
+
 ## [0.38.1] - 2026-06-11
 
 ### Fixed

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -294,6 +294,13 @@ func extractAgentAttrs(cfg ir.AgentConfig, attrs map[string]string) {
 	} else if _, paramsHasIt := cfg.Params["writable_paths"]; paramsHasIt {
 		attrs["writable_paths"] = ""
 	}
+	// tool_access: typed IR field is authoritative over Params (issue #366).
+	// No claim-the-attr-on-empty defense needed here: downstream fail-closes
+	// on ANY non-empty value (agent.IsToolAccessRestricted), so a Params
+	// spill can only restrict, never grant, tool access.
+	if strings.TrimSpace(cfg.ToolAccess) != "" {
+		attrs["tool_access"] = cfg.ToolAccess
+	}
 	for k, v := range cfg.Params {
 		if _, exists := attrs[k]; !exists {
 			attrs[k] = v

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -296,8 +296,8 @@ func extractAgentAttrs(cfg ir.AgentConfig, attrs map[string]string) {
 	}
 	// tool_access: typed IR field is authoritative over Params (issue #366).
 	// No claim-the-attr-on-empty defense needed here: downstream fail-closes
-	// on ANY non-empty value (agent.IsToolAccessRestricted), so a Params
-	// spill can only restrict, never grant, tool access.
+	// on ANY non-empty value (agent.SessionConfig.IsToolAccessRestricted),
+	// so a Params spill can only restrict, never grant, tool access.
 	if strings.TrimSpace(cfg.ToolAccess) != "" {
 		attrs["tool_access"] = cfg.ToolAccess
 	}

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -2473,9 +2473,9 @@ func TestExtractAgentAttrs_ToolAccess(t *testing.T) {
 	})
 
 	t.Run("whitespace-only typed field = no attr", func(t *testing.T) {
-		// Whitespace-only is semantically unset: IsToolAccessRestricted
-		// trims before checking, so " " would read as unrestricted anyway.
-		// Don't claim the attr for it.
+		// Whitespace-only is semantically unset:
+		// agent.SessionConfig.IsToolAccessRestricted trims before checking,
+		// so " " would read as unrestricted anyway. Don't claim the attr.
 		cfg := ir.AgentConfig{
 			ToolAccess: "   ",
 		}

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -2427,3 +2427,71 @@ func TestExtractAgentAttrs_WritablePaths(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractAgentAttrs_ToolAccess(t *testing.T) {
+	t.Run("typed field populates attrs", func(t *testing.T) {
+		// Issue #366: top-level `tool_access: none` is the documented form;
+		// the adapter must copy the typed IR field, not just Params.
+		cfg := ir.AgentConfig{
+			ToolAccess: "none",
+		}
+		attrs := map[string]string{}
+		extractAgentAttrs(cfg, attrs)
+		got, ok := attrs["tool_access"]
+		if !ok {
+			t.Fatal("attrs missing tool_access key")
+		}
+		if got != "none" {
+			t.Errorf("attrs[tool_access] = %q, want %q", got, "none")
+		}
+	})
+
+	t.Run("typed field wins over conflicting Params", func(t *testing.T) {
+		cfg := ir.AgentConfig{
+			ToolAccess: "none",
+			Params:     map[string]string{"tool_access": "full"},
+		}
+		attrs := map[string]string{}
+		extractAgentAttrs(cfg, attrs)
+		if attrs["tool_access"] != "none" {
+			t.Errorf("Params override won (got %q); typed field should have won (want %q)",
+				attrs["tool_access"], "none")
+		}
+	})
+
+	t.Run("Params form still works when typed empty", func(t *testing.T) {
+		// Back-compat: the params: spelling enforced before #366 and must
+		// keep enforcing after.
+		cfg := ir.AgentConfig{
+			Params: map[string]string{"tool_access": "none"},
+		}
+		attrs := map[string]string{}
+		extractAgentAttrs(cfg, attrs)
+		if attrs["tool_access"] != "none" {
+			t.Errorf("attrs[tool_access] = %q, want %q", attrs["tool_access"], "none")
+		}
+	})
+
+	t.Run("whitespace-only typed field = no attr", func(t *testing.T) {
+		// Whitespace-only is semantically unset: IsToolAccessRestricted
+		// trims before checking, so " " would read as unrestricted anyway.
+		// Don't claim the attr for it.
+		cfg := ir.AgentConfig{
+			ToolAccess: "   ",
+		}
+		attrs := map[string]string{}
+		extractAgentAttrs(cfg, attrs)
+		if _, ok := attrs["tool_access"]; ok {
+			t.Errorf("attrs has tool_access key = %q, want absent", attrs["tool_access"])
+		}
+	})
+
+	t.Run("typed empty + no params = no attr", func(t *testing.T) {
+		cfg := ir.AgentConfig{}
+		attrs := map[string]string{}
+		extractAgentAttrs(cfg, attrs)
+		if _, ok := attrs["tool_access"]; ok {
+			t.Errorf("attrs has tool_access key = %q, want absent", attrs["tool_access"])
+		}
+	})
+}


### PR DESCRIPTION
Closes #366.

## What

`pipeline/dippin_adapter.go::extractAgentAttrs` copied `cfg.Backend`, `cfg.WorkingDir`, and `cfg.WritablePaths` from the typed IR but never read `cfg.ToolAccess` — so the documented top-level `tool_access: none` spelling silently ran agents with full tool access. Only the `params: tool_access` spelling (which DIP139 steers authors away from) reached `attrs["tool_access"]`.

This adds the missing copy, same shape as `Backend`/`WorkingDir`. Adapter-only change — downstream enforcement (`node_config.go:125`, `agent.IsToolAccessRestricted` fail-closing on any non-empty value, session tool-registry gating) was already correct.

## Design decisions

1. **Copy shape**: `if strings.TrimSpace(cfg.ToolAccess) != "" { attrs["tool_access"] = cfg.ToolAccess }` — TrimSpace on the guard (whitespace-only is semantically unset; downstream trims before checking, so `"   "` would read as unrestricted either way), raw value on the assignment (downstream trims).
2. **Precedence**: typed field wins over a conflicting `Params["tool_access"]` — the assignment runs after `extractAgentBackendAttrs` and before the Params spill (which never overwrites existing keys). Pinned by test.
3. **No claim-the-attr-on-empty defense** (the `writable_paths` D8 pattern in the same function): deliberately omitted. For `writable_paths` a Params spill could *widen* the jail (attacker-supplied globs), so the typed-empty case must claim the key. For `tool_access`, any non-empty value fail-closes (`IsToolAccessRestricted`), and an empty value is semantically "unrestricted" whether the key is absent or empty — a Params spill can only restrict, never grant, tool access. There is no bypass to defend against.

## Same-class gap found (reported, not fixed — out of scope)

While auditing other extractors for the same typed-field gap: `extractParallelAttrs` serializes per-branch `Model`/`Provider`/`Fidelity` from `BranchConfig` but **drops `BranchConfig.ToolAccess` and `BranchConfig.WritablePaths`** — the per-branch security overrides whose IR doc comments say "the runtime enforces the override, exactly as it does for Model/Provider/Fidelity". Same silent-drop class as #366, at the branch level. All other node kinds (Human/Tool/FanIn/Subgraph/ManagerLoop) copy all their behavioral typed fields. Will file a follow-up issue.

## Verification

- TDD: `TestExtractAgentAttrs_ToolAccess` written first, watched the two missing-wire subtests fail (RED), then the 7-line fix (GREEN). Back-compat subtests (params form, empty cases) pass on both sides.
- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓; `go test -race -short ./pipeline/...` ✓
- `dippin doctor` (each file separately): ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 ✓
- **Issue reproducer run end-to-end** against a configured Anthropic key with the patched binary: `Tool Calls: 0`, both nodes success (was >0 pre-fix per issue).
- CHANGELOG.md updated under [Unreleased] → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872086&installation_id=131176874&pr_number=367&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F367&signature=95b5000f46e07c185c607d928959e80aac0ed1cbd6a69665625f3de554bd512e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->