### PR TITLE
feat(adapter): wire dippin-lang v0.40–v0.42 IR fields (override, last_response_truncate, choice)

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -17,7 +17,7 @@ echo "═══ Pre-commit Quality Gates ═══"
 # 1. Format check
 echo ""
 echo "--- Format ---"
-UNFORMATTED=$(gofmt -l . 2>&1 | grep -v vendor || true)
+UNFORMATTED=$(gofmt -l . 2>&1 | grep -v vendor | grep -v '\.claude/' || true)
 if [ -n "$UNFORMATTED" ]; then
   fail "gofmt: these files need formatting:\n$UNFORMATTED"
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   With these guards in place, `max_turns` serves as a coarse backstop that
   should rarely bind during normal runs.
 
+### Changed
+
+- **dippin-lang upgraded to v0.42.0** (from v0.39.0). New IR fields wired in
+  subsequent commits: `Edge.Override` (v0.40.0, closes #271 input gap),
+  `AgentConfig.LastResponseTruncate` + `BranchConfig.LastResponseTruncate`
+  (v0.40.0, issue #56 chain-attack mitigation), and `Edge.Choice` (v0.42.0,
+  DIP150 explicit human-gate routing key).
+
 ### Fixed
 
 - **Remaining example workflows now hold A grades under `dippin doctor`**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`override:` edge attribute now wired end-to-end** (dippin-lang v0.40.0, closes #271 input
+  gap). Setting `override: true` on an edge in a `.dip` file now flows through the dippin adapter
+  into `pipeline.Edge.Override`, which the engine uses to produce `OutcomeValidationOverridden`
+  on success. Previously the field existed in the runtime but had no `.dip` input path.
+
+- **`last_response_truncate:` agent attribute now enforced** (dippin-lang v0.40.0, issue #56
+  chain-attack mitigation). An agent node with `last_response_truncate: 500` caps the Unicode
+  character count of the prior node's response injected into its prompt. Applies to both agent
+  nodes and per-branch overrides in parallel nodes. The stored context value is unchanged — only
+  the injected excerpt is capped.
+
+- **`choice:` edge attribute now wired for human-gate routing** (dippin-lang v0.42.0, DIP150).
+  Setting `choice: approve` on an edge declares a stable machine-readable routing key separate
+  from the human-readable `label:`. The TUI always displays `label:`; `choice:` becomes the
+  value stored in `ctx.preferred_label` and matched by the edge selector in both choice mode
+  and freeform mode.
+
 - **`stall_timeout` graph-level default now enforced at runtime** (issue #310).
   When no pipeline node completes within the declared wall-clock window, the run
   aborts through the same `OutcomeBudgetExceeded` / `on_failure` cascade as other

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ fmt:
 	gofmt -w .
 
 fmt-check:
-	@test -z "$$(gofmt -l .)" || { echo "gofmt: files need formatting:"; gofmt -l .; exit 1; }
+	@test -z "$$(gofmt -l . | grep -v '\.claude/')" || { echo "gofmt: files need formatting:"; gofmt -l . | grep -v '\.claude/'; exit 1; }
 
 vet:
 	go vet ./...

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require github.com/awalterschulze/gographviz v2.0.3+incompatible
 
 require (
-	github.com/2389-research/dippin-lang v0.39.0
+	github.com/2389-research/dippin-lang v0.42.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/2389-research/dippin-lang v0.38.0 h1:nkmT0abGrAZDRXmSSERDVcXz1AbxPCDM
 github.com/2389-research/dippin-lang v0.38.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/2389-research/dippin-lang v0.39.0 h1:hEV4wu7ZBkcQTp4YbgokcqVJMgzL17pYkPYWHZS3ioQ=
 github.com/2389-research/dippin-lang v0.39.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
+github.com/2389-research/dippin-lang v0.42.0 h1:xdYReDW9qvB5GVQM43FMkNVA1xHY7BAoEJE2jxg+iBg=
+github.com/2389-research/dippin-lang v0.42.0/go.mod h1:PG6D9DpD4Bdzz8cozRuiE7HWiHy4sjNRFujw5SUGGkA=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -840,10 +840,11 @@ func setIfNonEmpty(attrs map[string]string, key, value string) {
 // parser does this natively) or simplify the Parsed tree.
 func convertEdge(irEdge *ir.Edge) (*Edge, error) {
 	gEdge := &Edge{
-		From:  irEdge.From,
-		To:    irEdge.To,
-		Label: irEdge.Label,
-		Attrs: make(map[string]string),
+		From:     irEdge.From,
+		To:       irEdge.To,
+		Label:    irEdge.Label,
+		Override: irEdge.Override,
+		Attrs:    make(map[string]string),
 	}
 
 	// Serialize condition if present. We prefer Raw (set by the parser) and

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -347,6 +347,9 @@ func extractAgentLimitsAttrs(cfg ir.AgentConfig, attrs map[string]string) {
 	if cfg.CompactionThreshold > 0 {
 		attrs["context_compaction_threshold"] = fmt.Sprintf("%.2f", cfg.CompactionThreshold)
 	}
+	if cfg.LastResponseTruncate > 0 {
+		attrs["last_response_truncate"] = strconv.Itoa(cfg.LastResponseTruncate)
+	}
 }
 
 // extractAgentFeatureAttrs sets reasoning, fidelity, and pipeline feature flag attrs.
@@ -486,6 +489,9 @@ func extractParallelAttrs(cfg ir.ParallelConfig, attrs map[string]string) {
 		}
 		if len(branch.WritablePaths) > 0 {
 			attrs[prefix+"writable_paths"] = strings.Join(branch.WritablePaths, ",")
+		}
+		if branch.LastResponseTruncate > 0 {
+			attrs[prefix+"last_response_truncate"] = strconv.Itoa(branch.LastResponseTruncate)
 		}
 	}
 	// Generic params pass-through (dippin-lang v0.39.0, #313) — e.g.

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -21,6 +21,7 @@ var (
 	ErrUnknownConfig          = errors.New("unknown config type")
 	ErrInvalidSteerContextKey = errors.New("steer_context key contains ':' which breaks block-form round-trip through the .dip formatter")
 	ErrMissingManagerLoopCfg  = errors.New("manager_loop node is missing required ir.ManagerLoopConfig")
+	ErrOverrideOnNonHumanEdge = errors.New("override: true is only valid on edges from wait.human gate nodes")
 	// ErrParenthesizedParsedCondition is returned by convertEdge when a Parsed-only
 	// ir.Condition formats to an expression containing parentheses. The pipeline
 	// edge evaluator (pipeline/condition.go) does not support parens — it tokenizes
@@ -127,6 +128,12 @@ func addIREdges(g *Graph, irEdges []*ir.Edge) error {
 	for _, irEdge := range irEdges {
 		if irEdge == nil {
 			continue
+		}
+		if irEdge.Override {
+			src, ok := g.Nodes[irEdge.From]
+			if !ok || src.Shape != "hexagon" {
+				return fmt.Errorf("edge %s -> %s: %w", irEdge.From, irEdge.To, ErrOverrideOnNonHumanEdge)
+			}
 		}
 		gEdge, err := convertEdge(irEdge)
 		if err != nil {

--- a/pipeline/dippin_adapter.go
+++ b/pipeline/dippin_adapter.go
@@ -843,6 +843,7 @@ func convertEdge(irEdge *ir.Edge) (*Edge, error) {
 		From:     irEdge.From,
 		To:       irEdge.To,
 		Label:    irEdge.Label,
+		Choice:   irEdge.Choice,
 		Override: irEdge.Override,
 		Attrs:    make(map[string]string),
 	}

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -1733,6 +1733,31 @@ func TestConvertEdge_NoOverride(t *testing.T) {
 	}
 }
 
+func TestConvertEdge_Choice(t *testing.T) {
+	irEdge := &ir.Edge{From: "gate", To: "next", Label: "Approve and Continue", Choice: "approve"}
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge: %v", err)
+	}
+	if gEdge.Choice != "approve" {
+		t.Errorf("Choice = %q, want %q", gEdge.Choice, "approve")
+	}
+	if gEdge.Label != "Approve and Continue" {
+		t.Errorf("Label = %q, want %q", gEdge.Label, "Approve and Continue")
+	}
+}
+
+func TestConvertEdge_NoChoice(t *testing.T) {
+	irEdge := &ir.Edge{From: "a", To: "b", Label: "ok"}
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge: %v", err)
+	}
+	if gEdge.Choice != "" {
+		t.Errorf("Choice = %q, want empty for edge without choice", gEdge.Choice)
+	}
+}
+
 // TestEnsureStartExitNodes_ToolNodeKeepsHandler verifies that tool start/exit nodes
 // with a tool_command attribute keep their "tool" handler and are not overwritten
 // with the passthrough "start"/"exit" handler. This is the root cause of issue #69.

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -1559,6 +1559,39 @@ func TestExtractAgentAttrs_ZeroValueFieldsOmitted(t *testing.T) {
 	}
 }
 
+func TestExtractAgentAttrs_LastResponseTruncate(t *testing.T) {
+	attrs := make(map[string]string)
+	extractAgentAttrs(ir.AgentConfig{LastResponseTruncate: 500}, attrs)
+	if attrs["last_response_truncate"] != "500" {
+		t.Errorf("last_response_truncate = %q, want 500", attrs["last_response_truncate"])
+	}
+}
+
+func TestExtractAgentAttrs_ZeroLastResponseTruncateOmitted(t *testing.T) {
+	attrs := make(map[string]string)
+	extractAgentAttrs(ir.AgentConfig{}, attrs)
+	if _, ok := attrs["last_response_truncate"]; ok {
+		t.Error("last_response_truncate should be omitted when zero")
+	}
+}
+
+func TestExtractParallelAttrs_BranchLastResponseTruncate(t *testing.T) {
+	attrs := make(map[string]string)
+	cfg := ir.ParallelConfig{
+		Branches: []ir.BranchConfig{
+			{Target: "NodeA", LastResponseTruncate: 200},
+			{Target: "NodeB"},
+		},
+	}
+	extractParallelAttrs(cfg, attrs)
+	if attrs["branch.0.last_response_truncate"] != "200" {
+		t.Errorf("branch.0.last_response_truncate = %q, want 200", attrs["branch.0.last_response_truncate"])
+	}
+	if _, ok := attrs["branch.1.last_response_truncate"]; ok {
+		t.Error("branch.1.last_response_truncate should be omitted when zero")
+	}
+}
+
 func TestExtractHumanAttrs_ZeroValueFieldsOmitted(t *testing.T) {
 	attrs := map[string]string{}
 	extractHumanAttrs(ir.HumanConfig{}, attrs)

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -1711,6 +1711,28 @@ func TestConvertEdge_ZeroWeightOmitted(t *testing.T) {
 	}
 }
 
+func TestConvertEdge_Override(t *testing.T) {
+	irEdge := &ir.Edge{From: "gate", To: "accept", Label: "approve", Override: true}
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge: %v", err)
+	}
+	if !gEdge.Override {
+		t.Error("Override = false, want true")
+	}
+}
+
+func TestConvertEdge_NoOverride(t *testing.T) {
+	irEdge := &ir.Edge{From: "a", To: "b"}
+	gEdge, err := convertEdge(irEdge)
+	if err != nil {
+		t.Fatalf("convertEdge: %v", err)
+	}
+	if gEdge.Override {
+		t.Error("Override = true, want false for default edge")
+	}
+}
+
 // TestEnsureStartExitNodes_ToolNodeKeepsHandler verifies that tool start/exit nodes
 // with a tool_command attribute keep their "tool" handler and are not overwritten
 // with the passthrough "start"/"exit" handler. This is the root cause of issue #69.

--- a/pipeline/dippin_adapter_test.go
+++ b/pipeline/dippin_adapter_test.go
@@ -1766,6 +1766,53 @@ func TestConvertEdge_NoOverride(t *testing.T) {
 	}
 }
 
+func TestAddIREdges_OverrideOnNonHumanNodeErrors(t *testing.T) {
+	// override: true is only valid on edges from wait.human (hexagon) nodes.
+	// The adapter must reject it on agent/tool/etc. source nodes.
+	workflow := &ir.Workflow{
+		Name:  "test",
+		Start: "agent",
+		Exit:  "done",
+		Nodes: []*ir.Node{
+			{ID: "agent", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "do work"}},
+			{ID: "done", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "agent", To: "done", Override: true},
+		},
+	}
+	_, err := FromDippinIR(workflow)
+	if err == nil {
+		t.Fatal("expected error for override: true on non-human edge, got nil")
+	}
+	if !errors.Is(err, ErrOverrideOnNonHumanEdge) {
+		t.Errorf("expected ErrOverrideOnNonHumanEdge, got: %v", err)
+	}
+}
+
+func TestAddIREdges_OverrideOnHumanNodeOK(t *testing.T) {
+	workflow := &ir.Workflow{
+		Name:  "test",
+		Start: "gate",
+		Exit:  "done",
+		Nodes: []*ir.Node{
+			{ID: "gate", Kind: ir.NodeHuman, Config: ir.HumanConfig{}},
+			{ID: "done", Kind: ir.NodeAgent, Config: ir.AgentConfig{Prompt: "done"}},
+		},
+		Edges: []*ir.Edge{
+			{From: "gate", To: "done", Label: "approve", Override: true},
+		},
+	}
+	graph, err := FromDippinIR(workflow)
+	if err != nil {
+		t.Fatalf("unexpected error for override: true on human gate: %v", err)
+	}
+	edges := graph.OutgoingEdges("gate")
+	if len(edges) != 1 || !edges[0].Override {
+		t.Error("expected Override=true on cloned edge")
+	}
+}
+
 func TestConvertEdge_Choice(t *testing.T) {
 	irEdge := &ir.Edge{From: "gate", To: "next", Label: "Approve and Continue", Choice: "approve"}
 	gEdge, err := convertEdge(irEdge)

--- a/pipeline/engine_edges.go
+++ b/pipeline/engine_edges.go
@@ -114,7 +114,10 @@ func edgeRoutingKey(edge *Edge) string {
 	if edge.Choice != "" {
 		return edge.Choice
 	}
-	return edge.Label
+	if edge.Label != "" {
+		return edge.Label
+	}
+	return edge.To
 }
 
 // selectByLabel matches edges by the preferred label stored in context.

--- a/pipeline/engine_edges.go
+++ b/pipeline/engine_edges.go
@@ -20,49 +20,45 @@ func (e *Engine) selectEdge(runID string, edges []*Edge, pctx *PipelineContext) 
 		return edge, err
 	}
 
-	// All conditionals (if any) evaluated false. If any *did* exist AND the
-	// fallback path we take next is an unconditional edge, the routing is a
-	// "stated-intent miss" — emit EventConditionalFallthrough so
-	// `tracker diagnose` can correlate with EventToolOutputTruncated (#208).
-	// Skip the event when the selected edge still has a Condition (label and
-	// suggested matchers can pick a conditional edge whose condition evaluated
-	// false — that's not a fallthrough, it's a re-selection by other criteria,
-	// and labeling it fallthrough would trigger misleading diagnose guidance).
-	emitFallthrough := func(selected *Edge, priority string) {
-		if len(conditionsTried) == 0 || selected == nil || selected.Condition != "" {
-			return
-		}
-		e.emit(PipelineEvent{
-			Type:      EventConditionalFallthrough,
-			Timestamp: time.Now(),
-			RunID:     runID,
-			NodeID:    selected.From,
-			Message:   fmt.Sprintf("conditional fallthrough on node %q: %d condition(s) evaluated false, fell back to %s edge -> %q", selected.From, len(conditionsTried), priority, selected.To),
-			Decision: &DecisionDetail{
-				EdgeFrom:        selected.From,
-				EdgeTo:          selected.To,
-				EdgePriority:    priority,
-				ContextSnapshot: ctxSnap,
-				ConditionsTried: conditionsTried,
-			},
-		})
-	}
-
 	if edge := e.selectByLabel(runID, edges, pctx, ctxSnap); edge != nil {
-		emitFallthrough(edge, "label")
+		e.emitFallthroughIfNeeded(runID, edge, "label", conditionsTried, ctxSnap)
 		return edge, nil
 	}
 
 	if edge := e.selectBySuggested(runID, edges, pctx, ctxSnap); edge != nil {
-		emitFallthrough(edge, "suggested")
+		e.emitFallthroughIfNeeded(runID, edge, "suggested", conditionsTried, ctxSnap)
 		return edge, nil
 	}
 
 	edge, weightPriority, err := e.selectByWeight(runID, edges, pctx, ctxSnap)
 	if err == nil && edge != nil {
-		emitFallthrough(edge, weightPriority)
+		e.emitFallthroughIfNeeded(runID, edge, weightPriority, conditionsTried, ctxSnap)
 	}
 	return edge, err
+}
+
+// emitFallthroughIfNeeded fires EventConditionalFallthrough when conditionals
+// were tried but an unconditional fallback edge was selected instead. Skip the
+// event when the selected edge itself has a Condition (re-selection by label
+// or weight on a conditional edge is not a fallthrough).
+func (e *Engine) emitFallthroughIfNeeded(runID string, selected *Edge, priority string, conditionsTried []ConditionEval, ctxSnap map[string]string) {
+	if len(conditionsTried) == 0 || selected == nil || selected.Condition != "" {
+		return
+	}
+	e.emit(PipelineEvent{
+		Type:      EventConditionalFallthrough,
+		Timestamp: time.Now(),
+		RunID:     runID,
+		NodeID:    selected.From,
+		Message:   fmt.Sprintf("conditional fallthrough on node %q: %d condition(s) evaluated false, fell back to %s edge -> %q", selected.From, len(conditionsTried), priority, selected.To),
+		Decision: &DecisionDetail{
+			EdgeFrom:        selected.From,
+			EdgeTo:          selected.To,
+			EdgePriority:    priority,
+			ContextSnapshot: ctxSnap,
+			ConditionsTried: conditionsTried,
+		},
+	})
 }
 
 // selectByCondition evaluates condition expressions on edges, returning the
