### PR TITLE
fix(engine): stop logging every llm event twice in activity.jsonl (#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **activity.jsonl no longer logs every llm event twice** (issue #354). The
+  same LLM stream was written by two independent observers — the client-level
+  trace observer (short kinds: `request_start`, `text`, `finish`,
+  `provider_raw`, under source `llm`) and the agent session's re-emission
+  (`llm_request_start`, `llm_text`, …, under source `agent`) — doubling
+  ~92% of a 32MB / 207k-line case-study log. Trace events from requests
+  carrying request-level observers (i.e. agent sessions) are now stamped
+  `SessionOwned` and skipped by the client-level activity-log writer, so
+  session calls log once via the `llm_*` agent family while non-session
+  calls (e.g. the autopilot interviewer, which has no agent path) keep
+  logging via the trace path. Additionally, raw provider streaming chunks
+  (`provider_raw` / `llm_provider_raw` — per-token debugging payload that
+  dominated the census) are only captured in activity.jsonl under
+  `--verbose`. Diagnose continues to parse pre-existing doubled logs
+  unchanged (pinned by fixture test).
+
 ## [0.39.0] - 2026-06-12
 
 ### Added

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -223,6 +223,9 @@ func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool
 	}
 	activityLog := pipeline.NewJSONLEventHandler(artifactDir)
 	defer activityLog.Close()
+	// Raw provider streaming chunks are debugging payload — only capture
+	// them in the activity log under --verbose (#354).
+	activityLog.SetCaptureRawLLM(verbose)
 	// Stamp the .dipx bundle identity on agent/llm JSONL writes too —
 	// these bypass HandlePipelineEvent (and therefore Engine.emit and the
 	// registry's BundleIdentityStamper). Empty identity is a no-op for
@@ -293,12 +296,24 @@ func emitForcedBundleMismatch(activityLog *pipeline.JSONLEventHandler, info resu
 	activityLog.WriteBundleMismatchForced(info.RunID, info.OriginalIdentity, info.CurrentIdentity)
 }
 
+// llmTraceLogObserver returns the client-level trace → activity log writer.
+// Session-owned events are skipped: the agent session re-emits those as
+// llm_* agent events which reach the log via WriteAgentEvent, so writing
+// them here would log the same stream twice (#354). Non-session calls
+// (e.g. the autopilot interviewer) have no agent path and are kept.
+func llmTraceLogObserver(activityLog *pipeline.JSONLEventHandler) llm.TraceObserverFunc {
+	return func(evt llm.TraceEvent) {
+		if evt.SessionOwned {
+			return
+		}
+		activityLog.WriteLLMEvent(string(evt.Kind), evt.Provider, evt.Model, evt.ToolName, evt.Preview)
+	}
+}
+
 // wireLLMTraceToLog registers a trace observer that writes LLM events to the activity log.
 func wireLLMTraceToLog(llmClient *llm.Client, activityLog *pipeline.JSONLEventHandler) {
 	if llmClient != nil {
-		llmClient.AddTraceObserver(llm.TraceObserverFunc(func(evt llm.TraceEvent) {
-			activityLog.WriteLLMEvent(string(evt.Kind), evt.Provider, evt.Model, evt.ToolName, evt.Preview)
-		}))
+		llmClient.AddTraceObserver(llmTraceLogObserver(activityLog))
 	}
 }
 
@@ -632,6 +647,9 @@ func setupTUIProgram(graph *pipeline.Graph, subgraphs map[string]*pipeline.Graph
 
 	prog := tea.NewProgram(appModel, tea.WithAltScreen())
 	activityLog := pipeline.NewJSONLEventHandler(artifactDir)
+	// Raw provider streaming chunks are debugging payload — only capture
+	// them in the activity log under --verbose (#354).
+	activityLog.SetCaptureRawLLM(verbose)
 	return prog, store, activityLog, nil
 }
 
