### PR TITLE
feat(engine): commit-only scope guard for codergen nodes (#349)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`commit_only` node attribute for codergen agent nodes** (issue #349). Setting
+  `params: commit_only: true` on an agent node causes the codergen handler to
+  prepend a hardcoded scope-restriction block to the session's system prompt,
+  preventing the agent from authoring new implementation even when failure context
+  (spec violations, missing milestones) is present in the conversation window.
+  The block includes a `STATUS: fail` escape hatch so the pipeline can re-route
+  through the correct implement/test/verify path instead of silently shipping
+  unverified code. Only enforced for the native backend; `commit_only` on
+  `claude-code` or `acp` nodes is noted in the comment and has no effect on those
+  backends (they do not use `SessionConfig.SystemPrompt`).
+
 - **Per-node cost ceiling and no-progress detector for the engine** (issue #304).
   Two new guards complement the existing `max_turns` backstop. A node with
   `max_cost_usd: "0.50"` halts when its cumulative session cost exceeds that
@@ -22,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EventNodeCostLimitExceeded` / `EventNodeNoProgressDetected` pipeline events.
   With these guards in place, `max_turns` serves as a coarse backstop that
   should rarely bind during normal runs.
+
+### Fixed
+
+- **`build_product` FinalCommit commit scope** (issue #349). The `FinalCommit`
+  agent node now carries `commit_only: true` (engine-level scope guard) to prevent
+  it from authoring new implementation when failure context is present in the
+  conversation window. The prompt already contained explicit "do NOT implement"
+  language; the engine-level guard makes that restriction structurally enforced
+  rather than advisory-only. The case-study run `b68b532619c3` demonstrated the
+  failure mode: FinalCommit received a failure report and wrote an entire missing
+  milestone (new files, wrong model, signal-exit race, failing lint), bypassing
+  all quality gates.
 
 ## [0.39.2] - 2026-06-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prepend a hardcoded scope-restriction block to the session's system prompt,
   preventing the agent from authoring new implementation even when failure context
   (spec violations, missing milestones) is present in the conversation window.
-  The block includes a `STATUS: fail` escape hatch so the pipeline can re-route
-  through the correct implement/test/verify path instead of silently shipping
-  unverified code. Only enforced for the native backend; `commit_only` on
-  `claude-code` or `acp` nodes is noted in the comment and has no effect on those
-  backends (they do not use `SessionConfig.SystemPrompt`).
+  The block requires `STATUS: fail` on a standalone line (no trailing text, so
+  `parseStatusLine` accepts it), then the explanation on subsequent lines. Enforced
+  for the native backend (via `SessionConfig.SystemPrompt`) and the `claude-code`
+  backend (`AgentRunConfig.SystemPrompt` is passed as `--system-prompt`). The ACP
+  backend does not read `AgentRunConfig.SystemPrompt`, so `commit_only` is silently
+  ignored there.
 
 - **Per-node cost ceiling and no-progress detector for the engine** (issue #304).
   Two new guards complement the existing `max_turns` backstop. A node with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (spec violations, missing milestones) is present in the conversation window.
   The block requires `STATUS: fail` on a standalone line (no trailing text, so
   `parseStatusLine` accepts it), then the explanation on subsequent lines. Enforced
-  for the native backend (via `SessionConfig.SystemPrompt`) and the `claude-code`
-  backend (`AgentRunConfig.SystemPrompt` is passed as `--system-prompt`). The ACP
-  backend does not read `AgentRunConfig.SystemPrompt`, so `commit_only` is silently
-  ignored there.
+  for all three backends: native (via `SessionConfig.SystemPrompt`), `claude-code`
+  (`AgentRunConfig.SystemPrompt` passed as `--system-prompt`), and ACP
+  (`buildACPPromptBlocks` prepends it as a text block).
 
 - **Per-node cost ceiling and no-progress detector for the engine** (issue #304).
   Two new guards complement the existing `max_turns` backstop. A node with

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -2152,6 +2152,8 @@ workflow BuildProduct
     reasoning_effort: low
     auto_status: true
     fallback_target: EscalateReview
+    params:
+      commit_only: true
     prompt:
       FINAL COMMIT — COMMIT-ONLY SCOPE:
 

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -744,6 +744,19 @@ func (h *CodergenHandler) applyEpisodeContextUpdates(updates map[string]string, 
 	updates[pipeline.ContextKeyEpisodeSummaries] = agent.SerializeEpisodeSummaries(summaries)
 }
 
+// commitOnlyScopeGuard is prepended to the system prompt when a node has
+// commit_only: true (#349). It is a hardcoded safety rail, not a
+// customization surface — it prevents the agent from authoring new
+// implementation even when failure context (spec violations, missing
+// milestones) is present in the conversation window. The STATUS: fail
+// escape hatch lets the pipeline re-route through the correct
+// implement/test/verify path instead of silently shipping unverified code.
+const commitOnlyScopeGuard = "SCOPE RESTRICTION: You are operating in commit-only mode. " +
+	"You may run git status, git add, git commit, and read files to understand what to commit. " +
+	"You must NOT create, edit, or delete source files. " +
+	"If you observe that the work tree is missing required implementation, " +
+	"respond with STATUS: fail and explain what is missing — do not implement it yourself."
+
 // maxTurnsOverrideSubdir is the tracker-owned, working-dir-relative directory
 // holding per-node warm-continue MaxTurns overrides (#318). One file per node
 // ID; its integer contents replace the node's static max_turns on re-entry.
@@ -989,6 +1002,18 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	// Any non-empty value disables tools (fail-closed for typos).
 	if cfg.ToolAccess != "" {
 		config.ToolAccess = cfg.ToolAccess
+	}
+
+	// #349: commit_only scope guard — outermost prepend so the restriction acts
+	// as the strongest constraint, overriding any node-supplied system_prompt.
+	// Only enforced for the native backend (SessionConfig.SystemPrompt is not
+	// used by claude-code or ACP backends — they build their own Extra config).
+	if cfg.CommitOnly {
+		if config.SystemPrompt != "" {
+			config.SystemPrompt = commitOnlyScopeGuard + "\n\n" + config.SystemPrompt
+		} else {
+			config.SystemPrompt = commitOnlyScopeGuard
+		}
 	}
 
 	return config

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -748,14 +748,15 @@ func (h *CodergenHandler) applyEpisodeContextUpdates(updates map[string]string, 
 // commit_only: true (#349). It is a hardcoded safety rail, not a
 // customization surface — it prevents the agent from authoring new
 // implementation even when failure context (spec violations, missing
-// milestones) is present in the conversation window. The STATUS: fail
-// escape hatch lets the pipeline re-route through the correct
-// implement/test/verify path instead of silently shipping unverified code.
+// milestones) is present in the conversation window. The STATUS: fail escape
+// hatch must appear on a standalone line (no trailing text) so parseStatusLine
+// accepts it; the explanation follows on subsequent lines.
 const commitOnlyScopeGuard = "SCOPE RESTRICTION: You are operating in commit-only mode. " +
 	"You may run git status, git add, git commit, and read files to understand what to commit. " +
 	"You must NOT create, edit, or delete source files. " +
 	"If you observe that the work tree is missing required implementation, " +
-	"respond with STATUS: fail and explain what is missing — do not implement it yourself."
+	"emit STATUS: fail on a line by itself (no trailing text on that line), " +
+	"then explain what is missing on the following lines — do not implement it yourself."
 
 // maxTurnsOverrideSubdir is the tracker-owned, working-dir-relative directory
 // holding per-node warm-continue MaxTurns overrides (#318). One file per node
@@ -1006,8 +1007,10 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 
 	// #349: commit_only scope guard — outermost prepend so the restriction acts
 	// as the strongest constraint, overriding any node-supplied system_prompt.
-	// Only enforced for the native backend (SessionConfig.SystemPrompt is not
-	// used by claude-code or ACP backends — they build their own Extra config).
+	// Enforced for native (via SessionConfig.SystemPrompt → Extra) and claude-code
+	// (buildRunConfig copies SystemPrompt into AgentRunConfig.SystemPrompt, which
+	// the claude-code backend passes as --system-prompt). ACP does not read
+	// AgentRunConfig.SystemPrompt, so the guard is silently ignored there.
 	if cfg.CommitOnly {
 		if config.SystemPrompt != "" {
 			config.SystemPrompt = commitOnlyScopeGuard + "\n\n" + config.SystemPrompt

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -1007,10 +1007,9 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 
 	// #349: commit_only scope guard — outermost prepend so the restriction acts
 	// as the strongest constraint, overriding any node-supplied system_prompt.
-	// Enforced for native (via SessionConfig.SystemPrompt → Extra) and claude-code
-	// (buildRunConfig copies SystemPrompt into AgentRunConfig.SystemPrompt, which
-	// the claude-code backend passes as --system-prompt). ACP does not read
-	// AgentRunConfig.SystemPrompt, so the guard is silently ignored there.
+	// Enforced for all three backends: native (SessionConfig.SystemPrompt → Extra),
+	// claude-code (AgentRunConfig.SystemPrompt → --system-prompt flag), and ACP
+	// (buildACPPromptBlocks prepends AgentRunConfig.SystemPrompt as a text block).
 	if cfg.CommitOnly {
 		if config.SystemPrompt != "" {
 			config.SystemPrompt = commitOnlyScopeGuard + "\n\n" + config.SystemPrompt

--- a/pipeline/handlers/codergen_commitonly_test.go
+++ b/pipeline/handlers/codergen_commitonly_test.go
@@ -20,11 +20,8 @@ func TestCommitOnlyScopeGuardInjected(t *testing.T) {
 		},
 	}
 	cfg := h.buildConfig(node)
-	if !strings.Contains(cfg.SystemPrompt, "SCOPE RESTRICTION") {
-		t.Errorf("commit_only: true should inject scope guard into SystemPrompt, got: %q", cfg.SystemPrompt)
-	}
-	if !strings.Contains(cfg.SystemPrompt, "STATUS: fail") {
-		t.Errorf("scope guard must include STATUS: fail escape hatch, got: %q", cfg.SystemPrompt)
+	if cfg.SystemPrompt != commitOnlyScopeGuard {
+		t.Errorf("commit_only: true should set SystemPrompt to commitOnlyScopeGuard\ngot:  %q\nwant: %q", cfg.SystemPrompt, commitOnlyScopeGuard)
 	}
 }
 
@@ -69,15 +66,8 @@ func TestCommitOnlyScopeGuardPrependedBeforeNodeSystemPrompt(t *testing.T) {
 		},
 	}
 	cfg := h.buildConfig(node)
-	guardIdx := strings.Index(cfg.SystemPrompt, "SCOPE RESTRICTION")
-	nodePromptIdx := strings.Index(cfg.SystemPrompt, nodeSystemPrompt)
-	if guardIdx == -1 {
-		t.Fatalf("scope guard not found in SystemPrompt: %q", cfg.SystemPrompt)
-	}
-	if nodePromptIdx == -1 {
-		t.Fatalf("node system_prompt not found in SystemPrompt: %q", cfg.SystemPrompt)
-	}
-	if guardIdx > nodePromptIdx {
-		t.Errorf("scope guard must come before node system_prompt (guard at %d, node prompt at %d)", guardIdx, nodePromptIdx)
+	want := commitOnlyScopeGuard + "\n\n" + nodeSystemPrompt
+	if cfg.SystemPrompt != want {
+		t.Errorf("commit_only with node system_prompt: SystemPrompt mismatch\ngot:  %q\nwant: %q", cfg.SystemPrompt, want)
 	}
 }

--- a/pipeline/handlers/codergen_commitonly_test.go
+++ b/pipeline/handlers/codergen_commitonly_test.go
@@ -1,0 +1,83 @@
+// ABOUTME: Tests for commit_only scope-guard injection in the codergen handler (#349).
+// ABOUTME: Verifies that commit_only: true prepends commitOnlyScopeGuard to the session's
+// ABOUTME: SystemPrompt, and that commit_only: false / absent produces no injection.
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+func TestCommitOnlyScopeGuardInjected(t *testing.T) {
+	h := NewCodergenHandler(nil, t.TempDir())
+	node := &pipeline.Node{
+		ID: "FinalCommit", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":      "ensure all changes are committed",
+			"commit_only": "true",
+		},
+	}
+	cfg := h.buildConfig(node)
+	if !strings.Contains(cfg.SystemPrompt, "SCOPE RESTRICTION") {
+		t.Errorf("commit_only: true should inject scope guard into SystemPrompt, got: %q", cfg.SystemPrompt)
+	}
+	if !strings.Contains(cfg.SystemPrompt, "STATUS: fail") {
+		t.Errorf("scope guard must include STATUS: fail escape hatch, got: %q", cfg.SystemPrompt)
+	}
+}
+
+func TestCommitOnlyScopeGuardAbsent(t *testing.T) {
+	h := NewCodergenHandler(nil, t.TempDir())
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt": "implement the feature",
+		},
+	}
+	cfg := h.buildConfig(node)
+	if strings.Contains(cfg.SystemPrompt, "SCOPE RESTRICTION") {
+		t.Errorf("commit_only absent should not inject scope guard, got: %q", cfg.SystemPrompt)
+	}
+}
+
+func TestCommitOnlyScopeGuardFalseNoInjection(t *testing.T) {
+	h := NewCodergenHandler(nil, t.TempDir())
+	node := &pipeline.Node{
+		ID: "Implement", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":      "implement the feature",
+			"commit_only": "false",
+		},
+	}
+	cfg := h.buildConfig(node)
+	if strings.Contains(cfg.SystemPrompt, "SCOPE RESTRICTION") {
+		t.Errorf("commit_only: false should not inject scope guard, got: %q", cfg.SystemPrompt)
+	}
+}
+
+func TestCommitOnlyScopeGuardPrependedBeforeNodeSystemPrompt(t *testing.T) {
+	h := NewCodergenHandler(nil, t.TempDir())
+	nodeSystemPrompt := "You are a helpful assistant."
+	node := &pipeline.Node{
+		ID: "FinalCommit", Shape: "box", Handler: "codergen",
+		Attrs: map[string]string{
+			"prompt":        "ensure all changes are committed",
+			"commit_only":   "true",
+			"system_prompt": nodeSystemPrompt,
+		},
+	}
+	cfg := h.buildConfig(node)
+	guardIdx := strings.Index(cfg.SystemPrompt, "SCOPE RESTRICTION")
+	nodePromptIdx := strings.Index(cfg.SystemPrompt, nodeSystemPrompt)
+	if guardIdx == -1 {
+		t.Fatalf("scope guard not found in SystemPrompt: %q", cfg.SystemPrompt)
+	}
+	if nodePromptIdx == -1 {
+		t.Fatalf("node system_prompt not found in SystemPrompt: %q", cfg.SystemPrompt)
+	}
+	if guardIdx > nodePromptIdx {
+		t.Errorf("scope guard must come before node system_prompt (guard at %d, node prompt at %d)", guardIdx, nodePromptIdx)
+	}
+}

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -290,7 +290,7 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	}
 
 	if v, ok := n.Attrs["commit_only"]; ok {
-		cfg.CommitOnly = v == "true"
+		cfg.CommitOnly = parseBoolAttr(v)
 	}
 
 	return cfg

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -86,6 +86,12 @@ type AgentNodeConfig struct {
 	CacheToolResults    bool
 	CacheToolResultsSet bool
 
+	// CommitOnly restricts the node to commit-only operations. When true, the
+	// codergen handler prepends commitOnlyScopeGuard to the session's
+	// SystemPrompt, preventing the agent from authoring new implementation even
+	// when failure context is present. Issue: github.com/2389-research/tracker#349.
+	CommitOnly bool
+
 	// ContextCompaction carries the raw attr value. "auto" enables automatic
 	// compaction; any other non-empty value (e.g. "none") disables it; ""
 	// means the attr was absent. Kept as string so future modes can be added
@@ -281,6 +287,10 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	if raw, ok := n.Attrs["writable_paths"]; ok {
 		cfg.WritablePathsSet = true
 		cfg.WritablePaths = splitCommaNoEmpty(raw)
+	}
+
+	if v, ok := n.Attrs["commit_only"]; ok {
+		cfg.CommitOnly = v == "true"
 	}
 
 	return cfg


### PR DESCRIPTION
## Summary

- **New `commit_only` node attribute** (`params: commit_only: true`) for codergen agent nodes. When set, the codergen handler prepends a hardcoded `commitOnlyScopeGuard` block to `SessionConfig.SystemPrompt` as the outermost constraint. The block requires `STATUS: fail` on a **standalone line** (no trailing text, matching `parseStatusLine`'s exact-value requirement), followed by the explanation on subsequent lines. Enforced for all three backends: native (via `SessionConfig.SystemPrompt`), `claude-code` (`AgentRunConfig.SystemPrompt` passed as `--system-prompt`), and ACP (`buildACPPromptBlocks` prepends it as a text block).
- **`FinalCommit` in `build_product.dip`** now carries `commit_only: true` via `params:`, making the existing "do NOT implement" prompt language structurally enforced at the engine level rather than advisory-only.

## Problem

Case-study run `b68b532619c3`: `FinalCommit` received a failure report and wrote an entire missing milestone, bypassing all quality gates. The engine-level guard prevents this even when the agent ignores prompt-level instructions.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -short` passes including 4 new tests in `codergen_commitonly_test.go`
- [x] `dippin doctor` on all three core pipelines — A grade (95/100), no regressions
- [x] CHANGELOG updated under `[Unreleased]` — Added and Fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)