### PR TITLE
fix(build_product): scope milestone test-gate and stop accept from bypassing verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `GIT_COMMON_DIR`, and `ExportBundle` does the same. Git-using tests were
   hardened to set the same clean env, and the pre-commit hook runs its `go test`
   gates with the pointers stripped.
+- **`build_product` milestone test-gate scope and `accept` verification bypass**
+  (issue #392). Two structural defects in `examples/build_product.dip` are fixed:
+  (T1) `TestMilestone` ran a whole-tree `go test ./...` while the fix loop
+  (`Implement`/`FixMilestone`) is milestone-scoped by construction, so a failure
+  in a package the milestone never touched (e.g. a later milestone's pre-seeded
+  code) was un-fixable on every retry — the fix budget burned on zero-progress
+  "fixes" and the run escalated. The Go test invocation is now scoped to the
+  packages this milestone actually changed (derived from the diff against
+  `.ai/build/milestone-start-sha`, the same boundary `MarkMilestoneDone` uses);
+  the whole-tree suite still runs at `FinalBuild` before anything ships, so
+  cross-milestone regressions are still caught — just not inside a loop that
+  can't act on them. `go build ./...` stays whole-tree. (T2) The `accept`
+  escalation option routed `EscalateMilestone -> Cleanup -> FinalCommit -> Done`,
+  bypassing the entire cross-review + `FinalBuild` (whole-tree test) +
+  `FinalSpecCheck` subgraph — a run could exit `Done` over a red suite with no
+  compliance report. `accept` now routes through `CheckMilestoneOutputs` (the
+  same entry the normal all-done path uses, `restart: true` to avoid a DIP005
+  cycle), so accepting still earns the structural gate, three-way cross-review,
+  final build/test, and spec-compliance check before `Cleanup`. The option's
+  prompt text is relabeled to state that verification is NOT skipped. No engine
+  changes.
 - **Remaining example workflows now hold A grades under `dippin doctor`**
   (issue #335, scope 3). Four example `.dip` files that shipped with B or F
   grades (`megaplan`, `megaplan_quality`, `ralph-loop`, `semport`) have been

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -929,14 +929,67 @@ workflow BuildProduct
       # stack can't mask an earlier failing one. `go build` stays unguarded:
       # under set -eu a Go compile failure aborts immediately (exit 1, normal
       # fix-loop failure), same as before #305.
+      #
+      # Milestone-scoped Go test target (issue #392). The fix loop
+      # (FixMilestone) is milestone-scoped by construction — the Implement and
+      # FixMilestone prompts forbid touching files outside the current
+      # milestone's scope. A WHOLE-TREE `go test ./...` gate therefore creates
+      # an unwinnable loop: a failure in a package the milestone never touched
+      # (e.g. a later milestone's pre-seeded code) is un-fixable by every fix
+      # attempt, so the cap is burned on zero-progress "fixes" and the run
+      # escalates. We reconcile the two halves by scoping THIS gate to the
+      # packages this milestone actually changed; the WHOLE-tree suite still
+      # runs at FinalBuild before anything ships, so cross-milestone regressions
+      # are caught — just not inside a loop that can't act on them. `go build
+      # ./...` stays whole-tree: a broken compile anywhere is a real blocker and
+      # aborts immediately under set -eu.
+      #
+      # Scope = Go package dirs containing a .go file changed since this
+      # milestone's start commit (.ai/build/milestone-start-sha, written by
+      # PickNextMilestone — the same boundary MarkMilestoneDone diffs against).
+      # Empty/unreachable START (first milestone, or a retry that rewrote
+      # history) degrades to the empty tree, scoping to every touched package —
+      # correct, because on the first milestone every change IS this
+      # milestone's. Zero changed Go packages (a milestone that touched only
+      # non-Go files) falls back to `./...` so the gate still runs the suite
+      # rather than silently testing nothing. The derived package tokens are
+      # ONLY ever passed as `go test` package arguments — never eval'd, never
+      # interpolated into a shell command (CLAUDE.md tool-node rule).
       if [ -f go.mod ]; then
         go build ./... 2>&1
+        GO_TEST_TARGET="./..."
+        MS_START=$(cat .ai/build/milestone-start-sha 2>/dev/null || true)
+        if [ -z "$MS_START" ] || ! git cat-file -e "${MS_START}^{commit}" 2>/dev/null; then
+          MS_BASE=$(git hash-object -t tree /dev/null)
+        else
+          MS_BASE="$MS_START"
+        fi
+        # Changed .go files -> their package dirs as `go test` arguments,
+        # unique. A repo-ROOT .go file (no slash, e.g. `main.go`) maps to the
+        # root-package arg `.` — NOT `./main.go`: a single *.go FILE arg makes
+        # `go test` build the synthetic command-line-arguments package, which
+        # silently skips the sibling _test.go AND aborts (setup-failed) when
+        # mixed with directory args. A file in a subdir maps to `./<dir>`.
+        # Deleted files are excluded (--diff-filter=d) so we never target a dir
+        # git removed. The tokens are word-split into `go test` package args
+        # under POSIX sh (how tracker runs tool nodes) — never eval'd.
+        CHANGED_PKGS=$(git diff --name-only --diff-filter=d "${MS_BASE}..HEAD" 2>/dev/null \
+          | grep -E '\.go$' \
+          | awk -F/ 'NF==1 { print "." } NF>1 { sub(/\/[^/]*$/, ""); print "./" $0 }' \
+          | sort -u \
+          | paste -sd' ' -)
+        if [ -n "$CHANGED_PKGS" ]; then
+          GO_TEST_TARGET="$CHANGED_PKGS"
+          echo "--- milestone-scoped go test: $GO_TEST_TARGET ---"
+        else
+          echo "--- no changed Go packages in milestone range — testing ./... ---"
+        fi
         if [ -n "$SKIP_PATTERN" ]; then
           echo "--- skipping known failures: $SKIP_PATTERN ---"
           # Use -skip (Go 1.24+) which supports simple regex without lookahead.
-          go test ./... -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
         else
-          go test ./... 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=$?
         fi
       fi
       if [ -f package.json ]; then
@@ -2102,7 +2155,7 @@ workflow BuildProduct
       Options:
       - **mark done**: Override the test failure — you've verified the milestone is complete. Continues to the next milestone.
       - **retry**: Re-implement this milestone from scratch. Does NOT re-plan.
-      - **accept**: Stop building milestones, skip to cleanup/commit.
+      - **accept**: Stop building more milestones and ship what exists — but still run the full cross-review, final build/test, and spec-compliance gates first (does NOT skip verification).
       - **abandon**: Kill the pipeline immediately.
 
   human EscalateReview
@@ -2259,7 +2312,22 @@ workflow BuildProduct
     # Milestone escalation — human decides per-milestone
     EscalateMilestone -> MarkMilestoneDone  label: "mark done"
     EscalateMilestone -> Implement  label: "retry"  restart: true
-    EscalateMilestone -> Cleanup  label: "accept"
+    # #392: "accept" means "stop building more milestones, ship what exists" —
+    # but it must NOT ship UNVERIFIED. The pre-#392 edge jumped straight to
+    # Cleanup -> FinalCommit -> Done, bypassing the entire cross-review +
+    # FinalBuild (whole-tree `go test ./...`) + FinalSpecCheck subgraph, so a
+    # run could exit Done over a red suite with no compliance report. Route it
+    # instead to CheckMilestoneOutputs — the SAME entry the normal all-done
+    # path uses — so accepting still earns the structural gate, the three-way
+    # cross-review, the final build/test, and the spec-compliance check before
+    # Cleanup. CheckMilestoneOutputs's own fallback routes BACK to
+    # EscalateMilestone, so `restart: true` breaks what would otherwise be an
+    # unconditional EscalateMilestone -> CheckMilestoneOutputs ->
+    # EscalateMilestone cycle (DIP005) — the same mechanism the
+    # CheckReviewFixBudget -> CheckMilestoneOutputs re-review edge uses. accept
+    # is a forward transition out of the per-milestone loop into the review
+    # phase, so restart-on-entry semantics are correct.
+    EscalateMilestone -> CheckMilestoneOutputs  label: "accept"  restart: true
     EscalateMilestone -> Done  label: "abandon"
 
     # Cross-review

--- a/pipeline/build_product_milestone_gate_test.go
+++ b/pipeline/build_product_milestone_gate_test.go
@@ -1,0 +1,85 @@
+// ABOUTME: Regression guard for issue #392 — build_product.dip's per-milestone
+// ABOUTME: test gate is milestone-scoped and `accept` still earns verification.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// hasLabeledEdge reports whether `from` has an outgoing human-gate edge to `to`
+// with the given label. Labeled gate edges store the choice in Edge.Label (or
+// Edge.Choice for DIP150) — check both.
+func hasLabeledEdge(g *Graph, from, to, label string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && (e.Label == label || e.Choice == label) {
+			return true
+		}
+	}
+	return false
+}
+
+// labeledEdgeAttr returns the value of attr key on the labeled gate edge
+// from->to, or "" if no such edge/attr exists.
+func labeledEdgeAttr(g *Graph, from, to, label, key string) string {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && (e.Label == label || e.Choice == label) {
+			return e.Attrs[key]
+		}
+	}
+	return ""
+}
+
+// TestBuildProductIssue392AcceptDoesNotBypassVerification pins T2 of #392: the
+// EscalateMilestone "accept" option must route into CheckMilestoneOutputs — the
+// SAME entry the normal all-done path uses — NOT straight to Cleanup. The
+// pre-#392 edge (accept -> Cleanup -> FinalCommit -> Done) let a run exit Done
+// over a red suite, skipping the cross-review + FinalBuild (whole-tree test) +
+// FinalSpecCheck subgraph entirely. Routing through CheckMilestoneOutputs makes
+// "stop building more milestones" still ship verified work.
+func TestBuildProductIssue392AcceptDoesNotBypassVerification(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if _, ok := g.Nodes["EscalateMilestone"]; !ok {
+		t.Fatal("EscalateMilestone node missing from build_product.dip (issue #392)")
+	}
+	if !hasLabeledEdge(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept") {
+		t.Error("EscalateMilestone `accept` must route to CheckMilestoneOutputs so it still earns cross-review + final build + spec check (issue #392)")
+	}
+	if hasLabeledEdge(g, "EscalateMilestone", "Cleanup", "accept") {
+		t.Error("EscalateMilestone `accept` still routes directly to Cleanup — that bypasses all verification (issue #392 regression)")
+	}
+	// accept re-enters CheckMilestoneOutputs, whose own fallback loops back to
+	// EscalateMilestone; the edge must carry restart:true to break the DIP005
+	// cycle (same mechanism as the CheckReviewFixBudget re-review edge).
+	if got := labeledEdgeAttr(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept", "restart"); got != "true" {
+		t.Errorf("EscalateMilestone accept -> CheckMilestoneOutputs restart = %q, want \"true\" (DIP005 cycle break, issue #392)", got)
+	}
+}
+
+// TestBuildProductIssue392MilestoneScopedTestGate pins T1 of #392: the
+// per-milestone TestMilestone gate must run a milestone-scoped `go test`
+// target, not an unconditional whole-tree `go test ./...` that the
+// milestone-scoped fix loop (Implement/FixMilestone) cannot satisfy when a
+// later milestone's pre-seeded package is red. The whole-tree suite still runs
+// at FinalBuild before anything ships.
+//
+// This is a string-level guard because the gate logic lives inline in the .dip
+// tool command; issue #398 tracks extracting it to a bats-testable script file,
+// at which point this becomes a real script test.
+func TestBuildProductIssue392MilestoneScopedTestGate(t *testing.T) {
+	g := loadBuildProduct(t)
+	n, ok := g.Nodes["TestMilestone"]
+	if !ok {
+		t.Fatal("TestMilestone node missing from build_product.dip (issue #392)")
+	}
+	cmd := n.ToolConfig().Command
+	for _, marker := range []string{"milestone-start-sha", "GO_TEST_TARGET"} {
+		if !strings.Contains(cmd, marker) {
+			t.Errorf("TestMilestone command no longer references %q — the milestone-scoped go test gate may have reverted to whole-tree (issue #392)", marker)
+		}
+	}
+	if !strings.Contains(cmd, "go test $GO_TEST_TARGET") {
+		t.Error("TestMilestone must run `go test $GO_TEST_TARGET` (milestone-scoped), not a bare whole-tree `go test ./...` (issue #392)")
+	}
+}


