### PR TITLE
fix(examples): bring non-embedded examples to A grade under dippin doctor (#335 scope 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Non-embedded example workflows now hold A grades under `dippin doctor`** (#335 scope 2). Nine example `.dip` files that shipped with D or F grades (`consensus_task`, `consensus_task_parity`, `sprint_exec`, `human_gate_showcase`, `parallel-ralph-dev`, `semport_thematic`, `fix-tracker-visibility`, `human_gate_test_suite`, `reasoning_effort_demo`) have been structurally hardened: graph-level `on_failure` catch-alls, `max_restarts` defaults, corrected subgraph `ref:` paths, and removal of `label:` edges on interview-mode nodes (DIP129). All now reach A/95–A/100. Core embedded pipelines (`ask_and_execute`, `build_product`, `build_product_with_superspec`, `deep_review`) hold their existing grades with no regressions.
+
 - **`${ctx.tool_stdout}` and `${ctx.tool_stderr}` in agent prompts now render as fenced blocks** (issue #352, item 3). Previously, interpolating these context keys mid-sentence pasted raw tool output inline, garbling the instruction text. The variable expansion layer now wraps `tool_stdout`/`tool_stderr` values in a ` ```text ` fenced block under their own heading, so the output is clearly delimited regardless of which workflow uses them. Per-node scoped references (`${ctx.node.RunTests.tool_stdout}`) are also handled.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Non-embedded example workflows now hold A grades under `dippin doctor`** (#335 scope 2). Nine example `.dip` files that shipped with D or F grades (`consensus_task`, `consensus_task_parity`, `sprint_exec`, `human_gate_showcase`, `parallel-ralph-dev`, `semport_thematic`, `fix-tracker-visibility`, `human_gate_test_suite`, `reasoning_effort_demo`) have been structurally hardened: graph-level `on_failure` catch-alls, `max_restarts` defaults, corrected subgraph `ref:` paths, and removal of `label:` edges on interview-mode nodes (DIP129). All now reach A/95–A/100. Core embedded pipelines (`ask_and_execute`, `build_product`, `build_product_with_superspec`, `deep_review`) hold their existing grades with no regressions.
+- **Non-embedded example workflows now hold A grades under `dippin doctor`**
+  (issue #335, scope 2). Nine example `.dip` files that shipped with D or F
+  grades (`consensus_task`, `consensus_task_parity`, `sprint_exec`,
+  `human_gate_showcase`, `parallel-ralph-dev`, `semport_thematic`,
+  `fix-tracker-visibility`, `human_gate_test_suite`, `reasoning_effort_demo`)
+  have been structurally hardened: graph-level `on_failure` catch-alls,
+  `max_restarts` defaults, corrected subgraph `ref:` paths, and removal of
+  `label:` edges on interview-mode nodes (DIP129). All now reach A/95–A/100.
+  Core embedded pipelines (`ask_and_execute`, `build_product`,
+  `build_product_with_superspec`, `deep_review`) hold their existing grades
+  with no regressions.
 
 - **`${ctx.tool_stdout}` and `${ctx.tool_stderr}` in agent prompts now render as fenced blocks** (issue #352, item 3). Previously, interpolating these context keys mid-sentence pasted raw tool output inline, garbling the instruction text. The variable expansion layer now wraps `tool_stdout`/`tool_stderr` values in a ` ```text ` fenced block under their own heading, so the output is clearly delimited regardless of which workflow uses them. Per-node scoped references (`${ctx.node.RunTests.tool_stdout}`) are also handled.
 

--- a/examples/consensus_task.dip
+++ b/examples/consensus_task.dip
@@ -5,7 +5,9 @@ workflow ConsensusTask
 
   defaults
     max_retries: 3
+    max_restarts: 5
     fidelity: truncate
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/consensus_task_parity.dip
+++ b/examples/consensus_task_parity.dip
@@ -5,7 +5,9 @@ workflow ConsensusTaskParity
 
   defaults
     max_retries: 3
+    max_restarts: 5
     fidelity: truncate
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/fix-tracker-visibility.dip
+++ b/examples/fix-tracker-visibility.dip
@@ -5,7 +5,9 @@ workflow FixTrackerVisibility
 
   defaults
     max_retries: 2
+    max_restarts: 20
     fidelity: summary:high
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/human_gate_showcase.dip
+++ b/examples/human_gate_showcase.dip
@@ -5,6 +5,7 @@ workflow HumanGateShowcase
 
   defaults
     fidelity: summary:medium
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/human_gate_test_suite.dip
+++ b/examples/human_gate_test_suite.dip
@@ -6,6 +6,7 @@ workflow HumanGateTestSuite
   defaults
     fidelity: summary:medium
     max_retries: 1
+    on_failure: Exit
 
   tool Start
     label: "Start"
@@ -313,8 +314,8 @@ workflow HumanGateTestSuite
     # Section 7: Interview Cancel
     InterviewConfirm -> QuestionWriter2
     QuestionWriter2 -> CancelableInterview
-    CancelableInterview -> CompletedPath  when ctx.outcome = success  label: "Completed"  weight: 2
-    CancelableInterview -> CanceledPath  when ctx.outcome = fail  label: "Canceled"
+    CancelableInterview -> CompletedPath  when ctx.outcome = success  weight: 2
+    CancelableInterview -> CanceledPath  when ctx.outcome = fail
     CompletedPath -> CancelConfirm
     CanceledPath -> CancelConfirm
 

--- a/examples/parallel-ralph-dev.dip
+++ b/examples/parallel-ralph-dev.dip
@@ -5,7 +5,9 @@ workflow parallel_ralph_dev
 
   defaults
     max_retries: 2
+    max_restarts: 10
     fidelity: summary:high
+    on_failure: Exit
 
   agent Start
     label: Start
@@ -59,7 +61,7 @@ workflow parallel_ralph_dev
 
   subgraph Brainstorm
     label: "Brainstorm Requirements"
-    ref: subgraphs/brainstorm-human
+    ref: subgraphs/brainstorm-human.dip
 
   agent DecomposeFeature
     label: "Decompose into Streams"
@@ -201,7 +203,7 @@ workflow parallel_ralph_dev
 
   subgraph StreamA
     label: "Stream A — Adaptive Ralph"
-    ref: subgraphs/adaptive-ralph-stream
+    ref: subgraphs/adaptive-ralph-stream.dip
     params:
       stream_id: stream-a
       branch: feature/stream-a
@@ -209,7 +211,7 @@ workflow parallel_ralph_dev
 
   subgraph StreamB
     label: "Stream B — Adaptive Ralph"
-    ref: subgraphs/adaptive-ralph-stream
+    ref: subgraphs/adaptive-ralph-stream.dip
     params:
       stream_id: stream-b
       branch: feature/stream-b

--- a/examples/reasoning_effort_demo.dip
+++ b/examples/reasoning_effort_demo.dip
@@ -9,6 +9,7 @@ workflow ReasoningEffortDemo
   defaults
     max_retries: 2
     fidelity: summary:medium
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/semport_thematic.dip
+++ b/examples/semport_thematic.dip
@@ -5,6 +5,8 @@ workflow SemportThematic
 
   defaults
     max_retries: 5
+    max_restarts: 20
+    on_failure: Exit
 
   agent Start
     label: Start

--- a/examples/sprint_exec.dip
+++ b/examples/sprint_exec.dip
@@ -5,7 +5,7 @@ workflow SprintExec
 
   defaults
     fidelity: summary:medium
-    on_failure: Exit
+    on_failure: FailureSummary
 
   agent Start
     label: Start

--- a/examples/sprint_exec.dip
+++ b/examples/sprint_exec.dip
@@ -5,6 +5,7 @@ workflow SprintExec
 
   defaults
     fidelity: summary:medium
+    on_failure: Exit
 
   agent Start
     label: Start


### PR DESCRIPTION
## Summary

Nine non-embedded example `.dip` files that shipped with D or F grades under `dippin doctor` are now structurally hardened to A/95–A/100. These files are not embedded in the binary (not in `tracker_workflows.go`), so no shipped functionality changes.

**Before → After:**
| File | Before | After |
|------|--------|-------|
| `consensus_task.dip` | F/15 | A/100 |
| `consensus_task_parity.dip` | F/15 | A/100 |
| `sprint_exec.dip` | F/25 | A/100 |
| `human_gate_showcase.dip` | F/40 | A/100 |
| `parallel-ralph-dev.dip` | F/45 | A/95 |
| `semport_thematic.dip` | F/45 | A/100 |
| `fix-tracker-visibility.dip` | D/65 | A/100 |
| `human_gate_test_suite.dip` | C/70 | A/100 |
| `reasoning_effort_demo.dip` | B/80 | A/100 |

**Structural changes made (no behavior changes):**
- Graph-level `on_failure: Exit` defaults on all files (covers DIP144 nodes-with-no-failure-route warnings)
- `max_restarts` defaults where retry edges exist (covers DIP134)
- Fixed `parallel-ralph-dev.dip` subgraph `ref:` paths to include `.dip` extension (DIP126 missing-subgraph warnings)
- Removed `label:` from interview-mode outcome edges in `human_gate_test_suite.dip` (DIP129: interview mode routes by outcome, not label)

**Core pipeline grades (no regressions):**
- `ask_and_execute.dip`: A/95 ✓
- `build_product.dip`: A/90 ✓
- `build_product_with_superspec.dip`: A/100 ✓
- `deep_review.dip`: A/100 ✓

## Test plan

- [x] `dippin doctor` run on all 9 fixed files — all A grade
- [x] `dippin doctor` run on 4 core embedded pipelines — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784136003&installation_id=131176874&pr_number=386&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F386&signature=1877c90d92b859e46ab32d0c97df807dd1a992e7949f2d06254acbec166bae08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->