### PR TITLE
fix(engine): cap injected prior output and make human_response one-shot (#352 items 1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Context injection no longer pastes full prior transcripts or replays a
+  stale Human Response forever** (issue #352, items 1–2). In case-study run
+  b68b532619c3, every full-fidelity prompt carried the entire previous node
+  output (the ~9KB Milestone-7 verification report rode along into the
+  Milestone-8 Implement prompt and mis-anchored all three reviewers into
+  reviewing the wrong scope), and the single ApprovePlan "approve" was
+  re-injected verbatim into every subsequent prompt for the rest of the run.
+  Two changes: (1) the injected "Previous Node Output" section is now capped
+  (default 4096 bytes, head+tail truncation with an explicit elision marker;
+  per-node `injection_cap` attr overrides — negative disables, malformed
+  fails the node loudly). The cap applies at prompt-injection time only:
+  stored context, `node.<id>.last_response` scoping, and checkpoints keep
+  the full value. (2) `human_response` is now one-shot: the engine clears
+  the bare key after the first prompt-consuming node (codergen or parallel)
+  completes, the clear persists across checkpoint resume, and the gate's
+  scoped `node.<gateID>.human_response` copy retains the value for explicit
+  reference. Item 3 (fenced rendering of interpolated tool stdout) is
+  tracked in the .dip workflows separately; #352 stays open for it.
+
 - **FinalCommit is now explicitly commit-only in both build_product
   workflows** (issue #349, items 1–2). In case-study run b68b532619c3,
   FinalCommit's "ensure all changes are committed" prompt plus a failure

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -385,13 +386,46 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	return e.advanceToNextNode(s, currentNodeID, &traceEntry)
 }
 
-// humanResponseConsumers names the handlers whose execution feeds pipeline
-// context into an LLM prompt (codergen via ResolvePrompt; parallel resolves
-// each branch's prompt the same way). subgraph and stack.manager_loop run
+// consumesHumanResponse reports whether executing the node feeds pipeline
+// context into an LLM prompt: codergen does (via ResolvePrompt), and a
+// parallel node does when at least one of its branch targets is a codergen
+// node (the parallel handler resolves each branch's prompt the same way; a
+// tool-only fan-out resolves no prompts). subgraph and stack.manager_loop run
 // nested engines with their own contexts and are not consumers here.
-var humanResponseConsumers = map[string]bool{
-	"codergen": true,
-	"parallel": true,
+func (e *Engine) consumesHumanResponse(node *Node) bool {
+	switch node.Handler {
+	case "codergen":
+		return true
+	case "parallel":
+		for _, id := range e.parallelBranchTargets(node) {
+			if t, ok := e.graph.Nodes[id]; ok && t.Handler == "codergen" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parallelBranchTargets mirrors the parallel handler's branch resolution
+// (collectBranchEdges): the comma-separated parallel_targets attr when set,
+// otherwise the node's outgoing edge targets. The outgoing-edge fallback
+// includes the join node — harmless here, since a join is parallel.fan_in,
+// never codergen.
+func (e *Engine) parallelBranchTargets(node *Node) []string {
+	if attr := node.ParallelConfig().ParallelTargets; attr != "" {
+		var targets []string
+		for _, t := range strings.Split(attr, ",") {
+			if t = strings.TrimSpace(t); t != "" {
+				targets = append(targets, t)
+			}
+		}
+		return targets
+	}
+	var targets []string
+	for _, edge := range e.graph.OutgoingEdges(node.ID) {
+		targets = append(targets, edge.To)
+	}
+	return targets
 }
 
 // clearConsumedHumanResponse makes human_response one-shot (#352 item 2): the
@@ -404,7 +438,7 @@ var humanResponseConsumers = map[string]bool{
 // cannot resurrect the stale response. MergeWithoutDirty keeps the clear out
 // of the next ScopeToNode call — no node "wrote" it.
 func (e *Engine) clearConsumedHumanResponse(s *runState, node *Node, preVal string) {
-	if preVal == "" || !humanResponseConsumers[node.Handler] {
+	if preVal == "" || !e.consumesHumanResponse(node) {
 		return
 	}
 	// Don't clobber a fresh response the node itself wrote via ContextUpdates.

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -312,6 +312,11 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	s.pctx.Set(ContextKeyPreferredLabel, "")
 	s.pctx.Set(ContextKeySuggestedNextNodes, "")
 
+	// #352 item 2: human_response is one-shot. Record the value visible to
+	// this node so it can be cleared after the first prompt-consuming node
+	// completes (see clearConsumedHumanResponse below).
+	preHumanResponse, _ := s.pctx.Get(ContextKeyHumanResponse)
+
 	execNode := e.prepareExecNode(node, s)
 
 	outcome, traceEntry, err := e.executeNode(ctx, s, currentNodeID, execNode)
@@ -367,6 +372,10 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 		return e.processRetryOutcome(ctx, s, currentNodeID, execNode, &traceEntry)
 	}
 
+	// After the retry check: a retrying node re-executes and must still see
+	// the response; a node that completed (success OR fail) has consumed it.
+	e.clearConsumedHumanResponse(s, node, preHumanResponse)
+
 	e.handleOutcomeStatus(s, currentNodeID, outcome.Status)
 
 	if currentNodeID == e.graph.ExitNode {
@@ -374,6 +383,35 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	}
 
 	return e.advanceToNextNode(s, currentNodeID, &traceEntry)
+}
+
+// humanResponseConsumers names the handlers whose execution feeds pipeline
+// context into an LLM prompt (codergen via ResolvePrompt; parallel resolves
+// each branch's prompt the same way). subgraph and stack.manager_loop run
+// nested engines with their own contexts and are not consumers here.
+var humanResponseConsumers = map[string]bool{
+	"codergen": true,
+	"parallel": true,
+}
+
+// clearConsumedHumanResponse makes human_response one-shot (#352 item 2): the
+// first prompt-consuming node to complete with a non-empty response clears the
+// bare key so later nodes don't replay a stale human sign-off indefinitely.
+// The gate's scoped copy (node.<gateID>.human_response) keeps the full value
+// for explicit reference. The clear is an empty-set rather than a delete:
+// PipelineContext has no delete, both injection paths skip empty values, and
+// an empty value round-trips through checkpoint snapshots so a resumed run
+// cannot resurrect the stale response. MergeWithoutDirty keeps the clear out
+// of the next ScopeToNode call — no node "wrote" it.
+func (e *Engine) clearConsumedHumanResponse(s *runState, node *Node, preVal string) {
+	if preVal == "" || !humanResponseConsumers[node.Handler] {
+		return
+	}
+	// Don't clobber a fresh response the node itself wrote via ContextUpdates.
+	if cur, _ := s.pctx.Get(ContextKeyHumanResponse); cur != preVal {
+		return
+	}
+	s.pctx.MergeWithoutDirty(map[string]string{ContextKeyHumanResponse: ""})
 }
 
 // processRetryOutcome handles a retry outcome from a handler.

--- a/pipeline/engine_human_response_test.go
+++ b/pipeline/engine_human_response_test.go
@@ -246,12 +246,14 @@ func TestEngineHumanResponseNotClearedByNonConsumingNodes(t *testing.T) {
 }
 
 func TestEngineHumanResponseConsumedByParallel(t *testing.T) {
-	// The parallel handler resolves branch prompts (which receive the
-	// injection), so a parallel node counts as a consumer.
+	// A parallel node whose branches include a codergen node resolves branch
+	// prompts (which receive the injection), so it counts as a consumer.
 	g := NewGraph("human_response_parallel")
 	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
 	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
-	g.AddNode(&Node{ID: "P", Shape: "component", Label: "Parallel"})
+	g.AddNode(&Node{ID: "P", Shape: "component", Label: "Parallel",
+		Attrs: map[string]string{"parallel_targets": "B1"}})
+	g.AddNode(&Node{ID: "B1", Shape: "box", Label: "Branch"})
 	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
 	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
 	g.AddEdge(&Edge{From: "s", To: "Gate"})
@@ -266,7 +268,36 @@ func TestEngineHumanResponseConsumedByParallel(t *testing.T) {
 		t.Fatalf("engine run failed: %v", err)
 	}
 	if got, _ := rec.last("A"); got != "" {
-		t.Errorf("parallel node should consume human_response; A got %q", got)
+		t.Errorf("parallel node with a codergen branch should consume human_response; A got %q", got)
+	}
+}
+
+func TestEngineHumanResponseNotConsumedByToolOnlyParallel(t *testing.T) {
+	// A parallel fan-out whose branches are all non-LLM handlers (a tool-only
+	// validation fan-out, say) resolves no prompts — it must NOT consume the
+	// response; the first real codergen node after the join still gets it.
+	g := NewGraph("human_response_parallel_tools")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
+	g.AddNode(&Node{ID: "P", Shape: "component", Label: "Parallel",
+		Attrs: map[string]string{"parallel_targets": "T1, T2"}})
+	g.AddNode(&Node{ID: "T1", Shape: "parallelogram", Label: "Tool1"})
+	g.AddNode(&Node{ID: "T2", Shape: "parallelogram", Label: "Tool2"})
+	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "Gate"})
+	g.AddEdge(&Edge{From: "Gate", To: "P"})
+	g.AddEdge(&Edge{From: "P", To: "A"})
+	g.AddEdge(&Edge{From: "A", To: "end"})
+
+	reg, rec := newHumanResponseHarness("approve")
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if got, _ := rec.last("A"); got != "approve" {
+		t.Errorf("tool-only parallel must not consume human_response; A got %q", got)
 	}
 }
 

--- a/pipeline/engine_human_response_test.go
+++ b/pipeline/engine_human_response_test.go
@@ -1,0 +1,326 @@
+// ABOUTME: Tests for one-shot human_response semantics (#352 item 2): the engine
+// ABOUTME: clears human_response after the first prompt-consuming node, including across checkpoint resume.
+package pipeline
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// humanResponseRecorder builds a registry where the wait.human handler writes
+// human_response via ContextUpdates and every codergen node records the
+// human_response value visible at its execution time.
+type humanResponseRecorder struct {
+	mu   sync.Mutex
+	seen map[string][]string // nodeID -> value per execution
+}
+
+func (r *humanResponseRecorder) record(nodeID, val string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.seen[nodeID] = append(r.seen[nodeID], val)
+}
+
+func (r *humanResponseRecorder) last(nodeID string) (string, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	vals := r.seen[nodeID]
+	if len(vals) == 0 {
+		return "", false
+	}
+	return vals[len(vals)-1], true
+}
+
+func newHumanResponseHarness(gateResponse string) (*HandlerRegistry, *humanResponseRecorder) {
+	rec := &humanResponseRecorder{seen: make(map[string][]string)}
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "wait.human",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{
+				Status:         string(OutcomeSuccess),
+				ContextUpdates: map[string]string{ContextKeyHumanResponse: gateResponse},
+			}, nil
+		},
+	})
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			val, _ := pctx.Get(ContextKeyHumanResponse)
+			rec.record(node.ID, val)
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	return reg, rec
+}
+
+// gateChainGraph builds start -> Gate(hexagon) -> A(box) -> B(box) -> end.
+func gateChainGraph() *Graph {
+	g := NewGraph("human_response_oneshot")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
+	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
+	g.AddNode(&Node{ID: "B", Shape: "box", Label: "B"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "Gate"})
+	g.AddEdge(&Edge{From: "Gate", To: "A"})
+	g.AddEdge(&Edge{From: "A", To: "B"})
+	g.AddEdge(&Edge{From: "B", To: "end"})
+	return g
+}
+
+func TestEngineHumanResponseOneShot(t *testing.T) {
+	g := gateChainGraph()
+	reg, rec := newHumanResponseHarness("approve")
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Fatalf("expected success, got %q", result.Status)
+	}
+
+	// The first consuming node sees the response.
+	if got, _ := rec.last("A"); got != "approve" {
+		t.Errorf("node A should see human_response, got %q", got)
+	}
+	// The next consuming node must NOT see it (one-shot).
+	if got, _ := rec.last("B"); got != "" {
+		t.Errorf("node B should see cleared human_response, got %q", got)
+	}
+	// The bare key ends the run cleared.
+	if got := result.Context[ContextKeyHumanResponse]; got != "" {
+		t.Errorf("expected bare human_response cleared in final context, got %q", got)
+	}
+	// The gate's scoped copy keeps the full value for explicit reference.
+	if got := result.Context["node.Gate."+ContextKeyHumanResponse]; got != "approve" {
+		t.Errorf("expected node.Gate.human_response to retain the value, got %q", got)
+	}
+	// The clear must not be misattributed to any consuming node's scope.
+	for _, key := range []string{"node.A." + ContextKeyHumanResponse, "node.B." + ContextKeyHumanResponse} {
+		if val, ok := result.Context[key]; ok {
+			t.Errorf("unexpected scoped key %s=%q from engine-side clear", key, val)
+		}
+	}
+}
+
+func TestEngineHumanResponseSurvivesRetry(t *testing.T) {
+	// A node that retries must see the same human_response on re-execution;
+	// the clear fires only when the node completes.
+	g := NewGraph("human_response_retry")
+	g.Attrs["default_max_retry"] = "3"
+	g.Attrs["default_retry_policy"] = "none"
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
+	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
+	g.AddNode(&Node{ID: "B", Shape: "box", Label: "B"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "Gate"})
+	g.AddEdge(&Edge{From: "Gate", To: "A"})
+	g.AddEdge(&Edge{From: "A", To: "B"})
+	g.AddEdge(&Edge{From: "B", To: "end"})
+
+	rec := &humanResponseRecorder{seen: make(map[string][]string)}
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "wait.human",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{
+				Status:         string(OutcomeSuccess),
+				ContextUpdates: map[string]string{ContextKeyHumanResponse: "approve"},
+			}, nil
+		},
+	})
+	var mu sync.Mutex
+	attempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			val, _ := pctx.Get(ContextKeyHumanResponse)
+			rec.record(node.ID, val)
+			if node.ID == "A" {
+				mu.Lock()
+				attempts++
+				current := attempts
+				mu.Unlock()
+				if current < 2 {
+					return Outcome{Status: string(OutcomeRetry)}, nil
+				}
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Fatalf("expected success, got %q", result.Status)
+	}
+
+	rec.mu.Lock()
+	aSeen := append([]string(nil), rec.seen["A"]...)
+	rec.mu.Unlock()
+	if len(aSeen) != 2 {
+		t.Fatalf("expected 2 executions of A, got %d", len(aSeen))
+	}
+	for i, v := range aSeen {
+		if v != "approve" {
+			t.Errorf("A execution %d should still see human_response, got %q", i, v)
+		}
+	}
+	if got, _ := rec.last("B"); got != "" {
+		t.Errorf("node B should see cleared human_response, got %q", got)
+	}
+}
+
+func TestEngineHumanResponseFreshWriteNotClobbered(t *testing.T) {
+	// If the consuming node itself writes a new human_response via
+	// ContextUpdates, the engine must not clear the fresh value.
+	g := gateChainGraph()
+
+	rec := &humanResponseRecorder{seen: make(map[string][]string)}
+	reg := newTestRegistry()
+	reg.Register(&testHandler{
+		name: "wait.human",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{
+				Status:         string(OutcomeSuccess),
+				ContextUpdates: map[string]string{ContextKeyHumanResponse: "approve"},
+			}, nil
+		},
+	})
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			val, _ := pctx.Get(ContextKeyHumanResponse)
+			rec.record(node.ID, val)
+			if node.ID == "A" {
+				return Outcome{
+					Status:         string(OutcomeSuccess),
+					ContextUpdates: map[string]string{ContextKeyHumanResponse: "fresh"},
+				}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if got, _ := rec.last("B"); got != "fresh" {
+		t.Errorf("node B should see the fresh value written by A, got %q", got)
+	}
+}
+
+func TestEngineHumanResponseNotClearedByNonConsumingNodes(t *testing.T) {
+	// Tool/conditional nodes do not feed pctx into an LLM prompt; they must
+	// not consume the response.
+	g := NewGraph("human_response_tool_passthrough")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
+	g.AddNode(&Node{ID: "T", Shape: "parallelogram", Label: "Tool"})
+	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "Gate"})
+	g.AddEdge(&Edge{From: "Gate", To: "T"})
+	g.AddEdge(&Edge{From: "T", To: "A"})
+	g.AddEdge(&Edge{From: "A", To: "end"})
+
+	reg, rec := newHumanResponseHarness("approve")
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if got, _ := rec.last("A"); got != "approve" {
+		t.Errorf("tool node must not consume human_response; A got %q", got)
+	}
+}
+
+func TestEngineHumanResponseConsumedByParallel(t *testing.T) {
+	// The parallel handler resolves branch prompts (which receive the
+	// injection), so a parallel node counts as a consumer.
+	g := NewGraph("human_response_parallel")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Gate", Shape: "hexagon", Label: "Gate"})
+	g.AddNode(&Node{ID: "P", Shape: "component", Label: "Parallel"})
+	g.AddNode(&Node{ID: "A", Shape: "box", Label: "A"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "Gate"})
+	g.AddEdge(&Edge{From: "Gate", To: "P"})
+	g.AddEdge(&Edge{From: "P", To: "A"})
+	g.AddEdge(&Edge{From: "A", To: "end"})
+
+	reg, rec := newHumanResponseHarness("approve")
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("engine run failed: %v", err)
+	}
+	if got, _ := rec.last("A"); got != "" {
+		t.Errorf("parallel node should consume human_response; A got %q", got)
+	}
+}
+
+func TestEngineHumanResponseClearPersistsAcrossResume(t *testing.T) {
+	// The clear is a context mutation like any other: a resumed run must not
+	// resurrect the stale response from the checkpoint.
+	g := gateChainGraph()
+	cpPath := filepath.Join(t.TempDir(), "checkpoint.json")
+
+	// Run 1: A consumes, then B fails the run.
+	rec1 := &humanResponseRecorder{seen: make(map[string][]string)}
+	reg1 := newTestRegistry()
+	reg1.Register(&testHandler{
+		name: "wait.human",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			return Outcome{
+				Status:         string(OutcomeSuccess),
+				ContextUpdates: map[string]string{ContextKeyHumanResponse: "approve"},
+			}, nil
+		},
+	})
+	reg1.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			val, _ := pctx.Get(ContextKeyHumanResponse)
+			rec1.record(node.ID, val)
+			if node.ID == "B" {
+				return Outcome{Status: string(OutcomeFail)}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	engine1 := NewEngine(g, reg1, WithCheckpointPath(cpPath))
+	if _, err := engine1.Run(context.Background()); err == nil {
+		t.Fatalf("run 1 should have stopped at B's strict failure")
+	}
+	if got, _ := rec1.last("A"); got != "approve" {
+		t.Fatalf("run 1: A should see human_response, got %q", got)
+	}
+
+	// Run 2: resume from the checkpoint; B succeeds and must NOT see the
+	// stale response.
+	reg2, rec2 := newHumanResponseHarness("should-not-be-used")
+	engine2 := NewEngine(g, reg2, WithCheckpointPath(cpPath))
+	result2, err := engine2.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run 2 failed: %v", err)
+	}
+	if result2.Status != OutcomeSuccess {
+		t.Fatalf("run 2 expected success, got %q", result2.Status)
+	}
+	if got, ok := rec2.last("B"); !ok {
+		t.Fatalf("run 2: B never executed")
+	} else if got != "" {
+		t.Errorf("run 2: B resurrected stale human_response %q from checkpoint", got)
+	}
+}

