### PR TITLE
fix(examples): bring embedded deep_review from F/35 to A/100 under dippin doctor (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Embedded deep_review built-in no longer grades F/35 under dippin doctor**
+  (issue #335, scope 1). The workflow ships inside the binary
+  (`tracker run deep_review`), so an F-graded graph was a user's first
+  contact with built-ins. Structural fixes, now A/100: a graph-level
+  `on_failure: EscalateToHuman` catch-all plus a freeform escalation gate
+  (11 agent nodes had no failure route — DIP144); the `SaveGoal` tool node
+  is gone (its `${ctx.human_response}` interpolation is dippin's DIP124
+  anti-pattern, plus no timeout — DIP111/DIP125), `ExploreCodebase` now
+  receives the goal inline and snapshots it to `.ai/review/goal.txt`
+  verbatim; `AnalyzeParallel` declares `fan_in_policy: all` with a fail
+  edge to the gate, so a single failed analyzer can't be masked while
+  `SynthesizeFindings` silently synthesizes from two reports (#313 class);
+  `ApplyFormat` failure routes to the gate instead of unconditionally to
+  Done. The D/F long tail of non-embedded examples is #335 scopes 2–3.
+
 - **Inert per-branch `fallback_target` is now refused at parallel dispatch**
   (issue #313, defect 2). A `fallback_target` declared on a parallel
   branch-target node never did anything at runtime — `runBranch` calls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Embedded deep_review built-in no longer grades F/35 under dippin doctor**
   (issue #335, scope 1). The workflow ships inside the binary
-  (`tracker run deep_review`), so an F-graded graph was a user's first
+  (`tracker deep_review`), so an F-graded graph was a user's first
   contact with built-ins. Structural fixes, now A/100: a graph-level
   `on_failure: EscalateToHuman` catch-all plus a freeform escalation gate
   (11 agent nodes had no failure route — DIP144); the `SaveGoal` tool node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `on_failure: EscalateToHuman` catch-all plus a freeform escalation gate
   (11 agent nodes had no failure route — DIP144); the `SaveGoal` tool node
   is gone (its `${ctx.human_response}` interpolation is dippin's DIP124
-  anti-pattern, plus no timeout — DIP111/DIP125), `ExploreCodebase` now
-  receives the goal inline and snapshots it to `.ai/review/goal.txt`
-  verbatim; `AnalyzeParallel` declares `fan_in_policy: all` with a fail
+  anti-pattern, plus no timeout — DIP111/DIP125): every stage that read
+  `.ai/review/goal.txt` now interpolates the per-node scoped context key
+  `${ctx.node.DescribeGoal.human_response}` directly, so the goal reaches
+  each prompt verbatim with no LLM or file intermediary that could drop or
+  rewrite it; `AnalyzeParallel` declares `fan_in_policy: all` with a fail
   edge to the gate, so a single failed analyzer can't be masked while
   `SynthesizeFindings` silently synthesizes from two reports (#313 class);
   `ApplyFormat` failure routes to the gate instead of unconditionally to

--- a/examples/deep_review.dip
+++ b/examples/deep_review.dip
@@ -33,12 +33,9 @@ workflow DeepReview
     prompt:
       The developer wants a deep review of their codebase. Their stated goal:
 
-      ${ctx.human_response}
+      ${ctx.node.DescribeGoal.human_response}
 
-      FIRST: create .ai/review/ and save the goal above VERBATIM to
-      .ai/review/goal.txt — later review stages read it from that file.
-
-      Then explore the codebase thoroughly. Map out:
+      Explore the codebase thoroughly. Map out:
       - Architecture: packages, layers, key abstractions
       - Conventions: naming, error handling, test patterns
       - Dependencies: external packages, API boundaries
@@ -56,7 +53,8 @@ workflow DeepReview
     prompt:
       Read .ai/review/exploration.md to understand what was found.
 
-      The developer wants a review focused on their stated goal (read .ai/review/goal.txt).
+      The developer wants a review focused on their stated goal:
+      ${ctx.node.DescribeGoal.human_response}
 
       Generate 3-5 targeted questions to narrow the review scope.
       Tailor options to what the exploration actually found in this specific codebase.
@@ -97,7 +95,7 @@ workflow DeepReview
     prompt:
       You are reviewing this codebase for correctness issues.
 
-      Developer's goal: read .ai/review/goal.txt
+      Developer's goal: ${ctx.node.DescribeGoal.human_response}
       Review scope (from interview, JSON-formatted interview answers): ${ctx.scope_answers}
       Exploration: read .ai/review/exploration.md
 
@@ -126,7 +124,7 @@ workflow DeepReview
     prompt:
       You are reviewing this codebase for security vulnerabilities.
 
-      Developer's goal: read .ai/review/goal.txt
+      Developer's goal: ${ctx.node.DescribeGoal.human_response}
       Review scope (from interview, JSON-formatted interview answers): ${ctx.scope_answers}
       Exploration: read .ai/review/exploration.md
 
@@ -159,7 +157,7 @@ workflow DeepReview
     prompt:
       You are reviewing this codebase for design and maintainability issues.
 
-      Developer's goal: read .ai/review/goal.txt
+      Developer's goal: ${ctx.node.DescribeGoal.human_response}
       Review scope (from interview, JSON-formatted interview answers): ${ctx.scope_answers}
       Exploration: read .ai/review/exploration.md
 

--- a/examples/deep_review.dip
+++ b/examples/deep_review.dip
@@ -9,6 +9,9 @@ workflow DeepReview
     model: claude-sonnet-4-6
     provider: anthropic
     fidelity: summary:high
+    # Graph-level catch-all: any node failure with no node-level route
+    # escalates to a human instead of dead-stopping mid-review.
+    on_failure: EscalateToHuman
 
   agent Start
     label: Start
@@ -22,22 +25,20 @@ workflow DeepReview
     label: "What are you trying to review? Describe the codebase area, recent changes, or specific concerns."
     mode: freeform
 
-  tool SaveGoal
-    label: "Snapshot the developer's goal"
-    command:
-      mkdir -p .ai/review
-      printf '%s\n' "${ctx.human_response}" > .ai/review/goal.txt
-      echo "Goal saved to .ai/review/goal.txt"
-
   agent ExploreCodebase
     label: "Explore Codebase"
     model: claude-sonnet-4-6
     reasoning_effort: high
     fidelity: full
     prompt:
-      The developer wants a deep review of their codebase (read .ai/review/goal.txt for original goal).
+      The developer wants a deep review of their codebase. Their stated goal:
 
-      Explore the codebase thoroughly. Map out:
+      ${ctx.human_response}
+
+      FIRST: create .ai/review/ and save the goal above VERBATIM to
+      .ai/review/goal.txt — later review stages read it from that file.
+
+      Then explore the codebase thoroughly. Map out:
       - Architecture: packages, layers, key abstractions
       - Conventions: naming, error handling, test patterns
       - Dependencies: external packages, API boundaries
@@ -85,6 +86,8 @@ workflow DeepReview
   # ─── Phase 3: Deep Analysis ────────────────────────────────
 
   parallel AnalyzeParallel -> AnalyzeCorrectness, AnalyzeSecurity, AnalyzeDesign
+    params:
+      fan_in_policy: all
 
   agent AnalyzeCorrectness
     label: "Correctness Analysis"
@@ -344,15 +347,23 @@ workflow DeepReview
       3. If the plan mentions specific code changes, verify the file paths
          still exist and the line numbers are approximately correct
 
+  human EscalateToHuman
+    label: "The review hit a problem it could not recover from. Review the partial artifacts under .ai/review/ and decide how to proceed."
+    mode: freeform
+
   # ─── Edges ─────────────────────────────────────────────────
 
   edges
     Start -> DescribeGoal
-    DescribeGoal -> SaveGoal
-    SaveGoal -> ExploreCodebase
+    DescribeGoal -> ExploreCodebase
     ExploreCodebase -> GenerateScopeQuestions
     GenerateScopeQuestions -> ScopeInterview
     ScopeInterview -> AnalyzeParallel
+    # The three analyzers run as parallel branches; AnalyzeParallel declares
+    # fan_in_policy: all (issue #313), so a single failed analyzer routes
+    # here instead of being masked by success-if-any aggregation —
+    # SynthesizeFindings needs all three reports to produce a sound synthesis.
+    AnalyzeParallel -> EscalateToHuman  when ctx.outcome = fail
     AnalyzeCorrectness -> AnalyzeJoin
     AnalyzeSecurity -> AnalyzeJoin
     AnalyzeDesign -> AnalyzeJoin
@@ -366,4 +377,9 @@ workflow DeepReview
     ReviewPlan -> ApplyFormat                label: "approve"
     ReviewPlan -> WriteRemediationPlan       label: "revise"  restart: true
     ReviewPlan -> Done                       label: "reject"
-    ApplyFormat -> Done
+    # Safe fallback: a failed finalize routes to the escalation gate, not
+    # silently to Done (and gives EscalateToHuman an unconditional inbound
+    # edge so it is not skippable-only — DIP101).
+    ApplyFormat -> Done                      when ctx.outcome = success
+    ApplyFormat -> EscalateToHuman
+    EscalateToHuman -> Done


### PR DESCRIPTION
## Summary

Scope 1 of #335 only: the embedded `deep_review.dip` built-in (in the binary via `tracker_workflows.go` go:embed) graded **F/35** — 13 lint warnings + 1 hint. Now **A/100** with structural fixes; the workflow's behavior stays recognizable (same phases, same artifacts, same interview flow). The D/F long tail (megaplan, consensus_task, …) and the examples/-vs-workflows/ dedup are scopes 2–3 / #307 — out of scope here, the issue stays open.

### What was wrong, and the fixes

| Finding | Fix |
|---|---|
| **DIP144 × 11** — every agent node had no failure route; any agent failure dead-stopped the review mid-flight | Graph-level `defaults: on_failure: EscalateToHuman` catch-all + a freeform `EscalateToHuman` gate (same pattern as build_product_with_superspec) |
| **DIP124** — `SaveGoal` tool interpolated `${ctx.human_response}` in a shell command (dippin's documented anti-pattern; its blessed alternative is file IPC) | Removed the tool node. `ExploreCodebase` receives the goal inline in its prompt and writes `.ai/review/goal.txt` verbatim as its first action — every later stage reads the same file as before |
| **DIP111 / DIP125** — `SaveGoal` had no timeout; binary-extraction hint on its command | Gone with the node |
| **DIP101** (surfaced after the gate was added) — `EscalateToHuman` reachable only via conditional edges | `ApplyFormat -> Done when ctx.outcome = success` + unconditional `ApplyFormat -> EscalateToHuman` safe fallback (build_product pattern: fallbacks go to an escalation gate, never silently to Done) |
| **#313-class gap** (not lint-flagged, but the exact masked-branch failure mode fixed in build_product / PR #377): `AnalyzeParallel` aggregated success-if-any, so `SynthesizeFindings` could silently synthesize from two of three reports | `fan_in_policy: all` + `AnalyzeParallel -> EscalateToHuman when ctx.outcome = fail` |

## Verification

- `dippin doctor examples/deep_review.dip` → **A/100**, 0 warnings, 0 hints, 20/20 reachable, all paths terminate
- `go build ./...` and `GOOS=darwin GOARCH=arm64 go build ./...` — pass (re-embeds)
- `go test ./... -short` — pass (incl. `./cmd/tracker` embed/workflows tests)
- Bare-name resolution: built the binary, ran `tracker validate deep_review` from `/tmp` (no local file) → resolves the embedded copy, `valid (20 nodes, 26 edges)`
- Core three (run separately): ask_and_execute **A/95**, build_product **A/90**, build_product_with_superspec **A/100** — all hold

Part of #335 (issue stays open for scopes 2–3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783885792&installation_id=131176874&pr_number=378&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F378&signature=408ee3a692c1685618889ca88d7a7b9db8607cc5420f13b1a4da8920e4f309c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->