@@ -665,11 +683,12 @@ func formatParamOverridesForSummary(params map[string]string) string {
 // buildTUIPipelineHandler wires LLM trace events to TUI+activity log and returns the combined handler.
 func buildTUIPipelineHandler(prog *tea.Program, activityLog *pipeline.JSONLEventHandler, verbose bool, llmClient *llm.Client) pipeline.PipelineEventHandler {
 	if llmClient != nil {
+		logObserver := llmTraceLogObserver(activityLog)
 		llmClient.AddTraceObserver(llm.TraceObserverFunc(func(evt llm.TraceEvent) {
 			for _, m := range tui.AdaptLLMTraceEvent(evt, "", verbose) {
 				prog.Send(m)
 			}
-			activityLog.WriteLLMEvent(string(evt.Kind), evt.Provider, evt.Model, evt.ToolName, evt.Preview)
+			logObserver(evt)
 		}))
 	}
 	// PipelineAdapter is stateful (accumulates EventValidationOverridden so the

--- a/cmd/tracker/run_trace_log_test.go
+++ b/cmd/tracker/run_trace_log_test.go
@@ -1,0 +1,57 @@
+// ABOUTME: Tests for the client-level LLM trace → activity log observer (#354).
+// ABOUTME: Session-owned events are skipped (agent llm_* path already logs them).
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestLLMTraceLogObserver_SkipsSessionOwnedEvents(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TRACKER_AUDIT_DIR", filepath.Join(dir, "secure"))
+	activityLog := pipeline.NewJSONLEventHandler(dir)
+	activityLog.HandlePipelineEvent(pipeline.PipelineEvent{
+		Type:      pipeline.EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "trace1",
+	})
+
+	observer := llmTraceLogObserver(activityLog)
+
+	// Session-owned: the agent session re-emits this as an llm_* agent
+	// event, so the trace path must not write a duplicate line.
+	observer(llm.TraceEvent{Kind: llm.TraceText, Provider: "anthropic", Model: "m", Preview: "dup", SessionOwned: true})
+	// Non-session (e.g. autopilot interviewer): the trace path is the
+	// only log surface — must be written.
+	observer(llm.TraceEvent{Kind: llm.TraceText, Provider: "anthropic", Model: "m", Preview: "kept"})
+	if err := activityLog.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "trace1", "activity.jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines (pipeline + 1 llm), got %d:\n%s", len(lines), data)
+	}
+	var entry struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal([]byte(lines[1]), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry.Type != "text" || entry.Content != "kept" {
+		t.Errorf("logged entry = %+v, want type=text content=kept", entry)
+	}
+}

--- a/llm/client.go
+++ b/llm/client.go
@@ -284,12 +284,17 @@ func (c *Client) completeWithTrace(ctx context.Context, req *Request, adapter Pr
 	})
 	acc := NewStreamAccumulator()
 
+	// Request-level observers mean an agent session will re-emit these
+	// trace events as agent llm_* events; stamp SessionOwned so
+	// client-level log writers can skip them (#354).
+	sessionOwned := len(req.TraceObservers) > 0
+
 	for evt := range adapter.Stream(ctx, streamReq) {
 		if evt.Err != nil {
 			flushTraceObservers(observers)
 			return nil, evt.Err
 		}
-		processAndNotify(traceBuilder, observers, evt)
+		processAndNotify(traceBuilder, observers, evt, sessionOwned)
 		acc.Process(evt)
 	}
 
@@ -309,11 +314,14 @@ func flushTraceObservers(observers []TraceObserver) {
 	}
 }
 
