### PR TITLE
docs(site): v0.39.1 refresh — changelog section + latest pointer

### DIFF
--- a/site/content/_index.html
+++ b/site/content/_index.html
@@ -48,7 +48,7 @@ jsonld:
       Three agent backends &mdash; <strong>native</strong> (Anthropic / OpenAI / Gemini / OpenAI-compat),
       <strong>Claude&nbsp;Code</strong> (subscription auth, file editing, terminal),
       and <strong>ACP</strong> (claude-agent-acp&nbsp;/ codex-acp&nbsp;/ gemini --acp). Mix per node.
-      &middot; Latest: <a href="changelog.html#v0-39-0">v0.39.0</a>
+      &middot; Latest: <a href="changelog.html#v0-39-1">v0.39.1</a>
     </p>
   </section>
 

--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,6 +28,7 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
+    <a href="#v0-39-1">v0.39.1</a>
     <a href="#v0-39-0">v0.39.0</a>
     <a href="#v0-38-1">v0.38.1</a>
     <a href="#v0-38-0">v0.38.0</a>
@@ -73,6 +74,30 @@ jsonld:
     <a href="#v0-9-x">v0.9.x</a>
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
+
+  <!-- ═══ v0.39.1 ═══ -->
+  <section class="glass" id="v0-39-1" style="border-left: 3px solid var(--orange-600);">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.39.1" style="color: inherit; text-decoration: none;">v0.39.1</a></h2>
+      <span class="badge">2026-06-12</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.39.1" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">
+      <strong>Case-study hardening rounds 5&ndash;6 &mdash; the audit log stops double-counting, per-branch
+      security overrides actually apply, a silently-inert failure route is refused at dispatch, and the
+      embedded built-ins clean up their act.</strong> Six fixes, no breaking changes; all four embedded
+      workflows hold A grades on <code>dippin doctor</code>.
+    </p>
+    <h4>Fixed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong>activity.jsonl no longer logs every LLM event twice</strong> (<a href="https://github.com/2389-research/tracker/issues/354">#354</a>). The client-level trace observer and the agent session both wrote the same stream &mdash; doubling audit volume and skewing <code>tracker diagnose</code> event counts. One writer now owns the stream.</li>
+      <li><strong>Per-branch <code>tool_access:</code> / <code>writable_paths:</code> overrides reach the runtime</strong> (<a href="https://github.com/2389-research/tracker/issues/368">#368</a>). The adapter silently dropped the per-branch security overrides the IR carries; they now propagate with the same fail-closed canonicalization and jail refuse-to-start treatment as agent-level attrs, and duplicate-target branches resolve deterministically (last branch wins).</li>
+      <li><strong>Inert per-branch <code>fallback_target</code> is refused at parallel dispatch</strong> (<a href="https://github.com/2389-research/tracker/issues/313">#313</a> defect 2 &mdash; closes the issue). A fallback declared on a parallel branch target never did anything: branches bypass the engine's strict-failure path. The handler now fails fast before dispatching any branch &mdash; either attr spelling, on the target node or any <code>branch.N.*</code> group (shadowed duplicates included) &mdash; pointing at the supported pattern: <code>fan_in_policy</code> + a conditional fail edge at the aggregating node.</li>
+      <li><strong>build_product_with_superspec: a failed cross-reviewer can no longer be masked</strong> (<a href="https://github.com/2389-research/tracker/issues/313">#313</a>). <code>ReviewParallel</code> declares <code>fan_in_policy: all</code> with a fail edge to <code>EscalateToHuman</code>, so a single failed reviewer escalates instead of vanishing into success-if-any aggregation.</li>
+      <li><strong>Embedded deep_review goes from F/35 to A/100 under <code>dippin doctor</code></strong> (<a href="https://github.com/2389-research/tracker/issues/335">#335</a> scope 1). A graph-level <code>on_failure</code> catch-all + escalation gate replace eleven dead-stop failure paths; the review goal flows verbatim via the per-node scoped context key instead of an LLM-copied file; the analysis fan-out demands all three analyzers succeed.</li>
+      <li><strong>build_product stops leaking tracker's own issue/PR numbers into agent-visible text</strong> (<a href="https://github.com/2389-research/tracker/issues/316">#316</a>). 64 references excised from prompt text and tool echo strings &mdash; rules now state themselves on their own terms (<a href="https://github.com/2389-research/tracker/issues/355">#355</a> swept the last template-domain cruft, too).</li>
+    </ul>
+  </section>
 
   <!-- ═══ v0.39.0 ═══ -->
   <section class="glass" id="v0-39-0" style="border-left: 3px solid var(--orange-600);">


### PR DESCRIPTION
Mirrors the v0.39.0 site refresh (#373): adds the v0.39.1 section to the changelog page (TOC link + glass section with the six fixes) and bumps the home-page "Latest" pointer to v0.39.1. Will merge after `gh release view v0.39.1` shows the published release the section links to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783889732&installation_id=131176874&pr_number=382&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F382&signature=73b81f9be8b8532ab927d708fd56df92a37c157f2a9c66ef70b7bcbc26f0d0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->