### PR TITLE
fix(engine): refuse inert per-branch fallback_target at parallel dispatch (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Inert per-branch `fallback_target` is now refused at parallel dispatch**
+  (issue #313, defect 2). A `fallback_target` declared on a parallel
+  branch-target node never did anything at runtime — `runBranch` calls
+  `registry.Execute` directly, bypassing the engine's strict-failure path
+  (`checkStrictFailure`/`findFallbackTarget`) — so the failure route it
+  promised was silently absent. The parallel handler now fails fast before
+  dispatching any branch (covering both the target node's own attr and a
+  `branch.N.fallback_target` override), with an error pointing at the
+  supported pattern: route branch failure at the aggregating node via
+  `fan_in_policy` (#344) plus a conditional fail edge. Graph-level
+  `defaults: on_failure` is unaffected. No shipped example declared the
+  inert attr (PR #312 already removed them from build_product).
+
+- **build_product_with_superspec: a failed cross-reviewer can no longer be
+  silently masked** (issue #313). `ReviewParallel` had no `fan_in_policy`
+  and no fail edge, so the default success-if-any aggregation let a failed
+  `ReviewArchitect`/`ReviewQA`/`ReviewProduct` branch vanish — the same gap
+  PR #344 closed for build_product. It now declares `fan_in_policy: all`
+  with a `when ctx.outcome = fail` edge to `EscalateToHuman`. Doctor holds
+  A/100.
+
 - **build_product: domain-neutral FixMilestone example** (issue #355). The
   "If a test expects story events to NOT merge" clause was leftover domain
   language from whatever product the template was first written against,

--- a/docs/architecture/handlers/parallel-fan-in.md
+++ b/docs/architecture/handlers/parallel-fan-in.md
@@ -253,6 +253,15 @@ the parent trace entry reflects the full cost of the fan-out.
   explicit edges for parallel target fan-out; the adapter generates them so
   the graph is structurally complete. See `CLAUDE.md` § Dippin-lang
   compatibility.
+- **`fallback_target` on a branch-target node is refused at dispatch.**
+  Branch nodes execute via `registry.Execute` inside `runBranch` and never
+  pass through the engine's strict-failure path
+  (`checkStrictFailure`/`findFallbackTarget`), so a node-level
+  `fallback_target` on a branch target would be silently inert. The parallel
+  handler fails fast before dispatching any branch instead (#313). Route
+  branch failure at the aggregating node: declare `fan_in_policy: all` (or
+  `quorum`) and add a conditional `when ctx.outcome = fail` edge. Graph-level
+  `defaults: on_failure` is unaffected.
 - **Branch overrides are keyed by target node ID, not by branch index.**
   Two parallel nodes pointing at the same target with different overrides
   will collide if they run concurrently — make the targets distinct node

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -785,6 +785,8 @@ workflow BuildProductWithSuperspec
   # ═══════════════════════════════════════════════════════════════
 
   parallel ReviewParallel -> ReviewArchitect, ReviewQA, ReviewProduct
+    params:
+      fan_in_policy: all
 
   agent ReviewArchitect
     label: "Architect Review"
@@ -1128,6 +1130,15 @@ workflow BuildProductWithSuperspec
     MergePhase5 -> EscalateToHuman
 
     # Phase 6: Cross-review
+    # The three reviewers run as parallel branches; a branch runs via
+    # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
+    # path, so a per-branch fallback_target would be inert (the engine now
+    # refuses one at dispatch). ReviewParallel declares fan_in_policy: all
+    # (issue #313), so this edge fires when ANY of the three reviewers fails —
+    # a single missing review perspective can no longer be masked by the
+    # default success-if-any aggregation. On success the parallel handler's
+    # suggested-next routes to ReviewJoin.
+    ReviewParallel -> EscalateToHuman  when ctx.outcome = fail
     ReviewArchitect -> ReviewJoin
     ReviewQA -> ReviewJoin
     ReviewProduct -> ReviewJoin

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -1074,7 +1074,7 @@ workflow BuildProductWithSuperspec
     ApprovePlan -> BuildPlan  label: "adjust"  restart: true
     ApprovePlan -> Done  label: "reject"
 
-    # Phase 1: Foundation (A + B parallel)
+    # Phase 2: Foundation (A + B parallel)
     SetupPhase1Worktrees -> Phase1Parallel
     StreamA -> Phase1Join
     StreamB -> Phase1Join
@@ -1087,7 +1087,7 @@ workflow BuildProductWithSuperspec
     GatePhase1 -> EscalateToHuman
     FixPhase1 -> GatePhase1  restart: true
 
-    # Phase 2: Core (C + E parallel)
+    # Phase 3: Core (C + E parallel)
     SetupPhase2Worktrees -> Phase2Parallel
     StreamC -> Phase2Join
     StreamE -> Phase2Join
@@ -1100,14 +1100,14 @@ workflow BuildProductWithSuperspec
     GatePhase2 -> EscalateToHuman
     FixPhase2 -> GatePhase2  restart: true
 
-    # Phase 3: Story engine (D sequential, depends on C)
+    # Phase 4: Story engine (D sequential, depends on C)
     StreamD -> GateStreamD
     GateStreamD -> SetupPhase4Worktrees  when ctx.outcome = success
     GateStreamD -> FixStreamD  when ctx.outcome = fail
     GateStreamD -> EscalateToHuman
     FixStreamD -> GateStreamD  restart: true
 
-    # Phase 4: Surface (F + G parallel)
+    # Phase 5: Surface (F + G parallel)
     SetupPhase4Worktrees -> Phase4Parallel
     StreamF -> Phase4Join
     StreamG -> Phase4Join
@@ -1120,7 +1120,7 @@ workflow BuildProductWithSuperspec
     GatePhase4 -> EscalateToHuman
     FixPhase4 -> GatePhase4  restart: true
 
-    # Phase 5: Quality & Docs (H + I parallel)
+    # Phase 6: Quality & Docs (H + I parallel)
     SetupPhase5Worktrees -> Phase5Parallel
     StreamH -> Phase5Join
     StreamI -> Phase5Join
@@ -1129,7 +1129,7 @@ workflow BuildProductWithSuperspec
     MergePhase5 -> EscalateToHuman  when ctx.outcome = fail
     MergePhase5 -> EscalateToHuman
 
-    # Phase 6: Cross-review
+    # Phase 7: Cross-review
     # The three reviewers run as parallel branches; a branch runs via
     # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
     # path, so a per-branch fallback_target would be inert (the engine now
@@ -1148,7 +1148,7 @@ workflow BuildProductWithSuperspec
     SynthesizeReviews -> Done
     ApplyReviewFixes -> FinalGates
 
-    # Phase 7: Final verification
+    # Phase 8: Final verification
     FinalGates -> TraceabilityAudit  when ctx.outcome = success
     FinalGates -> EscalateToHuman  when ctx.outcome = fail
     FinalGates -> EscalateToHuman

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -68,6 +68,15 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 
 	branchOverrides := parseBranchOverrides(node.Attrs)
 
+	// Refuse a branch-target fallback_target before dispatching any branch
+	// (#313 defect 2): runBranch calls registry.Execute directly and never
+	// passes through Engine.checkStrictFailure/findFallbackTarget, so the
+	// attr would be silently inert at runtime. Route branch failure at the
+	// aggregating node instead (fan_in_policy + a conditional fail edge).
+	if err := refuseBranchFallbackTargets(node.ID, edges, h.graph, branchOverrides); err != nil {
+		return pipeline.Outcome{}, err
+	}
+
 	branchIDs := make([]string, len(edges))
 	for i, edge := range edges {
 		branchIDs[i] = edge.To
@@ -156,6 +165,29 @@ func aggregateChildOverrides(branchOverrides [][]pipeline.OverrideDetail) []pipe
 		}
 	}
 	return aggregated
+}
+
+// refuseBranchFallbackTargets fails fast when any branch-target node (or a
+// branch.N.* override) declares a node-level fallback_target. Branch nodes
+// execute via registry.Execute inside runBranch and never reach the engine's
+// strict-failure path, so the attr would do nothing at runtime — refusing
+// loudly beats shipping a silently-inert failure route (#313 defect 2).
+// Graph-level fallback_target (dippin `defaults: on_failure`) is unaffected:
+// it lives on graph attrs and applies in the engine's main loop.
+func refuseBranchFallbackTargets(parallelID string, edges []*pipeline.Edge, graph *pipeline.Graph, branchOverrides map[string]map[string]string) error {
+	for _, edge := range edges {
+		declared := ""
+		if tn, ok := graph.Nodes[edge.To]; ok {
+			declared = tn.Attrs["fallback_target"]
+		}
+		if ov, ok := branchOverrides[edge.To]; ok && ov["fallback_target"] != "" {
+			declared = ov["fallback_target"]
+		}
+		if declared != "" {
+			return fmt.Errorf("parallel node %q: branch target %q declares fallback_target %q, which is never honored inside a parallel branch — remove it and route branch failure at the aggregating node via fan_in_policy (any|all|quorum) and a conditional fail edge", parallelID, edge.To, declared)
+		}
+	}
+	return nil
 }
 
 // resolveBranchEdges determines the branch target edges for a parallel node.

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -167,24 +167,33 @@ func aggregateChildOverrides(branchOverrides [][]pipeline.OverrideDetail) []pipe
 	return aggregated
 }
 
+// branchFallbackAttrs are the node-attr spellings the engine's
+// findFallbackTarget consults: the raw "fallback_target" key and
+// "fallback_retry_target", which is where the adapter's extractRetryAttrs
+// stores a .dip node-level `fallback_target:` declaration.
+var branchFallbackAttrs = []string{"fallback_target", "fallback_retry_target"}
+
 // refuseBranchFallbackTargets fails fast when any branch-target node (or a
-// branch.N.* override) declares a node-level fallback_target. Branch nodes
-// execute via registry.Execute inside runBranch and never reach the engine's
-// strict-failure path, so the attr would do nothing at runtime — refusing
-// loudly beats shipping a silently-inert failure route (#313 defect 2).
-// Graph-level fallback_target (dippin `defaults: on_failure`) is unaffected:
-// it lives on graph attrs and applies in the engine's main loop.
+// branch.N.* override) declares a node-level fallback target under either
+// spelling. Branch nodes execute via registry.Execute inside runBranch and
+// never reach the engine's strict-failure path, so the attr would do nothing
+// at runtime — refusing loudly beats shipping a silently-inert failure route
+// (#313 defect 2). Graph-level fallback_target (dippin `defaults:
+// on_failure`) is unaffected: it lives on graph attrs and applies in the
+// engine's main loop.
 func refuseBranchFallbackTargets(parallelID string, edges []*pipeline.Edge, graph *pipeline.Graph, branchOverrides map[string]map[string]string) error {
 	for _, edge := range edges {
-		declared := ""
-		if tn, ok := graph.Nodes[edge.To]; ok {
-			declared = tn.Attrs["fallback_target"]
-		}
-		if ov, ok := branchOverrides[edge.To]; ok && ov["fallback_target"] != "" {
-			declared = ov["fallback_target"]
-		}
-		if declared != "" {
-			return fmt.Errorf("parallel node %q: branch target %q declares fallback_target %q, which is never honored inside a parallel branch — remove it and route branch failure at the aggregating node via fan_in_policy (any|all|quorum) and a conditional fail edge", parallelID, edge.To, declared)
+		for _, attr := range branchFallbackAttrs {
+			declared := ""
+			if tn, ok := graph.Nodes[edge.To]; ok {
+				declared = tn.Attrs[attr]
+			}
+			if ov, ok := branchOverrides[edge.To]; ok && ov[attr] != "" {
+				declared = ov[attr]
+			}
+			if declared != "" {
+				return fmt.Errorf("parallel node %q: branch target %q declares %s %q, which is never honored inside a parallel branch — remove it and route branch failure at the aggregating node via fan_in_policy (any|all|quorum) and a conditional fail edge", parallelID, edge.To, attr, declared)
+			}
 		}
 	}
 	return nil

--- a/pipeline/handlers/parallel_test.go
+++ b/pipeline/handlers/parallel_test.go
@@ -1148,3 +1148,94 @@ func TestParseBranchOverrides_DuplicateTargetLastBranchWins(t *testing.T) {
 		}
 	}
 }
+
+// TestParallelHandlerRefusesBranchFallbackTarget pins the refuse-loudly
+// semantics for issue #313 defect 2: a branch-target node declaring a
+// node-level fallback_target gets a hard error at parallel dispatch instead
+// of silent inertness (runBranch bypasses Engine.checkStrictFailure, so the
+// attr would never be honored). Branch failure must be routed at the
+// aggregating node via fan_in_policy instead.
+func TestParallelHandlerRefusesBranchFallbackTarget(t *testing.T) {
+	g := buildTestGraph([]string{"branch_a", "branch_b"}, "stub_success")
+	g.Nodes["branch_a"].Attrs["fallback_target"] = "EscalateToHuman"
+	registry := pipeline.NewHandlerRegistry()
+	stub := &stubHandler{
+		name:    "stub_success",
+		outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+	}
+	registry.Register(stub)
+
+	h := NewParallelHandler(g, registry, nil)
+	pctx := pipeline.NewPipelineContext()
+
+	_, err := h.Execute(context.Background(), g.Nodes["parallel_node"], pctx)
+	if err == nil {
+		t.Fatal("expected error for branch target with fallback_target, got nil")
+	}
+	for _, want := range []string{"branch_a", "fallback_target", "fan_in_policy"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q should mention %q", err.Error(), want)
+		}
+	}
+	if stub.called.Load() != 0 {
+		t.Errorf("no branch should run after refusal, got %d calls", stub.called.Load())
+	}
+}
+
+// TestParallelHandlerRefusesBranchFallbackTargetViaOverride covers the same
+// refusal when fallback_target arrives through a branch.N.* override rather
+// than the target node's own attrs.
+func TestParallelHandlerRefusesBranchFallbackTargetViaOverride(t *testing.T) {
+	g := buildTestGraph([]string{"branch_a"}, "stub_success")
+	g.Nodes["parallel_node"].Attrs["branch.0.target"] = "branch_a"
+	g.Nodes["parallel_node"].Attrs["branch.0.fallback_target"] = "EscalateToHuman"
+	registry := pipeline.NewHandlerRegistry()
+	stub := &stubHandler{
+		name:    "stub_success",
+		outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+	}
+	registry.Register(stub)
+
+	h := NewParallelHandler(g, registry, nil)
+	pctx := pipeline.NewPipelineContext()
+
+	_, err := h.Execute(context.Background(), g.Nodes["parallel_node"], pctx)
+	if err == nil {
+		t.Fatal("expected error for branch override fallback_target, got nil")
+	}
+	if !strings.Contains(err.Error(), "fallback_target") {
+		t.Errorf("error %q should mention fallback_target", err.Error())
+	}
+	if stub.called.Load() != 0 {
+		t.Errorf("no branch should run after refusal, got %d calls", stub.called.Load())
+	}
+}
+
+// TestParallelHandlerGraphLevelFallbackAllowed pins that a graph-level
+// fallback_target (dippin `defaults: on_failure`) does NOT trigger the
+// branch-level refusal — it lives on graph attrs, applies via the engine's
+// main loop, and pipelines like build_product_with_superspec rely on it.
+func TestParallelHandlerGraphLevelFallbackAllowed(t *testing.T) {
+	g := buildTestGraph([]string{"branch_a", "branch_b"}, "stub_success")
+	g.Attrs["fallback_target"] = "EscalateToHuman"
+	registry := pipeline.NewHandlerRegistry()
+	stub := &stubHandler{
+		name:    "stub_success",
+		outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+	}
+	registry.Register(stub)
+
+	h := NewParallelHandler(g, registry, nil)
+	pctx := pipeline.NewPipelineContext()
+
+	outcome, err := h.Execute(context.Background(), g.Nodes["parallel_node"], pctx)
+	if err != nil {
+		t.Fatalf("graph-level fallback_target must not refuse dispatch: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("expected success, got %q", outcome.Status)
+	}
+	if stub.called.Load() != 2 {
+		t.Errorf("expected 2 branch executions, got %d", stub.called.Load())
+	}
+}

--- a/pipeline/handlers/parallel_test.go
+++ b/pipeline/handlers/parallel_test.go
@@ -1239,3 +1239,49 @@ func TestParallelHandlerGraphLevelFallbackAllowed(t *testing.T) {
 		t.Errorf("expected 2 branch executions, got %d", stub.called.Load())
 	}
 }
+
+// TestParallelHandlerRefusesBranchFallbackRetryTarget pins the second attr
+// spelling: a .dip node-level `fallback_target:` is stored by the adapter as
+// fallback_retry_target (extractRetryAttrs), and Engine.findFallbackTarget
+// honors both. The refusal must fire on either spelling, on the node's own
+// attrs and via branch.N.* overrides (Codex P1, PR #377).
+func TestParallelHandlerRefusesBranchFallbackRetryTarget(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(g *pipeline.Graph)
+	}{
+		{"node attr", func(g *pipeline.Graph) {
+			g.Nodes["branch_a"].Attrs["fallback_retry_target"] = "EscalateToHuman"
+		}},
+		{"branch override", func(g *pipeline.Graph) {
+			g.Nodes["parallel_node"].Attrs["branch.0.target"] = "branch_a"
+			g.Nodes["parallel_node"].Attrs["branch.0.fallback_retry_target"] = "EscalateToHuman"
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := buildTestGraph([]string{"branch_a"}, "stub_success")
+			tc.setup(g)
+			registry := pipeline.NewHandlerRegistry()
+			stub := &stubHandler{
+				name:    "stub_success",
+				outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+			}
+			registry.Register(stub)
+
+			h := NewParallelHandler(g, registry, nil)
+			_, err := h.Execute(context.Background(), g.Nodes["parallel_node"], pipeline.NewPipelineContext())
+			if err == nil {
+				t.Fatal("expected error for branch fallback_retry_target, got nil")
+			}
+			for _, want := range []string{"branch_a", "fallback_retry_target", "fan_in_policy"} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q should mention %q", err.Error(), want)
+				}
+			}
+			if stub.called.Load() != 0 {
+				t.Errorf("no branch should run after refusal, got %d calls", stub.called.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes the remainder of #313 (defect 2 + the superspec workflow exposure). Defect 1 (success-if-any aggregation) shipped in #344 and is untouched here.

### Design decision: refuse loudly, not an in-branch mini-engine

`fallback_target` on a parallel branch-target node has always been runtime-inert: `runBranch` calls `registry.Execute` directly, so branch nodes never pass through `Engine.checkStrictFailure` / `findFallbackTarget`. Two options were on the table:

- **(a)** honor it — teach `runBranch` to consult the branch node's `fallback_target` and execute the fallback inside the branch context (an in-branch mini-engine);
- **(b)** refuse loudly — fail at parallel dispatch, before any branch burns work, and direct authors to the supported pattern.

This PR implements **(b)**. `fan_in_policy` (#344) subsumes the practical cases — branch failure is observable and routable at the aggregating node — and "silently inert" is exactly the bug class this repo keeps paying for (#366, #368). An in-branch fallback would also raise unanswered semantics questions (does the fallback's context merge at fan-in? does it count toward the policy tally?) for no demonstrated need.

The refusal covers both the target node's own attr and a `branch.N.fallback_target` override, and is checked before dispatch (same fail-fast posture as `resolveFanInPolicy`). **Graph-level `defaults: on_failure` is unaffected** — it lands on graph attrs, applies in the engine's main loop, and `build_product_with_superspec` relies on it; pinned by `TestParallelHandlerGraphLevelFallbackAllowed`.

Swept all `examples/*.dip`: no branch-target node declares `fallback_target` (PR #312 already removed them from build_product), so nothing starts failing.

### Superspec ReviewParallel: failed reviewer no longer masked

`build_product_with_superspec.dip` `ReviewParallel` had no `fan_in_policy` and no fail edge — a failed `ReviewArchitect`/`ReviewQA`/`ReviewProduct` was silently swallowed by success-if-any aggregation. Ported the build_product pattern (#344 / PR #312):

- `fan_in_policy: all` via `params:` on the parallel node
- `ReviewParallel -> EscalateToHuman when ctx.outcome = fail`

A direct fail edge works here (no DIP005 cycle — `EscalateToHuman` routes only forward to `Cleanup`/`Done`, never back into the review loop), so the node-attr fallback workaround build_product needed for `FinalCommit` isn't required.

## Verification

- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- `go test ./... -short` — pass
- `go test -race -short ./pipeline/...` — pass
- TDD: both refusal tests watched failing before the implementation existed
- `dippin doctor` (run separately): ask_and_execute **A/95**, build_product **A/90**, build_product_with_superspec **A/100** — all hold

Closes #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885445&installation_id=131176874&pr_number=377&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F377&signature=5a8875b766575edf152b4c96b23e13fc8033889aefcf1b36de23eef7f6d49ae3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->