### PR TITLE
feat(engine): per-node cost ceiling and no-progress detector (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Per-node cost ceiling and no-progress detector for the engine** (issue #304).
+  Two new guards complement the existing `max_turns` backstop. A node with
+  `max_cost_usd: "0.50"` halts when its cumulative session cost exceeds that
+  threshold, independent of turn count, and routes `OutcomeRetry` so the
+  existing retry/escalation path handles it. A node with `no_progress_turns: 5`
+  halts after five consecutive turns without any tool calls and routes
+  `OutcomeRetry` — catching agents stuck generating text without taking action.
+  Both limits support graph-level defaults (set as graph attrs) that individual
+  nodes can override per-node. The signals are exposed as `NodeCostExceeded` and
+  `NoProgressDetected` on `agent.SessionResult` and emitted as
+  `EventNodeCostLimitExceeded` / `EventNodeNoProgressDetected` pipeline events.
+  With these guards in place, `max_turns` serves as a coarse backstop that
+  should rarely bind during normal runs.
+
 ## [0.39.2] - 2026-06-15
 
 ### Fixed

--- a/agent/config.go
+++ b/agent/config.go
@@ -133,6 +133,16 @@ type SessionConfig struct {
 	// (fail-closed) before wiring the writable_paths fs-jail. Empty string
 	// is treated as "native" by configureJail. See issue #272.
 	Backend string
+
+	// MaxCostUSD is the per-node cumulative cost ceiling in USD. The session
+	// halts after any turn whose cumulative cost exceeds this value and sets
+	// SessionResult.NodeCostExceeded. Zero means no limit. (#304)
+	MaxCostUSD float64
+
+	// NoProgressTurns is the number of consecutive turns with no tool calls
+	// after which the session halts and sets SessionResult.NoProgressDetected.
+	// Zero means the detector is disabled. (#304)
+	NoProgressTurns int
 }
 
 // IsToolAccessRestricted reports whether ToolAccess is set to any non-empty

--- a/agent/config.go
+++ b/agent/config.go
@@ -194,6 +194,9 @@ func (c SessionConfig) Validate() error {
 	if err := c.validateCheckpoints(); err != nil {
 		return err
 	}
+	if err := c.validateGuards(); err != nil {
+		return err
+	}
 	return c.validateResponseFormat()
 }
 
@@ -245,6 +248,18 @@ func (c SessionConfig) validateLimits() error {
 	}
 	if c.MaxVerifyRetries < 0 {
 		return fmt.Errorf("MaxVerifyRetries must be >= 0, got %d", c.MaxVerifyRetries)
+	}
+	return nil
+}
+
+// validateGuards checks the #304 per-node runaway guard fields.
+// Zero is the valid "disabled" sentinel; only negative values are rejected.
+func (c SessionConfig) validateGuards() error {
+	if c.MaxCostUSD < 0 {
+		return fmt.Errorf("MaxCostUSD must be >= 0, got %f", c.MaxCostUSD)
+	}
+	if c.NoProgressTurns < 0 {
+		return fmt.Errorf("NoProgressTurns must be >= 0, got %d", c.NoProgressTurns)
 	}
 	return nil
 }

--- a/agent/result.go
+++ b/agent/result.go
@@ -31,6 +31,8 @@ type SessionResult struct {
 	MaxTurnsUsed       bool
 	LoopDetected       bool
 	BreachVerify       BreachVerifyState // #303: result of the verify-on-breach pass
+	NodeCostExceeded   bool              // #304: true when per-node MaxCostUSD was breached
+	NoProgressDetected bool              // #304: true when NoProgressTurns consecutive tool-call-free turns elapsed
 	ToolCalls          map[string]int
 	FilesModified      []string
 	FilesCreated       []string

--- a/agent/session.go
+++ b/agent/session.go
@@ -208,7 +208,11 @@ func (s *Session) Run(ctx context.Context, userInput string) (SessionResult, err
 		return result, err
 	}
 
-	if !stoppedNaturally {
+	// #304: node-level guards (NodeCostExceeded, NoProgressDetected) stop the
+	// loop early and are not turn exhaustion — skip MaxTurnsUsed and
+	// verify-on-breach so the codergen handler can route them correctly.
+	guardStop := result.NodeCostExceeded || result.NoProgressDetected
+	if !stoppedNaturally && !guardStop {
 		result.MaxTurnsUsed = true
 		// #303 verify-on-breach: only on plain exhaustion (not a detected
 		// loop), only when the pipeline asked for it via VerifyOnBreach, and

--- a/agent/session.go
+++ b/agent/session.go
@@ -163,10 +163,11 @@ const maxReflectionTurns = 3
 
 // turnState carries per-loop mutable state for the agentic turn loop.
 type turnState struct {
-	lastToolSignature    string
-	consecutiveLoopCount int
-	emptyResponseRetries int
-	consecutiveReflected int // turns in a row that triggered reflection
+	lastToolSignature      string
+	consecutiveLoopCount   int
+	emptyResponseRetries   int
+	consecutiveReflected   int // turns in a row that triggered reflection
+	consecutiveNoToolTurns int // #304: turns in a row with no tool calls (no-progress detector)
 }
 
 // Run executes the agentic loop: send user input to the LLM, execute any tool
@@ -234,12 +235,30 @@ func (s *Session) runTurnLoop(ctx context.Context, start time.Time, tracker *Con
 			result.Duration = time.Since(start)
 			return false, err
 		}
+		prevToolCount := result.TotalToolCalls()
 		done, stop, err := s.executeTurn(ctx, turn, start, tracker, result, ts)
 		if err != nil {
 			return false, err
 		}
 		if stop {
 			return done, nil
+		}
+		// #304: per-node cost ceiling — halt when cumulative cost exceeds limit.
+		if s.config.MaxCostUSD > 0 && result.Usage.EstimatedCost > s.config.MaxCostUSD {
+			result.NodeCostExceeded = true
+			return false, nil
+		}
+		// #304: no-progress detector — halt after K consecutive tool-call-free turns.
+		if s.config.NoProgressTurns > 0 {
+			if result.TotalToolCalls() > prevToolCount {
+				ts.consecutiveNoToolTurns = 0
+			} else {
+				ts.consecutiveNoToolTurns++
+				if ts.consecutiveNoToolTurns >= s.config.NoProgressTurns {
+					result.NoProgressDetected = true
+					return false, nil
+				}
+			}
 		}
 	}
 	return false, nil

--- a/agent/session.go
+++ b/agent/session.go
@@ -240,6 +240,7 @@ func (s *Session) runTurnLoop(ctx context.Context, start time.Time, tracker *Con
 			return false, err
 		}
 		prevToolCount := result.TotalToolCalls()
+		prevEmptyRetries := ts.emptyResponseRetries
 		done, stop, err := s.executeTurn(ctx, turn, start, tracker, result, ts)
 		if err != nil {
 			return false, err
@@ -253,7 +254,9 @@ func (s *Session) runTurnLoop(ctx context.Context, start time.Time, tracker *Con
 			return false, nil
 		}
 		// #304: no-progress detector — halt after K consecutive tool-call-free turns.
-		if s.config.NoProgressTurns > 0 {
+		// Skip the check during empty-response retry sequences: the session is
+		// actively recovering from a provider hiccup, not truly stuck.
+		if s.config.NoProgressTurns > 0 && ts.emptyResponseRetries == prevEmptyRetries {
 			if result.TotalToolCalls() > prevToolCount {
 				ts.consecutiveNoToolTurns = 0
 			} else {

--- a/agent/session.go
+++ b/agent/session.go
@@ -245,13 +245,15 @@ func (s *Session) runTurnLoop(ctx context.Context, start time.Time, tracker *Con
 		if err != nil {
 			return false, err
 		}
-		if stop {
-			return done, nil
-		}
-		// #304: per-node cost ceiling — halt when cumulative cost exceeds limit.
+		// #304: per-node cost ceiling — checked before honouring stop so the
+		// ceiling takes precedence even on the turn that naturally completes
+		// the session (cost updated by executeTurn before it returns).
 		if s.config.MaxCostUSD > 0 && result.Usage.EstimatedCost > s.config.MaxCostUSD {
 			result.NodeCostExceeded = true
 			return false, nil
+		}
+		if stop {
+			return done, nil
 		}
 		// #304: no-progress detector — halt after K consecutive tool-call-free turns.
 		// Skip the check during empty-response retry sequences: the session is

--- a/agent/session_guards_test.go
+++ b/agent/session_guards_test.go
@@ -137,6 +137,35 @@ func TestSessionNoProgressNotSetWhenLimitUnset(t *testing.T) {
 	}
 }
 
+func TestSessionNoProgressNotTriggeredByEmptyResponseRetry(t *testing.T) {
+	// An empty API response causes the session to retry (not a progress failure).
+	// With NoProgressTurns=1, the retry turn must NOT count as a no-progress turn.
+	empty := &llm.Response{
+		Message:      llm.Message{Role: llm.RoleAssistant},
+		FinishReason: llm.FinishReason{Reason: "stop"},
+		Usage:        llm.Usage{OutputTokens: 0},
+	}
+	done := &llm.Response{
+		Message:      llm.AssistantMessage("done"),
+		FinishReason: llm.FinishReason{Reason: "stop"},
+		Usage:        llm.Usage{OutputTokens: 10},
+	}
+	client := &mockCompleter{responses: []*llm.Response{empty, done}}
+
+	cfg := DefaultConfig()
+	cfg.NoProgressTurns = 1 // very aggressive — fires on first no-tool turn
+	cfg.MaxTurns = 10
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NoProgressDetected {
+		t.Error("NoProgressDetected should not fire during empty-response retry sequence")
+	}
+}
+
 func TestSessionNoProgressResetsWhenToolsCalled(t *testing.T) {
 	// Tool calls reset the no-progress counter. Pattern: no-tool, tool-call,
 	// no-tool — only one consecutive no-tool turn before and after the tool

--- a/agent/session_guards_test.go
+++ b/agent/session_guards_test.go
@@ -1,0 +1,172 @@
+// ABOUTME: Tests for per-node cost ceiling and no-progress detector guards (#304).
+// ABOUTME: Validates that the session halts and sets the correct result flags.
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// lengthTruncatedResponse returns a response with the given estimated cost
+// and FinishReason "length" so the session loop continues without stopping naturally.
+func lengthTruncatedResponse(estimatedCost float64) *llm.Response {
+	return &llm.Response{
+		Message:      llm.AssistantMessage("still working..."),
+		FinishReason: llm.FinishReason{Reason: "length"},
+		Usage: llm.Usage{
+			EstimatedCost: estimatedCost,
+			InputTokens:   100,
+			OutputTokens:  50,
+			TotalTokens:   150,
+		},
+	}
+}
+
+func TestSessionNodeCostExceededHaltsLoop(t *testing.T) {
+	// Two turns at $0.006 each → cumulative $0.012 > $0.01 limit after turn 2.
+	// The third response should never be reached.
+	client := &mockCompleter{responses: []*llm.Response{
+		lengthTruncatedResponse(0.006),
+		lengthTruncatedResponse(0.006),
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.MaxCostUSD = 0.01
+	cfg.MaxTurns = 10
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.NodeCostExceeded {
+		t.Error("NodeCostExceeded should be true when cost exceeds MaxCostUSD")
+	}
+	if result.NoProgressDetected {
+		t.Error("NoProgressDetected should not be set when cost guard fires")
+	}
+	if result.Usage.EstimatedCost <= cfg.MaxCostUSD {
+		t.Errorf("cost %.4f should exceed limit %.4f", result.Usage.EstimatedCost, cfg.MaxCostUSD)
+	}
+	// Client should have been called exactly twice (cost guard fires after turn 2).
+	if client.calls != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", client.calls)
+	}
+}
+
+func TestSessionNodeCostExceededNotSetWhenLimitUnset(t *testing.T) {
+	// With MaxCostUSD=0 (unset), the cost guard is disabled — even expensive
+	// responses should not set NodeCostExceeded.
+	client := &mockCompleter{responses: []*llm.Response{
+		lengthTruncatedResponse(0.999),
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.MaxCostUSD = 0 // disabled
+	cfg.MaxTurns = 5
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NodeCostExceeded {
+		t.Error("NodeCostExceeded should not be set when MaxCostUSD is 0")
+	}
+}
+
+func TestSessionNoProgressDetectedAfterKTurns(t *testing.T) {
+	// K=2: two consecutive length-truncated turns with no tool calls → no progress.
+	client := &mockCompleter{responses: []*llm.Response{
+		lengthTruncatedResponse(0.0001),
+		lengthTruncatedResponse(0.0001),
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.NoProgressTurns = 2
+	cfg.MaxTurns = 10
+	cfg.MaxCostUSD = 0 // disable cost guard so no-progress fires first
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.NoProgressDetected {
+		t.Error("NoProgressDetected should be true after K consecutive no-tool turns")
+	}
+	if result.NodeCostExceeded {
+		t.Error("NodeCostExceeded should not be set when no-progress guard fires")
+	}
+	// Guard fires after K=2 turns; third response never reached.
+	if client.calls != 2 {
+		t.Errorf("expected 2 LLM calls, got %d", client.calls)
+	}
+}
+
+func TestSessionNoProgressNotSetWhenLimitUnset(t *testing.T) {
+	// With NoProgressTurns=0 (unset), the no-progress guard is disabled.
+	client := &mockCompleter{responses: []*llm.Response{
+		lengthTruncatedResponse(0.0001),
+		lengthTruncatedResponse(0.0001),
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.NoProgressTurns = 0 // disabled
+	cfg.MaxTurns = 10
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NoProgressDetected {
+		t.Error("NoProgressDetected should not be set when NoProgressTurns is 0")
+	}
+}
+
+func TestSessionNoProgressResetsWhenToolsCalled(t *testing.T) {
+	// Tool calls reset the no-progress counter. Pattern: no-tool, tool-call,
+	// no-tool — only one consecutive no-tool turn before and after the tool
+	// turn; with K=2, the guard never fires.
+	toolResp := &llm.Response{
+		Message: llm.Message{
+			Role: llm.RoleAssistant,
+			Content: []llm.ContentPart{{
+				Kind: llm.KindToolCall,
+				ToolCall: &llm.ToolCallData{
+					ID:        "t1",
+					Name:      "read",
+					Arguments: []byte(`{"path":"no_such_file.txt"}`),
+				},
+			}},
+		},
+		FinishReason: llm.FinishReason{Reason: "tool_calls"},
+		Usage:        llm.Usage{EstimatedCost: 0.0001},
+	}
+	client := &mockCompleter{responses: []*llm.Response{
+		lengthTruncatedResponse(0.0001), // turn 1: no tool, counter=1
+		toolResp,                        // turn 2: tool called, counter reset to 0; loop continues due to error response from tool
+		lengthTruncatedResponse(0.0001), // turn 3: no tool, counter=1
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.NoProgressTurns = 2
+	cfg.MaxTurns = 10
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NoProgressDetected {
+		t.Error("NoProgressDetected should not fire when tool calls reset the counter")
+	}
+}

--- a/agent/session_guards_test.go
+++ b/agent/session_guards_test.go
@@ -60,6 +60,35 @@ func TestSessionNodeCostExceededHaltsLoop(t *testing.T) {
 	}
 }
 
+func TestSessionNodeCostExceededOnNaturalCompletion(t *testing.T) {
+	// The cost ceiling must fire even when the session completes naturally on
+	// the same turn that pushes cumulative cost over the threshold.
+	client := &mockCompleter{responses: []*llm.Response{
+		// Single turn: natural stop (FinishReason=stop), but cost=$0.02 > $0.01 limit.
+		{
+			Message:      llm.AssistantMessage("done"),
+			FinishReason: llm.FinishReason{Reason: "stop"},
+			Usage:        llm.Usage{EstimatedCost: 0.02, OutputTokens: 10},
+		},
+	}}
+
+	cfg := DefaultConfig()
+	cfg.MaxCostUSD = 0.01
+	cfg.MaxTurns = 5
+
+	sess := mustNewSession(t, client, cfg)
+	result, err := sess.Run(context.Background(), "do work")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.NodeCostExceeded {
+		t.Error("NodeCostExceeded should be true when final turn pushes cost over ceiling")
+	}
+	if result.MaxTurnsUsed {
+		t.Error("MaxTurnsUsed should not be set when cost guard fires")
+	}
+}
+
 func TestSessionNodeCostExceededNotSetWhenLimitUnset(t *testing.T) {
 	// With MaxCostUSD=0 (unset), the cost guard is disabled — even expensive
 	// responses should not set NodeCostExceeded.

--- a/agent/session_guards_test.go
+++ b/agent/session_guards_test.go
@@ -48,6 +48,9 @@ func TestSessionNodeCostExceededHaltsLoop(t *testing.T) {
 	if result.NoProgressDetected {
 		t.Error("NoProgressDetected should not be set when cost guard fires")
 	}
+	if result.MaxTurnsUsed {
+		t.Error("MaxTurnsUsed should not be set when cost guard fires — guard stop is not turn exhaustion")
+	}
 	if result.Usage.EstimatedCost <= cfg.MaxCostUSD {
 		t.Errorf("cost %.4f should exceed limit %.4f", result.Usage.EstimatedCost, cfg.MaxCostUSD)
 	}
@@ -102,6 +105,9 @@ func TestSessionNoProgressDetectedAfterKTurns(t *testing.T) {
 	}
 	if result.NodeCostExceeded {
 		t.Error("NodeCostExceeded should not be set when no-progress guard fires")
+	}
+	if result.MaxTurnsUsed {
+		t.Error("MaxTurnsUsed should not be set when no-progress guard fires — guard stop is not turn exhaustion")
 	}
 	// Guard fires after K=2 turns; third response never reached.
 	if client.calls != 2 {

--- a/pipeline/context.go
+++ b/pipeline/context.go
@@ -68,6 +68,15 @@ const (
 	// (which reproduces today's guillotine exactly).
 	ContextKeyTurnBreachClass = "turn_breach_class"
 
+	// ContextKeyNodeCostExceeded is set to "true" when the per-node MaxCostUSD
+	// ceiling is breached; cleared to "" by all other outcome paths so downstream
+	// conditional routing sees a clean state after recovery. (#304)
+	ContextKeyNodeCostExceeded = "node_cost_exceeded"
+
+	// ContextKeyNodeNoProgress is set to "true" when the no-progress detector
+	// fires; cleared to "" by all other outcome paths. (#304)
+	ContextKeyNodeNoProgress = "node_no_progress"
+
 	// Turn-breach classification values (#303).
 	TurnBreachClassPathological     = "pathological"      // loop / no-progress → stop
 	TurnBreachClassVerifiedGreen    = "verified_green"    // breach verify passed → advance as success

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -51,6 +51,16 @@ const (
 	// unconditional-only routing.
 	EventConditionalFallthrough PipelineEventType = "conditional_fallthrough"
 
+	// EventNodeCostLimitExceeded fires when a node's per-node MaxCostUSD
+	// ceiling is breached during the session turn loop. Carries NodeID and
+	// Message. Signals the codergen handler to route OutcomeRetry. (#304)
+	EventNodeCostLimitExceeded PipelineEventType = "node_cost_limit_exceeded"
+
+	// EventNodeNoProgressDetected fires when the no-progress detector halts a
+	// session after NoProgressTurns consecutive tool-call-free turns. Carries
+	// NodeID and Message. Signals the codergen handler to route OutcomeRetry. (#304)
+	EventNodeNoProgressDetected PipelineEventType = "node_no_progress_detected"
+
 	// EventBundleMismatchForced is emitted to activity.jsonl when resume
 	// proceeds despite a bundle-identity mismatch because --force-bundle-mismatch
 	// was set. Records both the original (checkpoint) and current identities

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -52,13 +52,15 @@ const (
 	EventConditionalFallthrough PipelineEventType = "conditional_fallthrough"
 
 	// EventNodeCostLimitExceeded fires when a node's per-node MaxCostUSD
-	// ceiling is breached during the session turn loop. Carries NodeID and
-	// Message. Signals the codergen handler to route OutcomeRetry. (#304)
+	// ceiling is breached during the session turn loop. Emitted by the
+	// codergen handler after routing OutcomeRetry. Carries NodeID and
+	// Message. (#304)
 	EventNodeCostLimitExceeded PipelineEventType = "node_cost_limit_exceeded"
 
-	// EventNodeNoProgressDetected fires when the no-progress detector halts a
-	// session after NoProgressTurns consecutive tool-call-free turns. Carries
-	// NodeID and Message. Signals the codergen handler to route OutcomeRetry. (#304)
+	// EventNodeNoProgressDetected fires when the no-progress detector halts
+	// a session after NoProgressTurns consecutive tool-call-free turns.
+	// Emitted by the codergen handler after routing OutcomeRetry. Carries
+	// NodeID and Message. (#304)
 	EventNodeNoProgressDetected PipelineEventType = "node_no_progress_detected"
 
 	// EventBundleMismatchForced is emitted to activity.jsonl when resume

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -505,8 +505,8 @@ func (h *CodergenHandler) handleRunError(runErr error, node *pipeline.Node, prom
 			pipeline.ContextKeyResponsePrefix + node.ID: runErr.Error(),
 			// #304: clear guard flags so a prior retry's state doesn't
 			// persist into downstream conditional routing.
-			"node_cost_exceeded": "",
-			"node_no_progress":   "",
+			pipeline.ContextKeyNodeCostExceeded: "",
+			pipeline.ContextKeyNodeNoProgress:   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -568,8 +568,8 @@ func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prom
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_cost_exceeded":                        "true",
-			"node_no_progress":                          "", // clear sibling guard flag
+			pipeline.ContextKeyNodeCostExceeded:         "true",
+			pipeline.ContextKeyNodeNoProgress:           "", // clear sibling guard flag
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -605,8 +605,8 @@ func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, ar
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_cost_exceeded":                        "", // clear sibling guard flag
-			"node_no_progress":                          "true",
+			pipeline.ContextKeyNodeCostExceeded:         "", // clear sibling guard flag
+			pipeline.ContextKeyNodeNoProgress:           "true",
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -652,8 +652,8 @@ func (h *CodergenHandler) buildEmptyResponseOutcome(node *pipeline.Node, prompt,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
 			// #304: clear guard flags so a prior retry's state doesn't
 			// persist into downstream conditional routing.
-			"node_cost_exceeded": "",
-			"node_no_progress":   "",
+			pipeline.ContextKeyNodeCostExceeded: "",
+			pipeline.ContextKeyNodeNoProgress:   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -688,8 +688,8 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 			pipeline.ContextKeyResponsePrefix + node.ID: responseText,
 			// #304: clear guard signals so a prior retry's flags don't
 			// persist into downstream routing on subsequent nodes/retries.
-			"node_cost_exceeded": "",
-			"node_no_progress":   "",
+			pipeline.ContextKeyNodeCostExceeded: "",
+			pipeline.ContextKeyNodeNoProgress:   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -503,6 +503,10 @@ func (h *CodergenHandler) handleRunError(runErr error, node *pipeline.Node, prom
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             runErr.Error(),
 			pipeline.ContextKeyResponsePrefix + node.ID: runErr.Error(),
+			// #304: clear guard flags so a prior retry's state doesn't
+			// persist into downstream conditional routing.
+			"node_cost_exceeded": "",
+			"node_no_progress":   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -644,6 +648,10 @@ func (h *CodergenHandler) buildEmptyResponseOutcome(node *pipeline.Node, prompt,
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
+			// #304: clear guard flags so a prior retry's state doesn't
+			// persist into downstream conditional routing.
+			"node_cost_exceeded": "",
+			"node_no_progress":   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -553,9 +553,10 @@ func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prom
 	msg := fmt.Sprintf("node %q: per-node cost ceiling exceeded (cost=%.4f USD)", node.ID, sessResult.Usage.EstimatedCost)
 	if h.pipelineEmitter != nil {
 		h.pipelineEmitter.HandlePipelineEvent(pipeline.PipelineEvent{
-			Type:    pipeline.EventNodeCostLimitExceeded,
-			NodeID:  node.ID,
-			Message: msg,
+			Type:      pipeline.EventNodeCostLimitExceeded,
+			NodeID:    node.ID,
+			Message:   msg,
+			Timestamp: time.Now(),
 		})
 	}
 	outcome := pipeline.Outcome{
@@ -588,9 +589,10 @@ func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, ar
 	msg := fmt.Sprintf("node %q: no-progress detected (%d consecutive turns with no tool calls)", node.ID, cfg.NoProgressTurns)
 	if h.pipelineEmitter != nil {
 		h.pipelineEmitter.HandlePipelineEvent(pipeline.PipelineEvent{
-			Type:    pipeline.EventNodeNoProgressDetected,
-			NodeID:  node.ID,
-			Message: msg,
+			Type:      pipeline.EventNodeNoProgressDetected,
+			NodeID:    node.ID,
+			Message:   msg,
+			Timestamp: time.Now(),
 		})
 	}
 	outcome := pipeline.Outcome{
@@ -674,6 +676,10 @@ func (h *CodergenHandler) buildSuccessOutcome(node *pipeline.Node, prompt, artif
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             responseText,
 			pipeline.ContextKeyResponsePrefix + node.ID: responseText,
+			// #304: clear guard signals so a prior retry's flags don't
+			// persist into downstream routing on subsequent nodes/retries.
+			"node_cost_exceeded": "",
+			"node_no_progress":   "",
 		},
 		Stats: buildSessionStats(sessResult),
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -584,7 +584,8 @@ func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prom
 // fired after NoProgressTurns consecutive tool-call-free turns. Emits
 // EventNodeNoProgressDetected. (#304)
 func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, artifactRoot, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string) (pipeline.Outcome, error) {
-	msg := fmt.Sprintf("node %q: no-progress detected (%d consecutive turns with no tool calls)", node.ID, sessResult.Turns)
+	cfg := node.AgentConfig(h.graphAttrs)
+	msg := fmt.Sprintf("node %q: no-progress detected (%d consecutive turns with no tool calls)", node.ID, cfg.NoProgressTurns)
 	if h.pipelineEmitter != nil {
 		h.pipelineEmitter.HandlePipelineEvent(pipeline.PipelineEvent{
 			Type:    pipeline.EventNodeNoProgressDetected,

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -568,8 +568,8 @@ func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prom
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_cost_exceeded": "true",
-			"node_no_progress":   "", // clear sibling guard flag
+			"node_cost_exceeded":                        "true",
+			"node_no_progress":                          "", // clear sibling guard flag
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -605,8 +605,8 @@ func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, ar
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_cost_exceeded": "", // clear sibling guard flag
-			"node_no_progress":   "true",
+			"node_cost_exceeded":                        "", // clear sibling guard flag
+			"node_no_progress":                          "true",
 		},
 		Stats: buildSessionStats(sessResult),
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -568,7 +568,8 @@ func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prom
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_cost_exceeded":                        "true",
+			"node_cost_exceeded": "true",
+			"node_no_progress":   "", // clear sibling guard flag
 		},
 		Stats: buildSessionStats(sessResult),
 	}
@@ -604,7 +605,8 @@ func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, ar
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyLastResponse:             msg,
 			pipeline.ContextKeyResponsePrefix + node.ID: msg,
-			"node_no_progress":                          "true",
+			"node_cost_exceeded": "", // clear sibling guard flag
+			"node_no_progress":   "true",
 		},
 		Stats: buildSessionStats(sessResult),
 	}

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -27,6 +27,7 @@ type CodergenHandler struct {
 	env                exec.ExecutionEnvironment
 	workingDir         string
 	eventHandler       agent.EventHandler
+	pipelineEmitter    pipeline.PipelineEventHandler // #304: for node-level guard events
 	graphAttrs         map[string]string
 	tokenTracker       *llm.TokenTracker     // for reporting claude-code usage
 	nativeBackend      pipeline.AgentBackend // always available
@@ -58,6 +59,14 @@ type CodergenOption func(*CodergenHandler)
 func WithGraphAttrs(attrs map[string]string) CodergenOption {
 	return func(h *CodergenHandler) {
 		h.graphAttrs = attrs
+	}
+}
+
+// WithPipelineEmitter configures the handler to emit pipeline-level events for
+// node guard signals (cost limit exceeded, no-progress detected). (#304)
+func WithPipelineEmitter(e pipeline.PipelineEventHandler) CodergenOption {
+	return func(h *CodergenHandler) {
+		h.pipelineEmitter = e
 	}
 }
 
@@ -514,6 +523,7 @@ func (h *CodergenHandler) handleRunError(runErr error, node *pipeline.Node, prom
 // through failure edges when present, stops on strict-failure-edge otherwise),
 // OutcomeFail/OutcomeRetry for empty sessions, or OutcomeSuccess for normal
 // completion. auto_status can override any of these.
+// #304: NodeCostExceeded and NoProgressDetected are checked first and route OutcomeRetry.
 func (h *CodergenHandler) buildOutcome(node *pipeline.Node, prompt, artifactRoot string, sessResult agent.SessionResult, collector *transcriptCollector, priorEpisodes []string, native bool) (pipeline.Outcome, error) {
 	responseText := collector.text()
 	responseArtifact := collector.transcript()
@@ -522,11 +532,86 @@ func (h *CodergenHandler) buildOutcome(node *pipeline.Node, prompt, artifactRoot
 	}
 	responseArtifact += "\n\n" + sessResult.String()
 
+	// #304: node-level guards take priority over all other outcome paths.
+	if sessResult.NodeCostExceeded {
+		return h.buildNodeCostExceededOutcome(node, prompt, artifactRoot, responseArtifact, sessResult, priorEpisodes)
+	}
+	if sessResult.NoProgressDetected {
+		return h.buildNoProgressOutcome(node, prompt, artifactRoot, responseArtifact, sessResult, priorEpisodes)
+	}
+
 	if outcome, ok, err := h.buildEmptyResponseOutcome(node, prompt, artifactRoot, responseText, responseArtifact, sessResult); ok {
 		return outcome, err
 	}
 
 	return h.buildSuccessOutcome(node, prompt, artifactRoot, responseText, responseArtifact, sessResult, priorEpisodes, native)
+}
+
+// buildNodeCostExceededOutcome returns an OutcomeRetry when the node's per-node
+// cost ceiling was breached. Emits EventNodeCostLimitExceeded. (#304)
+func (h *CodergenHandler) buildNodeCostExceededOutcome(node *pipeline.Node, prompt, artifactRoot, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string) (pipeline.Outcome, error) {
+	msg := fmt.Sprintf("node %q: per-node cost ceiling exceeded (cost=%.4f USD)", node.ID, sessResult.Usage.EstimatedCost)
+	if h.pipelineEmitter != nil {
+		h.pipelineEmitter.HandlePipelineEvent(pipeline.PipelineEvent{
+			Type:    pipeline.EventNodeCostLimitExceeded,
+			NodeID:  node.ID,
+			Message: msg,
+		})
+	}
+	outcome := pipeline.Outcome{
+		Status: string(pipeline.OutcomeRetry),
+		ContextUpdates: map[string]string{
+			pipeline.ContextKeyLastResponse:             msg,
+			pipeline.ContextKeyResponsePrefix + node.ID: msg,
+			"node_cost_exceeded":                        "true",
+		},
+		Stats: buildSessionStats(sessResult),
+	}
+	if sessResult.Usage.EstimatedCost > 0 {
+		outcome.ContextUpdates["last_cost"] = fmt.Sprintf("%.4f", sessResult.Usage.EstimatedCost)
+	}
+	if sessResult.Turns > 0 {
+		outcome.ContextUpdates["last_turns"] = strconv.Itoa(sessResult.Turns)
+	}
+	h.applyEpisodeContextUpdates(outcome.ContextUpdates, sessResult, priorEpisodes)
+	if err := pipeline.WriteStageArtifacts(artifactRoot, node.ID, prompt, responseArtifact, outcome); err != nil {
+		return pipeline.Outcome{}, err
+	}
+	return outcome, nil
+}
+
+// buildNoProgressOutcome returns an OutcomeRetry when the no-progress detector
+// fired after NoProgressTurns consecutive tool-call-free turns. Emits
+// EventNodeNoProgressDetected. (#304)
+func (h *CodergenHandler) buildNoProgressOutcome(node *pipeline.Node, prompt, artifactRoot, responseArtifact string, sessResult agent.SessionResult, priorEpisodes []string) (pipeline.Outcome, error) {
+	msg := fmt.Sprintf("node %q: no-progress detected (%d consecutive turns with no tool calls)", node.ID, sessResult.Turns)
+	if h.pipelineEmitter != nil {
+		h.pipelineEmitter.HandlePipelineEvent(pipeline.PipelineEvent{
+			Type:    pipeline.EventNodeNoProgressDetected,
+			NodeID:  node.ID,
+			Message: msg,
+		})
+	}
+	outcome := pipeline.Outcome{
+		Status: string(pipeline.OutcomeRetry),
+		ContextUpdates: map[string]string{
+			pipeline.ContextKeyLastResponse:             msg,
+			pipeline.ContextKeyResponsePrefix + node.ID: msg,
+			"node_no_progress":                          "true",
+		},
+		Stats: buildSessionStats(sessResult),
+	}
+	if sessResult.Usage.EstimatedCost > 0 {
+		outcome.ContextUpdates["last_cost"] = fmt.Sprintf("%.4f", sessResult.Usage.EstimatedCost)
+	}
+	if sessResult.Turns > 0 {
+		outcome.ContextUpdates["last_turns"] = strconv.Itoa(sessResult.Turns)
+	}
+	h.applyEpisodeContextUpdates(outcome.ContextUpdates, sessResult, priorEpisodes)
+	if err := pipeline.WriteStageArtifacts(artifactRoot, node.ID, prompt, responseArtifact, outcome); err != nil {
+		return pipeline.Outcome{}, err
+	}
+	return outcome, nil
 }
 
 // buildEmptyResponseOutcome handles the two empty-response cases and returns
@@ -832,6 +917,13 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	}
 	if cfg.MaxTurns > 0 {
 		config.MaxTurns = cfg.MaxTurns
+	}
+	// #304: per-node cost ceiling and no-progress detector.
+	if cfg.MaxCostUSD > 0 {
+		config.MaxCostUSD = cfg.MaxCostUSD
+	}
+	if cfg.NoProgressTurns > 0 {
+		config.NoProgressTurns = cfg.NoProgressTurns
 	}
 	// #318 warm continue+N: a node-scoped, disk-driven override bumps MaxTurns
 	// on warm re-entry of this agent node (the operator-decision "continue"

--- a/pipeline/handlers/codergen_guards_test.go
+++ b/pipeline/handlers/codergen_guards_test.go
@@ -61,7 +61,7 @@ func TestCodergenNoProgressDetectedRoutesToRetry(t *testing.T) {
 	node := &pipeline.Node{
 		ID: "gen", Shape: "box", Handler: "codergen",
 		Attrs: map[string]string{
-			"prompt":           "do something",
+			"prompt":            "do something",
 			"no_progress_turns": "2",
 		},
 	}

--- a/pipeline/handlers/codergen_guards_test.go
+++ b/pipeline/handlers/codergen_guards_test.go
@@ -150,3 +150,66 @@ func TestCodergenNodeZeroMaxCostUSDDisablesGraphDefault(t *testing.T) {
 		t.Errorf("node max_cost_usd=0 should disable graph default: want success, got %q", outcome.Status)
 	}
 }
+
+// stubPipelineEmitter records every pipeline event it receives.
+type stubPipelineEmitter struct {
+	events []pipeline.PipelineEvent
+}
+
+func (s *stubPipelineEmitter) HandlePipelineEvent(evt pipeline.PipelineEvent) {
+	s.events = append(s.events, evt)
+}
+
+func TestCodergenNodeCostExceededEmitsPipelineEvent(t *testing.T) {
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.006),
+		truncatedCostResponse(0.006),
+	}}
+	emitter := &stubPipelineEmitter{}
+	h := NewCodergenHandler(client, t.TempDir(), WithPipelineEmitter(emitter))
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "do something", "max_cost_usd": "0.01"},
+	}
+	pctx := pipeline.NewPipelineContext()
+	_, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found bool
+	for _, evt := range emitter.events {
+		if evt.Type == pipeline.EventNodeCostLimitExceeded && evt.NodeID == "gen" && !evt.Timestamp.IsZero() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected EventNodeCostLimitExceeded with NodeID=gen and non-zero Timestamp; got events: %v", emitter.events)
+	}
+}
+
+func TestCodergenNoProgressEmitsPipelineEvent(t *testing.T) {
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.0001),
+		truncatedCostResponse(0.0001),
+	}}
+	emitter := &stubPipelineEmitter{}
+	h := NewCodergenHandler(client, t.TempDir(), WithPipelineEmitter(emitter))
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "do something", "no_progress_turns": "2"},
+	}
+	pctx := pipeline.NewPipelineContext()
+	_, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found bool
+	for _, evt := range emitter.events {
+		if evt.Type == pipeline.EventNodeNoProgressDetected && evt.NodeID == "gen" && !evt.Timestamp.IsZero() {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected EventNodeNoProgressDetected with NodeID=gen and non-zero Timestamp; got events: %v", emitter.events)
+	}
+}

--- a/pipeline/handlers/codergen_guards_test.go
+++ b/pipeline/handlers/codergen_guards_test.go
@@ -94,8 +94,8 @@ func TestCodergenNodeCostExceededContextKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if outcome.ContextUpdates["node_cost_exceeded"] != "true" {
-		t.Errorf("want node_cost_exceeded=true in context updates, got %q", outcome.ContextUpdates["node_cost_exceeded"])
+	if outcome.ContextUpdates[pipeline.ContextKeyNodeCostExceeded] != "true" {
+		t.Errorf("want node_cost_exceeded=true in context updates, got %q", outcome.ContextUpdates[pipeline.ContextKeyNodeCostExceeded])
 	}
 }
 

--- a/pipeline/handlers/codergen_guards_test.go
+++ b/pipeline/handlers/codergen_guards_test.go
@@ -1,0 +1,124 @@
+// ABOUTME: Tests for per-node cost ceiling and no-progress detector in the codergen handler (#304).
+// ABOUTME: Validates that NodeCostExceeded and NoProgressDetected result signals route to OutcomeRetry.
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// truncatedCostResponse builds a length-truncated LLM response with the given estimated cost.
+// FinishReason "length" keeps the session loop running (no natural stop).
+func truncatedCostResponse(estimatedCost float64) *llm.Response {
+	return &llm.Response{
+		Message:      llm.AssistantMessage("partial work..."),
+		FinishReason: llm.FinishReason{Reason: "length"},
+		Usage: llm.Usage{
+			EstimatedCost: estimatedCost,
+			InputTokens:   100,
+			OutputTokens:  50,
+			TotalTokens:   150,
+		},
+	}
+}
+
+func TestCodergenNodeCostExceededRoutesToRetry(t *testing.T) {
+	// Two turns at $0.006 each → $0.012 > $0.01 limit. Guard fires after turn 2.
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.006),
+		truncatedCostResponse(0.006),
+		// third response never reached
+	}}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":       "do something",
+			"max_cost_usd": "0.01",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeRetry) {
+		t.Errorf("want %q on cost limit exceeded, got %q", pipeline.OutcomeRetry, outcome.Status)
+	}
+}
+
+func TestCodergenNoProgressDetectedRoutesToRetry(t *testing.T) {
+	// no_progress_turns=2: two consecutive truncated turns without tool calls → no-progress fires.
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.0001),
+		truncatedCostResponse(0.0001),
+		// third response never reached
+	}}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":           "do something",
+			"no_progress_turns": "2",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeRetry) {
+		t.Errorf("want %q on no-progress detection, got %q", pipeline.OutcomeRetry, outcome.Status)
+	}
+}
+
+func TestCodergenNodeCostExceededContextKey(t *testing.T) {
+	// The node_cost_exceeded context key should be set so pipelines can route on it.
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.1),
+		truncatedCostResponse(0.1),
+	}}
+	h := NewCodergenHandler(client, t.TempDir())
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":       "do something",
+			"max_cost_usd": "0.05",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.ContextUpdates["node_cost_exceeded"] != "true" {
+		t.Errorf("want node_cost_exceeded=true in context updates, got %q", outcome.ContextUpdates["node_cost_exceeded"])
+	}
+}
+
+func TestCodergenGraphDefaultMaxCostUSD(t *testing.T) {
+	// Graph-level default max_cost_usd applies when not overridden per-node.
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.006),
+		truncatedCostResponse(0.006),
+	}}
+	h := NewCodergenHandler(client, t.TempDir(), WithGraphAttrs(map[string]string{
+		"max_cost_usd": "0.01",
+	}))
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{"prompt": "do something"},
+		// No per-node max_cost_usd — inherits from graph
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeRetry) {
+		t.Errorf("graph-level max_cost_usd: want %q, got %q", pipeline.OutcomeRetry, outcome.Status)
+	}
+}

--- a/pipeline/handlers/codergen_guards_test.go
+++ b/pipeline/handlers/codergen_guards_test.go
@@ -122,3 +122,31 @@ func TestCodergenGraphDefaultMaxCostUSD(t *testing.T) {
 		t.Errorf("graph-level max_cost_usd: want %q, got %q", pipeline.OutcomeRetry, outcome.Status)
 	}
 }
+
+func TestCodergenNodeZeroMaxCostUSDDisablesGraphDefault(t *testing.T) {
+	// A per-node max_cost_usd: "0" must disable an inherited graph-level default.
+	// The session runs all responses and succeeds without hitting the guard.
+	client := &scriptedCompleter{responses: []*llm.Response{
+		truncatedCostResponse(0.006),
+		truncatedCostResponse(0.006),
+		{Message: llm.AssistantMessage("done"), FinishReason: llm.FinishReason{Reason: "stop"}},
+	}}
+	h := NewCodergenHandler(client, t.TempDir(), WithGraphAttrs(map[string]string{
+		"max_cost_usd": "0.01", // graph-level ceiling
+	}))
+	node := &pipeline.Node{
+		ID: "gen", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":       "do something",
+			"max_cost_usd": "0", // node explicitly disables the graph default
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	outcome, err := h.Execute(context.Background(), node, pctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.Status != string(pipeline.OutcomeSuccess) {
+		t.Errorf("node max_cost_usd=0 should disable graph default: want success, got %q", outcome.Status)
+	}
+}

--- a/pipeline/handlers/registry.go
+++ b/pipeline/handlers/registry.go
@@ -285,6 +285,7 @@ func registerCodergenHandler(registry *pipeline.HandlerRegistry, cfg *registryCo
 		handler := NewCodergenHandler(cfg.llmClient, cfg.workingDir, WithGraphAttrs(graph.Attrs))
 		handler.env = cfg.execEnv
 		handler.eventHandler = cfg.agentEvents
+		handler.pipelineEmitter = cfg.pipelineEvents // #304: node-level guard events
 		if cfg.llmClient != nil {
 			handler.nativeBackend = NewNativeBackend(cfg.llmClient, cfg.execEnv)
 		}

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -30,6 +30,8 @@ type AgentNodeConfig struct {
 	AllowedTools    string
 	DisallowedTools string
 	MaxBudgetUSD    float64
+	MaxCostUSD      float64 // #304: per-node cost ceiling in USD; 0 = unlimited
+	NoProgressTurns int     // #304: halt after K consecutive tool-call-free turns; 0 = disabled
 	PermissionMode  string
 	ACPAgent        string
 
@@ -131,6 +133,28 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	if v := n.Attrs["max_budget_usd"]; v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			cfg.MaxBudgetUSD = f
+		}
+	}
+	// #304: max_cost_usd — per-node cost ceiling. Graph default then node override.
+	if v, ok := graphAttrs["max_cost_usd"]; ok && v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			cfg.MaxCostUSD = f
+		}
+	}
+	if v, ok := n.Attrs["max_cost_usd"]; ok && v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			cfg.MaxCostUSD = f
+		}
+	}
+	// #304: no_progress_turns — no-progress detector K. Graph default then node override.
+	if v, ok := graphAttrs["no_progress_turns"]; ok && v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			cfg.NoProgressTurns = i
+		}
+	}
+	if v, ok := n.Attrs["no_progress_turns"]; ok && v != "" {
+		if i, err := strconv.Atoi(v); err == nil && i > 0 {
+			cfg.NoProgressTurns = i
 		}
 	}
 	if v := n.Attrs["max_turns"]; v != "" {

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -135,26 +135,28 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.MaxBudgetUSD = f
 		}
 	}
