### PR TITLE
fix(build_product): make FinalCommit mechanically commit-only via writable_paths jail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`build_product.dip` FinalCommit is now mechanically commit-only** (issue #349).
+  Building on the existing `commit_only` prompt/engine guard, the FinalCommit node
+  now also declares `writable_paths: .git/**, .ai/**`, wiring the native fs-jail
+  (#272) so its file-mutation tools — Bash + descendants AND in-process
+  Write/Edit/ApplyPatch — can only write under `.git/` and `.ai/`. `git add`/`git
+  commit` still work, but the node physically cannot author product source even
+  when upstream failure context primes it to "just fix it" (the case-study failure
+  where FinalCommit wrote an entire unreviewed milestone that shipped through zero
+  quality gates). This is the primary, mechanical defense; the `commit_only`
+  prompt/system-prompt guard remains the backstop. Linux native backend only —
+  see #272 platform/backend caveats.
 - **dippin-lang upgraded to v0.42.0** (from v0.39.0). New IR fields wired in
   subsequent commits: `Edge.Override` (v0.40.0, closes #271 input gap),
   `AgentConfig.LastResponseTruncate` + `BranchConfig.LastResponseTruncate`

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -2152,6 +2152,17 @@ workflow BuildProduct
     reasoning_effort: low
     auto_status: true
     fallback_target: EscalateReview
+    # #349 mechanical scope guard (primary defense): bound this node's file-
+    # mutation tools to git internals + tracker's .ai/ scratch via the native
+    # fs-jail (#272). Bash + its descendants AND in-process Write/Edit/ApplyPatch
+    # may only write under .git/ and .ai/ — so `git add`/`git commit` still work,
+    # but the node CANNOT author product source even when upstream failure context
+    # primes it to "just fix it" (the case-study failure: FinalCommit wrote an
+    # entire unreviewed milestone). Landlock bounds the Bash subprocess at the
+    # directory ancestor of each glob's static prefix, so `.git/**` -> `.git`,
+    # `.ai/**` -> `.ai`. The commit_only prompt/system-prompt guard below is the
+    # backstop. Linux native backend only — see #272 platform/backend caveats.
+    writable_paths: .git/**, .ai/**
     params:
       commit_only: true
     prompt:

--- a/pipeline/build_product_finalcommit_scope_test.go
+++ b/pipeline/build_product_finalcommit_scope_test.go
@@ -1,0 +1,57 @@
+// ABOUTME: Regression guard for issue #349 — FinalCommit in build_product.dip must
+// ABOUTME: carry a MECHANICAL writable_paths fs-jail bounding writes to git + .ai/ only.
+package pipeline
+
+import "testing"
+
+const finalCommitNodeID = "FinalCommit"
+
+// TestBuildProductFinalCommitWritablePathsJail pins the primary, mechanical
+// scope guard for #349: FinalCommit (a late-pipeline agent node with commit
+// ability and a fat context window) must declare writable_paths so the native
+// fs-jail (#272) bounds its file-mutation tools — Bash + descendants AND
+// in-process Write/Edit/ApplyPatch — to git internals + tracker's .ai/ scratch.
+// This is what physically prevents the case-study failure (FinalCommit authored
+// an entire unreviewed milestone): with the jail, `git add`/`git commit` still
+// work but product source cannot be written even if the prompt is subverted.
+//
+// The prompt + commit_only system-prompt guard remain the backstop and are
+// pinned elsewhere (handlers TestCommitOnlyScopeGuard*); this test pins the
+// mechanical layer that does not rely on the model obeying instructions.
+func TestBuildProductFinalCommitWritablePathsJail(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	n, ok := g.Nodes[finalCommitNodeID]
+	if !ok {
+		t.Fatalf("%s node missing from build_product.dip (issue #349)", finalCommitNodeID)
+	}
+
+	cfg := n.AgentConfig(nil)
+	if !cfg.WritablePathsSet {
+		t.Fatalf("%s must declare writable_paths so the fs-jail bounds its tools — without it the node can author unreviewed product code (issue #349)", finalCommitNodeID)
+	}
+
+	// The jail must allow git internals (so commits work) and .ai/ scratch, and
+	// nothing else (so product source is unwritable). Order-independent set check.
+	want := map[string]bool{".git/**": true, ".ai/**": true}
+	got := map[string]bool{}
+	for _, p := range cfg.WritablePaths {
+		got[p] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Errorf("%s writable_paths missing %q (have %v) — git+.ai/ scope required for a commit-only node (issue #349)", finalCommitNodeID, w, cfg.WritablePaths)
+		}
+	}
+	for g := range got {
+		if !want[g] {
+			t.Errorf("%s writable_paths has unexpected entry %q (have %v) — widening the jail beyond git+.ai/ re-opens the product-source write path (issue #349)", finalCommitNodeID, g, cfg.WritablePaths)
+		}
+	}
+
+	// The mechanical jail must not have silently displaced the prompt/system-prompt
+	// backstop: commit_only stays on as defense-in-depth.
+	if !cfg.CommitOnly {
+		t.Errorf("%s lost commit_only — the prompt/system-prompt backstop must remain alongside the fs-jail (issue #349)", finalCommitNodeID)
+	}
+}


### PR DESCRIPTION
> **Stacked on #401** (`fix/399-gitsafeenv-git-dir-leak`). Base is that branch, not `main` — review/merge #401 first, then this. The diff below is **only** the #349 change; the git-env-leak fix that originally rode along in this branch was split out to #401.

## Problem

`build_product.dip`'s FinalCommit node is meant to commit already-reviewed work and nothing else. But the only thing stopping it from authoring source was an advisory `commit_only` prompt/engine guard. In the case-study failure, FinalCommit — primed by upstream failure context to "just fix it" — wrote an **entire unreviewed milestone** that shipped through zero quality gates.

## Root cause

An LLM node can ignore a prompt-level instruction. There was no mechanical bound on what files FinalCommit could write.

## Fix

Add `writable_paths: .git/**, .ai/**` to the FinalCommit node, wiring the native fs-jail (#272). Bash + its descendants **and** in-process Write/Edit/ApplyPatch may now only write under `.git/` and `.ai/`, so `git add`/`git commit` still work but the node **physically cannot** author product source. The `commit_only` prompt/system-prompt guard remains as the backstop. Landlock bounds the Bash subprocess at the directory ancestor of each glob's static prefix (`.git/**` → `.git`, `.ai/**` → `.ai`).

Linux native backend only — see #272 platform/backend caveats (claude-code/acp/non-Linux/kernel<6.7 refuse to start with `writable_paths`).

## Scope

- `examples/build_product.dip` — `writable_paths` attr + explanatory comment on FinalCommit
- `pipeline/build_product_finalcommit_scope_test.go` — `TestBuildProductFinalCommitWritablePathsJail` asserts the node carries the attr
- `CHANGELOG.md` — Changed entry

## Verification

- `go build ./...` — clean
- `gofmt` — clean
- `TestBuildProductFinalCommitWritablePathsJail` — passes
- Full pre-commit hook (coverage, complexity, dippin lint on core pipelines) — passed on commit

## Sibling-PR note

#402 (issue #392) also edits `examples/build_product.dip` (different regions: TestMilestone gate + EscalateMilestone routing). Whichever of #400/#402 merges second rebases onto the first.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)