### PR TITLE
feat(engine): wire stall_timeout from .dip defaults into BudgetGuard (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`stall_timeout` graph-level default now enforced at runtime** (issue #310).
+  When no pipeline node completes within the declared wall-clock window, the run
+  aborts through the same `OutcomeBudgetExceeded` / `on_failure` cascade as other
+  budget breaches. Set via the `.dip` `defaults:` block (`stall_timeout: 5m`);
+  the value flows through the dippin adapter into `graph.Attrs["stall_timeout"]`,
+  is picked up by `ResolveBudgetLimits`, and enforced by `BudgetGuard` using a
+  per-node progress clock reset by `NotifyProgress()` on each node completion.
+  Closes #310 (the three graph-level budget ceilings were already wired in prior
+  work; `stall_timeout` was the remaining piece).
+
 - **`commit_only` node attribute for codergen agent nodes** (issue #349). Setting
   `params: commit_only: true` on an agent node causes the codergen handler to
   prepend a hardcoded scope-restriction block to the session's system prompt,

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"math"
+	"sync/atomic"
 	"time"
 )
 
@@ -59,7 +60,7 @@ type BudgetBreach struct {
 // start time. The zero value is not usable; construct via NewBudgetGuard.
 type BudgetGuard struct {
 	limits     BudgetLimits
-	progressAt time.Time // last node completion; reset by NotifyProgress
+	progressAt atomic.Int64 // UnixNano of last node completion; written by NotifyProgress
 }
 
 // NewBudgetGuard constructs a BudgetGuard with the given limits. Returns nil
@@ -69,16 +70,19 @@ func NewBudgetGuard(limits BudgetLimits) *BudgetGuard {
 	if limits.IsZero() {
 		return nil
 	}
-	return &BudgetGuard{limits: limits, progressAt: time.Now()}
+	g := &BudgetGuard{limits: limits}
+	g.progressAt.Store(time.Now().UnixNano())
+	return g
 }
 
 // NotifyProgress resets the stall clock. Call after each node completes
-// (success or fail — both count as forward progress). Safe to call on nil.
+// (success or fail — both count as forward progress). Safe to call on nil
+// and from concurrent goroutines.
 func (g *BudgetGuard) NotifyProgress() {
 	if g == nil {
 		return
 	}
-	g.progressAt = time.Now()
+	g.progressAt.Store(time.Now().UnixNano())
 }
 
 // Check reports whether the given usage snapshot breaches any configured
@@ -94,7 +98,7 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
 		return BudgetBreach{Kind: BudgetWallTime, Message: "max_wall_time exceeded"}
 	}
-	if g.limits.StallTimeout > 0 && time.Since(g.progressAt) > g.limits.StallTimeout {
+	if g.limits.StallTimeout > 0 && time.Since(time.Unix(0, g.progressAt.Load())) > g.limits.StallTimeout {
 		return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
 	}
 	return BudgetBreach{Kind: BudgetOK}

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -98,8 +98,16 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
 		return BudgetBreach{Kind: BudgetWallTime, Message: "max_wall_time exceeded"}
 	}
-	if g.limits.StallTimeout > 0 && time.Since(time.Unix(0, g.progressAt.Load())) > g.limits.StallTimeout {
-		return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
+	if g.limits.StallTimeout > 0 {
+		// Clamp to started so pre-run idle time (between NewBudgetGuard and
+		// Run()) does not consume the stall window before the first node fires.
+		lastProgress := time.Unix(0, g.progressAt.Load())
+		if lastProgress.Before(started) {
+			lastProgress = started
+		}
+		if time.Since(lastProgress) > g.limits.StallTimeout {
+			return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
+		}
 	}
 	return BudgetBreach{Kind: BudgetOK}
 }

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -13,11 +13,12 @@ type BudgetLimits struct {
 	MaxTotalTokens int
 	MaxCostCents   int
 	MaxWallTime    time.Duration
+	StallTimeout   time.Duration // abort when no node completes for this wall-clock span
 }
 
 // IsZero reports whether every limit is unset.
 func (l BudgetLimits) IsZero() bool {
-	return l.MaxTotalTokens == 0 && l.MaxCostCents == 0 && l.MaxWallTime == 0
+	return l.MaxTotalTokens == 0 && l.MaxCostCents == 0 && l.MaxWallTime == 0 && l.StallTimeout == 0
 }
 
 // BudgetBreachKind classifies which limit was hit.
@@ -28,6 +29,7 @@ const (
 	BudgetTokens
 	BudgetCost
 	BudgetWallTime
+	BudgetStall
 )
 
 // String returns a human-readable label for a breach kind.
@@ -40,6 +42,8 @@ func (k BudgetBreachKind) String() string {
 		return "cost"
 	case BudgetWallTime:
 		return "wall_time"
+	case BudgetStall:
+		return "stall"
 	default:
 		return "ok"
 	}
@@ -54,7 +58,8 @@ type BudgetBreach struct {
 // BudgetGuard evaluates BudgetLimits against a UsageSummary snapshot and a run
 // start time. The zero value is not usable; construct via NewBudgetGuard.
 type BudgetGuard struct {
-	limits BudgetLimits
+	limits     BudgetLimits
+	progressAt time.Time // last node completion; reset by NotifyProgress
 }
 
 // NewBudgetGuard constructs a BudgetGuard with the given limits. Returns nil
@@ -64,7 +69,16 @@ func NewBudgetGuard(limits BudgetLimits) *BudgetGuard {
 	if limits.IsZero() {
 		return nil
 	}
-	return &BudgetGuard{limits: limits}
+	return &BudgetGuard{limits: limits, progressAt: time.Now()}
+}
+
+// NotifyProgress resets the stall clock. Call after each node completes
+// (success or fail — both count as forward progress). Safe to call on nil.
+func (g *BudgetGuard) NotifyProgress() {
+	if g == nil {
+		return
+	}
+	g.progressAt = time.Now()
 }
 
 // Check reports whether the given usage snapshot breaches any configured
@@ -79,6 +93,9 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	}
 	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
 		return BudgetBreach{Kind: BudgetWallTime, Message: "max_wall_time exceeded"}
+	}
+	if g.limits.StallTimeout > 0 && time.Since(g.progressAt) > g.limits.StallTimeout {
+		return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
 	}
 	return BudgetBreach{Kind: BudgetOK}
 }

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -82,3 +82,38 @@ func TestBudgetGuard_CostCeiling_RoundsBoundaryValue(t *testing.T) {
 		t.Errorf("cost %.20f should breach 50¢ ceiling after rounding, got %v", justBelow, breach.Kind)
 	}
 }
