### PR TITLE
fix(engine): wrap ${ctx.tool_stdout}/tool_stderr expansions in fenced blocks (#352 item 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`${ctx.tool_stdout}` and `${ctx.tool_stderr}` in agent prompts now render as fenced blocks** (issue #352, item 3). Previously, interpolating these context keys mid-sentence pasted raw tool output inline, garbling the instruction text. The variable expansion layer now wraps `tool_stdout`/`tool_stderr` values in a ` ```text ` fenced block under their own heading, so the output is clearly delimited regardless of which workflow uses them.
+
 ## [0.39.1] - 2026-06-12
 
 ### Fixed

--- a/pipeline/expand.go
+++ b/pipeline/expand.go
@@ -161,6 +161,19 @@ func resolveVariableValue(
 		}
 		return "", nil
 	}
+
+	// tool_stdout and tool_stderr are raw tool output — render as a fenced block
+	// so they're clearly delimited when pasted into agent prompts mid-sentence.
+	// Other ctx keys expand inline unchanged.
+	if namespace == "ctx" && !toolCommandMode && value != "" {
+		switch key {
+		case "tool_stdout":
+			return "\n\n## Tool Stdout\n\n```text\n" + value + "\n```\n", nil
+		case "tool_stderr":
+			return "\n\n## Tool Stderr\n\n```text\n" + value + "\n```\n", nil
+		}
+	}
+
 	return value, nil
 }
 

--- a/pipeline/expand.go
+++ b/pipeline/expand.go
@@ -165,11 +165,14 @@ func resolveVariableValue(
 	// tool_stdout and tool_stderr are raw tool output — render as a fenced block
 	// so they're clearly delimited when pasted into agent prompts mid-sentence.
 	// Other ctx keys expand inline unchanged.
+	// Both bare keys ("tool_stdout") and per-node scoped keys
+	// ("node.RunTests.tool_stdout") are matched by checking the suffix, so
+	// ${ctx.node.RunTests.tool_stdout} also gets fenced rendering.
 	if namespace == "ctx" && !toolCommandMode && value != "" {
-		switch key {
-		case "tool_stdout":
+		switch {
+		case key == "tool_stdout" || strings.HasSuffix(key, ".tool_stdout"):
 			return "\n\n## Tool Stdout\n\n```text\n" + value + "\n```\n", nil
-		case "tool_stderr":
+		case key == "tool_stderr" || strings.HasSuffix(key, ".tool_stderr"):
 			return "\n\n## Tool Stderr\n\n```text\n" + value + "\n```\n", nil
 		}
 	}

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -658,6 +658,103 @@ func TestExpandVariables_NormalMode_AllowsEverything(t *testing.T) {
 	}
 }
 
+func TestExpandVariables_ToolStdoutFencedBlock(t *testing.T) {
+	ctx := NewPipelineContext()
+	ctx.Set("tool_stdout", "line one\nline two\nline three")
+	ctx.Set("tool_stderr", "error: something went wrong")
+	ctx.Set("outcome", "fail")
+	ctx.Set("human_response", "yes please")
+
+	tests := []struct {
+		name            string
+		input           string
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:  "tool_stdout renders as fenced block",
+			input: "The output was: ${ctx.tool_stdout} and we should proceed.",
+			wantContains: []string{
+				"## Tool Stdout",
+				"```text",
+				"line one\nline two\nline three",
+				"```",
+			},
+			wantNotContains: []string{
+				"The output was: line one",
+			},
+		},
+		{
+			name:  "tool_stderr renders as fenced block",
+			input: "Errors: ${ctx.tool_stderr} done.",
+			wantContains: []string{
+				"## Tool Stderr",
+				"```text",
+				"error: something went wrong",
+				"```",
+			},
+			wantNotContains: []string{
+				"Errors: error: something went wrong done.",
+			},
+		},
+		{
+			name:  "outcome still expands inline",
+			input: "Result: ${ctx.outcome} end.",
+			wantContains: []string{
+				"Result: fail end.",
+			},
+			wantNotContains: []string{
+				"```text",
+				"## Tool",
+			},
+		},
+		{
+			name:  "human_response still expands inline",
+			input: "User said: ${ctx.human_response}.",
+			wantContains: []string{
+				"User said: yes please.",
+			},
+			wantNotContains: []string{
+				"```text",
+				"## Tool",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExpandVariables(tt.input, ctx, nil, nil, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result does not contain %q\ngot: %q", want, result)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(result, notWant) {
+					t.Errorf("result unexpectedly contains %q\ngot: %q", notWant, result)
+				}
+			}
+		})
+	}
+}
+
+func TestExpandVariables_ToolStdoutEmpty(t *testing.T) {
+	ctx := NewPipelineContext()
+	ctx.Set("tool_stdout", "")
+
+	result, err := ExpandVariables("Before: ${ctx.tool_stdout} After.", ctx, nil, nil, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Empty tool_stdout should not produce a spurious fenced block
+	if strings.Contains(result, "```text") {
+		t.Errorf("empty tool_stdout produced spurious fenced block: %q", result)
+	}
+}
+
 func TestInjectParamsIntoGraphPreservesValidationAndIndexes(t *testing.T) {
 	g := NewGraph("sub")
 	g.AddNode(&Node{ID: "a", Shape: "box"})

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -749,9 +749,14 @@ func TestExpandVariables_ToolStdoutEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Empty tool_stdout should not produce a spurious fenced block
+	// Empty tool_stdout should not produce a spurious fenced block — it expands
+	// to empty string like any other undefined/empty ctx key.
 	if strings.Contains(result, "```text") {
 		t.Errorf("empty tool_stdout produced spurious fenced block: %q", result)
+	}
+	want := "Before:  After."
+	if result != want {
+		t.Errorf("expected %q for empty tool_stdout, got %q", want, result)
 	}
 }
 

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -755,6 +755,57 @@ func TestExpandVariables_ToolStdoutEmpty(t *testing.T) {
 	}
 }
 