@@ -76,28 +72,10 @@ func (e *Engine) selectByCondition(runID string, edges []*Edge, pctx *PipelineCo
 		if edge.Condition == "" {
 			continue
 		}
-		expandedCondition, err := ExpandVariables(edge.Condition, pctx, params, e.graph.Attrs, false)
+		match, err := e.evaluateEdgeCondition(runID, edge, pctx, params, ctxSnap)
 		if err != nil {
-			return nil, nil, fmt.Errorf("expand condition on edge %s->%s: %w", edge.From, edge.To, err)
+			return nil, nil, err
 		}
-		match, err := EvaluateCondition(expandedCondition, pctx)
-		if err != nil {
-			return nil, nil, fmt.Errorf("evaluate condition on edge %s->%s: %w", edge.From, edge.To, err)
-		}
-		e.emit(PipelineEvent{
-			Type:      EventDecisionCondition,
-			Timestamp: time.Now(),
-			RunID:     runID,
-			NodeID:    edge.From,
-			Message:   fmt.Sprintf("condition %q on edge %s->%s evaluated to %v", edge.Condition, edge.From, edge.To, match),
-			Decision: &DecisionDetail{
-				EdgeFrom:        edge.From,
-				EdgeTo:          edge.To,
-				EdgeCondition:   edge.Condition,
-				ConditionMatch:  match,
-				ContextSnapshot: ctxSnap,
-			},
-		})
 		if match {
 			e.emitEdgeSelected(runID, edge, "condition", ctxSnap)
 			return edge, nil, nil
@@ -107,9 +85,37 @@ func (e *Engine) selectByCondition(runID string, edges []*Edge, pctx *PipelineCo
 	return nil, triedFalse, nil
 }
 
+// evaluateEdgeCondition expands and evaluates a single conditional edge,
+// emits the decision event, and returns whether the condition matched.
+func (e *Engine) evaluateEdgeCondition(runID string, edge *Edge, pctx *PipelineContext, params map[string]string, ctxSnap map[string]string) (bool, error) {
+	expandedCondition, err := ExpandVariables(edge.Condition, pctx, params, e.graph.Attrs, false)
+	if err != nil {
+		return false, fmt.Errorf("expand condition on edge %s->%s: %w", edge.From, edge.To, err)
+	}
+	match, err := EvaluateCondition(expandedCondition, pctx)
+	if err != nil {
+		return false, fmt.Errorf("evaluate condition on edge %s->%s: %w", edge.From, edge.To, err)
+	}
+	e.emit(PipelineEvent{
+		Type:      EventDecisionCondition,
+		Timestamp: time.Now(),
+		RunID:     runID,
+		NodeID:    edge.From,
+		Message:   fmt.Sprintf("condition %q on edge %s->%s evaluated to %v", edge.Condition, edge.From, edge.To, match),
+		Decision: &DecisionDetail{
+			EdgeFrom:        edge.From,
+			EdgeTo:          edge.To,
+			EdgeCondition:   edge.Condition,
+			ConditionMatch:  match,
+			ContextSnapshot: ctxSnap,
+		},
+	})
+	return match, nil
+}
+
 // edgeRoutingKey returns the routing key for an edge: Choice when non-empty,
-// otherwise Label. Used so edges with an explicit choice: attribute route on
-// the choice key, not the display label (DIP150).
+// Label when non-empty, otherwise To. Used so edges with an explicit choice:
+// attribute route on the choice key, not the display label (DIP150).
 func edgeRoutingKey(edge *Edge) string {
 	if edge.Choice != "" {
 		return edge.Choice

--- a/pipeline/engine_edges.go
+++ b/pipeline/engine_edges.go
@@ -107,14 +107,26 @@ func (e *Engine) selectByCondition(runID string, edges []*Edge, pctx *PipelineCo
 	return nil, triedFalse, nil
 }
 
+// edgeRoutingKey returns the routing key for an edge: Choice when non-empty,
+// otherwise Label. Used so edges with an explicit choice: attribute route on
+// the choice key, not the display label (DIP150).
+func edgeRoutingKey(edge *Edge) string {
+	if edge.Choice != "" {
+		return edge.Choice
+	}
+	return edge.Label
+}
+
 // selectByLabel matches edges by the preferred label stored in context.
+// When an edge has a Choice key, the preferred label is compared against
+// Choice (the stable routing key) rather than Label (the display string).
 func (e *Engine) selectByLabel(runID string, edges []*Edge, pctx *PipelineContext, ctxSnap map[string]string) *Edge {
 	preferred, ok := pctx.Get(ContextKeyPreferredLabel)
 	if !ok || preferred == "" {
 		return nil
 	}
 	for _, edge := range edges {
-		if edge.Label == preferred {
+		if edgeRoutingKey(edge) == preferred {
 			e.emitEdgeSelected(runID, edge, "label", ctxSnap)
 			return edge
 		}

--- a/pipeline/engine_edges_test.go
+++ b/pipeline/engine_edges_test.go
@@ -1,0 +1,83 @@
+// ABOUTME: Tests for edge routing helpers in engine_edges.go — specifically the
+// ABOUTME: edgeRoutingKey helper and Choice-aware selectByLabel (DIP150).
+package pipeline
+
+import (
+	"testing"
+)
+
+func TestEdgeRoutingKey_ChoiceWinsOverLabel(t *testing.T) {
+	e := &Edge{Label: "Approve and Continue", Choice: "approve"}
+	if got := edgeRoutingKey(e); got != "approve" {
+		t.Errorf("edgeRoutingKey = %q, want %q", got, "approve")
+	}
+}
+
+func TestEdgeRoutingKey_LabelFallback(t *testing.T) {
+	e := &Edge{Label: "Reject"}
+	if got := edgeRoutingKey(e); got != "Reject" {
+		t.Errorf("edgeRoutingKey = %q, want %q", got, "Reject")
+	}
+}
+
+func TestEdgeRoutingKey_EmptyBoth(t *testing.T) {
+	e := &Edge{}
+	if got := edgeRoutingKey(e); got != "" {
+		t.Errorf("edgeRoutingKey = %q, want empty", got)
+	}
+}
+
+func TestSelectByLabel_ChoiceKey(t *testing.T) {
+	g := NewGraph("test")
+	g.StartNode = "start"
+	g.ExitNode = "end"
+	g.AddNode(&Node{ID: "gate", Shape: "hexagon", Handler: "wait.human"})
+	g.AddNode(&Node{ID: "next", Shape: "rectangle", Handler: "tool"})
+	g.AddNode(&Node{ID: "reject", Shape: "rectangle", Handler: "tool"})
+	// Edge with Choice key — preferred_label should match on "approve", not the display label.
+	g.AddEdge(&Edge{From: "gate", To: "next", Label: "Approve and Continue", Choice: "approve"})
+	// Edge without Choice — preferred_label matches on Label directly.
+	g.AddEdge(&Edge{From: "gate", To: "reject", Label: "Reject"})
+
+	reg := NewHandlerRegistry()
+	engine := NewEngine(g, reg)
+
+	pctx := NewPipelineContext()
+	pctx.Set(ContextKeyPreferredLabel, "approve")
+
+	edges := g.OutgoingEdges("gate")
+	ctxSnap := engine.routingContextSnapshot(pctx)
+	selected := engine.selectByLabel("test-run", edges, pctx, ctxSnap)
+	if selected == nil {
+		t.Fatal("selectByLabel returned nil, want edge to next")
+	}
+	if selected.To != "next" {
+		t.Errorf("selected.To = %q, want %q", selected.To, "next")
+	}
+}
+
+func TestSelectByLabel_LabelFallback(t *testing.T) {
+	g := NewGraph("test")
+	g.StartNode = "start"
+	g.ExitNode = "end"
+	g.AddNode(&Node{ID: "gate", Shape: "hexagon", Handler: "wait.human"})
+	g.AddNode(&Node{ID: "reject", Shape: "rectangle", Handler: "tool"})
+	// Edge without Choice — preferred_label matches on Label.
+	g.AddEdge(&Edge{From: "gate", To: "reject", Label: "Reject"})
+
+	reg := NewHandlerRegistry()
+	engine := NewEngine(g, reg)
+
+	pctx := NewPipelineContext()
+	pctx.Set(ContextKeyPreferredLabel, "Reject")
+
+	edges := g.OutgoingEdges("gate")
+	ctxSnap := engine.routingContextSnapshot(pctx)
+	selected := engine.selectByLabel("test-run", edges, pctx, ctxSnap)
+	if selected == nil {
+		t.Fatal("selectByLabel returned nil, want edge to reject")
+	}
+	if selected.To != "reject" {
+		t.Errorf("selected.To = %q, want %q", selected.To, "reject")
+	}
+}

--- a/pipeline/expand.go
+++ b/pipeline/expand.go
@@ -317,6 +317,7 @@ func InjectParamsIntoGraph(g *Graph, params map[string]string) (*Graph, error) {
 			From:      e.From,
 			To:        e.To,
 			Label:     e.Label,
+			Choice:    e.Choice,
 			Condition: e.Condition,
 			Override:  e.Override,
 			Attrs:     copyStringMap(e.Attrs),

--- a/pipeline/expand_test.go
+++ b/pipeline/expand_test.go
@@ -811,6 +811,24 @@ func TestExpandVariables_NodeScopedToolStdoutFencedBlock(t *testing.T) {
 	}
 }
 
+func TestInjectParamsIntoGraph_PreservesEdgeChoice(t *testing.T) {
+	g := NewGraph("sub")
+	g.AddNode(&Node{ID: "gate", Shape: "hexagon"})
+	g.AddNode(&Node{ID: "next", Shape: "box"})
+	g.AddEdge(&Edge{From: "gate", To: "next", Label: "Approve and Continue", Choice: "approve"})
+
+	clone, err := InjectParamsIntoGraph(g, map[string]string{})
+	if err != nil {
+		t.Fatalf("InjectParamsIntoGraph: %v", err)
+	}
+	if len(clone.Edges) != 1 {
+		t.Fatalf("expected 1 edge, got %d", len(clone.Edges))
+	}
+	if clone.Edges[0].Choice != "approve" {
+		t.Errorf("cloned edge Choice = %q, want %q", clone.Edges[0].Choice, "approve")
+	}
+}
+
 func TestInjectParamsIntoGraphPreservesValidationAndIndexes(t *testing.T) {
 	g := NewGraph("sub")
 	g.AddNode(&Node{ID: "a", Shape: "box"})

--- a/pipeline/graph.go
+++ b/pipeline/graph.go
@@ -239,6 +239,10 @@ type Edge struct {
 	From      string
 	To        string
 	Label     string
+	// Choice is the stable routing key for human-gate edges (DIP150, dippin-lang
+	// v0.42.0). When non-empty, edge selection uses Choice instead of Label.
+	// Display in the TUI always uses Label.
+	Choice    string
 	Condition string
 	// Override marks the edge as a validation-override path. When the engine
 	// traverses an override edge from a wait.human gate, the run's terminal

--- a/pipeline/graph.go
+++ b/pipeline/graph.go
@@ -241,7 +241,7 @@ type Edge struct {
 	Label string
 	// Choice is the stable routing key for human-gate edges (DIP150, dippin-lang
 	// v0.42.0). When non-empty, edge selection uses Choice instead of Label.
-	// Display in the TUI always uses Label.
+	// Display in the TUI uses Label when set, falling back to To.
 	Choice    string
 	Condition string
 	// Override marks the edge as a validation-override path. When the engine

--- a/pipeline/graph.go
+++ b/pipeline/graph.go
@@ -236,9 +236,9 @@ type Node struct {
 
 // Edge represents a directed connection between two nodes.
 type Edge struct {
-	From      string
-	To        string
-	Label     string
+	From  string
+	To    string
+	Label string
 	// Choice is the stable routing key for human-gate edges (DIP150, dippin-lang
 	// v0.42.0). When non-empty, edge selection uses Choice instead of Label.
 	// Display in the TUI always uses Label.

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -951,6 +951,19 @@ func (h *HumanHandler) executeChoice(node *pipeline.Node, prompt string) (pipeli
 		return pipeline.Outcome{}, fmt.Errorf("human gate choice selection failed for node %q: %w", node.ID, err)
 	}
 
+	// Translate the selected display label to its routing key (Choice when set),
+	// mirroring what matchFreeformLabel does in freeform mode.
+	for _, e := range edges {
+		label := e.Label
+		if label == "" {
+			label = e.To
+		}
+		if label == selected && e.Choice != "" {
+			selected = e.Choice
+			break
+		}
+	}
+
 	return pipeline.Outcome{Status: string(pipeline.OutcomeSuccess), PreferredLabel: selected}, nil
 }
 

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -712,11 +712,21 @@ func askFreeformWithTimeout(fi FreeformInterviewer, prompt string, labels []stri
 }
 
 // matchFreeformLabel tries to match freeform response text against outgoing edge labels.
+// When an edge has a Choice key (DIP150), matching by Label returns Choice so the
+// engine routes on the stable key rather than the display label. Direct match against
+// the Choice key is also accepted so autopilot/webhook responders can use the short key.
 func matchFreeformLabel(graph *pipeline.Graph, node *pipeline.Node, response string) string {
 	normalized := strings.ToLower(strings.TrimSpace(response))
 	for _, e := range graph.OutgoingEdges(node.ID) {
 		if e.Label != "" && strings.ToLower(e.Label) == normalized {
+			if e.Choice != "" {
+				return e.Choice
+			}
 			return e.Label
+		}
+		// Also accept a direct match against the Choice key.
+		if e.Choice != "" && strings.ToLower(e.Choice) == normalized {
+			return e.Choice
 		}
 	}
 	// matchFreeformLabel compares against the bare "default" attr (not

--- a/pipeline/handlers/human.go
+++ b/pipeline/handlers/human.go
@@ -609,9 +609,10 @@ func (h *HumanHandler) handleHumanTimeout(node *pipeline.Node) pipeline.Outcome 
 			pipeline.ContextKeyHumanResponse: "timed out (no default)",
 		}}
 	}
+	routing := mapSelectionToRoutingKey(h.graph.OutgoingEdges(node.ID), def)
 	return pipeline.Outcome{
 		Status:         string(pipeline.OutcomeSuccess),
-		PreferredLabel: def,
+		PreferredLabel: routing,
 		ContextUpdates: map[string]string{
 			pipeline.ContextKeyHumanResponse:            def,
 			pipeline.ContextKeyResponsePrefix + node.ID: def,
@@ -713,8 +714,8 @@ func askFreeformWithTimeout(fi FreeformInterviewer, prompt string, labels []stri
 
 // matchFreeformLabel tries to match freeform response text against outgoing edge labels.
 // When an edge has a Choice key (DIP150), matching by Label returns Choice so the
-// engine routes on the stable key rather than the display label. Direct match against
-// the Choice key is also accepted so autopilot/webhook responders can use the short key.
+// engine routes on the stable key rather than the display label. A direct match against
+// the Choice key is also accepted when the responder sends the key directly.
 func matchFreeformLabel(graph *pipeline.Graph, node *pipeline.Node, response string) string {
 	normalized := strings.ToLower(strings.TrimSpace(response))
 	for _, e := range graph.OutgoingEdges(node.ID) {
@@ -951,20 +952,24 @@ func (h *HumanHandler) executeChoice(node *pipeline.Node, prompt string) (pipeli
 		return pipeline.Outcome{}, fmt.Errorf("human gate choice selection failed for node %q: %w", node.ID, err)
 	}
 
-	// Translate the selected display label to its routing key (Choice when set),
-	// mirroring what matchFreeformLabel does in freeform mode.
+	return pipeline.Outcome{Status: string(pipeline.OutcomeSuccess), PreferredLabel: mapSelectionToRoutingKey(edges, selected)}, nil
+}
+
+// mapSelectionToRoutingKey translates a human-selected display label to the
+// edge's Choice routing key when one is set. Falls back to the label itself
+// (or edge.To for unlabeled edges) when no Choice is present, preserving
+// the behaviour of edgeRoutingKey for the same edge.
+func mapSelectionToRoutingKey(edges []*pipeline.Edge, selected string) string {
 	for _, e := range edges {
 		label := e.Label
 		if label == "" {
 			label = e.To
 		}
 		if label == selected && e.Choice != "" {
-			selected = e.Choice
-			break
+			return e.Choice
 		}
 	}
-
-	return pipeline.Outcome{Status: string(pipeline.OutcomeSuccess), PreferredLabel: selected}, nil
+	return selected
 }
 
 // executeYesNo handles yes_no mode: presents Yes/No choices and maps them to

--- a/pipeline/handlers/human_test.go
+++ b/pipeline/handlers/human_test.go
@@ -1373,6 +1373,32 @@ func TestHumanHandler_PopulatesOverrideActor_Unknown(t *testing.T) {
 
 // TestMatchFreeformLabel_ChoiceKey verifies that matchFreeformLabel returns the
 // Choice key when an edge has one, and falls back to Label when Choice is empty.
+func TestHumanHandler_ChoiceMode_ChoiceKeyRouting(t *testing.T) {
+	// In default (choice) mode, when an edge has both Label and Choice,
+	// the human handler must store the Choice key (not the display Label)
+	// as PreferredLabel so the engine's selectByLabel can route correctly.
+	graph := pipeline.NewGraph("test")
+	graph.AddNode(&pipeline.Node{ID: "gate", Shape: "hexagon"})
+	graph.AddNode(&pipeline.Node{ID: "accept", Shape: "box"})
+	graph.AddNode(&pipeline.Node{ID: "reject", Shape: "box"})
+	graph.AddEdge(&pipeline.Edge{From: "gate", To: "accept", Label: "Approve and Continue", Choice: "approve"})
+	graph.AddEdge(&pipeline.Edge{From: "gate", To: "reject", Label: "Reject"})
+
+	// Interviewer returns the display label the user sees.
+	rec := &recordingInterviewer{response: "Approve and Continue"}
+	h := NewHumanHandler(rec, graph)
+	node := graph.Nodes["gate"]
+
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Must be the Choice routing key, not the display Label.
+	if outcome.PreferredLabel != "approve" {
+		t.Errorf("PreferredLabel = %q, want %q (Choice key)", outcome.PreferredLabel, "approve")
+	}
+}
+
 func TestMatchFreeformLabel_ChoiceKey(t *testing.T) {
 	graph := pipeline.NewGraph("test")
 	graph.AddNode(&pipeline.Node{ID: "gate", Shape: "hexagon"})

--- a/pipeline/handlers/human_test.go
+++ b/pipeline/handlers/human_test.go
@@ -1370,3 +1370,36 @@ func TestHumanHandler_PopulatesOverrideActor_Unknown(t *testing.T) {
 			outcome.OverrideActor, pipeline.ActorUnknown)
 	}
 }
+
+// TestMatchFreeformLabel_ChoiceKey verifies that matchFreeformLabel returns the
+// Choice key when an edge has one, and falls back to Label when Choice is empty.
+func TestMatchFreeformLabel_ChoiceKey(t *testing.T) {
+	graph := pipeline.NewGraph("test")
+	graph.AddNode(&pipeline.Node{ID: "gate", Shape: "hexagon"})
+	graph.AddNode(&pipeline.Node{ID: "next", Shape: "box"})
+	graph.AddNode(&pipeline.Node{ID: "reject", Shape: "box"})
+	// Edge with both Label and Choice set.
+	graph.AddEdge(&pipeline.Edge{From: "gate", To: "next", Label: "Approve and Continue", Choice: "approve"})
+	// Edge with only Label (no Choice).
+	graph.AddEdge(&pipeline.Edge{From: "gate", To: "reject", Label: "Reject"})
+
+	node := graph.Nodes["gate"]
+
+	// Matching by Label should return Choice when Choice is non-empty.
+	got := matchFreeformLabel(graph, node, "Approve and Continue")
+	if got != "approve" {
+		t.Errorf("matchFreeformLabel(\"Approve and Continue\") = %q, want %q", got, "approve")
+	}
+
+	// Matching by Label when no Choice: should return the Label.
+	got = matchFreeformLabel(graph, node, "Reject")
+	if got != "Reject" {
+		t.Errorf("matchFreeformLabel(\"Reject\") = %q, want %q", got, "Reject")
+	}
+
+	// Matching by Choice key directly returns the Choice key.
+	got = matchFreeformLabel(graph, node, "approve")
+	if got != "approve" {
+		t.Errorf("matchFreeformLabel(\"approve\") = %q, want %q", got, "approve")
+	}
+}

--- a/pipeline/handlers/human_test.go
+++ b/pipeline/handlers/human_test.go
@@ -1405,9 +1405,8 @@ func TestHumanHandler_PopulatesOverrideActor_Unknown(t *testing.T) {
 // TestMatchFreeformLabel_ChoiceKey verifies that matchFreeformLabel returns the
 // Choice key when an edge has one, and falls back to Label when Choice is empty.
 func TestHumanHandler_ChoiceMode_ChoiceKeyRouting(t *testing.T) {
-	// In default (choice) mode, when an edge has both Label and Choice,
-	// the human handler must store the Choice key (not the display Label)
-	// as PreferredLabel so the engine's selectByLabel can route correctly.
+	// executeChoice returns the edge's Choice key as PreferredLabel (not the
+	// display Label) so selectByLabel can route via edgeRoutingKey.
 	graph := pipeline.NewGraph("test")
 	graph.AddNode(&pipeline.Node{ID: "gate", Shape: "hexagon"})
 	graph.AddNode(&pipeline.Node{ID: "accept", Shape: "box"})

--- a/pipeline/handlers/human_test.go
+++ b/pipeline/handlers/human_test.go
@@ -1064,6 +1064,37 @@ func TestHumanHandler_TimeoutUsesDefault(t *testing.T) {
 	}
 }
 
+func TestHumanHandler_TimeoutUsesDefault_ChoiceKey(t *testing.T) {
+	// When default_choice is a display Label and the edge has a Choice key,
+	// handleHumanTimeout must store the Choice key as PreferredLabel.
+	graph := pipeline.NewGraph("test")
+	graph.AddNode(&pipeline.Node{
+		ID:    "gate",
+		Shape: "hexagon",
+		Attrs: map[string]string{
+			"timeout":        "100ms",
+			"default_choice": "Approve and Continue",
+		},
+	})
+	graph.AddNode(&pipeline.Node{ID: "accept", Shape: "box"})
+	graph.AddEdge(&pipeline.Edge{From: "gate", To: "accept", Label: "Approve and Continue", Choice: "approve"})
+
+	h := NewHumanHandler(&blockingInterviewer{}, graph)
+	node := graph.Nodes["gate"]
+
+	outcome, err := h.Execute(context.Background(), node, pipeline.NewPipelineContext())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if outcome.PreferredLabel != "approve" {
+		t.Errorf("PreferredLabel = %q, want %q (Choice key)", outcome.PreferredLabel, "approve")
+	}
+	// human_response should still carry the display label, not the Choice key.
+	if outcome.ContextUpdates[pipeline.ContextKeyHumanResponse] != "Approve and Continue" {
+		t.Errorf("human_response = %q, want display label", outcome.ContextUpdates[pipeline.ContextKeyHumanResponse])
+	}
+}
+
 // --- Human gate correctness: all modes must route correctly ---
 
 // yesNoInterviewer simulates a user picking a specific choice from the presented options.

--- a/pipeline/handlers/prompt.go
+++ b/pipeline/handlers/prompt.go
@@ -28,6 +28,24 @@ func ResolvePrompt(node *pipeline.Node, pctx *pipeline.PipelineContext,
 
 	prompt = pipeline.ExpandPromptVariables(prompt, pctx)
 
+	// Apply last_response_truncate: temporarily cap pctx's last_response to
+	// N Unicode characters for this prompt build, then restore. Bounds how
+	// much of a prior agent's output reaches this agent's prompt context
+	// (chain-attack mitigation, issue #56 / dippin-lang v0.40.0).
+	truncChars, err := resolveLastResponseTruncate(node)
+	if err != nil {
+		return "", err
+	}
+	if truncChars > 0 {
+		if resp, ok := pctx.Get(pipeline.ContextKeyLastResponse); ok {
+			runes := []rune(resp)
+			if len(runes) > truncChars {
+				pctx.Set(pipeline.ContextKeyLastResponse, string(runes[:truncChars]))
+				defer pctx.Set(pipeline.ContextKeyLastResponse, resp)
+			}
+		}
+	}
+
 	fidelity := pipeline.ResolveFidelity(node, graphAttrs)
 	if fidelity != pipeline.FidelityFull {
 		compacted := pipeline.CompactContextWithPinnedKeys(
@@ -48,6 +66,21 @@ func ResolvePrompt(node *pipeline.Node, pctx *pipeline.PipelineContext,
 	}
 
 	return prompt, nil
+}
+
+// resolveLastResponseTruncate reads the optional last_response_truncate node
+// attr: a Unicode character cap on the ctx.last_response value injected into
+// the prompt. 0/absent means no truncation. A malformed value fails loudly.
+func resolveLastResponseTruncate(node *pipeline.Node) (int, error) {
+	raw := node.Attrs["last_response_truncate"]
+	if raw == "" {
+		return 0, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("node %q has malformed last_response_truncate %q: %w", node.ID, raw, err)
+	}
+	return n, nil
 }
 
 // resolveInjectionCap reads the optional injection_cap node attr (#352): the

--- a/pipeline/handlers/prompt.go
+++ b/pipeline/handlers/prompt.go
@@ -20,31 +20,24 @@ func ResolvePrompt(node *pipeline.Node, pctx *pipeline.PipelineContext,
 		return "", fmt.Errorf("node %q missing required attribute 'prompt'", node.ID)
 	}
 
+	// Apply last_response_truncate before any variable expansion so that
+	// ${ctx.last_response} references in the prompt template are also capped
+	// (chain-attack mitigation, issue #56 / dippin-lang v0.40.0).
+	restore, err := applyLastResponseTruncate(node, pctx)
+	if err != nil {
+		return "", err
+	}
+	if restore != nil {
+		defer restore()
+	}
+
 	params := pipeline.ExtractParamsFromGraphAttrs(graphAttrs)
-	prompt, err := pipeline.ExpandVariables(prompt, pctx, params, graphAttrs, false)
+	prompt, err = pipeline.ExpandVariables(prompt, pctx, params, graphAttrs, false)
 	if err != nil {
 		return "", fmt.Errorf("node %q variable expansion failed: %w", node.ID, err)
 	}
 
 	prompt = pipeline.ExpandPromptVariables(prompt, pctx)
-
-	// Apply last_response_truncate: temporarily cap pctx's last_response to
-	// N Unicode characters for this prompt build, then restore. Bounds how
-	// much of a prior agent's output reaches this agent's prompt context
-	// (chain-attack mitigation, issue #56 / dippin-lang v0.40.0).
-	truncChars, err := resolveLastResponseTruncate(node)
-	if err != nil {
-		return "", err
-	}
-	if truncChars > 0 {
-		if resp, ok := pctx.Get(pipeline.ContextKeyLastResponse); ok {
-			runes := []rune(resp)
-			if len(runes) > truncChars {
-				pctx.Set(pipeline.ContextKeyLastResponse, string(runes[:truncChars]))
-				defer pctx.Set(pipeline.ContextKeyLastResponse, resp)
-			}
-		}
-	}
 
 	fidelity := pipeline.ResolveFidelity(node, graphAttrs)
 	if fidelity != pipeline.FidelityFull {
@@ -68,9 +61,30 @@ func ResolvePrompt(node *pipeline.Node, pctx *pipeline.PipelineContext,
 	return prompt, nil
 }
 
+// applyLastResponseTruncate caps pctx's last_response to the node's
+// last_response_truncate limit before prompt building. Returns a restore
+// function (non-nil only when truncation actually changed the value) so the
+// caller can defer-restore the original. Returns an error for invalid attrs.
+func applyLastResponseTruncate(node *pipeline.Node, pctx *pipeline.PipelineContext) (func(), error) {
+	truncChars, err := resolveLastResponseTruncate(node)
+	if err != nil || truncChars == 0 {
+		return nil, err
+	}
+	resp, ok := pctx.Get(pipeline.ContextKeyLastResponse)
+	if !ok {
+		return nil, nil
+	}
+	runes := []rune(resp)
+	if len(runes) <= truncChars {
+		return nil, nil
+	}
+	pctx.Set(pipeline.ContextKeyLastResponse, string(runes[:truncChars]))
+	return func() { pctx.Set(pipeline.ContextKeyLastResponse, resp) }, nil
+}
+
 // resolveLastResponseTruncate reads the optional last_response_truncate node
-// attr: a Unicode character cap on the ctx.last_response value injected into
-// the prompt. 0/absent means no truncation. A malformed value fails loudly.
+// attr: a Unicode character cap on the ctx.last_response value. 0/absent means
+// no truncation. Negative values and non-integers are rejected loudly.
 func resolveLastResponseTruncate(node *pipeline.Node) (int, error) {
 	raw := node.Attrs["last_response_truncate"]
 	if raw == "" {
@@ -79,6 +93,9 @@ func resolveLastResponseTruncate(node *pipeline.Node) (int, error) {
 	n, err := strconv.Atoi(raw)
 	if err != nil {
 		return 0, fmt.Errorf("node %q has malformed last_response_truncate %q: %w", node.ID, raw, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("node %q has invalid last_response_truncate %d: must be >= 0", node.ID, n)
 	}
 	return n, nil
 }

--- a/pipeline/handlers/prompt.go
+++ b/pipeline/handlers/prompt.go
@@ -78,8 +78,11 @@ func applyLastResponseTruncate(node *pipeline.Node, pctx *pipeline.PipelineConte
 	if len(runes) <= truncChars {
 		return nil, nil
 	}
-	pctx.Set(pipeline.ContextKeyLastResponse, string(runes[:truncChars]))
-	return func() { pctx.Set(pipeline.ContextKeyLastResponse, resp) }, nil
+	// Use MergeWithoutDirty so the temporary truncation is not attributed to
+	// this node if ResolvePrompt returns an error and the engine calls
+	// ScopeToNode on the error path.
+	pctx.MergeWithoutDirty(map[string]string{pipeline.ContextKeyLastResponse: string(runes[:truncChars])})
+	return func() { pctx.MergeWithoutDirty(map[string]string{pipeline.ContextKeyLastResponse: resp}) }, nil
 }
 
 // resolveLastResponseTruncate reads the optional last_response_truncate node

--- a/pipeline/handlers/prompt.go
+++ b/pipeline/handlers/prompt.go
@@ -5,6 +5,7 @@ package handlers
 import (
 	"fmt"
 	"strconv"
+	"unicode/utf8"
 
 	"github.com/2389-research/tracker/pipeline"
 )
@@ -74,14 +75,21 @@ func applyLastResponseTruncate(node *pipeline.Node, pctx *pipeline.PipelineConte
 	if !ok {
 		return nil, nil
 	}
-	runes := []rune(resp)
-	if len(runes) <= truncChars {
-		return nil, nil
+	// Walk forward exactly truncChars runes to find the byte cut point.
+	// This avoids allocating a full []rune for large responses.
+	byteIdx, count := 0, 0
+	for byteIdx < len(resp) && count < truncChars {
+		_, size := utf8.DecodeRuneInString(resp[byteIdx:])
+		byteIdx += size
+		count++
+	}
+	if count < truncChars {
+		return nil, nil // fewer runes than the limit — nothing to truncate
 	}
 	// Use MergeWithoutDirty so the temporary truncation is not attributed to
 	// this node if ResolvePrompt returns an error and the engine calls
 	// ScopeToNode on the error path.
-	pctx.MergeWithoutDirty(map[string]string{pipeline.ContextKeyLastResponse: string(runes[:truncChars])})
+	pctx.MergeWithoutDirty(map[string]string{pipeline.ContextKeyLastResponse: resp[:byteIdx]})
 	return func() { pctx.MergeWithoutDirty(map[string]string{pipeline.ContextKeyLastResponse: resp}) }, nil
 }
 

--- a/pipeline/handlers/prompt_test.go
+++ b/pipeline/handlers/prompt_test.go
@@ -202,3 +202,58 @@ func TestResolvePromptInjectionCapMalformed(t *testing.T) {
 		t.Errorf("expected error to name injection_cap, got: %v", err)
 	}
 }
+
+func TestResolvePrompt_LastResponseTruncate(t *testing.T) {
+	node := &pipeline.Node{
+		ID: "TestNode",
+		Attrs: map[string]string{
+			"prompt":                  "Do the task.",
+			"last_response_truncate": "10",
+		},
+	}
+	pctx := pipeline.NewPipelineContext()
+	const longResp = "hello world this is a long response from the previous node"
+	pctx.Set(pipeline.ContextKeyLastResponse, longResp)
+
+	got, err := ResolvePrompt(node, pctx, nil, "")
+	if err != nil {
+		t.Fatalf("ResolvePrompt: %v", err)
+	}
+	if strings.Contains(got, "hello world this") {
+		t.Errorf("last_response not truncated: full string appears in output")
+	}
+	// Original pctx value must be restored.
+	restored, _ := pctx.Get(pipeline.ContextKeyLastResponse)
+	if restored != longResp {
+		t.Errorf("pctx last_response not restored: got %q", restored)
+	}
+}
+
+func TestResolvePrompt_LastResponseTruncate_Zero_NoChange(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "TestNode",
+		Attrs: map[string]string{"prompt": "Do the task."},
+	}
+	pctx := pipeline.NewPipelineContext()
+	const resp = "short response"
+	pctx.Set(pipeline.ContextKeyLastResponse, resp)
+
+	got, err := ResolvePrompt(node, pctx, nil, "")
+	if err != nil {
+		t.Fatalf("ResolvePrompt: %v", err)
+	}
+	if !strings.Contains(got, resp) {
+		t.Errorf("expected %q in prompt when truncate is 0", resp)
+	}
+}
+
+func TestResolvePrompt_LastResponseTruncate_Malformed(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "TestNode",
+		Attrs: map[string]string{"prompt": "Do the task.", "last_response_truncate": "abc"},
+	}
+	_, err := ResolvePrompt(node, pipeline.NewPipelineContext(), nil, "")
+	if err == nil {
+		t.Fatal("expected error for malformed last_response_truncate")
+	}
+}

--- a/pipeline/handlers/prompt_test.go
+++ b/pipeline/handlers/prompt_test.go
@@ -207,7 +207,7 @@ func TestResolvePrompt_LastResponseTruncate(t *testing.T) {
 	node := &pipeline.Node{
 		ID: "TestNode",
 		Attrs: map[string]string{
-			"prompt":                  "Do the task.",
+			"prompt":                 "Do the task.",
 			"last_response_truncate": "10",
 		},
 	}

--- a/pipeline/handlers/prompt_test.go
+++ b/pipeline/handlers/prompt_test.go
@@ -204,10 +204,12 @@ func TestResolvePromptInjectionCapMalformed(t *testing.T) {
 }
 
 func TestResolvePrompt_LastResponseTruncate(t *testing.T) {
+	// The prompt references ${ctx.last_response} directly — truncation must
+	// apply before variable expansion so the template reference is also capped.
 	node := &pipeline.Node{
 		ID: "TestNode",
 		Attrs: map[string]string{
-			"prompt":                 "Do the task.",
+			"prompt":                 "Previous: ${ctx.last_response}",
 			"last_response_truncate": "10",
 		},
 	}
@@ -219,13 +221,28 @@ func TestResolvePrompt_LastResponseTruncate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolvePrompt: %v", err)
 	}
+	// The first 10 chars ("hello worl") should appear; the rest must not.
+	if !strings.Contains(got, "hello worl") {
+		t.Errorf("truncated prefix missing from prompt: %s", got)
+	}
 	if strings.Contains(got, "hello world this") {
 		t.Errorf("last_response not truncated: full string appears in output")
 	}
-	// Original pctx value must be restored.
+	// Original pctx value must be restored after ResolvePrompt returns.
 	restored, _ := pctx.Get(pipeline.ContextKeyLastResponse)
 	if restored != longResp {
 		t.Errorf("pctx last_response not restored: got %q", restored)
+	}
+}
+
+func TestResolvePrompt_LastResponseTruncate_Negative(t *testing.T) {
+	node := &pipeline.Node{
+		ID:    "TestNode",
+		Attrs: map[string]string{"prompt": "Do the task.", "last_response_truncate": "-1"},
+	}
+	_, err := ResolvePrompt(node, pipeline.NewPipelineContext(), nil, "")
+	if err == nil {
+		t.Fatal("expected error for negative last_response_truncate")
 	}
 }
 

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -23,7 +23,7 @@ import (
 
 // PinnedDippinVersion is the dippin-lang version from go.mod. Kept in sync
 // with go.mod by TestPinnedDippinVersionMatchesGoMod.
-const PinnedDippinVersion = "v0.39.0"
+const PinnedDippinVersion = "v0.42.0"
 
 // DoctorConfig configures a Doctor() run.
 type DoctorConfig struct {


### PR DESCRIPTION
## Summary

Wires three new dippin-lang IR fields that were previously carried by the parser but not enforced by the tracker runtime:

- **`override:` edge** (v0.40.0): `ir.Edge.Override` → `pipeline.Edge.Override` — 1-line adapter fix closing the known #271 input gap; the engine already enforced it
- **`last_response_truncate:`** (v0.40.0): adapter writes attr → `ResolvePrompt` temporarily caps `pctx.last_response` to N Unicode chars before injection then restores (chain-attack mitigation, #56); covers agent and branch-level overrides
- **`choice:` edge** (v0.42.0, DIP150): new `pipeline.Edge.Choice` field; `matchFreeformLabel` returns Choice as routing key; `executeChoice` translates selected label to Choice key; `selectByLabel` routes on `edgeRoutingKey()` = Choice‖Label

Also upgrades go.mod to dippin-lang v0.42.0 and bumps `PinnedDippinVersion`.

## Test plan

- [ ] `go build ./... && go test ./... -short` — all green
- [ ] `dippin doctor` on all three core examples — Grade A
- [ ] `TestConvertEdge_Override` / `TestConvertEdge_NoOverride`
- [ ] `TestConvertEdge_Choice` / `TestConvertEdge_NoChoice`
- [ ] `TestExtractAgentAttrs_LastResponseTruncate` / `TestExtractAgentAttrs_ZeroLastResponseTruncateOmitted`
- [ ] `TestExtractParallelAttrs_BranchLastResponseTruncate`
- [ ] `TestResolvePrompt_LastResponseTruncate` / `TestResolvePrompt_LastResponseTruncate_Zero_NoChange`
- [ ] `TestMatchFreeformLabel_ChoiceKey`
- [ ] `TestHumanHandler_ChoiceMode_ChoiceKeyRouting`
- [ ] `TestSelectByLabel_ChoiceKey` / `TestEdgeRoutingKey_*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784313371&installation_id=131176874&pr_number=391&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F391&signature=c1bac9bd9d12cc8f41ba162cdee1ab2d73abfe39bcb44044320c0ebb79a1e8cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stable routing for human-gate decisions now prefers the stable `Choice` key over display `Label`, including human timeout/default selections and choice-mode mapping.
  * Prompt generation now enforces `last_response_truncate`, including per-branch limits, at prompt resolution time.
* **Changed**
  * Human-gate edge `Override: true` is now validated/enforced (rejects invalid placements) and propagated correctly.
  * Edge routing metadata (`Choice`, `Override`) is preserved through graph expansion and selection.
  * Upgraded `dippin-lang` to v0.42.0.
* **Tests**
  * Added coverage for `Choice`/`Override` mapping, human routing selection, and truncate validation/truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->