### PR DESCRIPTION
> **Stacked on #401** (`fix/399-gitsafeenv-git-dir-leak`). Base is that branch, not `main` — review/merge #401 first. The diff below is only the #392 change.

## Problem

Two structural defects in `examples/build_product.dip`:

**T1 — milestone test-gate scope.** `TestMilestone` ran a whole-tree `go test ./...`, but the fix loop (`Implement`/`FixMilestone`) is milestone-scoped by construction — its prompts forbid touching files outside the current milestone. So a failure in a package the milestone never touched (e.g. a later milestone's pre-seeded code) was **un-fixable on every retry**: the fix budget burned on zero-progress "fixes" and the run escalated.

**T2 — `accept` skips verification.** The `accept` escalation option routed `EscalateMilestone -> Cleanup -> FinalCommit -> Done`, bypassing the entire cross-review + `FinalBuild` (whole-tree test) + `FinalSpecCheck` subgraph. A run could exit `Done` over a red suite with no compliance report.

## Fix

**T1:** Scope the Go test invocation to the packages this milestone actually changed — the diff against `.ai/build/milestone-start-sha` (the same boundary `MarkMilestoneDone` uses), mapped to package args, with a `./...` fallback when no Go packages changed. The whole-tree suite still runs at `FinalBuild` before anything ships, so cross-milestone regressions are still caught — just not inside a loop that can't act on them. `go build ./...` stays whole-tree (a broken compile anywhere is a real blocker). Derived package tokens are only ever `go test` arguments — never eval'd or interpolated into a shell command (CLAUDE.md tool-node rule).

**T2:** `accept` now routes through `CheckMilestoneOutputs` — the same entry the normal all-done path uses — with `restart: true` to break the DIP005 cycle its fallback (`CheckMilestoneOutputs -> EscalateMilestone`) would otherwise form. Accepting now still earns the structural gate, three-way cross-review, final build/test, and spec-compliance check before `Cleanup`. The option's prompt text is relabeled to state verification is NOT skipped.

## Scope

- `examples/build_product.dip` — TestMilestone gate scoping + EscalateMilestone `accept` reroute + prompt relabel
- `pipeline/build_product_milestone_gate_test.go` — `TestBuildProductIssue392AcceptDoesNotBypassVerification` + `TestBuildProductIssue392MilestoneScopedTestGate`
- `CHANGELOG.md` — Fixed entry

## Verification

- `go build ./...` — clean
- `gofmt` — clean
- both #392 regression tests — pass
- `tracker validate examples/build_product.dip` — valid (pinned dippin-lang v0.42.0)
- `tracker simulate examples/build_product.dip -all-paths` — exit 0, no routing cycle, 34 nodes / 72 edges

### Known advisory (out of scope)

`tracker validate` emits `TRK102` on the `accept` edge ("not marked `override: true`"), exactly as it already does for the pre-existing `mark done` edge. `override: true` has **no `.dip` input path** until dippin-lang#124 lands (the #271/#348 override-input gap), so this advisory cannot be cleared here. Routing is unaffected; only the audit-only terminal status differs.

## Sibling-PR note

#400 also edits `examples/build_product.dip` (FinalCommit `writable_paths`, a different region). Whichever of #392/#400 merges second rebases onto the first.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784744121&installation_id=131176874&pr_number=402&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F402&signature=03a54957486da18dfef966733ff3015bf68ffa08a9363f37d03241344eea6528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->