+func TestExpandVariables_NodeScopedToolStdoutFencedBlock(t *testing.T) {
+	// Node-scoped keys like ${ctx.node.RunTests.tool_stdout} must also render
+	// as fenced blocks — not inline. Codex finding P2: the bare-key switch only
+	// matched "tool_stdout"; per-node references used key="node.RunTests.tool_stdout"
+	// and bypassed the fenced rendering.
+	ctx := NewPipelineContext()
+	ctx.Set("node.RunTests.tool_stdout", "line one\nline two")
+	ctx.Set("node.RunTests.tool_stderr", "warn: something")
+
+	tests := []struct {
+		name         string
+		input        string
+		wantContains []string
+	}{
+		{
+			name:  "node-scoped tool_stdout renders as fenced block",
+			input: "Output: ${ctx.node.RunTests.tool_stdout} done.",
+			wantContains: []string{
+				"## Tool Stdout",
+				"```text",
+				"line one\nline two",
+				"```",
+			},
+		},
+		{
+			name:  "node-scoped tool_stderr renders as fenced block",
+			input: "Errors: ${ctx.node.RunTests.tool_stderr} done.",
+			wantContains: []string{
+				"## Tool Stderr",
+				"```text",
+				"warn: something",
+				"```",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ExpandVariables(tt.input, ctx, nil, nil, false)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, want := range tt.wantContains {
+				if !strings.Contains(result, want) {
+					t.Errorf("result does not contain %q\ngot: %q", want, result)
+				}
+			}
+		})
+	}
+}
+
 func TestInjectParamsIntoGraphPreservesValidationAndIndexes(t *testing.T) {
 	g := NewGraph("sub")
 	g.AddNode(&Node{ID: "a", Shape: "box"})


### PR DESCRIPTION
## Summary

- Transform-level fix for #352 item 3: `ExpandVariables` now wraps `tool_stdout` and `tool_stderr` ctx values in a fenced ` ```text ` block under their own heading, instead of pasting raw output inline
- Other ctx keys (`outcome`, `human_response`, `tool_marker`, etc.) expand unchanged  
- Completes issue #352 (items 1+2 shipped in v0.39.0 via #370)

## Test plan

- [x] Failing tests written first (TDD RED)
- [x] Tests verified to fail before implementation
- [x] Implementation makes tests pass (TDD GREEN)
- [x] `go build ./...` passes
- [x] `go test ./... -short` passes
- [x] `go test -race -short ./pipeline/...` passes
- [x] dippin doctor A grade on all three example pipelines

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent prompt variable interpolation where tool output (`${ctx.tool_stdout}` and `${ctx.tool_stderr}`) is now rendered as formatted markdown blocks with dedicated sections instead of inline text, preventing prompt corruption and improving readability. Node-scoped tool output references are handled identically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784131278&installation_id=131176874&pr_number=384&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F384&signature=7fb3864eda9141247bb68616fa95e8458c0bcff433ccc1c8e63b22e241ea904e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->