-// processAndNotify processes a stream event through the trace builder and notifies observers.
-func processAndNotify(traceBuilder *TraceBuilder, observers []TraceObserver, evt StreamEvent) {
+// processAndNotify processes a stream event through the trace builder and
+// notifies observers. sessionOwned is stamped onto each emitted trace event —
+// see TraceEvent.SessionOwned.
+func processAndNotify(traceBuilder *TraceBuilder, observers []TraceObserver, evt StreamEvent, sessionOwned bool) {
 	before := len(traceBuilder.events)
 	traceBuilder.Process(evt)
 	for _, traceEvt := range traceBuilder.events[before:] {
+		traceEvt.SessionOwned = sessionOwned
 		notifyTraceObservers(observers, traceEvt)
 	}
 }

--- a/llm/client_trace_test.go
+++ b/llm/client_trace_test.go
@@ -1,0 +1,85 @@
+// ABOUTME: Tests for client-level trace observer behavior, including SessionOwned
+// ABOUTME: stamping that lets log writers dedup session-re-emitted llm events (#354).
+package llm
+
+import (
+	"context"
+	"testing"
+)
+
+// streamingMockEvents is a minimal stream that produces request_start, text,
+// finish, and (verbose) provider_raw trace events.
+func streamingMockEvents() []StreamEvent {
+	return []StreamEvent{
+		{Type: EventStreamStart},
+		{Type: EventTextDelta, Delta: "hello"},
+		{Type: EventFinish, FinishReason: &FinishReason{Reason: "stop"}},
+	}
+}
+
+func TestClientTraceEvents_NotSessionOwnedWithoutRequestObservers(t *testing.T) {
+	adapter := &mockAdapter{name: "alpha", events: streamingMockEvents()}
+	client, err := NewClient(WithProvider(adapter), WithDefaultProvider("alpha"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer client.Close()
+
+	var seen []TraceEvent
+	client.AddTraceObserver(TraceObserverFunc(func(evt TraceEvent) {
+		seen = append(seen, evt)
+	}))
+
+	if _, err := client.Complete(context.Background(), &Request{
+		Model:    "m",
+		Messages: []Message{UserMessage("hi")},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(seen) == 0 {
+		t.Fatal("expected client-level observer to receive trace events")
+	}
+	for _, evt := range seen {
+		if evt.SessionOwned {
+			t.Errorf("event %s: SessionOwned = true for request without request-level observers", evt.Kind)
+		}
+	}
+}
+
+func TestClientTraceEvents_SessionOwnedWithRequestObservers(t *testing.T) {
+	adapter := &mockAdapter{name: "alpha", events: streamingMockEvents()}
+	client, err := NewClient(WithProvider(adapter), WithDefaultProvider("alpha"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer client.Close()
+
+	var clientSeen []TraceEvent
+	client.AddTraceObserver(TraceObserverFunc(func(evt TraceEvent) {
+		clientSeen = append(clientSeen, evt)
+	}))
+
+	var requestSeen []TraceEvent
+	if _, err := client.Complete(context.Background(), &Request{
+		Model:    "m",
+		Messages: []Message{UserMessage("hi")},
+		TraceObservers: []TraceObserver{TraceObserverFunc(func(evt TraceEvent) {
+			requestSeen = append(requestSeen, evt)
+		})},
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(clientSeen) == 0 {
+		t.Fatal("expected client-level observer to receive trace events")
+	}
+	if len(requestSeen) != len(clientSeen) {
+		t.Fatalf("request-level observer saw %d events, client-level saw %d", len(requestSeen), len(clientSeen))
+	}
+	for _, evt := range clientSeen {
+		if !evt.SessionOwned {
+			t.Errorf("event %s: SessionOwned = false for request with request-level observers", evt.Kind)
+		}
+	}
+}

--- a/llm/trace.go
+++ b/llm/trace.go
@@ -32,6 +32,15 @@ type TraceEvent struct {
 	RawPreview    string
 	FinishReason  string
 	Usage         Usage
+	// SessionOwned is true when the originating request carried
+	// request-level TraceObservers — in tracker only the agent session
+	// registers those, and it re-emits every trace event as an agent
+	// llm_* event. Activity-log writers listening at the client level
+	// skip SessionOwned events to avoid logging the same stream twice
+	// (issue #354); non-session calls (e.g. the autopilot interviewer)
+	// stay SessionOwned=false so the trace path remains their only,
+	// and therefore kept, log surface.
+	SessionOwned bool
 }
 
 // TraceOptions configure trace building behavior.

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -120,6 +120,7 @@ type JSONLEventHandler struct {
 	securePath     string
 	file           *os.File
 	bundleIdentity string
+	captureRawLLM  bool  // write provider_raw / llm_provider_raw lines (see SetCaptureRawLLM)
 	snapshotErr    error // populated by Close; readable via SnapshotErr.
 }
 
@@ -144,6 +145,24 @@ func (h *JSONLEventHandler) SetBundleIdentity(id string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	h.bundleIdentity = id
+}
+
+// SetCaptureRawLLM controls whether raw provider streaming chunks
+// (agent "llm_provider_raw" and trace "provider_raw" lines) are written
+// to the activity log. Off by default: per-token raw chunks are
+// debugging payload, not run telemetry, and they dominated log size
+// (~92% of lines in the #354 census). Wired from --verbose so debug
+// runs keep full capture.
+func (h *JSONLEventHandler) SetCaptureRawLLM(enabled bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.captureRawLLM = enabled
+}
+
+// isRawLLMEventType reports whether evtType is a raw provider streaming
+// chunk under either spelling (agent event or llm trace kind).
+func isRawLLMEventType(evtType string) bool {
+	return evtType == "provider_raw" || evtType == "llm_provider_raw"
 }
 
 // openFile creates the secure activity log file on first use.
@@ -296,6 +315,9 @@ func (h *JSONLEventHandler) WriteAgentEvent(evtType, nodeID, toolName, toolOutpu
 	if h.file == nil {
 		return
 	}
+	if isRawLLMEventType(evtType) && !h.captureRawLLM {
+		return
+	}
 
 	content := toolOutput
 	if content == "" {
@@ -338,6 +360,9 @@ func (h *JSONLEventHandler) WriteLLMEvent(kind, provider, model, toolName, previ
 	defer h.mu.Unlock()
 
 	if h.file == nil {
+		return
+	}
+	if isRawLLMEventType(kind) && !h.captureRawLLM {
 		return
 	}
 

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -868,3 +868,68 @@ func isolateSecureLog(t *testing.T) {
 type testErr struct{ msg string }
 
 func (e *testErr) Error() string { return e.msg }
+
+func TestJSONLEventHandler_DropsRawLLMEventsByDefault(t *testing.T) {
+	dir := t.TempDir()
+	isolateSecureLog(t)
+	h := NewJSONLEventHandler(dir)
+
+	h.HandlePipelineEvent(PipelineEvent{
+		Type:      EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "raw123",
+	})
+
+	// Raw provider chunks are debugging payload (#354): both spellings
+	// are dropped unless raw capture is enabled.
+	h.WriteAgentEvent("llm_provider_raw", "gen_code", "", "", "", "chunk", "", "anthropic", "m")
+	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
+	// Non-raw events still land.
+	h.WriteAgentEvent("llm_text", "gen_code", "", "", "", "hello", "", "anthropic", "m")
+	h.WriteLLMEvent("text", "anthropic", "m", "", "hello")
+	h.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "raw123", "activity.jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (pipeline + 2 text), got %d:\n%s", len(lines), data)
+	}
+	for _, line := range lines {
+		var entry jsonlLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if entry.Type == "provider_raw" || entry.Type == "llm_provider_raw" {
+			t.Errorf("raw event %q written despite capture disabled", entry.Type)
+		}
+	}
+}
+
+func TestJSONLEventHandler_WritesRawLLMEventsWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	isolateSecureLog(t)
+	h := NewJSONLEventHandler(dir)
+	h.SetCaptureRawLLM(true)
+
+	h.HandlePipelineEvent(PipelineEvent{
+		Type:      EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "raw456",
+	})
+
+	h.WriteAgentEvent("llm_provider_raw", "gen_code", "", "", "", "chunk", "", "anthropic", "m")
+	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
+	h.Close()
+
+	data, err := os.ReadFile(filepath.Join(dir, "raw456", "activity.jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines (pipeline + 2 raw), got %d:\n%s", len(lines), data)
+	}
+}

--- a/testdata/runs/doubled_llm/Build/status.json
+++ b/testdata/runs/doubled_llm/Build/status.json
@@ -1,0 +1,7 @@
+{
+  "outcome": "fail",
+  "context_updates": {
+    "tool_stdout": "",
+    "tool_stderr": "bash: missing_tool: command not found"
+  }
+}

--- a/testdata/runs/doubled_llm/activity.jsonl
+++ b/testdata/runs/doubled_llm/activity.jsonl
@@ -1,0 +1,12 @@
+{"ts":"2026-04-17T11:00:00Z","type":"pipeline_started"}
+{"ts":"2026-04-17T11:00:01Z","type":"stage_started","node_id":"Build","handler":"tool"}
+{"ts":"2026-04-17T11:00:01.100Z","source":"llm","type":"request_start","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"ts":"2026-04-17T11:00:01.100Z","source":"agent","type":"llm_request_start","node_id":"Build","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"ts":"2026-04-17T11:00:01.200Z","source":"llm","type":"provider_raw","provider":"anthropic","model":"claude-sonnet-4-6","content":"{\"type\":\"content_block_delta\"}"}
+{"ts":"2026-04-17T11:00:01.200Z","source":"agent","type":"llm_provider_raw","node_id":"Build","provider":"anthropic","model":"claude-sonnet-4-6","content":"{\"type\":\"content_block_delta\"}"}
+{"ts":"2026-04-17T11:00:01.300Z","source":"llm","type":"text","provider":"anthropic","model":"claude-sonnet-4-6","content":"hello"}
+{"ts":"2026-04-17T11:00:01.300Z","source":"agent","type":"llm_text","node_id":"Build","provider":"anthropic","model":"claude-sonnet-4-6","content":"hello"}
+{"ts":"2026-04-17T11:00:01.400Z","source":"llm","type":"finish","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"ts":"2026-04-17T11:00:01.400Z","source":"agent","type":"llm_finish","node_id":"Build","provider":"anthropic","model":"claude-sonnet-4-6"}
+{"ts":"2026-04-17T11:00:02Z","type":"stage_failed","node_id":"Build","handler":"tool","error":"exit 127","tool_error":"missing_tool: command not found"}
+{"ts":"2026-04-17T11:00:03Z","type":"pipeline_failed"}

--- a/testdata/runs/doubled_llm/checkpoint.json
+++ b/testdata/runs/doubled_llm/checkpoint.json
@@ -1,0 +1,8 @@
+{
+  "run_id": "doubled-llm-run",
+  "completed_nodes": ["Setup"],
+  "current_node": "Build",
+  "retry_counts": {},
+  "restart_count": 0,
+  "timestamp": "2026-04-17T11:00:00Z"
+}

--- a/tracker_diagnose_test.go
+++ b/tracker_diagnose_test.go
@@ -514,3 +514,25 @@ func TestDiagnose_AutoStatusMissing(t *testing.T) {
 		t.Errorf("plain suggestion should warn about the success default: %q", plain.Message)
 	}
 }
+
+// TestDiagnose_PreDedupDoubledLLMLog pins backward compatibility for
+// pre-#354 activity logs in which every llm event appears twice (the
+// short trace kind under source "llm" and the llm_* agent spelling under
+// source "agent"). Diagnose must keep parsing those logs and surface the
+// failure signal unchanged — the doubled llm lines are ignored noise,
+// never an error.
+func TestDiagnose_PreDedupDoubledLLMLog(t *testing.T) {
+	r, err := Diagnose(context.Background(), "testdata/runs/doubled_llm")
+	if err != nil {
+		t.Fatalf("Diagnose: %v", err)
+	}
+	if r.RunID != "doubled-llm-run" {
+		t.Errorf("run_id = %q", r.RunID)
+	}
+	if len(r.Failures) != 1 {
+		t.Fatalf("got %d failures, want 1", len(r.Failures))
+	}
+	if r.Failures[0].NodeID != "Build" {
+		t.Errorf("node = %q, want Build", r.Failures[0].NodeID)
+	}
+}


### PR DESCRIPTION
Closes #354.

## Problem

`activity.jsonl` for one ~110-minute run was **32MB / 206,843 lines**; ~92% was the same LLM stream written twice — once by the client-level trace observer (short kinds `request_start` / `text` / `finish` / `provider_raw` under `source:"llm"`) and once by the agent session's re-emission (`llm_request_start` / `llm_text` / … under `source:"agent"`).

## Design decisions (per issue discussion)

1. **Canonical name — per origin, drop at emit.** Session-originated events log once as the `llm_*` agent family; non-session events log once under the short trace kind. Drop-at-emit was chosen over alias-at-read because **no consumer keys on the short names from activity.jsonl** — `tracker diagnose` / `tracker.Audit` only switch on pipeline event names (`stage_*`, `pipeline_*`, …), and the TUI consumes live trace events, never the log.
2. **`wireLLMTraceToLog` is NOT dropped wholesale.** The autopilot interviewer calls `llm.Client.Complete` without an agent session, so the client-level trace observer is its *only* path into the log. Instead, the dedup is scoped to exactly what the agent path provably covers: `completeWithTrace` stamps `TraceEvent.SessionOwned` when the request carries request-level observers (only `agent.Session` registers those, and it re-emits every one as an agent `llm_*` event). Both log-writing trace observers (console + TUI) skip session-owned events; TUI live rendering is untouched.
3. **`provider_raw` volume**: raw provider streaming chunks are now captured in activity.jsonl only under the existing `--verbose` flag (gated centrally in `JSONLEventHandler`, both spellings). One existing flag, no new file — so no new #213 secure-path/sentinel surface, and diagnose/audit posture is unchanged.
4. **Backward compat**: diagnose ignores llm-family lines entirely; pinned with fixture `testdata/runs/doubled_llm` containing a pre-#354 doubled log.

## Verification

- `go build ./...`, `GOOS=darwin GOARCH=arm64 go build ./...` ✓
- `go test ./... -short` ✓; `go test -race -short ./pipeline/... ./agent/... ./llm/...` ✓
- `dippin doctor` A/95, A/90, A/100 on the three core pipelines ✓
- **Live smoke run** (1-agent haiku pipeline): activity.jsonl census shows zero short/`llm_*` duplicate pairs, zero raw chunks; with `--verbose`, `llm_provider_raw` present exactly once per chunk; `tracker diagnose` on the run dir works ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783882780&installation_id=131176874&pr_number=374&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F374&signature=fb12df532c1cbe81777f453479b4e84c1b356bfa2c2910874678e60be02ee3fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->