--- a/pipeline/handlers/prompt.go
+++ b/pipeline/handlers/prompt.go
@@ -4,6 +4,7 @@ package handlers
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/2389-research/tracker/pipeline"
 )
@@ -39,8 +40,29 @@ func ResolvePrompt(node *pipeline.Node, pctx *pipeline.PipelineContext,
 		)
 		prompt = prependContextSummary(prompt, compacted, fidelity)
 	} else {
-		prompt = pipeline.InjectPipelineContext(prompt, pctx)
+		capBytes, err := resolveInjectionCap(node)
+		if err != nil {
+			return "", err
+		}
+		prompt = pipeline.InjectPipelineContext(prompt, pctx, capBytes)
 	}
 
 	return prompt, nil
+}
+
+// resolveInjectionCap reads the optional injection_cap node attr (#352): the
+// byte budget for the injected "Previous Node Output" section. 0/absent means
+// pipeline.DefaultInjectedResponseCap; negative disables capping. Strict-parse
+// raw attr read (not in AgentNodeConfig): a malformed value must fail the node
+// loudly, not silently fall back to the default cap.
+func resolveInjectionCap(node *pipeline.Node) (int, error) {
+	raw := node.Attrs["injection_cap"]
+	if raw == "" {
+		return 0, nil
+	}
+	capBytes, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("node %q has malformed injection_cap %q: %w", node.ID, raw, err)
+	}
+	return capBytes, nil
 }