+
+func TestBudgetGuard_StallTimeout(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
+	// Force progressAt into the past so the stall window is already exceeded.
+	g.progressAt = time.Now().Add(-time.Second)
+	breach := g.Check(nil, time.Now())
+	if breach.Kind != BudgetStall {
+		t.Errorf("got %v, want BudgetStall", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_NotifyProgress_ResetsStallClock(t *testing.T) {
+	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
+	// Push progressAt into the past.
+	g.progressAt = time.Now().Add(-time.Second)
+	// After NotifyProgress the timer is reset — no breach.
+	g.NotifyProgress()
+	breach := g.Check(nil, time.Now())
+	if breach.Kind != BudgetOK {
+		t.Errorf("got %v after NotifyProgress, want BudgetOK", breach.Kind)
+	}
+}
+
+func TestBudgetGuard_NotifyProgress_NilSafe(t *testing.T) {
+	var g *BudgetGuard
+	g.NotifyProgress() // must not panic
+}
+
+func TestBudgetGuard_StallTimeout_OnlyLimitIsStall(t *testing.T) {
+	// A guard built with only StallTimeout should not be nil.
+	g := NewBudgetGuard(BudgetLimits{StallTimeout: time.Minute})
+	if g == nil {
+		t.Fatal("NewBudgetGuard with StallTimeout should not return nil")
+	}
+}

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -86,7 +86,7 @@ func TestBudgetGuard_CostCeiling_RoundsBoundaryValue(t *testing.T) {
 func TestBudgetGuard_StallTimeout(t *testing.T) {
 	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
 	// Force progressAt into the past so the stall window is already exceeded.
-	g.progressAt = time.Now().Add(-time.Second)
+	g.progressAt.Store(time.Now().Add(-time.Second).UnixNano())
 	breach := g.Check(nil, time.Now())
 	if breach.Kind != BudgetStall {
 		t.Errorf("got %v, want BudgetStall", breach.Kind)
@@ -96,7 +96,7 @@ func TestBudgetGuard_StallTimeout(t *testing.T) {
 func TestBudgetGuard_NotifyProgress_ResetsStallClock(t *testing.T) {
 	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
 	// Push progressAt into the past.
-	g.progressAt = time.Now().Add(-time.Second)
+	g.progressAt.Store(time.Now().Add(-time.Second).UnixNano())
 	// After NotifyProgress the timer is reset — no breach.
 	g.NotifyProgress()
 	breach := g.Check(nil, time.Now())

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -85,21 +85,24 @@ func TestBudgetGuard_CostCeiling_RoundsBoundaryValue(t *testing.T) {
 
 func TestBudgetGuard_StallTimeout(t *testing.T) {
 	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
-	// Force progressAt into the past so the stall window is already exceeded.
-	g.progressAt.Store(time.Now().Add(-time.Second).UnixNano())
-	breach := g.Check(nil, time.Now())
+	now := time.Now()
+	// progressAt is 1s ago; started is 2s ago so clamping doesn't mask the stall.
+	g.progressAt.Store(now.Add(-time.Second).UnixNano())
+	breach := g.Check(nil, now.Add(-2*time.Second))
 	if breach.Kind != BudgetStall {
 		t.Errorf("got %v, want BudgetStall", breach.Kind)
 	}
 }
 
 func TestBudgetGuard_NotifyProgress_ResetsStallClock(t *testing.T) {
-	g := NewBudgetGuard(BudgetLimits{StallTimeout: 10 * time.Millisecond})
-	// Push progressAt into the past.
-	g.progressAt.Store(time.Now().Add(-time.Second).UnixNano())
+	// Use a generous timeout so the test is not flaky under scheduler pressure.
+	g := NewBudgetGuard(BudgetLimits{StallTimeout: time.Minute})
+	now := time.Now()
+	// Push progressAt into the past so it would stall without a reset.
+	g.progressAt.Store(now.Add(-2 * time.Minute).UnixNano())
 	// After NotifyProgress the timer is reset — no breach.
 	g.NotifyProgress()
-	breach := g.Check(nil, time.Now())
+	breach := g.Check(nil, now.Add(-3*time.Minute))
 	if breach.Kind != BudgetOK {
 		t.Errorf("got %v after NotifyProgress, want BudgetOK", breach.Kind)
 	}

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -773,6 +773,9 @@ func extractWorkflowDefaults(defaults ir.WorkflowDefaults, attrs map[string]stri
 	if defaults.MaxWallTime > 0 {
 		attrs["max_wall_time"] = defaults.MaxWallTime.String()
 	}
+	if defaults.StallTimeout > 0 {
+		attrs["stall_timeout"] = defaults.StallTimeout.String()
+	}
 }
 
 func extractWorkflowVars(vars map[string]string, attrs map[string]string) {

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -625,6 +625,7 @@ func TestFromDippinIR_WorkflowBudgetDefaults(t *testing.T) {
 			MaxTotalTokens: 50000,
 			MaxCostCents:   250,
 			MaxWallTime:    15 * time.Minute,
+			StallTimeout:   5 * time.Minute,
 		},
 		Nodes: []*ir.Node{
 			{ID: "start", Kind: ir.NodeAgent, Config: ir.AgentConfig{}},
@@ -646,6 +647,9 @@ func TestFromDippinIR_WorkflowBudgetDefaults(t *testing.T) {
 	if graph.Attrs["max_wall_time"] != "15m0s" {
 		t.Errorf("max_wall_time = %q, want 15m0s", graph.Attrs["max_wall_time"])
 	}
+	if graph.Attrs["stall_timeout"] != "5m0s" {
+		t.Errorf("stall_timeout = %q, want 5m0s", graph.Attrs["stall_timeout"])
+	}
 }
 
 // TestFromDippinIR_WorkflowBudgetUnsetOmitted verifies zero-value budget
@@ -665,7 +669,7 @@ func TestFromDippinIR_WorkflowBudgetUnsetOmitted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FromDippinIR: %v", err)
 	}
-	for _, k := range []string{"max_total_tokens", "max_cost_cents", "max_wall_time"} {
+	for _, k := range []string{"max_total_tokens", "max_cost_cents", "max_wall_time", "stall_timeout"} {
 		if _, ok := graph.Attrs[k]; ok {
 			t.Errorf("expected %q to be omitted when unset, got %q", k, graph.Attrs[k])
 		}

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -520,11 +520,11 @@ func (e *Engine) advanceToNextNode(s *runState, currentNodeID string, traceEntry
 	traceEntry.EdgeTo = next.To
 	s.trace.AddEntry(*traceEntry)
 	e.emitGitCommit(s, currentNodeID, traceEntry)
-	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if lr := e.checkBudgetAfterEmit(s); lr != nil {
 		return *lr
 	}
+	e.budgetGuard.NotifyProgress()
 	s.cp.SetEdgeSelection(currentNodeID, next.To)
 
 	if s.cp.IsCompleted(next.To) {
@@ -668,11 +668,11 @@ func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *Trac
 	// Apply the same post-node budget check as advanceToNextNode before
 	// advancing, so a node that already breached a hard ceiling halts the run
 	// rather than spending more on the fallback node (#311 review).
-	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if lr := e.checkBudgetAfterEmit(s); lr != nil {
 		return lr
 	}
+	e.budgetGuard.NotifyProgress()
 	if s.cp.FallbackTaken == nil {
 		s.cp.FallbackTaken = map[string]bool{}
 	}

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -520,6 +520,7 @@ func (e *Engine) advanceToNextNode(s *runState, currentNodeID string, traceEntry
 	traceEntry.EdgeTo = next.To
 	s.trace.AddEntry(*traceEntry)
 	e.emitGitCommit(s, currentNodeID, traceEntry)
+	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if lr := e.checkBudgetAfterEmit(s); lr != nil {
 		return *lr
@@ -667,6 +668,7 @@ func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *Trac
 	// Apply the same post-node budget check as advanceToNextNode before
 	// advancing, so a node that already breached a hard ceiling halts the run
 	// rather than spending more on the fallback node (#311 review).
+	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if lr := e.checkBudgetAfterEmit(s); lr != nil {
 		return lr

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -857,6 +857,7 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
+		e.budgetGuard.NotifyProgress()
 		e.emitCostUpdate(s)
 		if lr := e.checkBudgetAfterEmit(s); lr != nil {
 			return "", false, lr.result, nil
@@ -1008,6 +1009,7 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 	}
 	s.trace.AddEntry(*traceEntry)
 	e.emitGitCommit(s, currentNodeID, traceEntry)
+	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if halt := e.checkBudgetHaltForExit(s); halt != nil {
 		return false, "", halt

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -857,11 +857,11 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
-		e.budgetGuard.NotifyProgress()
 		e.emitCostUpdate(s)
 		if lr := e.checkBudgetAfterEmit(s); lr != nil {
 			return "", false, lr.result, nil
 		}
+		e.budgetGuard.NotifyProgress()
 		e.clearDownstream(fallback, s.cp)
 		s.cp.CurrentNode = fallback
 		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
@@ -1009,11 +1009,11 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 	}
 	s.trace.AddEntry(*traceEntry)
 	e.emitGitCommit(s, currentNodeID, traceEntry)
-	e.budgetGuard.NotifyProgress()
 	e.emitCostUpdate(s)
 	if halt := e.checkBudgetHaltForExit(s); halt != nil {
 		return false, "", halt
 	}
+	e.budgetGuard.NotifyProgress()
 	return true, "", nil
 }
 

--- a/tracker.go
+++ b/tracker.go
@@ -501,8 +501,8 @@ func buildEngineOpts(cfg Config, graph *pipeline.Graph) []pipeline.EngineOption 
 // Returns the original cfg unchanged if graph is nil or has no attrs.
 //
 // The graph-level keys consulted are max_total_tokens, max_cost_cents,
-// and max_wall_time, which the dippin adapter writes from
-// WorkflowDefaults.Max* fields in v0.21.0+.
+// max_wall_time, and stall_timeout, which the dippin adapter writes from
+// WorkflowDefaults fields in v0.21.0+.
 //
 // Exported so the tracker CLI can merge its --max-* flag values with
 // workflow defaults without re-implementing the same logic.
@@ -528,6 +528,13 @@ func ResolveBudgetLimits(cfg pipeline.BudgetLimits, graph *pipeline.Graph) pipel
 		if v, ok := graph.Attrs["max_wall_time"]; ok {
 			if d, err := time.ParseDuration(v); err == nil && d > 0 {
 				cfg.MaxWallTime = d
+			}
+		}
+	}
+	if cfg.StallTimeout == 0 {
+		if v, ok := graph.Attrs["stall_timeout"]; ok {
+			if d, err := time.ParseDuration(v); err == nil && d > 0 {
+				cfg.StallTimeout = d
 			}
 		}
 	}

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -900,6 +900,7 @@ func TestResolveBudgetLimits_FallsBackToGraphAttrs(t *testing.T) {
 		"max_total_tokens": "50000",
 		"max_cost_cents":   "250",
 		"max_wall_time":    "15m",
+		"stall_timeout":    "5m",
 	}}
 	got := ResolveBudgetLimits(pipeline.BudgetLimits{}, graph)
 	if got.MaxTotalTokens != 50000 {
@@ -911,6 +912,9 @@ func TestResolveBudgetLimits_FallsBackToGraphAttrs(t *testing.T) {
 	if got.MaxWallTime != 15*time.Minute {
 		t.Errorf("MaxWallTime = %v, want 15m", got.MaxWallTime)
 	}
+	if got.StallTimeout != 5*time.Minute {
+		t.Errorf("StallTimeout = %v, want 5m", got.StallTimeout)
+	}
 }
 
 // TestResolveBudgetLimits_ConfigWinsOverGraph verifies that explicit
@@ -921,11 +925,13 @@ func TestResolveBudgetLimits_ConfigWinsOverGraph(t *testing.T) {
 		"max_total_tokens": "50000",
 		"max_cost_cents":   "250",
 		"max_wall_time":    "15m",
+		"stall_timeout":    "5m",
 	}}
 	cfg := pipeline.BudgetLimits{
 		MaxTotalTokens: 9999,
 		MaxCostCents:   1,
 		MaxWallTime:    time.Second,
+		StallTimeout:   30 * time.Second,
 	}
 	got := ResolveBudgetLimits(cfg, graph)
 	if got.MaxTotalTokens != 9999 {
@@ -936,6 +942,9 @@ func TestResolveBudgetLimits_ConfigWinsOverGraph(t *testing.T) {
 	}
 	if got.MaxWallTime != time.Second {
 		t.Errorf("explicit MaxWallTime overridden: got %v, want 1s", got.MaxWallTime)
+	}
+	if got.StallTimeout != 30*time.Second {
+		t.Errorf("explicit StallTimeout overridden: got %v, want 30s", got.StallTimeout)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `stall_timeout` as a fourth `BudgetLimits` field with a new `BudgetStall` breach kind; `BudgetGuard` tracks a `progressAt` timestamp reset by `NotifyProgress()` on each non-retry node completion
- `extractWorkflowDefaults` in `dippin_adapter.go` writes `StallTimeout > 0` to `graph.Attrs["stall_timeout"]`; `ResolveBudgetLimits` in `tracker.go` reads it back (CLI-flag-wins pattern, matching `max_wall_time`)
- Engine calls `e.budgetGuard.NotifyProgress()` before `emitCostUpdate` at all four non-retry node-completion sites: `advanceToNextNode`, `strictFailureFallback`, `handleRetryExhausted` (fallback path), and `handleExitNode` (success path)

Closes #310. The three graph-level budget ceilings (`max_total_tokens`, `max_cost_cents`, `max_wall_time`) were already wired in prior work; `stall_timeout` was the remaining piece.

## Test plan

- [ ] `TestBudgetGuard_StallTimeout` — breach fires when `progressAt` is in the past
- [ ] `TestBudgetGuard_NotifyProgress_ResetsStallClock` — reset prevents breach
- [ ] `TestBudgetGuard_NotifyProgress_NilSafe` — nil guard doesn't panic
- [ ] `TestBudgetGuard_StallTimeout_OnlyLimitIsStall` — guard is non-nil with only StallTimeout set
- [ ] `TestFromDippinIR_WorkflowBudgetDefaults` — adapter round-trips `stall_timeout` attr
- [ ] `TestFromDippinIR_WorkflowBudgetUnsetOmitted` — zero StallTimeout omits attr
- [ ] `TestResolveBudgetLimits_FallsBackToGraphAttrs` — fills StallTimeout from graph attr
- [ ] `TestResolveBudgetLimits_ConfigWinsOverGraph` — explicit StallTimeout is not overridden
- [ ] `go build ./... && go test ./... -short` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784306414&installation_id=131176874&pr_number=390&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F390&signature=30134b60bd76b6b32385b86cd18a5ff717e3b1e228e250baa99b63bb9533be3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->