-	// #304: max_cost_usd — per-node cost ceiling. Graph default then node override.
+	// #304: max_cost_usd — per-node cost ceiling. Graph default (positive only)
+	// then node override. Node-level "0" explicitly disables a graph default.
 	if v, ok := graphAttrs["max_cost_usd"]; ok && v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
 			cfg.MaxCostUSD = f
 		}
 	}
 	if v, ok := n.Attrs["max_cost_usd"]; ok && v != "" {
-		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
-			cfg.MaxCostUSD = f
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
+			cfg.MaxCostUSD = f // 0 disables the inherited graph default
 		}
 	}
-	// #304: no_progress_turns — no-progress detector K. Graph default then node override.
+	// #304: no_progress_turns — no-progress detector K. Graph default (positive
+	// only) then node override. Node-level "0" explicitly disables a graph default.
 	if v, ok := graphAttrs["no_progress_turns"]; ok && v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {
 			cfg.NoProgressTurns = i
 		}
 	}
 	if v, ok := n.Attrs["no_progress_turns"]; ok && v != "" {
-		if i, err := strconv.Atoi(v); err == nil && i > 0 {
-			cfg.NoProgressTurns = i
+		if i, err := strconv.Atoi(v); err == nil && i >= 0 {
+			cfg.NoProgressTurns = i // 0 disables the inherited graph default
 		}
 	}
 	if v := n.Attrs["max_turns"]; v != "" {

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -13,9 +13,10 @@ import (
 // For the subset of attrs that support graph-level defaults (llm_model,
 // llm_provider, reasoning_effort, verify_after_edit, verify_command,
 // max_verify_retries, plan_before_execute, cache_tool_results,
-// context_compaction), AgentConfig resolves the value from graphAttrs first,
-// then lets node.Attrs override when the same key is set on the node. The
-// remaining fields are node-only and have no graph fallback.
+// context_compaction, turn_breach_policy, max_cost_usd, no_progress_turns),
+// AgentConfig resolves the value from graphAttrs first, then lets node.Attrs
+// override when the same key is set on the node. The remaining fields are
+// node-only and have no graph fallback.
 //
 // Unless documented otherwise on the specific field, fields absent from their
 // applicable source use the Go zero value. ReflectOnError is the one

--- a/pipeline/node_config_test.go
+++ b/pipeline/node_config_test.go
@@ -461,3 +461,61 @@ func TestAgentConfig_WritablePaths(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentConfigMaxCostUSDAndNoProgressTurns(t *testing.T) {
+	cases := []struct {
+		name           string
+		graphAttrs     map[string]string
+		nodeAttrs      map[string]string
+		wantMaxCostUSD float64
+		wantNoProgress int
+	}{
+		{
+			name:           "absent: both zero",
+			graphAttrs:     nil,
+			nodeAttrs:      map[string]string{},
+			wantMaxCostUSD: 0,
+			wantNoProgress: 0,
+		},
+		{
+			name:           "graph default applies",
+			graphAttrs:     map[string]string{"max_cost_usd": "1.50", "no_progress_turns": "5"},
+			nodeAttrs:      map[string]string{},
+			wantMaxCostUSD: 1.50,
+			wantNoProgress: 5,
+		},
+		{
+			name:           "node overrides graph default",
+			graphAttrs:     map[string]string{"max_cost_usd": "1.50", "no_progress_turns": "5"},
+			nodeAttrs:      map[string]string{"max_cost_usd": "0.25", "no_progress_turns": "3"},
+			wantMaxCostUSD: 0.25,
+			wantNoProgress: 3,
+		},
+		{
+			name:           "node zero disables graph default",
+			graphAttrs:     map[string]string{"max_cost_usd": "1.50", "no_progress_turns": "5"},
+			nodeAttrs:      map[string]string{"max_cost_usd": "0", "no_progress_turns": "0"},
+			wantMaxCostUSD: 0,
+			wantNoProgress: 0,
+		},
+		{
+			name:           "graph zero is not applied (positive only)",
+			graphAttrs:     map[string]string{"max_cost_usd": "0", "no_progress_turns": "0"},
+			nodeAttrs:      map[string]string{},
+			wantMaxCostUSD: 0,
+			wantNoProgress: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &Node{Attrs: tc.nodeAttrs}
+			cfg := n.AgentConfig(tc.graphAttrs)
+			if cfg.MaxCostUSD != tc.wantMaxCostUSD {
+				t.Errorf("MaxCostUSD = %v, want %v", cfg.MaxCostUSD, tc.wantMaxCostUSD)
+			}
+			if cfg.NoProgressTurns != tc.wantNoProgress {
+				t.Errorf("NoProgressTurns = %v, want %v", cfg.NoProgressTurns, tc.wantNoProgress)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **Per-node cost ceiling** (`max_cost_usd`): a node halts mid-session when its cumulative LLM cost exceeds the configured threshold, independent of turn count. Routes `OutcomeRetry` so the existing retry/escalation path handles it.
- **No-progress detector** (`no_progress_turns`): a node halts after K consecutive turns with no tool calls — catching agents stuck generating text without taking action. Also routes `OutcomeRetry`.
- Both limits support **graph-level defaults** (set as graph attrs) with per-node override, following the same pattern as `reasoning_effort` and other graph-defaultable attrs.
- New signals `NodeCostExceeded` and `NoProgressDetected` on `agent.SessionResult` are consumed by the codergen handler's outcome classification and emitted as `EventNodeCostLimitExceeded` / `EventNodeNoProgressDetected` pipeline events (when a `pipelineEmitter` is wired in from the registry).
- With these guards in place, `max_turns` demotes to a coarse backstop that should rarely bind during normal runs.

Note: `#353` (build_product.dip restructuring to use these guards) is out of scope for this PR.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` passes — all packages green, zero failures
- [x] 5 new session-level tests in `agent/session_guards_test.go` cover cost guard, no-progress guard, disabled states, and counter-reset when tools fire
- [x] 4 new handler-level tests in `pipeline/handlers/codergen_guards_test.go` cover `OutcomeRetry` routing, context key presence, and graph-default inheritance
- [x] No `--no-verify` used
- [x] CHANGELOG updated under `[Unreleased]`
- [x] No changes to `.dip` example files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784216737&installation_id=131176874&pr_number=387&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F387&signature=6341d74ce10a33e1a576d35b965cfd200e8c3cec1aa077d48ac164fb1f6e0200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-node runaway guards to stop sessions early via `max_cost_usd` (cumulative cost ceiling) and `no_progress_turns` (consecutive tool-call-free turns), with `0` disabling each limit.
  * Sessions now report new outcome flags, and the pipeline emits dedicated events when each guard triggers.
  * Added graph-level defaults for both limits with per-node overrides, including `0` to disable inherited defaults. Codergen now propagates these guard signals and can emit the corresponding pipeline events.

* **Tests**
  * Added coverage for cost/no-progress detection, disabling/reset behavior, precedence rules, and event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->