### PR TITLE
fix(engine): refuse fallback declarations on shadowed duplicate-target branch groups (#313 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `on_failure: EscalateToHuman` catch-all plus a freeform escalation gate
   (11 agent nodes had no failure route — DIP144); the `SaveGoal` tool node
   is gone (its `${ctx.human_response}` interpolation is dippin's DIP124
-  anti-pattern, plus no timeout — DIP111/DIP125): every stage that read
-  `.ai/review/goal.txt` now interpolates the per-node scoped context key
-  `${ctx.node.DescribeGoal.human_response}` directly, so the goal reaches
-  each prompt verbatim with no LLM or file intermediary that could drop or
-  rewrite it; `AnalyzeParallel` declares `fan_in_policy: all` with a fail
+  anti-pattern, plus no timeout — DIP111/DIP125): `.ai/review/goal.txt` is
+  no longer written at all — every stage that read it now interpolates the
+  per-node scoped context key `${ctx.node.DescribeGoal.human_response}`
+  directly, so the goal reaches each prompt verbatim with no LLM or file
+  intermediary that could drop or rewrite it; `AnalyzeParallel` declares
+  `fan_in_policy: all` with a fail
   edge to the gate, so a single failed analyzer can't be masked while
   `SynthesizeFindings` silently synthesizes from two reports (#313 class);
   `ApplyFormat` failure routes to the gate instead of unconditionally to
@@ -32,8 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `registry.Execute` directly, bypassing the engine's strict-failure path
   (`checkStrictFailure`/`findFallbackTarget`) — so the failure route it
   promised was silently absent. The parallel handler now fails fast before
-  dispatching any branch (covering both the target node's own attr and a
-  `branch.N.fallback_target` override), with an error pointing at the
+  dispatching any branch (covering the target node's own attr and every
+  `branch.N.*` override group — including groups shadowed by the
+  last-branch-wins duplicate-target collapse), with an error pointing at the
   supported pattern: route branch failure at the aggregating node via
   `fan_in_policy` (#344) plus a conditional fail edge. Graph-level
   `defaults: on_failure` is unaffected. No shipped example declared the

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -73,7 +73,7 @@ func (h *ParallelHandler) Execute(ctx context.Context, node *pipeline.Node, pctx
 	// passes through Engine.checkStrictFailure/findFallbackTarget, so the
 	// attr would be silently inert at runtime. Route branch failure at the
 	// aggregating node instead (fan_in_policy + a conditional fail edge).
-	if err := refuseBranchFallbackTargets(node.ID, edges, h.graph, branchOverrides); err != nil {
+	if err := refuseBranchFallbackTargets(node.ID, edges, h.graph, node.Attrs); err != nil {
 		return pipeline.Outcome{}, err
 	}
 
@@ -173,23 +173,43 @@ func aggregateChildOverrides(branchOverrides [][]pipeline.OverrideDetail) []pipe
 // stores a .dip node-level `fallback_target:` declaration.
 var branchFallbackAttrs = []string{"fallback_target", "fallback_retry_target"}
 
-// refuseBranchFallbackTargets fails fast when any branch-target node (or a
-// branch.N.* override) declares a node-level fallback target under either
-// spelling. Branch nodes execute via registry.Execute inside runBranch and
-// never reach the engine's strict-failure path, so the attr would do nothing
-// at runtime — refusing loudly beats shipping a silently-inert failure route
-// (#313 defect 2). Graph-level fallback_target (dippin `defaults:
-// on_failure`) is unaffected: it lives on graph attrs and applies in the
-// engine's main loop.
-func refuseBranchFallbackTargets(parallelID string, edges []*pipeline.Edge, graph *pipeline.Graph, branchOverrides map[string]map[string]string) error {
+// refuseBranchFallbackTargets fails fast when any branch-target node (or any
+// branch.N.* override group) declares a node-level fallback target under
+// either spelling. Branch nodes execute via registry.Execute inside runBranch
+// and never reach the engine's strict-failure path, so the attr would do
+// nothing at runtime — refusing loudly beats shipping a silently-inert
+// failure route (#313 defect 2). The scan reads the raw indexed branch attrs
+// rather than the collapsed target-keyed override map: with duplicate-target
+// branches the collapse keeps only the highest index wholesale (#368), which
+// would hide an earlier branch's equally-dead fallback declaration (Copilot,
+// PR #377). Graph-level fallback_target (dippin `defaults: on_failure`) is
+// unaffected: it lives on graph attrs and applies in the engine's main loop.
+func refuseBranchFallbackTargets(parallelID string, edges []*pipeline.Edge, graph *pipeline.Graph, parallelAttrs map[string]string) error {
+	// target node ID → fallback attr spelling → declared value, across ALL
+	// branch.N.* groups naming that target (not just the surviving one).
+	declaredByTarget := make(map[string]map[string]string)
+	for _, branchAttrs := range indexBranchAttrs(parallelAttrs) {
+		target := branchAttrs["target"]
+		if target == "" {
+			continue
+		}
+		for _, attr := range branchFallbackAttrs {
+			if v := branchAttrs[attr]; v != "" {
+				if declaredByTarget[target] == nil {
+					declaredByTarget[target] = make(map[string]string)
+				}
+				declaredByTarget[target][attr] = v
+			}
+		}
+	}
 	for _, edge := range edges {
 		for _, attr := range branchFallbackAttrs {
 			declared := ""
 			if tn, ok := graph.Nodes[edge.To]; ok {
 				declared = tn.Attrs[attr]
 			}
-			if ov, ok := branchOverrides[edge.To]; ok && ov[attr] != "" {
-				declared = ov[attr]
+			if v := declaredByTarget[edge.To][attr]; v != "" {
+				declared = v
 			}
 			if declared != "" {
 				return fmt.Errorf("parallel node %q: branch target %q declares %s %q, which is never honored inside a parallel branch — remove it and route branch failure at the aggregating node via fan_in_policy (any|all|quorum) and a conditional fail edge", parallelID, edge.To, attr, declared)

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -187,8 +187,14 @@ var branchFallbackAttrs = []string{"fallback_target", "fallback_retry_target"}
 func refuseBranchFallbackTargets(parallelID string, edges []*pipeline.Edge, graph *pipeline.Graph, parallelAttrs map[string]string) error {
 	// target node ID → fallback attr spelling → declared value, across ALL
 	// branch.N.* groups naming that target (not just the surviving one).
+	// Indices are visited in ascending order so that when several groups
+	// declare a fallback for the same target, the highest index's value is
+	// the one reported — deterministic output, matching the last-branch-wins
+	// duplicate-target convention (#368).
+	indexed := indexBranchAttrs(parallelAttrs)
 	declaredByTarget := make(map[string]map[string]string)
-	for _, branchAttrs := range indexBranchAttrs(parallelAttrs) {
+	for _, idx := range slices.Sorted(maps.Keys(indexed)) {
+		branchAttrs := indexed[idx]
 		target := branchAttrs["target"]
 		if target == "" {
 			continue

--- a/pipeline/handlers/parallel_test.go
+++ b/pipeline/handlers/parallel_test.go
@@ -1324,3 +1324,35 @@ func TestParallelHandlerRefusesFallbackOnShadowedDuplicateTargetBranch(t *testin
 		})
 	}
 }
+
+// TestParallelHandlerRefusalReportsHighestBranchIndexFallback pins
+// deterministic refusal output (Copilot, PR #380): when multiple branch.N.*
+// groups declare a fallback for the same target, the guard must visit
+// indices in ascending order so the highest index's value is the one
+// reported — matching the last-branch-wins duplicate-target convention
+// (#368) — instead of whichever group map iteration yields. Looped to catch
+// map-order flakiness, mirroring the #368 determinism test.
+func TestParallelHandlerRefusalReportsHighestBranchIndexFallback(t *testing.T) {
+	for run := 0; run < 20; run++ {
+		g := buildTestGraph([]string{"branch_a"}, "stub_success")
+		pn := g.Nodes["parallel_node"]
+		for i := 0; i < 8; i++ {
+			pn.Attrs[fmt.Sprintf("branch.%d.target", i)] = "branch_a"
+			pn.Attrs[fmt.Sprintf("branch.%d.fallback_target", i)] = fmt.Sprintf("Escalate%d", i)
+		}
+		registry := pipeline.NewHandlerRegistry()
+		registry.Register(&stubHandler{
+			name:    "stub_success",
+			outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+		})
+
+		h := NewParallelHandler(g, registry, nil)
+		_, err := h.Execute(context.Background(), pn, pipeline.NewPipelineContext())
+		if err == nil {
+			t.Fatalf("run %d: expected refusal, got nil", run)
+		}
+		if !strings.Contains(err.Error(), `"Escalate7"`) {
+			t.Fatalf("run %d: refusal should report highest-index value Escalate7, got: %v", run, err)
+		}
+	}
+}

--- a/pipeline/handlers/parallel_test.go
+++ b/pipeline/handlers/parallel_test.go
@@ -1285,3 +1285,42 @@ func TestParallelHandlerRefusesBranchFallbackRetryTarget(t *testing.T) {
 		})
 	}
 }
+
+// TestParallelHandlerRefusesFallbackOnShadowedDuplicateTargetBranch pins the
+// duplicate-target edge of the #313 refusal (Copilot, PR #377): when two
+// branch.N.* groups name the same target, groupBranchOverridesByTarget keeps
+// only the highest index wholesale — an earlier branch's fallback_target /
+// fallback_retry_target is dropped before the collapsed-map check sees it.
+// The declaration in the workflow is still silently dead, so the guard must
+// scan the raw indexed branch attrs, not just the collapsed overrides.
+func TestParallelHandlerRefusesFallbackOnShadowedDuplicateTargetBranch(t *testing.T) {
+	for _, attr := range []string{"fallback_target", "fallback_retry_target"} {
+		t.Run(attr, func(t *testing.T) {
+			g := buildTestGraph([]string{"branch_a"}, "stub_success")
+			pn := g.Nodes["parallel_node"]
+			pn.Attrs["branch.0.target"] = "branch_a"
+			pn.Attrs["branch.0."+attr] = "EscalateToHuman"
+			// branch.1 shadows branch.0 wholesale (last-branch-wins, #368).
+			pn.Attrs["branch.1.target"] = "branch_a"
+			pn.Attrs["branch.1.llm_model"] = "gpt-4o"
+			registry := pipeline.NewHandlerRegistry()
+			stub := &stubHandler{
+				name:    "stub_success",
+				outcome: pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)},
+			}
+			registry.Register(stub)
+
+			h := NewParallelHandler(g, registry, nil)
+			_, err := h.Execute(context.Background(), pn, pipeline.NewPipelineContext())
+			if err == nil {
+				t.Fatalf("expected refusal for shadowed %s on duplicate-target branch, got nil", attr)
+			}
+			if !strings.Contains(err.Error(), attr) {
+				t.Errorf("error %q should mention %q", err.Error(), attr)
+			}
+			if stub.called.Load() != 0 {
+				t.Errorf("no branch should run after refusal, got %d calls", stub.called.Load())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #377, addressing Copilot's post-merge finding: `refuseBranchFallbackTargets` read the **collapsed** target-keyed override map, where duplicate-target branches keep only the highest-index group wholesale (`groupBranchOverridesByTarget`, last-branch-wins per #368). An earlier `branch.N.fallback_target` / `branch.N.fallback_retry_target` naming the same target was dropped before the guard could see it — leaving exactly the silently-dead fallback declaration the guard exists to refuse.

The guard now scans the **raw indexed** `branch.N.*` groups (`indexBranchAttrs`): any group naming a branch target with a fallback attr under either spelling refuses at dispatch, shadowed or not.

Also tightens the deep_review changelog entry per the #378 post-merge comment: states explicitly that `.ai/review/goal.txt` is no longer written.

## Verification

- TDD: `TestParallelHandlerRefusesFallbackOnShadowedDuplicateTargetBranch` (both spellings) watched failing against the collapsed-map implementation first
- `go build ./...`, `go test ./... -short`, `go test -race -short ./pipeline/...` — pass
- gofmt clean

Refs #313 (closed — this is hardening on the shipped guard, not new scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783887481&installation_id=131176874&pr_number=380&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F380&signature=b9ee4a74dbbed344499a2f14c685661dea34e4dc3a4d7915b65c2f7c580ee937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->