--- a/pipeline/handlers/prompt_test.go
+++ b/pipeline/handlers/prompt_test.go
@@ -141,3 +141,64 @@ func TestResolvePromptSummaryMediumPinsReads(t *testing.T) {
 		t.Fatalf("expected custom_key pinned by reads in prompt summary, got %q", prompt)
 	}
 }
+
+// --- #352 item 1: injection_cap node attr overrides the default cap ---
+
+func TestResolvePromptInjectionCapNodeAttr(t *testing.T) {
+	node := &pipeline.Node{
+		ID: "gen",
+		Attrs: map[string]string{
+			"prompt":        "do work",
+			"injection_cap": "64",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	pctx.Set(pipeline.ContextKeyLastResponse, strings.Repeat("x", 1000))
+
+	prompt, err := ResolvePrompt(node, pctx, map[string]string{}, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(prompt, "elided") {
+		t.Errorf("expected injection_cap=64 to truncate last_response, got %q", prompt)
+	}
+	if strings.Contains(prompt, strings.Repeat("x", 200)) {
+		t.Errorf("expected at most ~64 bytes of last_response in prompt")
+	}
+}
+
+func TestResolvePromptInjectionCapDefaultApplies(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "gen",
+		Attrs: map[string]string{"prompt": "do work"},
+	}
+	pctx := pipeline.NewPipelineContext()
+	pctx.Set(pipeline.ContextKeyLastResponse, strings.Repeat("y", pipeline.DefaultInjectedResponseCap*3))
+
+	prompt, err := ResolvePrompt(node, pctx, map[string]string{}, t.TempDir())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(prompt, "elided") {
+		t.Errorf("expected default cap to truncate oversized last_response")
+	}
+}
+
+func TestResolvePromptInjectionCapMalformed(t *testing.T) {
+	node := &pipeline.Node{
+		ID: "gen",
+		Attrs: map[string]string{
+			"prompt":        "do work",
+			"injection_cap": "lots",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+
+	_, err := ResolvePrompt(node, pctx, map[string]string{}, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error for malformed injection_cap")
+	}
+	if !strings.Contains(err.Error(), "injection_cap") {
+		t.Errorf("expected error to name injection_cap, got: %v", err)
+	}
+}

--- a/pipeline/transforms.go
+++ b/pipeline/transforms.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 func ExpandPromptVariables(prompt string, ctx *PipelineContext) string {
@@ -86,26 +87,73 @@ func ExpandGraphVariables(text string, vars map[string]string) string {
 	return b.String()
 }
 
+// DefaultInjectedResponseCap is the default byte budget for the
+// "Previous Node Output" section appended by InjectPipelineContext (#352).
+// Without a cap, a prior node's full transcript (verification reports, grep
+// tables) is pasted wholesale into every downstream prompt — wasteful and,
+// when the prior node failed, actively mis-anchoring. The cap applies at
+// prompt-injection time only; the stored context value (and therefore
+// node.<id>.last_response scoping and checkpoints) keeps the full value.
+const DefaultInjectedResponseCap = 4096
+
 // contextKeysForInjection lists the pipeline context keys whose values should
 // be appended to the LLM prompt so that downstream nodes can see prior outputs.
+// capped marks keys subject to the injection byte budget: last_response is an
+// LLM transcript and gets head+tail truncation; human_response is human-typed
+// and injected whole.
 var contextKeysForInjection = []struct {
-	key   string
-	label string
+	key    string
+	label  string
+	capped bool
 }{
-	{ContextKeyHumanResponse, "Human Response"},
-	{ContextKeyLastResponse, "Previous Node Output"},
+	{ContextKeyHumanResponse, "Human Response", false},
+	{ContextKeyLastResponse, "Previous Node Output", true},
+}
+
+// capHeadTail truncates s to roughly capBytes by keeping the head and tail
+// halves and replacing the middle with an explicit elision marker. Cuts land
+// on UTF-8 rune boundaries. Head+tail (not tail-only like tool output capture)
+// because prose transcripts carry the task framing up front and the
+// conclusion at the end; there is no end-of-output routing marker to protect.
+func capHeadTail(s string, capBytes int) string {
+	if capBytes <= 0 || len(s) <= capBytes {
+		return s
+	}
+	headEnd := capBytes / 2
+	for headEnd > 0 && !utf8.RuneStart(s[headEnd]) {
+		headEnd--
+	}
+	tailStart := len(s) - (capBytes - headEnd)
+	for tailStart < len(s) && !utf8.RuneStart(s[tailStart]) {
+		tailStart++
+	}
+	elided := tailStart - headEnd
+	return s[:headEnd] +
+		fmt.Sprintf("\n\n[... tracker elided %d of %d bytes from the middle of this output ...]\n\n", elided, len(s)) +
+		s[tailStart:]
 }
 
 // InjectPipelineContext appends relevant pipeline context values to the prompt
 // so the LLM can see prior node outputs, human responses, etc.
-func InjectPipelineContext(prompt string, ctx *PipelineContext) string {
+//
+// capBytes bounds the injected "Previous Node Output" section: 0 applies
+// DefaultInjectedResponseCap, negative disables capping, positive values are
+// used as-is. Oversized values are head+tail truncated with an explicit
+// elision marker (see capHeadTail).
+func InjectPipelineContext(prompt string, ctx *PipelineContext, capBytes int) string {
 	if ctx == nil {
 		return prompt
+	}
+	if capBytes == 0 {
+		capBytes = DefaultInjectedResponseCap
 	}
 
 	var sections []string
 	for _, entry := range contextKeysForInjection {
 		if val, ok := ctx.Get(entry.key); ok && val != "" {
+			if entry.capped {
+				val = capHeadTail(val, capBytes)
+			}
 			sections = append(sections, fmt.Sprintf("## %s\n%s", entry.label, val))
 		}
 	}

--- a/pipeline/transforms_test.go
+++ b/pipeline/transforms_test.go
@@ -5,6 +5,7 @@ package pipeline
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestExpandPromptVariables_Goal(t *testing.T) {
@@ -28,7 +29,7 @@ func TestInjectPipelineContext_HumanResponse(t *testing.T) {
 	ctx := NewPipelineContext()
 	ctx.Set(ContextKeyHumanResponse, "Build me a todo app")
 
-	result := InjectPipelineContext("Do the task.", ctx)
+	result := InjectPipelineContext("Do the task.", ctx, 0)
 	if !strings.Contains(result, "Build me a todo app") {
 		t.Fatalf("expected human response in output, got %q", result)
 	}
@@ -41,7 +42,7 @@ func TestInjectPipelineContext_LastResponse(t *testing.T) {
 	ctx := NewPipelineContext()
 	ctx.Set(ContextKeyLastResponse, "Previous node did X")
 
-	result := InjectPipelineContext("Continue.", ctx)
+	result := InjectPipelineContext("Continue.", ctx, 0)
 	if !strings.Contains(result, "Previous node did X") {
 		t.Fatalf("expected last response in output, got %q", result)
 	}
@@ -49,14 +50,14 @@ func TestInjectPipelineContext_LastResponse(t *testing.T) {
 
 func TestInjectPipelineContext_NoContext(t *testing.T) {
 	ctx := NewPipelineContext()
-	result := InjectPipelineContext("Plain prompt.", ctx)
+	result := InjectPipelineContext("Plain prompt.", ctx, 0)
 	if result != "Plain prompt." {
 		t.Fatalf("expected unchanged prompt with empty context, got %q", result)
 	}
 }
 
 func TestInjectPipelineContext_NilContext(t *testing.T) {
-	result := InjectPipelineContext("Plain prompt.", nil)
+	result := InjectPipelineContext("Plain prompt.", nil, 0)
 	if result != "Plain prompt." {
 		t.Fatalf("expected unchanged prompt with nil context, got %q", result)
 	}
@@ -67,7 +68,7 @@ func TestInjectPipelineContext_BothKeys(t *testing.T) {
 	ctx.Set(ContextKeyHumanResponse, "user said this")
 	ctx.Set(ContextKeyLastResponse, "node said that")
 
-	result := InjectPipelineContext("Do work.", ctx)
+	result := InjectPipelineContext("Do work.", ctx, 0)
 	if !strings.Contains(result, "user said this") {
 		t.Fatalf("expected human response, got %q", result)
 	}
@@ -179,5 +180,111 @@ func TestExpandGraphVariablesSinglePass(t *testing.T) {
 	want := "value=literal $a inside flag=EXPANDED"
 	if got != want {
 		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// --- #352 item 1: cap "Previous Node Output" at injection time ---
+
+func TestInjectPipelineContext_CapsLargeLastResponse(t *testing.T) {
+	ctx := NewPipelineContext()
+	head := strings.Repeat("H", 3000)
+	middle := strings.Repeat("M", 6000)
+	tail := strings.Repeat("T", 3000)
+	ctx.Set(ContextKeyLastResponse, head+middle+tail)
+
+	result := InjectPipelineContext("Continue.", ctx, 0)
+
+	// Head and tail of the prior output survive; the middle is elided.
+	if !strings.Contains(result, strings.Repeat("H", 1000)) {
+		t.Errorf("expected head of last_response to survive capping")
+	}
+	if !strings.Contains(result, strings.Repeat("T", 1000)) {
+		t.Errorf("expected tail of last_response to survive capping")
+	}
+	if strings.Contains(result, strings.Repeat("M", 100)) {
+		t.Errorf("expected middle of last_response to be elided")
+	}
+	if !strings.Contains(result, "elided") {
+		t.Errorf("expected explicit elision marker, got %q", result[:min(len(result), 200)])
+	}
+	// The injected section is bounded: prompt + headers + cap + marker.
+	if len(result) > DefaultInjectedResponseCap+500 {
+		t.Errorf("injected prompt too large: %d bytes (cap %d)", len(result), DefaultInjectedResponseCap)
+	}
+}
+
+func TestInjectPipelineContext_SmallLastResponseUncapped(t *testing.T) {
+	ctx := NewPipelineContext()
+	ctx.Set(ContextKeyLastResponse, "short output")
+
+	result := InjectPipelineContext("Continue.", ctx, 0)
+	if !strings.Contains(result, "short output") {
+		t.Fatalf("expected full short value, got %q", result)
+	}
+	if strings.Contains(result, "elided") {
+		t.Fatalf("unexpected elision marker on small value: %q", result)
+	}
+}
+
+func TestInjectPipelineContext_ExplicitCap(t *testing.T) {
+	ctx := NewPipelineContext()
+	ctx.Set(ContextKeyLastResponse, strings.Repeat("x", 1000))
+
+	result := InjectPipelineContext("Continue.", ctx, 100)
+	if !strings.Contains(result, "elided") {
+		t.Fatalf("expected elision at explicit cap 100")
+	}
+	if len(result) > 400 {
+		t.Fatalf("expected result bounded by cap 100 plus marker/headers, got %d bytes", len(result))
+	}
+}
+
+func TestInjectPipelineContext_NegativeCapUnlimited(t *testing.T) {
+	ctx := NewPipelineContext()
+	big := strings.Repeat("y", DefaultInjectedResponseCap*3)
+	ctx.Set(ContextKeyLastResponse, big)
+
+	result := InjectPipelineContext("Continue.", ctx, -1)
+	if !strings.Contains(result, big) {
+		t.Fatalf("expected full value with negative (unlimited) cap")
+	}
+}
+
+func TestInjectPipelineContext_HumanResponseNotCapped(t *testing.T) {
+	// The cap targets last_response (transcript paste); human responses are
+	// human-typed and injected whole.
+	ctx := NewPipelineContext()
+	big := strings.Repeat("h", DefaultInjectedResponseCap*2)
+	ctx.Set(ContextKeyHumanResponse, big)
+
+	result := InjectPipelineContext("Continue.", ctx, 0)
+	if !strings.Contains(result, big) {
+		t.Fatalf("expected human_response injected whole")
+	}
+}
+
+func TestInjectPipelineContext_CapDoesNotMutateContext(t *testing.T) {
+	// The cap applies at prompt-injection time only — the stored context value
+	// (and therefore node.<id>.last_response scoping and checkpoints) keeps
+	// the full value.
+	ctx := NewPipelineContext()
+	full := strings.Repeat("z", DefaultInjectedResponseCap*2)
+	ctx.Set(ContextKeyLastResponse, full)
+
+	_ = InjectPipelineContext("Continue.", ctx, 0)
+
+	got, _ := ctx.Get(ContextKeyLastResponse)
+	if got != full {
+		t.Fatalf("injection mutated stored context: len %d, want %d", len(got), len(full))
+	}
+}
+
+func TestInjectPipelineContext_CapRespectsUTF8Boundaries(t *testing.T) {
+	ctx := NewPipelineContext()
+	ctx.Set(ContextKeyLastResponse, strings.Repeat("é", 2000))
+
+	result := InjectPipelineContext("Continue.", ctx, 101)
+	if !utf8.ValidString(result) {
+		t.Fatalf("capped injection produced invalid UTF-8")
 	}
 }


### PR DESCRIPTION
Part-addresses #352 (items 1 and 2; #352 stays open for item 3).

## What happened (case study `b68b532619c3`)

- `InjectPipelineContext` appended the entire previous node output to every full-fidelity prompt — the ~9KB Milestone-7 verification report rode into the Milestone-8 Implement prompt, and a fail report mis-anchored all three reviewers into reviewing the wrong scope.
- The single ApprovePlan "approve" was re-injected verbatim into every subsequent prompt for the rest of the run, implying sign-off on artifacts the human never saw.

## Item 1 — cap "Previous Node Output" at injection time

- **Cap shape**: head+tail truncation with an explicit elision marker (`[... tracker elided N of M bytes from the middle of this output ...]`). Head+tail, not tail-only like `ctx.tool_stdout` capture: tool output keeps the tail because routing markers print last; prose transcripts carry task framing up front and the conclusion at the end, with no routing token to protect. Cuts land on UTF-8 rune boundaries. The marker carries byte counts and the word "tracker" — it cannot collide with routing tokens a next node greps for.
- **Budget**: constant `DefaultInjectedResponseCap = 4096` bytes (case-study harm started at ~7–14KB per prompt). One override knob: per-node `injection_cap` attr (reachable today via dippin `params:` pass-through). `0`/absent → default; negative → unlimited; malformed → the node fails loudly (strict raw-attr parse, deliberately not in the permissive `AgentNodeConfig`).
- **Scope**: applies only to `last_response` ("Previous Node Output"). `human_response` is human-typed and injected whole (pinned by test). Only the `FidelityFull` path changes — compaction (`CompactContextWithPinnedKeys`) is untouched.
- **Stored context keeps the full value**: the cap is at prompt-injection time only; `node.<id>.last_response` scoping and checkpoints carry the full value (pinned by test).

## Item 2 — human_response is one-shot

- **Semantics chosen**: cleared after the FIRST node that consumed it (not expire-at-next-gate). ApprovePlan's "approve" legitimately informs the immediate next node (Decompose reads it); milestone-loop nodes hours later must not see it. "Consumed" = a `codergen` or `parallel` node completed while the response was visible — both feed pctx into LLM prompts (parallel resolves each branch's prompt the same way), and both compaction fidelities include `human_response` via `mediumKeys`, so the clear is fidelity-independent. `subgraph`/`stack.manager_loop` run nested engines with their own contexts and are not consumers.
- **Hook is engine-side** (`processActiveNode`), after the retry check — a retrying node re-executes and still sees the response; a node that completed (success OR fail — a failed consumer still consumed) clears it. `ResolvePrompt` stays read-only (parallel branches share pctx).
- **Empty-set, not Delete**: `PipelineContext` deliberately gains no Delete. Both injection paths (`InjectPipelineContext` and `prependContextSummary`) skip empty values, and an empty value round-trips through checkpoint snapshots — so a resumed run cannot resurrect the stale response (pinned by a resume test). A real Delete would complicate the dirty-set/ScopeToNode contract for no behavioral gain, and a missing key is indistinguishable from never-set in audit trails; an empty value says "was here, consumed".
- **No scope pollution**: the clear uses `MergeWithoutDirty`, so it is never misattributed to a node's `node.<id>.*` namespace; the gate's own `node.<gateID>.human_response` scoped copy retains the full value for pipelines that want to reference it explicitly. A value-compare guard means a consuming node that itself writes a fresh `human_response` via `ContextUpdates` is not clobbered.

## Item 3 — deliberately not here

The transform-level fix (fenced rendering of interpolated tool stdout) changes expansion semantics for every workflow; the surgical .dip-side fix (wrap `${ctx.tool_stdout}` interpolations in fenced blocks) lands with the #350 PR, which already touches `build_product.dip`. #352 stays open ("part-addresses").

## Verification

- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- `go test ./... -short` — pass
- `go test -race -short ./pipeline/...` — pass
- `dippin doctor` (run separately): ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 — held
- New tests: 7 injection-cap tests (incl. no-mutation pin, UTF-8 boundaries), 3 ResolvePrompt knob tests (incl. malformed-fails-loudly), 6 engine one-shot tests (incl. retry survival, fresh-write guard, parallel consumer, checkpoint-resume persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783875623&installation_id=131176874&pr_number=370&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F370&signature=7d024b03dfd392e26eb1617e4b806465ed90ed96811a3135f3f2520ace710816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->