### PR TITLE
feat(examples): structural existence gate before the review fan-out (#350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **build_product: structural existence gate before the review fan-out**
+  (issue #350). In case-study run b68b532619c3 the final milestone shipped
+  empty (`cmd/goblin/` never created) and TestMilestone's `go test ./...`
+  sentinel is blind to absent packages, so the pipeline spent ~$10 and 32
+  minutes of review fan-out rediscovering a missing directory. A new
+  sub-second `CheckMilestoneOutputs` tool node now reconciles the outputs
+  Decompose declared (per-milestone `**Files**:` lines in milestones.md)
+  against the disk before any reviewer token is spent, on BOTH fan-out
+  entries (the all-done path and the capped re-review restart loop). It
+  fails on missing declared output directories or a broken `go build ./...`
+  (Go stacks; other stacks get existence checks only), routing to the
+  operator-recoverable EscalateMilestone gate; missing files alone are
+  warnings, not failures — Decompose Files lists legitimately include files
+  to delete. Parsing follows the LLM-written-file rules: flexible header
+  regex, blank stripping, loud empty/garbled guards, tokens used only in
+  quoted existence tests. The superspec variant has its own per-phase
+  verification gates and a different declared-outputs shape; it is
+  deliberately not changed here. VerifyMilestone and FinalSpecCheck also
+  now receive interpolated tool stdout as a delimited fenced block under
+  its own heading instead of mid-sentence (#352 item 3, .dip-side).
+
 - **Runtime-facts block injected into every codergen prompt** (issue #347).
   Every agent prompt is now prefixed with a machine-written `# Runtime`
   section stating the absolute working directory ("all commands already run

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1442,6 +1442,16 @@ workflow BuildProduct
         esac
         CHECKED=$((CHECKED + 1))
         case "$tok" in
+          */)
+            # Trailing slash declares the DIRECTORY itself (e.g. cmd/goblin/)
+            # — its absence is the structural failure class, not a file-level
+            # warning, even when the parent dir exists.
+            DIR="${tok%/}"
+            if [ ! -d "$DIR" ]; then
+              MISSING_DIRS="$MISSING_DIRS $DIR"
+            fi
+            continue
+            ;;
           */*)
             DIR=$(dirname "$tok")
             if [ ! -d "$DIR" ]; then

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1018,7 +1018,8 @@ workflow BuildProduct
 
       TestMilestone already handled the language-stack tests AND the
       project CI gate (issue #233 Gap 1), so the verifier does NOT
-      need to re-run them. Note that `${ctx.tool_stdout}` is the
+      need to re-run them. Note that the "TestMilestone stdout" fenced
+      block at the END of this prompt is the
       tail of TestMilestone's stdout (64KB cap by default); on a
       repo with verbose test output the language-test lines may be
       elided entirely. The authoritative success signal is the
@@ -1135,8 +1136,9 @@ workflow BuildProduct
          when present; if it disagrees with a live SPEC.md re-read, SPEC.md
          wins.
 
-      6. TESTS + CI PASSED: The `tests-pass` sentinel in
-         ${ctx.tool_stdout} is authoritative for "TestMilestone step
+      6. TESTS + CI PASSED: The `tests-pass` sentinel in the
+         "TestMilestone stdout" fenced block at the END of this
+         prompt is authoritative for "TestMilestone step
          succeeded" — TestMilestone prints it when its language-stack
          runner passed-or-was-validly-skipped AND its project CI gate
          passed (a Makefile target OR the language-native gates, #299)
@@ -1208,6 +1210,16 @@ workflow BuildProduct
       If every check passes: STATUS:success
       If any check fails, describe exactly what failed (with the
       file:line, grep output, or failing assertion) and: STATUS:fail
+
+      ---
+      ## TestMilestone stdout
+
+      Tail of TestMilestone's stdout, 64KB cap. Delimited here under its
+      own heading (#352 item 3) — never interpolated mid-sentence.
+
+      ```text
+      ${ctx.tool_stdout}
+      ```
 
   tool MarkMilestoneDone
     label: "Mark Milestone Complete"
@@ -1337,6 +1349,155 @@ workflow BuildProduct
       green-but-uncommitted tree. (issue #297)
 
   # ─── Phase 3: Cross-Review ─────────────────────────────────
+
+  # Structural existence gate (issue #350). TestMilestone's `go test ./...`
+  # sentinel is blind to ABSENT packages — a package that was never created
+  # produces no failing tests, so a silently-skipped milestone sails into the
+  # review fan-out, where (case study b68b532619c3) five agents spent ~$10 and
+  # 32 minutes independently running `ls cmd/goblin` to rediscover that the
+  # final milestone shipped empty. This sub-second gate reconciles the outputs
+  # Decompose DECLARED (the per-milestone **Files**: lines in milestones.md)
+  # against what is ON DISK, before any reviewer token is spent. It guards
+  # BOTH entries to the review fan-out: the all-done path from
+  # PickNextMilestone and the capped re-review restart loop (ApplyReviewFixes
+  # can delete or move declared outputs too).
+  #
+  # Failure granularity (the deletion caveat): Decompose's Files lists include
+  # files to DELETE — destructive work is its own milestone by the Decompose
+  # rules — so a missing FILE may be a legitimate deletion, not a skipped
+  # milestone. File-level misses are therefore reported as warnings only.
+  # The gate FAILS on the structural class: a declared output DIRECTORY that
+  # does not exist (cmd/goblin/ never created — the actual #350 case), or a
+  # broken `go build ./...` on a Go stack. Failure routes to the
+  # EscalateMilestone HUMAN gate — a false positive (e.g. a whole declared
+  # directory legitimately removed) costs the operator one glance, while the
+  # silent skip it prevents costs the full review fan-out.
+  #
+  # Stack detection mirrors ci-probe (go.mod / package.json / pyproject.toml /
+  # Cargo.toml): Go gets `go build ./...` on top of the existence checks;
+  # other stacks get the existence checks only (sub-second contract — their
+  # build/test gates already ran in TestMilestone and run again in FinalBuild).
+  # The milestones.md parse follows the CLAUDE.md LLM-written-file rules:
+  # flexible header regex, blank-line stripping, empty-extraction guard that
+  # fails loudly, and the extracted tokens are only ever used in quoted
+  # `[ -d ]` / `[ -e ]` tests — never eval'd, never interpolated into a command.
+  tool CheckMilestoneOutputs
+    label: "Check Declared Milestone Outputs Exist"
+    timeout: 300s
+    command:
+      set -eu
+      PLAN=".ai/decisions/milestones.md"
+      mkdir -p .ai/build
+
+      if [ ! -s "$PLAN" ]; then
+        echo "ERROR: $PLAN missing or empty — cannot reconcile declared milestone outputs (#350)"
+        echo "Decompose writes per-milestone '**Files**:' lines there; without them this gate has no declaration to check."
+        printf 'outputs-missing'
+        exit 1
+      fi
+
+      # Extract the **Files**: declarations. LLM-written file: headers vary
+      # ("**Files**:", "Files:", "- **Files:** ..."), and the list may be
+      # inline on the header line or a bulleted block underneath it. A blank
+      # or non-bullet line ends a block.
+      awk '
+        /^[[:space:]]*[-*]?[[:space:]]*\*{0,2}[Ff]iles\*{0,2}[[:space:]]*:/ {
+          infiles = 1
+          line = $0
+          sub(/^[^:]*:[[:space:]]*/, "", line)
+          if (length(line) > 0) print line
+          next
+        }
+        infiles && /^[[:space:]]*[-*+][[:space:]]/ { print; next }
+        { infiles = 0 }
+      ' "$PLAN" > .ai/build/declared-files.raw
+
+      if [ ! -s .ai/build/declared-files.raw ]; then
+        echo "ERROR: no '**Files**:' lines found in $PLAN — the Decompose output contract was violated (#350)"
+        echo "First 30 lines of the plan for diagnosis:"
+        head -30 "$PLAN"
+        printf 'outputs-missing'
+        exit 1
+      fi
+
+      # Tokenize: split on commas/whitespace, strip markdown decoration
+      # (backticks, brackets, parens, bold markers), leading ./ and bullet
+      # dashes, trailing punctuation. Blank lines dropped per CLAUDE.md.
+      tr -s ',[:space:]' '\n' < .ai/build/declared-files.raw | \
+        sed -E 's/[][`*()"]//g; s/^-+//; s/^\.\///; s/[.:;]+$//' | \
+        grep -v '^[[:space:]]*$' > .ai/build/declared-files.list || true
+
+      MISSING_DIRS=""
+      MISSING_FILES=""
+      CHECKED=0
+      while IFS= read -r tok; do
+        # Path heuristic: keep tokens with a directory separator or a dotted
+        # filename; drop prose words. Skip absolute / home-anchored / parent-
+        # escaping tokens outright — declared outputs are repo-relative, and
+        # these must never re-anchor an existence check outside the workdir.
+        case "$tok" in
+          ''|/*|~*|*..*) continue ;;
+          */*|*.*) ;;
+          *) continue ;;
+        esac
+        CHECKED=$((CHECKED + 1))
+        case "$tok" in
+          */*)
+            DIR=$(dirname "$tok")
+            if [ ! -d "$DIR" ]; then
+              MISSING_DIRS="$MISSING_DIRS $DIR"
+              continue
+            fi
+            ;;
+        esac
+        if [ ! -e "$tok" ]; then
+          MISSING_FILES="$MISSING_FILES $tok"
+        fi
+      done < .ai/build/declared-files.list
+
+      if [ "$CHECKED" -eq 0 ]; then
+        echo "ERROR: Files lines exist in $PLAN but yielded zero path-like tokens — extraction is garbled (#350)"
+        echo "Raw extracted declarations:"
+        cat .ai/build/declared-files.raw
+        printf 'outputs-missing'
+        exit 1
+      fi
+
+      # Go stack: a declared package that exists but doesn't compile is as
+      # structurally absent as a missing directory. Detection mirrors
+      # ci-probe's go.mod check. Other stacks' build gates already ran in
+      # TestMilestone and run again in FinalBuild — re-running them here
+      # would break the sub-second contract for no new signal.
+      BUILD_FAIL=0
+      if [ -f go.mod ]; then
+        echo "--- go build ./... (structural gate, #350) ---"
+        go build ./... 2>&1 || BUILD_FAIL=$?
+      fi
+
+      if [ -n "$MISSING_DIRS" ] || [ "$BUILD_FAIL" -ne 0 ]; then
+        if [ -n "$MISSING_DIRS" ]; then
+          echo "ERROR: declared milestone output directories are MISSING from disk:"
+          for d in $MISSING_DIRS; do echo "  - $d"; done | sort -u
+        fi
+        if [ "$BUILD_FAIL" -ne 0 ]; then
+          echo "ERROR: go build ./... failed (exit $BUILD_FAIL) — see output above"
+        fi
+        if [ -n "$MISSING_FILES" ]; then
+          echo "Declared files also not on disk (these alone would not fail the gate — may be legitimate deletions):"
+          for f in $MISSING_FILES; do echo "  - $f"; done
+        fi
+        echo "A declared milestone output is structurally absent. Escalating BEFORE the review fan-out spends reviewer tokens (#350)."
+        printf 'outputs-missing'
+        exit 1
+      fi
+
+      if [ -n "$MISSING_FILES" ]; then
+        echo "WARNING: declared files not on disk (NOT failing — Decompose Files lists include files to delete, and destructive milestones are expected):"
+        for f in $MISSING_FILES; do echo "  - $f"; done
+        echo "Directory-level structure and the build are intact; a reviewer can disposition these in context."
+      fi
+      echo "structural existence gate passed: $CHECKED declared path tokens reconciled"
+      printf 'outputs-present'
 
   tool ClearStaleReviews
     label: "Clear Stale Review Reports"
@@ -1859,7 +2020,8 @@ workflow BuildProduct
         are expected outputs, never "extras".)
       - No TODO/FIXME/HACK comments added
       - All "throw away" items from the spec were actually removed
-      - Tests pass (check ${ctx.tool_stdout})
+      - Tests pass (check the "FinalBuild stdout" fenced block at the
+        END of this prompt)
 
       Write the final compliance report to .ai/decisions/compliance.md
 
@@ -1872,6 +2034,16 @@ workflow BuildProduct
       passed. Otherwise the early `STATUS:fail` from your first
       line stays in place. The parser requires `STATUS:<value>` on
       its own line, no leading characters, no fences/tables.
+
+      ---
+      ## FinalBuild stdout
+
+      Tail of FinalBuild's stdout, 64KB cap. Delimited here under its
+      own heading (#352 item 3) — never interpolated mid-sentence.
+
+      ```text
+      ${ctx.tool_stdout}
+      ```
 
   human OperatorDecision
     label: "Agent hit its turn limit mid-progress — pick how to proceed"
@@ -2021,8 +2193,24 @@ workflow BuildProduct
 
     # Build loop: pick → implement → test → verify → mark done → pick next
     PickNextMilestone -> Implement  when ctx.tool_stdout not contains all-done
-    PickNextMilestone -> ClearStaleReviews  when ctx.tool_stdout contains all-done
+    PickNextMilestone -> CheckMilestoneOutputs  when ctx.tool_stdout contains all-done
     PickNextMilestone -> EscalateMilestone
+    # #350 structural existence gate: declared milestone outputs must be on
+    # disk (and `go build ./...` green on a Go stack) before the expensive
+    # review fan-out. Routes on the end-of-stdout markers (printed LAST via
+    # printf, so they survive tail-capture by construction). Fail routes to
+    # the operator-recoverable EscalateMilestone gate, NOT back into a fix
+    # loop: a missing-deleted-dir false positive must cost one human glance,
+    # never an auto-fail loop. The unconditional fallback catches a gate run
+    # that crashed before printing either marker (timeout, set -eu abort) —
+    # same anomaly posture as PickNextMilestone's fallback above.
+    # outputs-missing is evaluated FIRST: the gate's failure diagnostics echo
+    # LLM-written plan content, which could conceivably contain the literal
+    # "outputs-present" — with fail checked first, a both-markers stdout
+    # escalates to the human gate instead of silently passing.
+    CheckMilestoneOutputs -> EscalateMilestone  when ctx.tool_stdout contains outputs-missing
+    CheckMilestoneOutputs -> ClearStaleReviews  when ctx.tool_stdout contains outputs-present
+    CheckMilestoneOutputs -> EscalateMilestone
     Implement -> CommitIfDirty  when ctx.outcome = success
     # #318: a steady-progress turn breach (verify ran but wasn't green, no loop)
     # routes to the operator-decision gate. Narrow `= operator_decision` so a
@@ -2101,7 +2289,10 @@ workflow BuildProduct
     # escalates to a human.
     ApplyReviewFixes -> CheckReviewFixBudget  when ctx.outcome = success
     ApplyReviewFixes -> EscalateReview
-    CheckReviewFixBudget -> ClearStaleReviews  when ctx.outcome = success  restart: true
+    # #350: the re-review restart loop ALSO passes through the structural
+    # gate — ApplyReviewFixes can delete or move declared outputs, and the
+    # gate is sub-second.
+    CheckReviewFixBudget -> CheckMilestoneOutputs  when ctx.outcome = success  restart: true
     CheckReviewFixBudget -> EscalateReview  when ctx.outcome = fail
 
     # Final verification

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -238,8 +238,8 @@ func TestBuildProductIssue303GreenBreachRescuePath(t *testing.T) {
 func TestBuildProductIssue313ReviewGate(t *testing.T) {
 	g := loadBuildProduct(t)
 
-	// Both guards are tool nodes.
-	for _, id := range []string{"CheckReviewsComplete", "ClearStaleReviews"} {
+	// All three guards are tool nodes (CheckMilestoneOutputs joined in #350).
+	for _, id := range []string{"CheckReviewsComplete", "ClearStaleReviews", "CheckMilestoneOutputs"} {
 		n, ok := g.Nodes[id]
 		if !ok {
 			t.Fatalf("%s node missing from build_product.dip (issue #313)", id)
@@ -263,27 +263,45 @@ func TestBuildProductIssue313ReviewGate(t *testing.T) {
 		t.Error("CheckReviewsComplete has no `ctx.outcome = fail` edge to EscalateReview — a missing review would not escalate (issue #313)")
 	}
 
-	// Pre-fan-out clear: both inbound paths to ReviewParallel go through ClearStaleReviews.
+	// Pre-fan-out guards: both inbound paths to ReviewParallel pass through
+	// the #350 structural existence gate (CheckMilestoneOutputs) and then
+	// ClearStaleReviews. The #313 invariant — stale reports cleared on BOTH
+	// entries — is preserved with the gate prepended.
 	if !hasUnconditionalEdgeTo(g, "ClearStaleReviews", "ReviewParallel") {
 		t.Error("ClearStaleReviews has no edge to ReviewParallel (issue #313)")
 	}
-	if !hasEdgeWithCondition(g, "PickNextMilestone", "ClearStaleReviews", "ctx.tool_stdout contains all-done") {
-		t.Error("PickNextMilestone all-done edge must enter ClearStaleReviews before ReviewParallel (issue #313)")
+	if !hasEdgeWithCondition(g, "PickNextMilestone", "CheckMilestoneOutputs", "ctx.tool_stdout contains all-done") {
+		t.Error("PickNextMilestone all-done edge must enter CheckMilestoneOutputs before the review fan-out (issue #350)")
 	}
-	if !hasEdgeWithCondition(g, "CheckReviewFixBudget", "ClearStaleReviews", "ctx.outcome = success") {
-		t.Error("CheckReviewFixBudget re-review edge must enter ClearStaleReviews before ReviewParallel (issue #313)")
+	if !hasEdgeWithCondition(g, "CheckReviewFixBudget", "CheckMilestoneOutputs", "ctx.outcome = success") {
+		t.Error("CheckReviewFixBudget re-review edge must enter CheckMilestoneOutputs before the review fan-out (issue #350)")
 	}
-	// The re-review edge moved from CheckReviewFixBudget->ReviewParallel to
-	// ->ClearStaleReviews; pin restart:true so a future edit can't drop the loop
-	// semantics (which would also stop clearing stale reports each pass).
-	if !hasEdgeAttr(g, "CheckReviewFixBudget", "ClearStaleReviews", "ctx.outcome = success", "restart", "true") {
-		t.Error("CheckReviewFixBudget -> ClearStaleReviews must keep restart: true (issue #313)")
+	// The re-review edge carries the restart loop; pin restart:true so a future
+	// edit can't drop the loop semantics (which would also stop clearing stale
+	// reports each pass).
+	if !hasEdgeAttr(g, "CheckReviewFixBudget", "CheckMilestoneOutputs", "ctx.outcome = success", "restart", "true") {
+		t.Error("CheckReviewFixBudget -> CheckMilestoneOutputs must keep restart: true (issues #313/#350)")
+	}
+	// Gate routing (#350): success marker proceeds to ClearStaleReviews; the
+	// missing marker escalates to the operator-recoverable human gate — never
+	// an auto-fail loop (a declared deletion can false-positive).
+	if !hasEdgeWithCondition(g, "CheckMilestoneOutputs", "ClearStaleReviews", "ctx.tool_stdout contains outputs-present") {
+		t.Error("CheckMilestoneOutputs has no outputs-present edge to ClearStaleReviews (issue #350)")
+	}
+	if !hasEdgeWithCondition(g, "CheckMilestoneOutputs", "EscalateMilestone", "ctx.tool_stdout contains outputs-missing") {
+		t.Error("CheckMilestoneOutputs has no outputs-missing edge to EscalateMilestone — a structurally absent milestone would not escalate (issue #350)")
 	}
 	if hasEdgeTo(g, "PickNextMilestone", "ReviewParallel") {
-		t.Error("PickNextMilestone still routes directly to ReviewParallel; it must clear stale reviews first (issue #313)")
+		t.Error("PickNextMilestone still routes directly to ReviewParallel; it must pass the existence gate and clear stale reviews first (issues #313/#350)")
 	}
 	if hasEdgeTo(g, "CheckReviewFixBudget", "ReviewParallel") {
-		t.Error("CheckReviewFixBudget still routes directly to ReviewParallel; it must clear stale reviews first (issue #313)")
+		t.Error("CheckReviewFixBudget still routes directly to ReviewParallel; it must pass the existence gate and clear stale reviews first (issues #313/#350)")
+	}
+	if hasEdgeTo(g, "PickNextMilestone", "ClearStaleReviews") {
+		t.Error("PickNextMilestone still routes directly to ClearStaleReviews; the #350 gate must run first")
+	}
+	if hasEdgeTo(g, "CheckReviewFixBudget", "ClearStaleReviews") {
+		t.Error("CheckReviewFixBudget still routes directly to ClearStaleReviews; the #350 gate must run first")
 	}
 }
 


### PR DESCRIPTION
Closes #350. Also lands #352 item 3 (.dip-side fencing) — #352 itself stays open per PR #370's part-addressing.

## What happened (case study `b68b532619c3`)

The final milestone shipped empty (`cmd/goblin/` never created) and `TestMilestone`'s `go test ./...` sentinel is structurally blind to absent packages, so the pipeline proceeded into the expensive tail: ~$10 and 32 minutes across five agents, each of which independently ran `ls cmd/goblin` as its first move.

## The gate

New `CheckMilestoneOutputs` tool node between `PickNextMilestone`'s all-done path and `ClearStaleReviews`, reconciling what Decompose **declared** (per-milestone `**Files**:` lines in `.ai/decisions/milestones.md`) against what is **on disk**, before any reviewer token is spent.

**Failure granularity — the deletion caveat (design choice):** Decompose's Files lists include files to DELETE (destructive work is its own milestone by the Decompose rules), so a missing *file* may be a legitimate deletion, not a skipped milestone. The gate therefore:
- **FAILS** on the structural class: a declared output *directory* missing from disk (the actual #350 case — `dirname` of each declared path, not just the top-level segment, so `cmd/goblin/` absent is caught even when `cmd/` exists), or a broken `go build ./...` on a Go stack.
- **WARNS only** on file-level misses, listing them for the reviewer/operator. A file-level hard-fail would false-positive on every build with a deletion milestone — which this workflow explicitly encourages.
- Failure routes to the **EscalateMilestone human gate** (operator-recoverable: mark done / retry / accept / abandon), never an auto-fail loop — a whole-directory-deletion false positive costs one human glance; the silent skip it prevents costs the full review fan-out.

**Stack detection** mirrors ci-probe (`go.mod` / `package.json` / `pyproject.toml` / `Cargo.toml`): Go gets `go build ./...` on top of existence checks; other stacks get existence checks only (sub-second contract — their build/test gates ran in TestMilestone and run again in FinalBuild). Deviation from the issue's `go list ./...` idea, stated: dirname-on-disk + `go build` covers the same absence class without false-failing a package whose declared `.go` files were all legitimately deleted; `go build` is the compile-level superset.

**LLM-written-file rules** (CLAUDE.md): flexible header regex (`**Files**:` / `Files:` / bulleted variants, inline or block list), blank-line stripping, loud guards (missing/empty plan, zero Files lines, zero path-like tokens each fail with diagnostics), and extracted tokens are only ever used in quoted `[ -d ]` / `[ -e ]` tests — never eval'd, never interpolated into a command. Absolute / `~` / parent-escaping tokens are skipped outright.

**Routing**: end-of-stdout markers printed LAST via `printf` (tail-capture safe). `outputs-missing` is evaluated **first**: failure diagnostics echo LLM-written plan content which could conceivably contain the literal `outputs-present`; with fail checked first a both-markers stdout escalates instead of silently passing. Unconditional fallback to EscalateMilestone catches a marker-less crash (same anomaly posture as PickNextMilestone's fallback). Initially wired as a `ctx.outcome` success/fail pair — switched to stdout markers because that's the house style doctor's coverage check expects (the outcome pair dropped build_product to B/80; markers restore A/90).

**Both fan-out entries are gated**: `PickNextMilestone --all-done-->` and the capped re-review restart loop (`CheckReviewFixBudget`, `restart: true` preserved) — ApplyReviewFixes can delete or move declared outputs too. The #313 pinned-routing test is updated to the new shape (its invariant — stale reports cleared on both entries — is preserved with the gate prepended; the updated test fails against the old .dip).

**Superspec variant — note only**: `build_product_with_superspec.dip` has no milestone loop or `milestones.md`; its declared outputs live in per-stream specs and every phase already has its own merge+gate verification before `MergePhase5 -> ReviewParallel`. An equivalent gate there needs a different declared-outputs source; deliberately not changed in this PR.

## #352 item 3 (.dip-side fencing)

`VerifyMilestone` (2 sites) and `FinalSpecCheck` (1 site) interpolated `${ctx.tool_stdout}` mid-sentence, garbling their own instruction text with 15-line test logs. The interpolation now lives in a delimited ` ```text ` block under its own heading at the END of each prompt; the inline sentences reference the block. The transform-level variant stays out of scope (changes expansion semantics for every workflow).

## Verification

- Gate shell logic executed standalone in scratch repos (byte-identical script): happy path ✅, missing package (`cmd/goblin` removed → fail) ✅, deleted file in existing dir (warn, pass) ✅, broken `go build` (fail) ✅, empty milestones.md (loud fail) ✅, no Files lines (loud fail) ✅, prose-only Files line (loud fail) ✅, bulleted Files block on a non-Go stack (pass) ✅, absolute/`..` tokens skipped ✅
- `dippin doctor` (run separately): ask_and_execute A/95, build_product A/90, build_product_with_superspec A/100 — held (the one remaining "uncovered outputs" partial is the pre-existing CheckReviewFixBudget)
- `dippin simulate -all-paths` on both variants: all enumerated paths terminate. Note: the simulator caps at 100 paths (baseline main also enumerates exactly 100), so the gate's fail edge isn't in the enumeration — it targets EscalateMilestone, which the enumeration enters 40× with all four labeled routes terminating
- `go build ./...` + `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- `go test ./... -short` — pass (incl. the updated #313 routing test, now also pinning the gate's edges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783876617&installation_id=131176874&pr_number=371&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F371&signature=8a1ba01add568384fb2f9b859bad9506259295c8b27bf28876f924b09b60b243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->