### PR TITLE
fix(examples): bring megaplan/ralph-loop/semport to A grade under dippin doctor (#335 scope 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Remaining example workflows now hold A grades under `dippin doctor`**
+  (issue #335, scope 3). Four example `.dip` files that shipped with B or F
+  grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been
+  structurally hardened: graph-level `on_failure: Exit` catch-alls and
+  `max_restarts` defaults added to each workflow's `defaults` block.
+  `megaplan_quality` and `ralph-loop` also had `max_retries` where
+  `max_restarts` was the correct intent for their loop-restart budgets (DIP134).
+  All four now reach A/100. No engine changes.
+
 - **`build_product` FinalCommit commit scope** (issue #349). The `FinalCommit`
   agent node now carries `commit_only: true` (engine-level scope guard) to prevent
   it from authoring new implementation when failure context is present in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been
   structurally hardened: graph-level `on_failure: Exit` catch-alls and
   `max_restarts` defaults added to each workflow's `defaults` block.
-  `megaplan_quality` and `ralph-loop` also had `max_retries` where
-  `max_restarts` was the correct intent for their loop-restart budgets (DIP134).
+  `megaplan_quality` and `ralph-loop` each had `max_retries` in defaults but
+  no `max_restarts`, triggering DIP134 (restart-budget vs per-node retry
+  confusion); `max_restarts` was added alongside the existing `max_retries`.
   All four now reach A/100. No engine changes.
 
 - **`build_product` FinalCommit commit scope** (issue #349). The `FinalCommit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Remaining example workflows now hold A grades under `dippin doctor`**
   (issue #335, scope 3). Four example `.dip` files that shipped with B or F
   grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been
-  structurally hardened: graph-level `on_failure: Exit` catch-alls and
-  `max_restarts` defaults added to each workflow's `defaults` block.
-  `megaplan_quality` and `ralph-loop` each had `max_retries` in defaults but
-  no `max_restarts`, triggering DIP134 (restart-budget vs per-node retry
-  confusion); `max_restarts` was added alongside the existing `max_retries`.
+  structurally hardened: graph-level `on_failure: Exit` catch-alls added to
+  each workflow's `defaults` block. `megaplan`, `megaplan_quality`, and
+  `ralph-loop` also received `max_restarts` defaults; `megaplan_quality` and
+  `ralph-loop` each had `max_retries` in defaults but no `max_restarts`,
+  triggering DIP134 (restart-budget vs per-node retry confusion), so
+  `max_restarts` was added alongside the existing `max_retries`.
   All four now reach A/100. No engine changes.
 
 - **`build_product` FinalCommit commit scope** (issue #349). The `FinalCommit`

--- a/examples/megaplan.dip
+++ b/examples/megaplan.dip
@@ -5,6 +5,8 @@ workflow Megaplan
 
   defaults
     max_retries: 5
+    max_restarts: 5
+    on_failure: Exit
     fidelity: summary:medium
 
   agent Start

--- a/examples/megaplan_quality.dip
+++ b/examples/megaplan_quality.dip
@@ -5,6 +5,8 @@ workflow Megaplan
 
   defaults
     max_retries: 5
+    max_restarts: 5
+    on_failure: Exit
     fidelity: summary:medium
 
   agent Start

--- a/examples/ralph-loop.dip
+++ b/examples/ralph-loop.dip
@@ -7,6 +7,8 @@ workflow RalphLoop
     model: claude-haiku-4-5
     provider: anthropic
     max_retries: 2
+    max_restarts: 10
+    on_failure: Exit
     fidelity: summary:high
 
   agent Start

--- a/examples/semport.dip
+++ b/examples/semport.dip
@@ -4,7 +4,6 @@ workflow Semport
   exit: Exit
 
   defaults
-    max_restarts: 10
     on_failure: Exit
 
   agent Start

--- a/examples/semport.dip
+++ b/examples/semport.dip
@@ -3,6 +3,10 @@ workflow Semport
   start: Start
   exit: Exit
 
+  defaults
+    max_restarts: 10
+    on_failure: Exit
+
   agent Start
     label: Start
 


### PR DESCRIPTION
## Summary

- Added `on_failure: Exit` and `max_restarts` to the `defaults` block of `megaplan.dip`, `megaplan_quality.dip`, `ralph-loop.dip`, and `semport.dip`
- Fixed DIP134 on `megaplan_quality` and `ralph-loop` (had `max_retries` where `max_restarts` was the correct intent for loop-restart budgets)
- All 29 example `.dip` files now hold A grade under `dippin doctor`; no regressions

## Test plan

- [ ] `dippin doctor examples/megaplan.dip examples/megaplan_quality.dip examples/ralph-loop.dip examples/semport.dip` — all A/100
- [ ] Full sweep `for f in examples/*.dip; do dippin doctor "$f"; done` — all A
- [ ] `go build ./...` — clean
- [ ] `go test ./... -short` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784237691&installation_id=131176874&pr_number=389&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F389&signature=6339dfe75399346a5fa93bd4c59a002b21d693907b1843ffc4c0389b61798bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced failure handling and restart policies in example workflows, improving structural reliability and quality standards.

## Documentation
* Updated changelog documenting workflow quality improvements and structural enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->