### PR TITLE
fix(examples): refresh active source files in build-context.md at MarkMilestoneDone (#351 item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **build-context.md now refreshed with active source files at each MarkMilestoneDone** (issue #351, item 3). The Setup node seeds the architecture map once; `MarkMilestoneDone` now appends an updated "Active source files" entry listing the milestone's changed files so agents reading the orientation file see which files are being actively worked, not just the initial entry-point list from project start. Tracker/build-metadata paths remain filtered (#351 items 1+2).
+
 ## [0.39.1] - 2026-06-12
 
 ### Fixed

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1291,6 +1291,12 @@ workflow BuildProduct
             [ "$NFILES" -gt 12 ] && echo "Files: … and $((NFILES - 12)) more"
           fi
           echo "Summary: $SUMMARY"
+          # #351 item 3: refresh the active-source-files section so agents
+          # reading the orientation file see which source files are being
+          # actively worked, not just the initial entry-point list from Setup.
+          if [ "$NFILES" -gt 0 ]; then
+            echo "Active source files (as of milestone $NEXT): $(printf '%s\n' "$FILES" | head -20 | paste -sd, -)"
+          fi
         } >> .ai/build/build-context.md
       ) 2>/dev/null || true
       rm -f .ai/build/milestone-start-sha


### PR DESCRIPTION
## Summary

- Implements #351 item 3: `MarkMilestoneDone` now refreshes the active-source-files section in `.ai/build/build-context.md`
- Each completed milestone appends an updated "Active source files" entry, so the orientation file tracks the evolving codebase rather than freezing at Setup's initial snapshot
- Tracker/build-metadata paths remain filtered (items 1+2 from #369)

## Test plan

- [x] `dippin doctor` A grade on build_product.dip (95/100)
- [x] `dippin doctor` A grade on ask_and_execute.dip and build_product_with_superspec.dip

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784129860&installation_id=131176874&pr_number=383&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F383&signature=10bf178fbb83a316b70627e2a559519417ffcf0e8a0048cef4b0cc2366f02dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build context documentation to clarify how active source files are tracked and refreshed during each milestone completion, showing which files are actively being worked on.

* **Chores**
  * Enhanced build workflow logging to include recently modified files (up to 20) in build metadata when milestones are completed, improving visibility into current development activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->