### PR TITLE
fix(examples): replace "story events" template cruft in FixMilestone prompt (#355)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **build_product: domain-neutral FixMilestone example** (issue #355). The
+  "If a test expects story events to NOT merge" clause was leftover domain
+  language from whatever product the template was first written against,
+  shipping verbatim into FixMilestone's instructions on unrelated builds.
+  Now reads "two records" — same root-cause-over-symptom point, no foreign
+  domain anchor. Swept the rest of the file; no other "story" leftovers.
+
 - **Per-branch `tool_access:` / `writable_paths:` overrides are no longer
   silently dropped** (issue #368). Same silent-drop class as #366:
   `extractParallelAttrs` serialized per-branch Model/Provider/Fidelity from

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1340,7 +1340,7 @@ workflow BuildProduct
       5. Run the specific failing test to verify before committing
       6. Commit the fix with a message like "fix(milestone-N): [what was fixed]"
 
-      Do NOT make superficial patches. If a test expects story events to NOT
+      Do NOT make superficial patches. If a test expects two records to NOT
       merge, understand WHY they're merging and fix the decision logic.
 
       The instant verification passes AND you have committed, emit DONE and


### PR DESCRIPTION
Closes #355.

One-line prompt edit in `examples/build_product.dip` (FixMilestone): the "If a test expects story events to NOT merge" clause was leftover domain language from another product, shipping verbatim into the fix agent's instructions on unrelated builds (observed in case-study run b68b532619c3, a Go daemon). Replaced with the domain-neutral "two records" while keeping the root-cause-over-symptom point.

Per the issue's suggestion, swept the rest of the file for similar leftovers — `grep -n "story\|stories"` finds no other domain anchors (remaining hits are "history").

## Verification
- `dippin doctor examples/build_product.dip` — **A / 90** (held)
- `go build ./...` ✓ (examples embed into the binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783884190&installation_id=131176874&pr_number=376&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F376&signature=15a7b79c14152157009d77e916043fb3f3664d217fa0d68d607eadcd36d2599f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->