### PR TITLE
fix(examples): keep .tracker/ run metadata out of the product repo (#351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   injection) and 4 (accept ⇒ override semantics) are tracked separately
   as #352 and #348/#271.
 
+- **CommitIfDirty no longer commits `.tracker/` run metadata into the
+  product repo** (issue #351, items 1–2). In case-study run b68b532619c3,
+  CommitIfDirty's `git add -A` swept `.tracker/runs/<id>/` internals
+  (prompt.md/response.md/checkpoint.json) into checkpoint commits —
+  polluting the product's history and dominating the #298 build-context
+  `Files:` lines with tracker noise, which effectively disabled the
+  per-node orientation file. `build_product.dip`'s Setup now adds
+  `.tracker/` to the local `.git/info/exclude` (the same idempotent
+  treatment the turn-override dir already gets), and MarkMilestoneDone
+  filters `^.tracker/` and `^.ai/build/` out of the `Files:` list as
+  belt-and-braces — saying "(only tracker/build metadata changed)"
+  explicitly when the filter empties the list, and gating the Summary
+  line on the unfiltered count so HEAD-moved detection is unchanged.
+  `build_product_with_superspec.dip` has no `git add -A` tool node
+  (its FinalCommit is the #349-guarded agent), so it needs no change.
+  Item 3 (refreshing the architecture section at MarkMilestoneDone) is
+  not included.
+
 ## [0.38.1] - 2026-06-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Files:` lines with tracker noise, which effectively disabled the
   per-node orientation file. `build_product.dip`'s Setup now adds
   `.tracker/` to the local `.git/info/exclude` (the same idempotent
-  treatment the turn-override dir already gets), and MarkMilestoneDone
-  filters `^.tracker/` and `^.ai/build/` out of the `Files:` list as
+  treatment the turn-override dir already gets) and untracks any
+  `.tracker/` files a pre-fix run already committed (ignore rules only
+  affect untracked paths), and MarkMilestoneDone filters `^\.tracker/`
+  and `^\.ai/build/` out of the `Files:` list as
   belt-and-braces — saying "(only tracker/build metadata changed)"
   explicitly when the filter empties the list, and gating the Summary
   line on the unfiltered count so HEAD-moved detection is unchanged.

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -31,6 +31,17 @@ workflow BuildProduct
       mkdir -p .ai/build .ai/decisions .ai/milestones
       echo '.ai/' >> .gitignore 2>/dev/null || true
       sort -u .gitignore -o .gitignore
+      # #351: keep tracker run metadata out of the product repo. CommitIfDirty
+      # runs `git add -A`, which would otherwise commit .tracker/runs/<id>/
+      # internals (prompt.md/response.md/checkpoint.json) into the user's
+      # history. Same LOCAL .git/info/exclude treatment the turn-override dir
+      # gets in ContinueWithMoreTurns (idempotent; safe outside a git repo).
+      GITDIR=$(git rev-parse --git-dir 2>/dev/null || true)
+      if [ -n "$GITDIR" ]; then
+        mkdir -p "$GITDIR/info"
+        grep -qxF ".tracker/" "$GITDIR/info/exclude" 2>/dev/null \
+          || echo ".tracker/" >> "$GITDIR/info/exclude"
+      fi
       # #318: clear any warm-continue cap counter / MaxTurns override left by a
       # prior run interrupted before its cleanup. Setup is skipped on checkpoint
       # resume (already completed), so a deliberately-resumed run keeps its state;
@@ -1221,15 +1232,24 @@ workflow BuildProduct
         fi
         TITLE=$(head -1 .ai/milestones/current.md 2>/dev/null)
         [ -n "$TITLE" ] || TITLE="## Milestone $NEXT"
-        FILES=$(git diff --name-only "${BASE}..HEAD" 2>/dev/null | sed '/^$/d')
+        FILES_ALL=$(git diff --name-only "${BASE}..HEAD" 2>/dev/null | sed '/^$/d')
+        # #351 belt-and-braces: filter tracker run metadata and the build-context
+        # machinery itself out of the Files: lines so they carry source signal,
+        # not pipeline internals. (.ai/ is gitignored at Setup and .tracker/ is
+        # excluded via .git/info/exclude, but a pre-existing tree or an agent
+        # rewriting .gitignore can still land them in checkpoint commits.)
+        FILES=$(printf '%s\n' "$FILES_ALL" | grep -vE '^\.tracker/|^\.ai/build/' || true)
         NFILES=$(printf '%s\n' "$FILES" | grep -c . || true)
+        NALL=$(printf '%s\n' "$FILES_ALL" | grep -c . || true)
         # Summary = this milestone's newest commit subject, read from HEAD
         # directly. NOT the BASE..HEAD range: when BASE is the empty tree (first
         # milestone / unreachable START), `git log <tree>..HEAD` leans on lenient
         # `^<tree>` handling that isn't guaranteed across git versions. Gate on
-        # NFILES so a no-op "mark done" milestone (zero files, HEAD unmoved)
-        # degrades to the title instead of echoing the prior milestone's subject.
-        if [ "$NFILES" -eq 0 ]; then
+        # NALL (the unfiltered count) so a no-op "mark done" milestone (zero
+        # files, HEAD unmoved) degrades to the title instead of echoing the
+        # prior milestone's subject — metadata-only commits still moved HEAD,
+        # so their subject is genuinely this milestone's.
+        if [ "$NALL" -eq 0 ]; then
           SUMMARY="$TITLE"
         else
           SUMMARY=$(git log -1 --format=%s HEAD 2>/dev/null)
@@ -1239,7 +1259,13 @@ workflow BuildProduct
           echo
           echo "$TITLE"
           if [ "$NFILES" -eq 0 ]; then
-            echo "Files: (none)"
+            # Distinguish "nothing changed" from "everything was filtered" —
+            # an empty Files: line must say why, not print nothing (#351).
+            if [ "$NALL" -gt 0 ]; then
+              echo "Files: (only tracker/build metadata changed)"
+            else
+              echo "Files: (none)"
+            fi
           else
             printf 'Files: %s\n' "$(printf '%s\n' "$FILES" | head -12 | paste -sd, -)"
             [ "$NFILES" -gt 12 ] && echo "Files: … and $((NFILES - 12)) more"

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -41,6 +41,14 @@ workflow BuildProduct
         mkdir -p "$GITDIR/info"
         grep -qxF ".tracker/" "$GITDIR/info/exclude" 2>/dev/null \
           || echo ".tracker/" >> "$GITDIR/info/exclude"
+        # Untrack any .tracker/ files committed by a pre-#351 run — ignore
+        # rules only affect UNTRACKED paths, so without this an already-
+        # polluted repo keeps committing metadata churn forever. Index-only
+        # removal (--cached, working tree untouched); the next CommitIfDirty
+        # commits the deletion, cleaning the product history going forward.
+        if git ls-files --cached -- .tracker | grep -q .; then
+          git rm -r -q --cached .tracker
+        fi
       fi
       # #318: clear any warm-continue cap counter / MaxTurns override left by a
       # prior run interrupted before its cleanup. Setup is skipped on checkpoint


### PR DESCRIPTION
Part-addresses #351 (items 1 and 2; item 3 deliberately not included).

## What

Case-study run b68b532619c3: CommitIfDirty's `git add -A` swept `.tracker/runs/<id>/` internals into checkpoint commits — 1,600+ line diffs of pipeline metadata in the product's history, and the #298 build-context `Files:` lines dominated by `.tracker/runs/...` paths instead of source files, effectively disabling the per-node orientation file.

**Item 1** — `Setup` adds `.tracker/` to the local `.git/info/exclude`, using the exact idempotent `grep -qxF || echo >> exclude` pattern the turn-override dir already gets in ContinueWithMoreTurns (safe under `set -eu`, safe outside a git repo).

**Item 2** (belt-and-braces) — `MarkMilestoneDone` filters `^\.tracker/` and `^\.ai/build/` out of the `FILES` list before writing build-context.md:
- Filter-empties-the-list case is explicit, not silent: `Files: (only tracker/build metadata changed)` when the unfiltered list was non-empty, `Files: (none)` when nothing changed at all (CLAUDE.md empty-result guard).
- The Summary HEAD-moved gate now uses the **unfiltered** count, so its original no-op-milestone semantics (degrade to title when HEAD didn't move) are unchanged — metadata-only commits did move HEAD, so their subject is genuinely this milestone's.

**Superspec variant**: `build_product_with_superspec.dip` has no `git add -A` tool node (its FinalCommit is the #349-guarded commit-only agent), so no change needed there.

**Item 3** (refresh the build-context architecture section at MarkMilestoneDone) is out of scope per the issue's "consider" framing — it needs new plumbing, not a one-line fix.

## Verification

- Shell logic executed in a scratch git repo: mixed / metadata-only / empty diff cases all produce the right `Files:` line; exclude block idempotent (1 line after 2 runs); `.tracker/` files no longer report dirty to `git status --porcelain`.
- `dippin doctor` (each file separately): ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 ✓
- `dippin simulate -all-paths` on both build_product variants: 100 paths each, all terminate ✓
- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` ✓ (examples are embedded)
- `go test ./... -short` ✓
- CHANGELOG.md updated under [Unreleased] → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783872460&installation_id=131176874&pr_number=369&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F369&signature=ae6bf1737a8bb76b8e85fd8ec3bf0aa6069d82fcb7bd6771101636ce9926ca3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->