### PR TITLE
fix(git): strip GIT_DIR/GIT_INDEX_FILE/GIT_WORK_TREE from git subprocess env

### DIFF
--- a/.pre-commit
+++ b/.pre-commit
@@ -3,6 +3,17 @@
 # ABOUTME: Install with: ln -sf ../../.pre-commit .git/hooks/pre-commit
 set -euo pipefail
 
+# git exports GIT_DIR/GIT_INDEX_FILE (pointing at THIS repo's gitdir and the
+# in-progress commit index) into hook child processes. The test gates below run
+# `go test ./...`, and several tests create throwaway git repos with
+# `git init`/`add`/`commit` in temp dirs — git honors the inherited GIT_DIR /
+# GIT_INDEX_FILE over their `-C tmpdir`, so without stripping these the test
+# suite writes to (and truncates) the real staging index mid-commit. Run the
+# test gates through `gotest` which drops the git-internal pointers; the hook's
+# own git commands (e.g. the staged-files diff) keep the real env.
+gotest() { env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE \
+  -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR go test "$@"; }
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[0;33m'
@@ -38,7 +49,7 @@ pass "go build"
 # 4. Tests (short mode for speed)
 echo ""
 echo "--- Tests ---"
-RESULT=$(go test ./... -short -count=1 2>&1)
+RESULT=$(gotest ./... -short -count=1 2>&1)
 PASS_COUNT=$(echo "$RESULT" | grep -c '^ok' || true)
 FAIL_COUNT=$(echo "$RESULT" | grep -c '^FAIL' || true)
 if [ "$FAIL_COUNT" -gt 0 ]; then
@@ -50,13 +61,13 @@ pass "tests ($PASS_COUNT packages)"
 # 5. Race detector on core packages
 echo ""
 echo "--- Race Detector ---"
-go test -race -short -count=1 ./pipeline/... ./tui/... 2>&1 | tail -5 || fail "race detected"
+gotest -race -short -count=1 ./pipeline/... ./tui/... 2>&1 | tail -5 || fail "race detected"
 pass "race detector"
 
 # 6. Coverage (check core packages meet 85% threshold)
 echo ""
 echo "--- Coverage ---"
-COVERAGE=$(go test ./pipeline/... -short -coverprofile=/tmp/tracker-coverage.out 2>&1 | tail -1)
+COVERAGE=$(gotest ./pipeline/... -short -coverprofile=/tmp/tracker-coverage.out 2>&1 | tail -1)
 TOTAL=$(go tool cover -func=/tmp/tracker-coverage.out 2>/dev/null | tail -1 | awk '{print $NF}' | tr -d '%')
 if [ -n "$TOTAL" ]; then
   THRESHOLD=80

--- a/.pre-commit
+++ b/.pre-commit
@@ -49,7 +49,7 @@ pass "go build"
 # 4. Tests (short mode for speed)
 echo ""
 echo "--- Tests ---"
-RESULT=$(gotest ./... -short -count=1 2>&1)
+RESULT=$(gotest ./... -short -count=1 2>&1) || true
 PASS_COUNT=$(echo "$RESULT" | grep -c '^ok' || true)
 FAIL_COUNT=$(echo "$RESULT" | grep -c '^FAIL' || true)
 if [ "$FAIL_COUNT" -gt 0 ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the isolated run-dir, corrupting/truncating the wrong index or
   bundling the wrong repo. `gitSafeEnv` (and thus `gitProbeEnv`) now strips
   `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, and
-  `GIT_COMMON_DIR`, and `ExportBundle` does the same. Git-using tests were
-  hardened to set the same clean env, and the pre-commit hook runs its `go test`
-  gates with the pointers stripped.
+  `GIT_COMMON_DIR`, and `ExportBundle` does the same. The redirect-pointer strip
+  is unconditional — applied even under `TRACKER_PASS_ENV=1`, which only gates
+  credential pass-through, never permission to re-anchor git at the outer repo;
+  key comparison is case-normalized so a mixed-case pointer can't slip past.
+  Git-using tests were hardened to set the same clean env, and the pre-commit
+  hook runs its `go test` gates with the pointers stripped.
 - **`build_product` milestone test-gate scope and `accept` verification bypass**
   (issue #392). Two structural defects in `examples/build_product.dip` are fixed:
   (T1) `TestMilestone` ran a whole-tree `go test ./...` while the fix loop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`build_product.dip` FinalCommit is now mechanically commit-only** (issue #349).
+  Building on the existing `commit_only` prompt/engine guard, the FinalCommit node
+  now also declares `writable_paths: .git/**, .ai/**`, wiring the native fs-jail
+  (#272) so its file-mutation tools — Bash + descendants AND in-process
+  Write/Edit/ApplyPatch — can only write under `.git/` and `.ai/`. `git add`/`git
+  commit` still work, but the node physically cannot author product source even
+  when upstream failure context primes it to "just fix it" (the case-study failure
+  where FinalCommit wrote an entire unreviewed milestone that shipped through zero
+  quality gates). This is the primary, mechanical defense; the `commit_only`
+  prompt/system-prompt guard remains the backstop. Linux native backend only —
+  see #272 platform/backend caveats.
 - **dippin-lang upgraded to v0.42.0** (from v0.39.0). New IR fields wired in
   subsequent commits: `Edge.Override` (v0.40.0, closes #271 input gap),
   `AgentConfig.LastResponseTruncate` + `BranchConfig.LastResponseTruncate`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GIT_COMMON_DIR`, and `ExportBundle` does the same. Git-using tests were
   hardened to set the same clean env, and the pre-commit hook runs its `go test`
   gates with the pointers stripped.
+- **`build_product` milestone test-gate scope and `accept` verification bypass**
+  (issue #392). Two structural defects in `examples/build_product.dip` are fixed:
+  (T1) `TestMilestone` ran a whole-tree `go test ./...` while the fix loop
+  (`Implement`/`FixMilestone`) is milestone-scoped by construction, so a failure
+  in a package the milestone never touched (e.g. a later milestone's pre-seeded
+  code) was un-fixable on every retry — the fix budget burned on zero-progress
+  "fixes" and the run escalated. The Go test invocation is now scoped to the
+  packages this milestone actually changed (derived from the diff against
+  `.ai/build/milestone-start-sha`, the same boundary `MarkMilestoneDone` uses);
+  the whole-tree suite still runs at `FinalBuild` before anything ships, so
+  cross-milestone regressions are still caught — just not inside a loop that
+  can't act on them. `go build ./...` stays whole-tree. (T2) The `accept`
+  escalation option routed `EscalateMilestone -> Cleanup -> FinalCommit -> Done`,
+  bypassing the entire cross-review + `FinalBuild` (whole-tree test) +
+  `FinalSpecCheck` subgraph — a run could exit `Done` over a red suite with no
+  compliance report. `accept` now routes through `CheckMilestoneOutputs` (the
+  same entry the normal all-done path uses, `restart: true` to avoid a DIP005
+  cycle), so accepting still earns the structural gate, three-way cross-review,
+  final build/test, and spec-compliance check before `Cleanup`. The option's
+  prompt text is relabeled to state that verification is NOT skipped. No engine
+  changes.
 - **Remaining example workflows now hold A grades under `dippin doctor`**
   (issue #335, scope 3). Four example `.dip` files that shipped with B or F
   grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Git subprocesses no longer inherit leaked `GIT_DIR`/`GIT_INDEX_FILE`**
+  (issue #399). When tracker runs from inside a git hook (or any context that
+  exports git-internal repo pointers), git honors an inherited
+  `GIT_DIR`/`GIT_INDEX_FILE` over a command's `-C <dir>`/working dir, so those
+  vars would redirect the artifact-repo `git init`/`add`/`commit` — and
+  `ExportBundle`'s `git -C runDir bundle create` — at the OUTER repository
+  instead of the isolated run-dir, corrupting/truncating the wrong index or
+  bundling the wrong repo. `gitSafeEnv` (and thus `gitProbeEnv`) now strips
+  `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, and
+  `GIT_COMMON_DIR`, and `ExportBundle` does the same. Git-using tests were
+  hardened to set the same clean env, and the pre-commit hook runs its `go test`
+  gates with the pointers stripped.
 - **Remaining example workflows now hold A grades under `dippin doctor`**
   (issue #335, scope 3). Four example `.dip` files that shipped with B or F
   grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -929,14 +929,67 @@ workflow BuildProduct
       # stack can't mask an earlier failing one. `go build` stays unguarded:
       # under set -eu a Go compile failure aborts immediately (exit 1, normal
       # fix-loop failure), same as before #305.
+      #
+      # Milestone-scoped Go test target (issue #392). The fix loop
+      # (FixMilestone) is milestone-scoped by construction — the Implement and
+      # FixMilestone prompts forbid touching files outside the current
+      # milestone's scope. A WHOLE-TREE `go test ./...` gate therefore creates
+      # an unwinnable loop: a failure in a package the milestone never touched
+      # (e.g. a later milestone's pre-seeded code) is un-fixable by every fix
+      # attempt, so the cap is burned on zero-progress "fixes" and the run
+      # escalates. We reconcile the two halves by scoping THIS gate to the
+      # packages this milestone actually changed; the WHOLE-tree suite still
+      # runs at FinalBuild before anything ships, so cross-milestone regressions
+      # are caught — just not inside a loop that can't act on them. `go build
+      # ./...` stays whole-tree: a broken compile anywhere is a real blocker and
+      # aborts immediately under set -eu.
+      #
+      # Scope = Go package dirs containing a .go file changed since this
+      # milestone's start commit (.ai/build/milestone-start-sha, written by
+      # PickNextMilestone — the same boundary MarkMilestoneDone diffs against).
+      # Empty/unreachable START (first milestone, or a retry that rewrote
+      # history) degrades to the empty tree, scoping to every touched package —
+      # correct, because on the first milestone every change IS this
+      # milestone's. Zero changed Go packages (a milestone that touched only
+      # non-Go files) falls back to `./...` so the gate still runs the suite
+      # rather than silently testing nothing. The derived package tokens are
+      # ONLY ever passed as `go test` package arguments — never eval'd, never
+      # interpolated into a shell command (CLAUDE.md tool-node rule).
       if [ -f go.mod ]; then
         go build ./... 2>&1
+        GO_TEST_TARGET="./..."
+        MS_START=$(cat .ai/build/milestone-start-sha 2>/dev/null || true)
+        if [ -z "$MS_START" ] || ! git cat-file -e "${MS_START}^{commit}" 2>/dev/null; then
+          MS_BASE=$(git hash-object -t tree /dev/null)
+        else
+          MS_BASE="$MS_START"
+        fi
+        # Changed .go files -> their package dirs as `go test` arguments,
+        # unique. A repo-ROOT .go file (no slash, e.g. `main.go`) maps to the
+        # root-package arg `.` — NOT `./main.go`: a single *.go FILE arg makes
+        # `go test` build the synthetic command-line-arguments package, which
+        # silently skips the sibling _test.go AND aborts (setup-failed) when
+        # mixed with directory args. A file in a subdir maps to `./<dir>`.
+        # Deleted files are excluded (--diff-filter=d) so we never target a dir
+        # git removed. The tokens are word-split into `go test` package args
+        # under POSIX sh (how tracker runs tool nodes) — never eval'd.
+        CHANGED_PKGS=$(git diff --name-only --diff-filter=d "${MS_BASE}..HEAD" 2>/dev/null \
+          | grep -E '\.go$' \
+          | awk -F/ 'NF==1 { print "." } NF>1 { sub(/\/[^/]*$/, ""); print "./" $0 }' \
+          | sort -u \
+          | paste -sd' ' -)
+        if [ -n "$CHANGED_PKGS" ]; then
+          GO_TEST_TARGET="$CHANGED_PKGS"
+          echo "--- milestone-scoped go test: $GO_TEST_TARGET ---"
+        else
+          echo "--- no changed Go packages in milestone range — testing ./... ---"
+        fi
         if [ -n "$SKIP_PATTERN" ]; then
           echo "--- skipping known failures: $SKIP_PATTERN ---"
           # Use -skip (Go 1.24+) which supports simple regex without lookahead.
-          go test ./... -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
         else
-          go test ./... 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=$?
         fi
       fi
       if [ -f package.json ]; then
@@ -2102,7 +2155,7 @@ workflow BuildProduct
       Options:
       - **mark done**: Override the test failure — you've verified the milestone is complete. Continues to the next milestone.
       - **retry**: Re-implement this milestone from scratch. Does NOT re-plan.
-      - **accept**: Stop building milestones, skip to cleanup/commit.
+      - **accept**: Stop building more milestones and ship what exists — but still run the full cross-review, final build/test, and spec-compliance gates first (does NOT skip verification).
       - **abandon**: Kill the pipeline immediately.
 
   human EscalateReview
@@ -2270,7 +2323,22 @@ workflow BuildProduct
     # Milestone escalation — human decides per-milestone
     EscalateMilestone -> MarkMilestoneDone  label: "mark done"
     EscalateMilestone -> Implement  label: "retry"  restart: true
-    EscalateMilestone -> Cleanup  label: "accept"
+    # #392: "accept" means "stop building more milestones, ship what exists" —
+    # but it must NOT ship UNVERIFIED. The pre-#392 edge jumped straight to
+    # Cleanup -> FinalCommit -> Done, bypassing the entire cross-review +
+    # FinalBuild (whole-tree `go test ./...`) + FinalSpecCheck subgraph, so a
+    # run could exit Done over a red suite with no compliance report. Route it
+    # instead to CheckMilestoneOutputs — the SAME entry the normal all-done
+    # path uses — so accepting still earns the structural gate, the three-way
+    # cross-review, the final build/test, and the spec-compliance check before
+    # Cleanup. CheckMilestoneOutputs's own fallback routes BACK to
+    # EscalateMilestone, so `restart: true` breaks what would otherwise be an
+    # unconditional EscalateMilestone -> CheckMilestoneOutputs ->
+    # EscalateMilestone cycle (DIP005) — the same mechanism the
+    # CheckReviewFixBudget -> CheckMilestoneOutputs re-review edge uses. accept
+    # is a forward transition out of the per-milestone loop into the review
+    # phase, so restart-on-entry semantics are correct.
+    EscalateMilestone -> CheckMilestoneOutputs  label: "accept"  restart: true
     EscalateMilestone -> Done  label: "abandon"
 
     # Cross-review

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1605,7 +1605,10 @@ workflow BuildProduct
     provider: anthropic
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. All milestones are done.
+      Review the COMPLETE implementation against SPEC.md. The build loop has
+      finished — either every planned milestone completed, or the operator chose
+      to stop early (the "accept" gate) and ship what exists. Review what is
+      actually present; do not assume unfinished work will arrive later.
 
       DO NOT TRUST SPEC ✅ MARKERS:
       - SPEC.md may contain ✅ or "Done" checkmarks. These were the author's
@@ -1666,7 +1669,10 @@ workflow BuildProduct
     provider: openai
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. All milestones are done.
+      Review the COMPLETE implementation against SPEC.md. The build loop has
+      finished — either every planned milestone completed, or the operator chose
+      to stop early (the "accept" gate) and ship what exists. Review what is
+      actually present; do not assume unfinished work will arrive later.
 
       DO NOT TRUST SPEC ✅ MARKERS:
       - SPEC.md may contain ✅ or "Done" checkmarks. These were the author's
@@ -1727,7 +1733,10 @@ workflow BuildProduct
     provider: gemini
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. All milestones are done.
+      Review the COMPLETE implementation against SPEC.md. The build loop has
+      finished — either every planned milestone completed, or the operator chose
+      to stop early (the "accept" gate) and ship what exists. Review what is
+      actually present; do not assume unfinished work will arrive later.
 
       YOUR ROLE IS ADVERSARIAL: steel-man the worst
       case. Assume the implementation is wrong somewhere — your job is

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -2152,6 +2152,17 @@ workflow BuildProduct
     reasoning_effort: low
     auto_status: true
     fallback_target: EscalateReview
+    # #349 mechanical scope guard (primary defense): bound this node's file-
+    # mutation tools to git internals + tracker's .ai/ scratch via the native
+    # fs-jail (#272). Bash + its descendants AND in-process Write/Edit/ApplyPatch
+    # may only write under .git/ and .ai/ — so `git add`/`git commit` still work,
+    # but the node CANNOT author product source even when upstream failure context
+    # primes it to "just fix it" (the case-study failure: FinalCommit wrote an
+    # entire unreviewed milestone). Landlock bounds the Bash subprocess at the
+    # directory ancestor of each glob's static prefix, so `.git/**` -> `.git`,
+    # `.ai/**` -> `.ai`. The commit_only prompt/system-prompt guard below is the
+    # backstop. Linux native backend only — see #272 platform/backend caveats.
+    writable_paths: .git/**, .ai/**
     params:
       commit_only: true
     prompt:

--- a/pipeline/build_product_finalcommit_scope_test.go
+++ b/pipeline/build_product_finalcommit_scope_test.go
@@ -1,0 +1,57 @@
+// ABOUTME: Regression guard for issue #349 — FinalCommit in build_product.dip must
+// ABOUTME: carry a MECHANICAL writable_paths fs-jail bounding writes to git + .ai/ only.
+package pipeline
+
+import "testing"
+
+const finalCommitNodeID = "FinalCommit"
+
+// TestBuildProductFinalCommitWritablePathsJail pins the primary, mechanical
+// scope guard for #349: FinalCommit (a late-pipeline agent node with commit
+// ability and a fat context window) must declare writable_paths so the native
+// fs-jail (#272) bounds its file-mutation tools — Bash + descendants AND
+// in-process Write/Edit/ApplyPatch — to git internals + tracker's .ai/ scratch.
+// This is what physically prevents the case-study failure (FinalCommit authored
+// an entire unreviewed milestone): with the jail, `git add`/`git commit` still
+// work but product source cannot be written even if the prompt is subverted.
+//
+// The prompt + commit_only system-prompt guard remain the backstop and are
+// pinned elsewhere (handlers TestCommitOnlyScopeGuard*); this test pins the
+// mechanical layer that does not rely on the model obeying instructions.
+func TestBuildProductFinalCommitWritablePathsJail(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	n, ok := g.Nodes[finalCommitNodeID]
+	if !ok {
+		t.Fatalf("%s node missing from build_product.dip (issue #349)", finalCommitNodeID)
+	}
+
+	cfg := n.AgentConfig(nil)
+	if !cfg.WritablePathsSet {
+		t.Fatalf("%s must declare writable_paths so the fs-jail bounds its tools — without it the node can author unreviewed product code (issue #349)", finalCommitNodeID)
+	}
+
+	// The jail must allow git internals (so commits work) and .ai/ scratch, and
+	// nothing else (so product source is unwritable). Order-independent set check.
+	want := map[string]bool{".git/**": true, ".ai/**": true}
+	got := map[string]bool{}
+	for _, p := range cfg.WritablePaths {
+		got[p] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Errorf("%s writable_paths missing %q (have %v) — git+.ai/ scope required for a commit-only node (issue #349)", finalCommitNodeID, w, cfg.WritablePaths)
+		}
+	}
+	for g := range got {
+		if !want[g] {
+			t.Errorf("%s writable_paths has unexpected entry %q (have %v) — widening the jail beyond git+.ai/ re-opens the product-source write path (issue #349)", finalCommitNodeID, g, cfg.WritablePaths)
+		}
+	}
+
+	// The mechanical jail must not have silently displaced the prompt/system-prompt
+	// backstop: commit_only stays on as defense-in-depth.
+	if !cfg.CommitOnly {
+		t.Errorf("%s lost commit_only — the prompt/system-prompt backstop must remain alongside the fs-jail (issue #349)", finalCommitNodeID)
+	}
+}

--- a/pipeline/build_product_milestone_gate_test.go
+++ b/pipeline/build_product_milestone_gate_test.go
@@ -1,0 +1,85 @@
+// ABOUTME: Regression guard for issue #392 — build_product.dip's per-milestone
+// ABOUTME: test gate is milestone-scoped and `accept` still earns verification.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasLabeledEdge reports whether `from` has an outgoing human-gate edge to `to`
+// with the given label. Labeled gate edges store the choice in Edge.Label (or
+// Edge.Choice for DIP150) — check both.
+func hasLabeledEdge(g *Graph, from, to, label string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && (e.Label == label || e.Choice == label) {
+			return true
+		}
+	}
+	return false
+}
+
+// labeledEdgeAttr returns the value of attr key on the labeled gate edge
+// from->to, or "" if no such edge/attr exists.
+func labeledEdgeAttr(g *Graph, from, to, label, key string) string {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && (e.Label == label || e.Choice == label) {
+			return e.Attrs[key]
+		}
+	}
+	return ""
+}
+
+// TestBuildProductIssue392AcceptDoesNotBypassVerification pins T2 of #392: the
+// EscalateMilestone "accept" option must route into CheckMilestoneOutputs — the
+// SAME entry the normal all-done path uses — NOT straight to Cleanup. The
+// pre-#392 edge (accept -> Cleanup -> FinalCommit -> Done) let a run exit Done
+// over a red suite, skipping the cross-review + FinalBuild (whole-tree test) +
+// FinalSpecCheck subgraph entirely. Routing through CheckMilestoneOutputs makes
+// "stop building more milestones" still ship verified work.
+func TestBuildProductIssue392AcceptDoesNotBypassVerification(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if _, ok := g.Nodes["EscalateMilestone"]; !ok {
+		t.Fatal("EscalateMilestone node missing from build_product.dip (issue #392)")
+	}
+	if !hasLabeledEdge(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept") {
+		t.Error("EscalateMilestone `accept` must route to CheckMilestoneOutputs so it still earns cross-review + final build + spec check (issue #392)")
+	}
+	if hasLabeledEdge(g, "EscalateMilestone", "Cleanup", "accept") {
+		t.Error("EscalateMilestone `accept` still routes directly to Cleanup — that bypasses all verification (issue #392 regression)")
+	}
+	// accept re-enters CheckMilestoneOutputs, whose own fallback loops back to
+	// EscalateMilestone; the edge must carry restart:true to break the DIP005
+	// cycle (same mechanism as the CheckReviewFixBudget re-review edge).
+	if got := labeledEdgeAttr(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept", "restart"); got != "true" {
+		t.Errorf("EscalateMilestone accept -> CheckMilestoneOutputs restart = %q, want \"true\" (DIP005 cycle break, issue #392)", got)
+	}
+}
+
+// TestBuildProductIssue392MilestoneScopedTestGate pins T1 of #392: the
+// per-milestone TestMilestone gate must run a milestone-scoped `go test`
+// target, not an unconditional whole-tree `go test ./...` that the
+// milestone-scoped fix loop (Implement/FixMilestone) cannot satisfy when a
+// later milestone's pre-seeded package is red. The whole-tree suite still runs
+// at FinalBuild before anything ships.
+//
+// This is a string-level guard because the gate logic lives inline in the .dip
+// tool command; issue #398 tracks extracting it to a bats-testable script file,
+// at which point this becomes a real script test.
+func TestBuildProductIssue392MilestoneScopedTestGate(t *testing.T) {
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["TestMilestone"]
+	if !ok {
+		t.Fatal("TestMilestone node missing from build_product.dip (issue #392)")
+	}
+	cmd := n.ToolConfig().Command
+	for _, marker := range []string{"milestone-start-sha", "GO_TEST_TARGET"} {
+		if !strings.Contains(cmd, marker) {
+			t.Errorf("TestMilestone command no longer references %q — the milestone-scoped go test gate may have reverted to whole-tree (issue #392)", marker)
+		}
+	}
+	if !strings.Contains(cmd, "go test $GO_TEST_TARGET") {
+		t.Error("TestMilestone must run `go test $GO_TEST_TARGET` (milestone-scoped), not a bare whole-tree `go test ./...` (issue #392)")
+	}
+}

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -300,7 +300,7 @@ func gitProbeEnv() []string {
 func gitSafeEnv() []string {
 	passEnv := os.Getenv("TRACKER_PASS_ENV") == "1"
 	env := os.Environ()
-	var filtered []string
+	filtered := make([]string, 0, len(env))
 	for _, e := range env {
 		name := strings.ToUpper(strings.SplitN(e, "=", 2)[0])
 		// Git-internal repository pointers are stripped UNCONDITIONALLY — even

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -298,36 +298,51 @@ func gitProbeEnv() []string {
 // Mirrors the filterSensitiveEnv logic used by the tool handler, including
 // the TRACKER_PASS_ENV=1 escape hatch.
 func gitSafeEnv() []string {
-	if os.Getenv("TRACKER_PASS_ENV") == "1" {
-		return os.Environ()
-	}
+	passEnv := os.Getenv("TRACKER_PASS_ENV") == "1"
 	env := os.Environ()
 	var filtered []string
 	for _, e := range env {
 		name := strings.ToUpper(strings.SplitN(e, "=", 2)[0])
-		if gitEnvIsSafe(name) {
-			filtered = append(filtered, e)
+		// Git-internal repository pointers are stripped UNCONDITIONALLY — even
+		// under TRACKER_PASS_ENV=1. That flag is a credential pass-through escape
+		// hatch, not permission to re-anchor git at the OUTER repo: an inherited
+		// GIT_DIR/GIT_INDEX_FILE overrides cmd.Dir and corrupts the wrong index
+		// regardless of credential intent (mirrors bundleGitEnv's strip).
+		if isGitRedirectVar(name) {
+			continue
 		}
+		// Credential-shaped vars pass through only when the operator opts in.
+		if !passEnv && !gitEnvIsCredentialSafe(name) {
+			continue
+		}
+		filtered = append(filtered, e)
 	}
 	return filtered
 }
 
-// gitEnvIsSafe returns true if the env var is safe to pass to git subprocesses.
-func gitEnvIsSafe(name string) bool {
+// gitEnvIsCredentialSafe returns false for credential-shaped env vars that must
+// not leak into git subprocesses unless TRACKER_PASS_ENV=1 is set.
+func gitEnvIsCredentialSafe(name string) bool {
 	for _, pattern := range []string{"_API_KEY", "_SECRET", "_TOKEN", "_PASSWORD"} {
 		if strings.Contains(name, pattern) {
 			return false
 		}
 	}
-	// Strip git-internal repository pointers. When tracker runs from inside a git
-	// hook (or any context that exports these), they would otherwise redirect the
-	// artifact-repo `git init`/`add`/`commit` at the OUTER repository's gitdir and
-	// staging index — committing into, or truncating, the wrong index instead of
-	// the isolated artifact run-dir. The artifact repo is always addressed via
-	// cmd.Dir, so these pointers are never wanted.
+	return true
+}
+
+// isGitRedirectVar reports whether name is a git-internal repository pointer.
+// When tracker runs from inside a git hook (or any context that exports these),
+// they would otherwise redirect the artifact-repo `git init`/`add`/`commit` at
+// the OUTER repository's gitdir and staging index — committing into, or
+// truncating, the wrong index instead of the isolated artifact run-dir. The
+// artifact repo is always addressed via cmd.Dir, so these pointers are never
+// wanted; they are stripped even under TRACKER_PASS_ENV=1. Name is expected
+// upper-cased by the caller.
+func isGitRedirectVar(name string) bool {
 	switch name {
 	case "GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR":
-		return false
+		return true
 	}
-	return true
+	return false
 }

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -307,7 +307,8 @@ func gitSafeEnv() []string {
 		// under TRACKER_PASS_ENV=1. That flag is a credential pass-through escape
 		// hatch, not permission to re-anchor git at the OUTER repo: an inherited
 		// GIT_DIR/GIT_INDEX_FILE overrides cmd.Dir and corrupts the wrong index
-		// regardless of credential intent (mirrors bundleGitEnv's strip).
+		// regardless of credential intent. This is the single source of truth for
+		// the redirect-pointer strip across all of tracker's git subprocesses.
 		if isGitRedirectVar(name) {
 			continue
 		}

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -58,31 +58,39 @@ func (r *gitArtifactRepo) Init() error {
 		return fmt.Errorf("create artifact dir %q: %w", r.dir, err)
 	}
 
-	// Initialize git repo if .git doesn't already exist. Any Stat error
-	// other than "not exist" (permission, IO) is treated as fatal so we
-	// don't silently skip init and hit confusing downstream failures.
+	// Initialize git repo if .git doesn't already exist, set local-only
+	// identity, and create .gitignore.
+	if err := r.ensureGitDir(); err != nil {
+		r.failed = true
+		return err
+	}
+
+	return r.ensureInitialCommit()
+}
+
+// ensureGitDir creates the .git repo (if absent), sets local-only git user
+// config (so we don't pollute the global config), and writes a .gitignore.
+// Any Stat error other than "not exist" (permission, IO) on the .git dir is
+// fatal so we don't silently skip init and hit confusing downstream failures.
+// Caller is responsible for setting r.failed on error.
+func (r *gitArtifactRepo) ensureGitDir() error {
 	gitDir := filepath.Join(r.dir, ".git")
 	gitDirExists := false
 	if _, err := os.Stat(gitDir); err == nil {
 		gitDirExists = true
 	} else if !errors.Is(err, os.ErrNotExist) {
-		r.failed = true
 		return fmt.Errorf("stat %q: %w", gitDir, err)
 	}
 	if !gitDirExists {
 		if out, err := r.git("init", "--quiet"); err != nil {
-			r.failed = true
 			return fmt.Errorf("git init: %w\n%s", err, out)
 		}
 	}
 
-	// Set local-only git user config so we don't pollute the global config.
 	if out, err := r.git("config", "user.name", "tracker"); err != nil {
-		r.failed = true
 		return fmt.Errorf("git config user.name: %w\n%s", err, out)
 	}
 	if out, err := r.git("config", "user.email", "tracker@local"); err != nil {
-		r.failed = true
 		return fmt.Errorf("git config user.email: %w\n%s", err, out)
 	}
 
@@ -92,11 +100,14 @@ func (r *gitArtifactRepo) Init() error {
 	if _, err := os.Stat(gitignorePath); errors.Is(err, os.ErrNotExist) {
 		_ = os.WriteFile(gitignorePath, []byte("*.tmp\ncheckpoint.json\n"), 0o644)
 	}
+	return nil
+}
 
-	// Only create the "run started" commit if the repo has no existing
-	// HEAD. On checkpoint resume, the artifact dir already has history
-	// from the earlier attempt and another empty commit would just add
-	// noise.
+// ensureInitialCommit makes the "run started" commit, but only if the repo has
+// no existing HEAD. On checkpoint resume the artifact dir already has history
+// from the earlier attempt and another empty commit would just add noise.
+// Sets r.failed on error.
+func (r *gitArtifactRepo) ensureInitialCommit() error {
 	if out, err := r.git("rev-parse", "--verify", "HEAD"); err == nil && strings.TrimSpace(out) != "" {
 		// Existing HEAD — this is a resume. Skip the initial commit.
 		return nil
@@ -307,6 +318,16 @@ func gitEnvIsSafe(name string) bool {
 		if strings.Contains(name, pattern) {
 			return false
 		}
+	}
+	// Strip git-internal repository pointers. When tracker runs from inside a git
+	// hook (or any context that exports these), they would otherwise redirect the
+	// artifact-repo `git init`/`add`/`commit` at the OUTER repository's gitdir and
+	// staging index — committing into, or truncating, the wrong index instead of
+	// the isolated artifact run-dir. The artifact repo is always addressed via
+	// cmd.Dir, so these pointers are never wanted.
+	switch name {
+	case "GIT_DIR", "GIT_INDEX_FILE", "GIT_WORK_TREE", "GIT_OBJECT_DIRECTORY", "GIT_COMMON_DIR":
+		return false
 	}
 	return true
 }

--- a/pipeline/git_artifacts_test.go
+++ b/pipeline/git_artifacts_test.go
@@ -27,6 +27,12 @@ func gitOutput(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmdArgs := append([]string{"-C", dir}, args...)
 	cmd := exec.Command("git", cmdArgs...) //nolint:gosec
+	// Strip git-internal repo pointers (GIT_DIR/GIT_INDEX_FILE/...) that leak
+	// from a calling `git commit`'s hook environment. Without this, this helper's
+	// `-C dir` is overridden by GIT_DIR/GIT_INDEX_FILE and writes to the OUTER
+	// repo's index instead of the test's temp dir — clobbering it when the suite
+	// runs under a pre-commit hook. Mirrors cleanGitEnv usage in git_preflight_test.go.
+	cmd.Env = cleanGitEnv()
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/pipeline/git_artifacts_test.go
+++ b/pipeline/git_artifacts_test.go
@@ -845,3 +845,59 @@ func TestEngine_CommitWIP_HandlerErrorPreservesWork(t *testing.T) {
 		t.Errorf("trace WIPRef for Implement: got %q want %q", traceRef, wantRef)
 	}
 }
+
+// hasEnvPrefix reports whether any env entry starts with the given "KEY=" prefix.
+func hasEnvPrefix(env []string, prefix string) bool {
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGitSafeEnv_StripsRedirectVarsEvenUnderPassEnv pins the #401 review finding
+// (codex P1 + Copilot ×2): git-internal repository pointers must be stripped
+// from the git-subprocess env UNCONDITIONALLY — including under
+// TRACKER_PASS_ENV=1, which is a credential pass-through escape hatch, not
+// permission to re-anchor git at the outer repo. The earlier code returned
+// os.Environ() unfiltered in pass-env mode, re-leaking GIT_DIR/GIT_INDEX_FILE.
+func TestGitSafeEnv_StripsRedirectVarsEvenUnderPassEnv(t *testing.T) {
+	t.Setenv("GIT_DIR", "/outer/.git")
+	t.Setenv("GIT_INDEX_FILE", "/outer/.git/index")
+	t.Setenv("GIT_WORK_TREE", "/outer")
+	t.Setenv("GIT_OBJECT_DIRECTORY", "/outer/.git/objects")
+	t.Setenv("GIT_COMMON_DIR", "/outer/.git")
+	t.Setenv("EXAMPLE_API_KEY", "sekret")
+
+	redirects := []string{
+		"GIT_DIR=", "GIT_INDEX_FILE=", "GIT_WORK_TREE=",
+		"GIT_OBJECT_DIRECTORY=", "GIT_COMMON_DIR=",
+	}
+
+	t.Run("pass-env off strips redirects and credentials", func(t *testing.T) {
+		t.Setenv("TRACKER_PASS_ENV", "")
+		env := gitSafeEnv()
+		for _, r := range redirects {
+			if hasEnvPrefix(env, r) {
+				t.Errorf("gitSafeEnv leaked %q without TRACKER_PASS_ENV", r)
+			}
+		}
+		if hasEnvPrefix(env, "EXAMPLE_API_KEY=") {
+			t.Error("gitSafeEnv leaked EXAMPLE_API_KEY without TRACKER_PASS_ENV")
+		}
+	})
+
+	t.Run("pass-env on still strips redirects but passes credentials", func(t *testing.T) {
+		t.Setenv("TRACKER_PASS_ENV", "1")
+		env := gitSafeEnv()
+		for _, r := range redirects {
+			if hasEnvPrefix(env, r) {
+				t.Errorf("gitSafeEnv leaked %q under TRACKER_PASS_ENV=1 — redirect strip must be unconditional (#401)", r)
+			}
+		}
+		if !hasEnvPrefix(env, "EXAMPLE_API_KEY=") {
+			t.Error("gitSafeEnv dropped EXAMPLE_API_KEY under TRACKER_PASS_ENV=1 — credential pass-through broken")
+		}
+	})
+}

--- a/tracker_bundle.go
+++ b/tracker_bundle.go
@@ -33,7 +33,10 @@ func bundleGitEnv() []string {
 	src := os.Environ()
 	out := make([]string, 0, len(src))
 	for _, e := range src {
-		if !gitInternalEnvPointers[strings.SplitN(e, "=", 2)[0]] {
+		// Normalize key case before lookup (the map is upper-cased), matching
+		// gitSafeEnv — so a mixed-case GIT_DIR can't slip past the strip.
+		name := strings.ToUpper(strings.SplitN(e, "=", 2)[0])
+		if !gitInternalEnvPointers[name] {
 			out = append(out, e)
 		}
 	}

--- a/tracker_bundle.go
+++ b/tracker_bundle.go
@@ -6,9 +6,39 @@ package tracker
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 )
+
+// gitInternalEnvPointers are the git-internal repository pointers that, when
+// present in the environment, override a command's `-C <dir>` and redirect it
+// at the OUTER repository. ExportBundle addresses the artifact repo via `-C
+// runDir`, so inheriting these (e.g. when tracker runs from inside a git hook)
+// would bundle the wrong repo — or silently succeed against the ambient repo
+// instead of failing for a non-repo runDir. Stripped before invoking git.
+var gitInternalEnvPointers = map[string]bool{
+	"GIT_DIR":              true,
+	"GIT_INDEX_FILE":       true,
+	"GIT_WORK_TREE":        true,
+	"GIT_OBJECT_DIRECTORY": true,
+	"GIT_COMMON_DIR":       true,
+}
+
+// bundleGitEnv returns os.Environ() with the git-internal repository pointers
+// stripped so `git -C runDir` is honored against runDir, not an inherited
+// GIT_DIR/GIT_INDEX_FILE.
+func bundleGitEnv() []string {
+	src := os.Environ()
+	out := make([]string, 0, len(src))
+	for _, e := range src {
+		if !gitInternalEnvPointers[strings.SplitN(e, "=", 2)[0]] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
 
 // ExportBundle writes a git bundle of the run directory's artifact repository
 // to outPath. The bundle captures all commits and tags (including checkpoint
@@ -31,6 +61,7 @@ func ExportBundle(runDir, outPath string) error {
 		return fmt.Errorf("resolve output path %q: %w", outPath, err)
 	}
 	cmd := exec.Command("git", "-C", runDir, "bundle", "create", absPath, "--all") //nolint:gosec
+	cmd.Env = bundleGitEnv()
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/tracker_bundle.go
+++ b/tracker_bundle.go
@@ -6,41 +6,21 @@ package tracker
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
+
+	"github.com/2389-research/tracker/pipeline"
 )
 
-// gitInternalEnvPointers are the git-internal repository pointers that, when
-// present in the environment, override a command's `-C <dir>` and redirect it
-// at the OUTER repository. ExportBundle addresses the artifact repo via `-C
-// runDir`, so inheriting these (e.g. when tracker runs from inside a git hook)
-// would bundle the wrong repo — or silently succeed against the ambient repo
-// instead of failing for a non-repo runDir. Stripped before invoking git.
-var gitInternalEnvPointers = map[string]bool{
-	"GIT_DIR":              true,
-	"GIT_INDEX_FILE":       true,
-	"GIT_WORK_TREE":        true,
-	"GIT_OBJECT_DIRECTORY": true,
-	"GIT_COMMON_DIR":       true,
-}
-
-// bundleGitEnv returns os.Environ() with the git-internal repository pointers
-// stripped so `git -C runDir` is honored against runDir, not an inherited
-// GIT_DIR/GIT_INDEX_FILE.
+// bundleGitEnv returns the sanitized environment for ExportBundle's git
+// subprocess. It delegates to pipeline.GitSafeEnv so bundle creation shares one
+// env-filtering posture with the artifact-repo git calls instead of drifting:
+// git-internal repository pointers (GIT_DIR/GIT_INDEX_FILE/...) are stripped
+// unconditionally so `git -C runDir` is honored against runDir (not an inherited
+// GIT_DIR that would bundle the OUTER repo), and credential-shaped vars are
+// dropped unless TRACKER_PASS_ENV=1.
 func bundleGitEnv() []string {
-	src := os.Environ()
-	out := make([]string, 0, len(src))
-	for _, e := range src {
-		// Normalize key case before lookup (the map is upper-cased), matching
-		// gitSafeEnv — so a mixed-case GIT_DIR can't slip past the strip.
-		name := strings.ToUpper(strings.SplitN(e, "=", 2)[0])
-		if !gitInternalEnvPointers[name] {
-			out = append(out, e)
-		}
-	}
-	return out
+	return pipeline.GitSafeEnv()
 }
 
 // ExportBundle writes a git bundle of the run directory's artifact repository

--- a/tracker_bundle_test.go
+++ b/tracker_bundle_test.go
@@ -197,9 +197,12 @@ func TestBundleGitEnv_StripsMixedCaseRedirectVars(t *testing.T) {
 	t.Setenv("KEEP_ME", "yes")
 
 	env := bundleGitEnv()
-	for _, bad := range []string{"Git_Dir=", "git_index_file="} {
+	// Compare case-insensitively: an OS that canonicalizes env-var casing
+	// (Windows) must not let a leaked redirect var slip past a case-sensitive
+	// prefix check and mask a real failure.
+	for _, bad := range []string{"git_dir=", "git_index_file="} {
 		for _, e := range env {
-			if strings.HasPrefix(e, bad) {
+			if strings.HasPrefix(strings.ToLower(e), bad) {
 				t.Errorf("bundleGitEnv leaked mixed-case redirect var %q (#401)", bad)
 			}
 		}

--- a/tracker_bundle_test.go
+++ b/tracker_bundle_test.go
@@ -29,6 +29,7 @@ func gitOutputBundle(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmdArgs := append([]string{"-C", dir}, args...)
 	cmd := exec.CommandContext(context.Background(), "git", cmdArgs...) //nolint:gosec
+	cmd.Env = cleanGitEnv()
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
@@ -102,6 +103,7 @@ func TestExportBundle_RoundTrip(t *testing.T) {
 	// Clone the bundle into a restore dir.
 	restoreDir := filepath.Join(t.TempDir(), "restored")
 	cmd := exec.CommandContext(context.Background(), "git", "clone", bundlePath, restoreDir) //nolint:gosec
+	cmd.Env = cleanGitEnv()
 	var cloneOut bytes.Buffer
 	cmd.Stdout = &cloneOut
 	cmd.Stderr = &cloneOut

--- a/tracker_bundle_test.go
+++ b/tracker_bundle_test.go
@@ -186,3 +186,31 @@ func (h *alwaysSucceedHandler) Name() string { return h.name }
 func (h *alwaysSucceedHandler) Execute(_ context.Context, _ *pipeline.Node, _ *pipeline.PipelineContext) (pipeline.Outcome, error) {
 	return pipeline.Outcome{Status: string(pipeline.OutcomeSuccess)}, nil
 }
+
+// TestBundleGitEnv_StripsMixedCaseRedirectVars pins the #401 review finding
+// (coderabbit): bundleGitEnv normalizes key case before the pointer lookup, so
+// a mixed-case redirect var can't slip past the strip the way a raw-key compare
+// against an upper-cased map would allow.
+func TestBundleGitEnv_StripsMixedCaseRedirectVars(t *testing.T) {
+	t.Setenv("Git_Dir", "/outer/.git")
+	t.Setenv("git_index_file", "/outer/.git/index")
+	t.Setenv("KEEP_ME", "yes")
+
+	env := bundleGitEnv()
+	for _, bad := range []string{"Git_Dir=", "git_index_file="} {
+		for _, e := range env {
+			if strings.HasPrefix(e, bad) {
+				t.Errorf("bundleGitEnv leaked mixed-case redirect var %q (#401)", bad)
+			}
+		}
+	}
+	kept := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "KEEP_ME=") {
+			kept = true
+		}
+	}
+	if !kept {
+		t.Error("bundleGitEnv dropped an unrelated env var KEEP_ME")
+	}
+}

--- a/tracker_doctor_test.go
+++ b/tracker_doctor_test.go
@@ -703,6 +703,7 @@ func TestDoctor_GitRequires_UnbornHEADReportsError(t *testing.T) {
 	// `git init` only — HEAD is unborn.
 	cmd := exec.CommandContext(context.Background(), "git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = cleanGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v: %s", err, out)
 	}
@@ -772,6 +773,7 @@ func TestDoctor_GitRequires_BareRepoHintMentionsCheckout(t *testing.T) {
 	tmp := t.TempDir()
 	bare := filepath.Join(tmp, "bare.git")
 	cmd := exec.CommandContext(context.Background(), "git", "init", "--bare", "-q", bare)
+	cmd.Env = cleanGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init --bare: %v: %s", err, out)
 	}
@@ -809,6 +811,7 @@ func TestDoctor_GitRequires_BareRepoReportsError(t *testing.T) {
 	tmp := t.TempDir()
 	bare := filepath.Join(tmp, "bare.git")
 	cmd := exec.CommandContext(context.Background(), "git", "init", "--bare", "-q", bare)
+	cmd.Env = cleanGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init --bare: %v: %s", err, out)
 	}
@@ -885,6 +888,7 @@ func mustGitInitForDoctor(t *testing.T, dir string) {
 	requireGit(t)
 	cmd := exec.CommandContext(context.Background(), "git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = cleanGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init in %s: %v: %s", dir, err, out)
 	}
@@ -897,6 +901,7 @@ func mustGitInitForDoctor(t *testing.T, dir string) {
 		"-c", "user.name=t", "-c", "user.email=t@t",
 		"commit", "--allow-empty", "-q", "-m", "init")
 	commitCmd.Dir = dir
+	commitCmd.Env = cleanGitEnv()
 	if out, err := commitCmd.CombinedOutput(); err != nil {
 		t.Fatalf("git commit --allow-empty in %s: %v: %s", dir, err, out)
 	}

--- a/tracker_git_preflight_integration_test.go
+++ b/tracker_git_preflight_integration_test.go
@@ -25,6 +25,33 @@ func requireGit(t *testing.T) {
 	}
 }
 
+// cleanGitEnv returns os.Environ() with git-internal repository pointers
+// stripped. Tests in this package create throwaway git repos via `git init`
+// in t.TempDir(); git honors an inherited GIT_DIR/GIT_INDEX_FILE over a
+// command's working directory, so when `go test ./...` runs from inside a git
+// hook (which exports those vars), an un-sanitized `git init` re-inits — and a
+// follow-up `git add`/`commit` truncates — the OUTER repo's index instead of
+// the temp dir. Set cmd.Env = cleanGitEnv() on every git subprocess in tests.
+// Mirrors the same-named helper in pipeline/git_preflight_test.go.
+func cleanGitEnv() []string {
+	stripped := map[string]bool{
+		"GIT_DIR":              true,
+		"GIT_INDEX_FILE":       true,
+		"GIT_WORK_TREE":        true,
+		"GIT_OBJECT_DIRECTORY": true,
+		"GIT_COMMON_DIR":       true,
+	}
+	src := os.Environ()
+	out := make([]string, 0, len(src))
+	for _, e := range src {
+		name := strings.SplitN(e, "=", 2)[0]
+		if !stripped[name] {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 const integrationFixtureRequiresGit = `workflow PreflightIntegration
   goal: "integration test"
   requires: git
@@ -78,6 +105,7 @@ func TestIntegration_Preflight_GitInitClears(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = cleanGitEnv()
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git init: %v: %s", err, out)
 	}

--- a/tracker_git_preflight_integration_test.go
+++ b/tracker_git_preflight_integration_test.go
@@ -32,7 +32,9 @@ func requireGit(t *testing.T) {
 // hook (which exports those vars), an un-sanitized `git init` re-inits — and a
 // follow-up `git add`/`commit` truncates — the OUTER repo's index instead of
 // the temp dir. Set cmd.Env = cleanGitEnv() on every git subprocess in tests.
-// Mirrors the same-named helper in pipeline/git_preflight_test.go.
+// Modeled on the same-named helper in pipeline/git_preflight_test.go, with an
+// added ToUpper so a mixed-case redirect var can't slip past on environments
+// that canonicalize env-var casing.
 func cleanGitEnv() []string {
 	stripped := map[string]bool{
 		"GIT_DIR":              true,

--- a/tracker_git_preflight_integration_test.go
+++ b/tracker_git_preflight_integration_test.go
@@ -44,7 +44,7 @@ func cleanGitEnv() []string {
 	src := os.Environ()
 	out := make([]string, 0, len(src))
 	for _, e := range src {
-		name := strings.SplitN(e, "=", 2)[0]
+		name := strings.ToUpper(strings.SplitN(e, "=", 2)[0])
 		if !stripped[name] {
 			out = append(out, e)
 		}

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -1190,6 +1190,7 @@ func TestNewEngine_PreflightPassesAfterGitInit(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = cleanGitEnv()
 	if out, runErr := cmd.CombinedOutput(); runErr != nil {
 		t.Fatalf("git init: %v: %s", runErr, out)
 	}
@@ -1252,6 +1253,7 @@ func TestNewEngine_PreflightPassesFromSourceLevelRequiresAfterInit(t *testing.T)
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init", "-q")
 	cmd.Dir = dir
+	cmd.Env = cleanGitEnv()
 	if out, runErr := cmd.CombinedOutput(); runErr != nil {
 		t.Fatalf("git init: %v: %s", runErr, out)
 	}


### PR DESCRIPTION
## Problem

`gitSafeEnv()` (`pipeline/git_artifacts.go`) builds the environment for every git subprocess tracker spawns (git_artifacts commits, bundle export, preflight, doctor). It strips only credential-shaped vars (`*_API_KEY`, `*_SECRET`, `*_TOKEN`, `*_PASSWORD`) and passes **everything else through unchanged** — including git's location-redirect vars.

When tracker runs under a context that exports an absolute `GIT_DIR`/`GIT_INDEX_FILE` (e.g. a git hook, or a parent git invocation), git honors those inherited vars **over** the explicit `-C <dir>` / repo path tracker passes. The subprocess then reads/writes the *outer* repo's index and object store instead of the run's artifact repo, corrupting the outer working tree.

This is the same class of bug that bit committing from a linked worktree: the pre-commit hook exports an absolute `GIT_DIR`/`GIT_INDEX_FILE`, the hook's `go test ./...` runs the git_artifacts tests, and their git subprocesses inherit the leak and write into the outer commit's index.

## Root cause

`gitEnvIsSafe()` filters on credential name patterns only. Git's path-redirect vars (`GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_COMMON_DIR`) are not credential-shaped, so they survive the filter. The test helper `cleanGitEnv()` (`pipeline/git_preflight_test.go`) already stripped exactly this set — production never mirrored it.

## Fix

Strip the five git location-redirect vars in `gitEnvIsSafe()` so no tracker-spawned git subprocess can be re-anchored onto an outer repo by inherited environment. Identity vars (`GIT_AUTHOR_*`, `GIT_COMMITTER_*`) still pass through. `TRACKER_PASS_ENV=1` is unaffected (it gates the credential allowlist, not these structural vars — leaking a redirect var is never intended).

## Scope

- `pipeline/git_artifacts.go` — the fix
- `pipeline/git_artifacts_test.go`, `tracker_bundle_test.go`, `tracker_doctor_test.go`, `tracker_git_preflight_integration_test.go`, `tracker_test.go` — regression coverage asserting the redirect vars are excluded
- `tracker_bundle.go` — env plumbing touched by the fix
- `.pre-commit` — wrap the hook's `go test` in `env -u GIT_DIR -u GIT_INDEX_FILE -u GIT_WORK_TREE -u GIT_OBJECT_DIRECTORY -u GIT_COMMON_DIR` so hook-run tests can't corrupt the commit's index (belt-and-suspenders alongside the production fix)
- `CHANGELOG.md` — Fixed entry

## Verification

- `go build ./...` — clean
- `gofmt` — clean
- `go test ./... -short` — pipeline, pipeline/handlers, tracker all green
- Full pre-commit hook (coverage 84.9%, complexity, dippin lint) passed on commit

Unblocks the build_product case-study fixes #349 and #392, which both edit `build_product.dip` and could not be committed from a worktree until this landed.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743422&installation_id=131176874&pr_number=401&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F401&signature=bbed59a33ec436e79458a427065167545005bf47b52211e10ca7d79888586863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where leaked git environment variables could cause tracker's git operations to target the wrong repository, particularly when running inside git hooks or similar nested git contexts.
  * Enhanced git subprocess isolation throughout the codebase to prevent inherited environment variables from interfering with git operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->