### PR TITLE
fix(build_product): dogfood-cascade hardening — green-tree durability, artifact hygiene, spec-contract grading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     self-applies the same `TEST-VERIFIES-CONTRACT` rubric `VerifyMilestone` grades
     against, including a test-shape rule: a "built binary" smoke test must spawn
     the built binary, not call an unexported function in-process.
+  - **PR #411 review hardening** (automated multi-bot review of the super-PR).
+    - `verify.sh` now collapses every non-zero language-test-runner exit to `1`,
+      reserving exit `2` strictly for the "`make` present but not installed"
+      escalation; a test runner that legitimately exits `2` (e.g. a pytest
+      collection error) no longer masquerades as the env-missing escalate.
+    - `CommitIfDirty` writes the runtime binary-artifact ignore to the local,
+      untracked `.git/info/exclude` instead of the tracked `.gitignore`, so the
+      skip itself is no longer an out-of-scope tree change `VerifyMilestone` FAILs.
+    - The `FixMilestone` green-breach commit edge is now guarded by a
+      `when ctx.outcome = fail -> TestMilestone` short-circuit declared ahead of
+      it, so a stale (sticky) `verified_green` class from an earlier milestone can
+      no longer route a normal fail down the commit path and checkpoint a
+      non-green tree.
 
 ## [0.40.0] - 2026-06-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`build_product` dogfood hardening — green-tree durability, artifact hygiene,
+  and spec-contract grading** (case study: run `634a2527ff56`; closes #405, #406,
+  #407, #408, #409). One super-PR fixing a cascade where a finished, green build
+  was discarded:
+  - **#406 — turn-limit green fix abandoned uncommitted.** The `commit-if-green`
+    breach guard (#303/#297) was never reached on the `Implement`/`FixMilestone`
+    fix loop because no `verify_command` was wired, so a breach with a passing
+    tree classified as `operator_decision` instead of `verified_green`. Fixed by
+    wiring a single shared green gate: `Setup` writes `.ai/build/verify.sh`,
+    `TestMilestone` delegates to it, and `Implement`/`FixMilestone` set
+    `params: verify_command: sh .ai/build/verify.sh`. A
+    `FixMilestone -> CommitIfDirty when ctx.turn_breach_class = verified_green`
+    edge (`restart: true`) now commits the green tree before escalating.
+  - **#405 — build artifacts swept into checkpoint commits.** `Setup` now seeds
+    `.gitignore` with toolchain build outputs (not just `.ai/`), and
+    `CommitIfDirty` detects untracked executable binaries (git-native
+    `git diff --no-index --numstat` binary check) and gitignores them instead of
+    committing, so a compiled binary like `goblin` no longer FAILs Verify as
+    out-of-scope work.
+  - **#407 — escalation discarded green trees silently.** `EscalateMilestone` now
+    surfaces the live verify result (`${ctx.tool_stdout}`), defaults to "mark
+    done" (preserving finished work on the unattended path), and reframes
+    `abandon` as a destructive last resort.
+  - **#408 — behaviorally-correct code FAILed over prose identifiers.**
+    `VerifyMilestone` gains an ADR-aware three-tier severity system (FAIL / WARN /
+    PASS). A prose-named identifier that differs from the spec wording but whose
+    behavioral tests are green and which is documented in a `.ai/decisions/` ADR
+    now WARNs instead of hard-FAILing. WARN is reserved for the spec-literal case;
+    scope, unmet-behavior, and test-contract violations remain categorical FAILs.
+  - **#409 — tests that pass but don't verify the contract.** `Implement` now
+    self-applies the same `TEST-VERIFIES-CONTRACT` rubric `VerifyMilestone` grades
+    against, including a test-shape rule: a "built binary" smoke test must spawn
+    the built binary, not call an unexported function in-process.
+
 ## [0.40.0] - 2026-06-22
 
 ### Added

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -959,12 +959,17 @@ workflow BuildProduct
       # delimited read (POSIX sh — tracker runs tool nodes under dash, where
       # `read -d ''` is illegal); git quotes any pathname with embedded newlines,
       # so such a name simply fails the `[ -x ]` test and is left for `git add
-      # -A` rather than mis-ignored.
+      # -A` rather than mis-ignored. The `-- "$f"` end-of-options separator on the
+      # diff keeps a leading-dash artifact name (e.g. `-weird`) from being parsed
+      # as switches (which would error, yield empty, miss the `-` case, and leak
+      # the binary into `git add -A`). The pattern is sed-escaped before being
+      # written so gitignore metacharacters (`* ? [ ] \ ! #`) in an LLM-influenced
+      # artifact name match the literal path only, never a broader source set.
       git ls-files --others --exclude-standard \
         | while IFS= read -r f; do
             [ -x "$f" ] && [ -s "$f" ] || continue
-            case "$(git diff --no-index --numstat /dev/null "$f" 2>/dev/null | cut -f1)" in
-              -) echo "/$f" >> .gitignore ;;
+            case "$(git diff --no-index --numstat /dev/null -- "$f" 2>/dev/null | cut -f1)" in
+              -) printf '/%s\n' "$(printf '%s' "$f" | sed 's/[][*?\\!#]/\\&/g')" >> .gitignore ;;
             esac
           done
       sort -u .gitignore -o .gitignore 2>/dev/null || true
@@ -2460,8 +2465,14 @@ workflow BuildProduct
     # the same durable-persistence node the #318 commit_advance path uses, then
     # re-verify through TestMilestone. Narrow `= verified_green` so a normal
     # (non-breach) fix carries no turn_breach_class and still falls through to
-    # the warm restart loop below; a pathological/non-green breach has no commit
-    # edge and reaches EscalateMilestone via fallback_target (strict-fail).
+    # the warm restart loop below. NOTE: adding this conditional edge makes
+    # FixMilestone `hasAnyConditionalEdge`, which disables engine strict-fail on
+    # this node — so a pathological/non-green breach no longer escalates via
+    # fallback_target. Instead it falls through the unconditional TestMilestone
+    # edge below, which deterministically re-runs verify.sh on the (still non-
+    # green) tree, increments the on-disk fix-attempt counter, and escalates to
+    # EscalateMilestone once that counter exceeds its cap (bounded, counter-
+    # driven escalation; no infinite loop, no work loss).
     FixMilestone -> CommitIfDirty  when ctx.turn_breach_class = verified_green  restart: true
     FixMilestone -> TestMilestone  restart: true
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1162,28 +1162,46 @@ workflow BuildProduct
          strings, exact JSON key names, exact header names, exact
          integer constants, exact log key names — grep the
          implementation for that literal and write the grep command
-         and its result inline. A missing literal is FAIL UNLESS the
-         Implement step recorded an explicit deviation in
-         `.ai/decisions/` that names this literal and justifies the
-         deviation. (The Implement prompt gives
-         the implementing agent two options for any literal mismatch:
-         fix the implementation OR document the deviation in
-         `.ai/decisions/`. VerifyMilestone must honor the same
-         contract.) Concretely: when a literal is missing, before
-         declaring FAIL run
+         and its result inline. A missing literal resolves to one of
+         three severities (see the SEVERITY TIERS rule below); decide
+         per literal and cite your evidence:
+           - FAIL (blocking): the literal is a CONTRACT value — a wire
+             format, a JSON key, a header name, a numeric constant, an
+             exact command string — where a paraphrase changes observable
+             behavior. Missing + no covering ADR = FAIL. Silent paraphrase
+             (`--head <branch>` for `--head <owner>:<branch>`) is the
+             canonical ship-wrong; stays FAIL.
+           - WARN (non-blocking): the literal is an ILLUSTRATIVE API
+             identifier named in spec PROSE (e.g. `signal.NotifyContext`
+             when the code uses `signal.Notify` + a manual channel) AND
+             the milestone's own behavioral tests prove the implemented
+             form is equivalent (the relevant tests are green) AND a
+             `.ai/decisions/` ADR documents the deviation. All three
+             hold → WARN, not FAIL: cite the ADR path, the passing test,
+             and why the behavior is equivalent. (Run 634a2527ff56 hard-
+             FAILed behaviorally-correct signal handling on exactly this
+             prose-identifier mismatch and triggered the fix loop that
+             collapsed the run.)
+           - PASS: the literal is present byte-for-byte, OR missing but an
+             ADR names it AND it is a contract value the ADR justifies a
+             genuine substitution for.
+         Concretely: when a literal is missing, before deciding run
            grep -rn '<literal>' .ai/decisions/
-         to look for a documented deviation. If one exists and names
-         this literal, treat it as PASS (and surface the decision-log
-         path + rationale in your report so the operator can audit
-         it). If no decision-log entry exists, FAIL.
+         to look for a documented deviation, and check whether the
+         milestone's behavioral tests for that area are green. Surface the
+         decision-log path + rationale in your report so the operator can
+         audit it. No ADR (or failing behavioral tests) for a deviated
+         identifier ⇒ FAIL.
          Example workflow:
            - Spec section says: `gh pr list --head <owner>:<branch> --json number,headRefName,headRepository`
            - Run: `grep -rn '<owner>:<branch>' --include='*.go' .`
            - Run: `grep -rn 'headRepository' --include='*.go' .`
            - If output is empty, run `grep -rn '<owner>:<branch>' .ai/decisions/`
              and `grep -rn 'headRepository' .ai/decisions/` — a hit
-             with a rationale means PASS (cite the decision file);
-             no hit means FAIL (cite the missing literal).
+             with a rationale on a contract value means PASS (cite the
+             decision file); an ADR on a behaviorally-verified PROSE
+             identifier means WARN; no hit means FAIL (cite the missing
+             literal).
 
       4. TEST-VERIFIES-CONTRACT: For each test
          touched by this milestone, read its assertions and ask: "If
@@ -1290,8 +1308,29 @@ workflow BuildProduct
          outside scope. Walk the diff for files / functions / fields
          the milestone didn't ask for.
 
-      If every check passes: STATUS:success
-      If any check fails, describe exactly what failed (with the
+      SEVERITY TIERS (applies to every finding above):
+      Tag each finding FAIL, WARN, or PASS.
+        - FAIL = a contract or behavioral violation: the milestone does
+          not do what the spec requires, or a test does not verify the
+          contract, or a CONTRACT literal is wrong. Blocking.
+        - WARN = a deviation that is behaviorally correct and documented:
+          an illustrative/prose-named identifier differs from the spec
+          wording, the milestone's behavioral tests for it are green, AND
+          a `.ai/decisions/` ADR records the deviation. Non-blocking —
+          show your work (ADR path + passing test) but do NOT fail on it.
+        - PASS = satisfied as written.
+      WARN is reserved for the check-3 SPEC-LITERAL prose-identifier case
+      ONLY. Scope violations (check 2 / check 7), unmet behavior, and tests
+      that don't verify the contract (check 4) are FAIL when violated —
+      never WARN, even with an ADR.
+      WARN findings are recorded, not gated: a milestone whose only
+      open items are WARN still passes. Do NOT escalate a WARN to FAIL
+      just because an identifier didn't match prose — that false-positive
+      FAIL is what this tier exists to prevent.
+
+      If every check is PASS or WARN: STATUS:success (list any WARNs with
+      their ADR + passing-test citations so the operator can audit them).
+      If any check is FAIL, describe exactly what failed (with the
       file:line, grep output, or failing assertion) and: STATUS:fail
 
       ---

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -884,7 +884,13 @@ workflow BuildProduct
         why. Silent paraphrase ("--head <branch>" when the spec says
         "--head <owner>:<branch>") is the most common way milestones ship wrong.
 
-      TESTS VERIFY THE CONTRACT, NOT YOUR CODE:
+      TEST-VERIFIES-CONTRACT (run this rubric BEFORE you emit DONE):
+      - This is the SAME rubric VerifyMilestone grades you against (its check
+        "TEST-VERIFIES-CONTRACT"). Apply it yourself first so a passing-but-
+        non-verifying test never ships — that asymmetry is what forces an
+        expensive Fix loop (run 634a2527ff56: a green smoke test that called the
+        function in-process FAILed Verify and the fix had to invent a whole
+        subprocess seam from scratch).
       - Tests must verify the spec's requirement, not whatever your
         implementation happens to do. Read each assertion you write and ask:
         "If I deleted my production code and rewrote it differently but
@@ -894,6 +900,18 @@ workflow BuildProduct
         `attempts == 2` when the spec says "max 2 retries" (= 3 attempts):
         the test green-lights the off-by-one because it was written from the
         code, not from the spec.
+      - TEST SHAPE: when a milestone's done-when names a concrete test SHAPE —
+        a "built binary" smoke test, a "subprocess", a "real `gh`", an
+        end-to-end run through `main()` — the test MUST exercise that exact
+        harness. A "built binary" smoke contract requires actually spawning the
+        built binary (compile it, run the process, assert on its behavior); an
+        in-process call to an unexported function is a WEAKER reading that
+        passes locally but does NOT prove the wiring the contract demands, and
+        Verify will FAIL it. List each named test shape from the done-when as a
+        checklist item, satisfy it with the real harness, and cite the shape you
+        matched. If satisfying it needs production plumbing (an injection seam,
+        a build tag, fake-dependency flags), build that plumbing NOW — do not
+        defer it to a Fix loop.
       - Snapshot / golden-file tests: the FIRST version of every snapshot
         must be hand-verified against the spec, not regenerated from the
         current implementation's output. If your test framework supports an
@@ -1213,6 +1231,17 @@ workflow BuildProduct
          spec says "max 2 retries" (= 3 attempts) is FAIL. A test
          asserting a populated field that the spec marks as deferred
          (a "DO NOT implement" entry from this milestone) is FAIL.
+         TEST SHAPE: when the done-when names a concrete test shape — a
+         "built binary" smoke test, a "subprocess", a "real `gh`", an
+         end-to-end run through `main()` — the test must exercise that
+         exact harness. A "built binary" smoke contract requires
+         spawning the built binary (compile + run the process); an
+         in-process call to an unexported function is a weaker reading
+         that does NOT prove the wiring and is FAIL. This is the SAME
+         rubric the Implement prompt now self-applies before DONE, so a
+         test reaching here should already satisfy it — if it does not,
+         name the shape the done-when required and the weaker shape the
+         test used.
 
       5. SPEC GAPS BEYOND MILESTONE NOTES: For every SPEC.md bullet
          intersecting this milestone's file list (whether or not the

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -30,6 +30,19 @@ workflow BuildProduct
       set -eu
       mkdir -p .ai/build .ai/decisions .ai/milestones
       echo '.ai/' >> .gitignore 2>/dev/null || true
+      # #405: seed common build-output patterns so a milestone whose tests
+      # compile/install artifacts doesn't have them swept into a CommitIfDirty
+      # checkpoint and then FAILed by Verify as out-of-scope work. This is the
+      # STATIC half (named/dir artifacts across the toolchains build_product
+      # targets); arbitrary-named compiled binaries (Go `go build -o <name>` has
+      # no fixed extension) are caught dynamically in CommitIfDirty. Appended +
+      # deduped exactly like `.ai/` above; idempotent across re-runs.
+      for pat in \
+        'node_modules/' 'dist/' 'build/' 'target/' 'coverage/' \
+        '__pycache__/' '.venv/' 'venv/' '*.pyc' \
+        '*.exe' '*.test' '*.out' '*.o' '*.a'; do
+        echo "$pat" >> .gitignore 2>/dev/null || true
+      done
       sort -u .gitignore -o .gitignore
       # #351: keep tracker run metadata out of the product repo. CommitIfDirty
       # runs `git add -A`, which would otherwise commit .tracker/runs/<id>/
@@ -911,6 +924,33 @@ workflow BuildProduct
       # dirty — a milestone that only adds new files would otherwise look clean
       # to `git diff` and skip the commit, leaving exactly the green-but-
       # uncommitted tree this node exists to prevent.
+      # #405: never checkpoint a compiled build artifact. A test that runs
+      # `go build -o <name>` drops an executable into the tree (Go binaries have
+      # no fixed extension, so Setup's static .gitignore seed can't catch them);
+      # `git add -A` would commit it and Verify then FAILs the milestone for
+      # out-of-scope work. Gitignore any UNTRACKED, executable, BINARY,
+      # non-empty file before staging — real source (text) and executable shell
+      # scripts (text) survive; only opaque binaries are filtered. Binary-ness
+      # comes from git itself: `git diff --no-index --numstat /dev/null <f>`
+      # reports `-` in the added-lines column for a binary file, a number for
+      # text. Using git (already required by this node) avoids depending on a
+      # GNU-only `grep -I`, whose unrecognized-flag failure mode would mis-ignore
+      # real source. The `[ -s ]` guard keeps an empty placeholder from being
+      # mistaken for an artifact. Listing comes from git's own untracked-not-
+      # ignored set, so nothing already tracked or ignored is touched. Newline-
+      # delimited read (POSIX sh — tracker runs tool nodes under dash, where
+      # `read -d ''` is illegal); git quotes any pathname with embedded newlines,
+      # so such a name simply fails the `[ -x ]` test and is left for `git add
+      # -A` rather than mis-ignored.
+      git ls-files --others --exclude-standard \
+        | while IFS= read -r f; do
+            [ -x "$f" ] && [ -s "$f" ] || continue
+            case "$(git diff --no-index --numstat /dev/null "$f" 2>/dev/null | cut -f1)" in
+              -) echo "/$f" >> .gitignore ;;
+            esac
+          done
+      sort -u .gitignore -o .gitignore 2>/dev/null || true
+
       if [ -n "$(git status --porcelain)" ]; then
         git add -A
         git -c user.name="build_product" -c user.email="build_product@tracker.local" \

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -248,6 +248,90 @@ workflow BuildProduct
       }
       PROBE_EOF
 
+      # Shared milestone green-gate (issue #406). TestMilestone wraps this with
+      # the fix-attempt counter + tests-pass/escalate sentinels; the
+      # Implement/FixMilestone breach verify_command runs the SAME script, so a
+      # turn-limit breach on a green tree classifies verified_green and commits
+      # the work instead of abandoning it. One source of truth — the gate logic
+      # lives here, exactly as it did inline in TestMilestone (mirrors the
+      # ci-probe.sh single-place discipline above).
+      cat > .ai/build/verify.sh <<'VERIFY_EOF'
+      # Source nothing — run this directly (`sh .ai/build/verify.sh`). Exit code:
+      #   0  green: build + every detected stack's tests + project CI gate pass
+      #   2  Makefile present but `make` not installed (environment; escalate)
+      #   1  build/test/CI failure (normal fix-loop failure)
+      set -eu
+      TEST_EXIT=0
+
+      # Build the skip pattern from known_failures, stripping comments and blanks.
+      SKIP_PATTERN=""
+      if [ -f .ai/milestones/known_failures ]; then
+        SKIP_PATTERN=$(grep -v '^#' .ai/milestones/known_failures | grep -v '^$' | paste -sd'|' -)
+      fi
+
+      # Run EVERY detected stack, not just the first match (issue #305).
+      # Failures accumulate into TEST_EXIT so a later passing stack can't mask an
+      # earlier failing one. `go build` stays unguarded: under set -eu a Go
+      # compile failure aborts immediately (exit 1, normal fix-loop failure).
+      # Milestone-scoped Go test target (issue #392): scope `go test` to the
+      # packages this milestone changed since .ai/build/milestone-start-sha; the
+      # WHOLE-tree suite still runs at FinalBuild. The derived package tokens are
+      # ONLY ever passed as `go test` package arguments — never eval'd.
+      if [ -f go.mod ]; then
+        go build ./... 2>&1
+        GO_TEST_TARGET="./..."
+        MS_START=$(cat .ai/build/milestone-start-sha 2>/dev/null || true)
+        if [ -z "$MS_START" ] || ! git cat-file -e "${MS_START}^{commit}" 2>/dev/null; then
+          MS_BASE=$(git hash-object -t tree /dev/null)
+        else
+          MS_BASE="$MS_START"
+        fi
+        CHANGED_PKGS=$(git diff --name-only --diff-filter=d "${MS_BASE}..HEAD" 2>/dev/null \
+          | grep -E '\.go$' \
+          | awk -F/ 'NF==1 { print "." } NF>1 { sub(/\/[^/]*$/, ""); print "./" $0 }' \
+          | sort -u \
+          | paste -sd' ' -)
+        if [ -n "$CHANGED_PKGS" ]; then
+          GO_TEST_TARGET="$CHANGED_PKGS"
+          echo "--- milestone-scoped go test: $GO_TEST_TARGET ---"
+        else
+          echo "--- no changed Go packages in milestone range — testing ./... ---"
+        fi
+        if [ -n "$SKIP_PATTERN" ]; then
+          echo "--- skipping known failures: $SKIP_PATTERN ---"
+          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
+        else
+          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=$?
+        fi
+      fi
+      if [ -f package.json ]; then
+        npm test 2>&1 || TEST_EXIT=$?
+      fi
+      if [ -f pyproject.toml ]; then
+        uv run pytest 2>&1 || TEST_EXIT=$?
+      fi
+      if [ -f Cargo.toml ]; then
+        cargo test 2>&1 || TEST_EXIT=$?
+      fi
+      if [ ! -f go.mod ] && [ ! -f package.json ] && [ ! -f pyproject.toml ] && [ ! -f Cargo.toml ]; then
+        echo "no known build system — skipping tests"
+      fi
+
+      # Project CI gate (issue #233 Gap 1). Source the shared helper; rc=2 means
+      # a Makefile is present but `make` isn't installed — an environment problem
+      # the LLM fix loop can't resolve, surfaced as exit 2 so the caller escalates.
+      . .ai/build/ci-probe.sh
+      CI_RC=0
+      run_project_ci_gate || CI_RC=$?
+      if [ "$CI_RC" -eq 2 ]; then
+        exit 2
+      fi
+      if [ "$CI_RC" -ne 0 ]; then
+        TEST_EXIT="$CI_RC"
+      fi
+      exit "$TEST_EXIT"
+      VERIFY_EOF
+
       # Shared interface-reachability rubric (issue #233 Gap 7).
       # FinalSpecCheck and the three reviewer prompts source this file
       # so the discipline lives in exactly one place — mirrors the
@@ -737,6 +821,13 @@ workflow BuildProduct
     fidelity: full
     max_turns: 50
     fallback_target: EscalateMilestone
+    # Turn-limit commit-if-green guard (#297/#303/#406). If this session
+    # exhausts its turn budget on a GREEN tree, the breach verifier runs this
+    # command; exit 0 classifies the breach verified_green (outcome=success) so
+    # the finished work is committed instead of abandoned. Same script the
+    # TestMilestone gate wraps — one source of truth.
+    params:
+      verify_command: sh .ai/build/verify.sh
     prompt:
       FIRST, in one turn, read .ai/build/build-context.md for orientation — it
       holds an architecture map and a one-entry-per-milestone log (files touched
@@ -906,137 +997,36 @@ workflow BuildProduct
       ATTEMPTS=$((ATTEMPTS + 1))
       echo "$ATTEMPTS" > "$ATTEMPT_FILE"
 
-      # Run tests AND the project CI gate. If both pass, the milestone is
-      # done regardless of how many fix attempts we've burned. The CI gate
-      # (added per #233 Gap 1, further down in this command) can fail
-      # after the language-stack tests pass — that's intentional: a green
-      # `go test ./...` doesn't catch lint/vet/format failures that the
-      # project's own `make ci` would, and the previous version of this
-      # node reported "Done" on a commit whose CI was red because it only
-      # ran the language-stack default.
-      TEST_EXIT=0
-
-      # Run the project's test suite.
-      # Build the skip pattern from known_failures, stripping comments and blanks.
-      SKIP_PATTERN=""
-      if [ -f .ai/milestones/known_failures ]; then
-        SKIP_PATTERN=$(grep -v '^#' .ai/milestones/known_failures | grep -v '^$' | paste -sd'|' -)
-      fi
-
-      # Run EVERY detected stack, not just the first match (issue #305) — a
-      # polyglot repo (e.g. Go backend + JS frontend) must exercise all of its
-      # test suites. Failures accumulate into TEST_EXIT so a later passing
-      # stack can't mask an earlier failing one. `go build` stays unguarded:
-      # under set -eu a Go compile failure aborts immediately (exit 1, normal
-      # fix-loop failure), same as before #305.
+      # Run the ONE shared milestone green-gate (issue #406). The full
+      # build + per-stack tests + project CI logic lives in .ai/build/verify.sh
+      # (written by Setup) so this node, the Implement breach verify_command,
+      # and the FixMilestone breach verify_command all adjudicate "green" with
+      # the SAME script — a single source of truth. This node is the only place
+      # that wraps it with the fix-attempt counter and the tracker routing
+      # sentinels (tests-pass / escalate); verify.sh itself prints no markers.
       #
-      # Milestone-scoped Go test target (issue #392). The fix loop
-      # (FixMilestone) is milestone-scoped by construction — the Implement and
-      # FixMilestone prompts forbid touching files outside the current
-      # milestone's scope. A WHOLE-TREE `go test ./...` gate therefore creates
-      # an unwinnable loop: a failure in a package the milestone never touched
-      # (e.g. a later milestone's pre-seeded code) is un-fixable by every fix
-      # attempt, so the cap is burned on zero-progress "fixes" and the run
-      # escalates. We reconcile the two halves by scoping THIS gate to the
-      # packages this milestone actually changed; the WHOLE-tree suite still
-      # runs at FinalBuild before anything ships, so cross-milestone regressions
-      # are caught — just not inside a loop that can't act on them. `go build
-      # ./...` stays whole-tree: a broken compile anywhere is a real blocker and
-      # aborts immediately under set -eu.
-      #
-      # Scope = Go package dirs containing a .go file changed since this
-      # milestone's start commit (.ai/build/milestone-start-sha, written by
-      # PickNextMilestone — the same boundary MarkMilestoneDone diffs against).
-      # Empty/unreachable START (first milestone, or a retry that rewrote
-      # history) degrades to the empty tree, scoping to every touched package —
-      # correct, because on the first milestone every change IS this
-      # milestone's. Zero changed Go packages (a milestone that touched only
-      # non-Go files) falls back to `./...` so the gate still runs the suite
-      # rather than silently testing nothing. The derived package tokens are
-      # ONLY ever passed as `go test` package arguments — never eval'd, never
-      # interpolated into a shell command (CLAUDE.md tool-node rule).
-      if [ -f go.mod ]; then
-        go build ./... 2>&1
-        GO_TEST_TARGET="./..."
-        MS_START=$(cat .ai/build/milestone-start-sha 2>/dev/null || true)
-        if [ -z "$MS_START" ] || ! git cat-file -e "${MS_START}^{commit}" 2>/dev/null; then
-          MS_BASE=$(git hash-object -t tree /dev/null)
-        else
-          MS_BASE="$MS_START"
-        fi
-        # Changed .go files -> their package dirs as `go test` arguments,
-        # unique. A repo-ROOT .go file (no slash, e.g. `main.go`) maps to the
-        # root-package arg `.` — NOT `./main.go`: a single *.go FILE arg makes
-        # `go test` build the synthetic command-line-arguments package, which
-        # silently skips the sibling _test.go AND aborts (setup-failed) when
-        # mixed with directory args. A file in a subdir maps to `./<dir>`.
-        # Deleted files are excluded (--diff-filter=d) so we never target a dir
-        # git removed. The tokens are word-split into `go test` package args
-        # under POSIX sh (how tracker runs tool nodes) — never eval'd.
-        CHANGED_PKGS=$(git diff --name-only --diff-filter=d "${MS_BASE}..HEAD" 2>/dev/null \
-          | grep -E '\.go$' \
-          | awk -F/ 'NF==1 { print "." } NF>1 { sub(/\/[^/]*$/, ""); print "./" $0 }' \
-          | sort -u \
-          | paste -sd' ' -)
-        if [ -n "$CHANGED_PKGS" ]; then
-          GO_TEST_TARGET="$CHANGED_PKGS"
-          echo "--- milestone-scoped go test: $GO_TEST_TARGET ---"
-        else
-          echo "--- no changed Go packages in milestone range — testing ./... ---"
-        fi
-        if [ -n "$SKIP_PATTERN" ]; then
-          echo "--- skipping known failures: $SKIP_PATTERN ---"
-          # Use -skip (Go 1.24+) which supports simple regex without lookahead.
-          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
-        else
-          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=$?
-        fi
-      fi
-      if [ -f package.json ]; then
-        npm test 2>&1 || TEST_EXIT=$?
-      fi
-      if [ -f pyproject.toml ]; then
-        uv run pytest 2>&1 || TEST_EXIT=$?
-      fi
-      if [ -f Cargo.toml ]; then
-        cargo test 2>&1 || TEST_EXIT=$?
-      fi
-      if [ ! -f go.mod ] && [ ! -f package.json ] && [ ! -f pyproject.toml ] && [ ! -f Cargo.toml ]; then
-        echo "no known build system — skipping tests"
-      fi
+      # verify.sh exit codes:
+      #   0  green: build + every detected stack's tests + project CI gate pass
+      #   2  environment escalation (e.g. Makefile present but `make` absent) —
+      #      the LLM fix loop can't resolve it, so route straight to escalate
+      #   1  ordinary build/test/CI failure — hand to the fix loop
+      VERIFY_RC=0
+      sh .ai/build/verify.sh 2>&1 || VERIFY_RC=$?
 
-      # Project CI gate (issue #233 Gap 1). Source the shared helper
-      # written by Setup so the probe/run logic lives in exactly one
-      # place — see Setup for the full design. Helper returns 2 when
-      # a Makefile is present but `make` isn't installed; that's an
-      # environment problem the LLM fix loop can't resolve, so we
-      # route directly to EscalateMilestone via the `escalate`
-      # marker instead of burning fix attempts (#246 Copilot round-5).
-      . .ai/build/ci-probe.sh
-      CI_RC=0
-      run_project_ci_gate || CI_RC=$?
-      if [ "$CI_RC" -eq 2 ]; then
+      if [ "$VERIFY_RC" -eq 2 ]; then
         echo "0" > "$ATTEMPT_FILE"
         printf 'escalate'
         exit 1
       fi
-      if [ "$CI_RC" -ne 0 ]; then
-        TEST_EXIT="$CI_RC"
-      fi
 
-      # Note: milestone-specific verification is handled by the Implement agent
-      # (which runs the verify command as part of its session) and the VerifyMilestone
-      # agent (which checks completion criteria). We do NOT eval LLM-generated
-      # commands here — that would be arbitrary code execution from free-form text.
-
-      # Tests passed — reset counter and succeed
-      if [ "$TEST_EXIT" -eq 0 ]; then
+      # Green — reset counter and succeed.
+      if [ "$VERIFY_RC" -eq 0 ]; then
         echo "0" > "$ATTEMPT_FILE"
         printf 'tests-pass'
         exit 0
       fi
 
-      # Tests failed — check if we've exhausted fix attempts
+      # Failure — check if we've exhausted fix attempts.
       echo "--- attempt $ATTEMPTS of 3 ---"
       if [ "$ATTEMPTS" -gt 3 ]; then
         echo "ESCALATE: milestone failed after $ATTEMPTS attempts"
@@ -1371,6 +1361,13 @@ workflow BuildProduct
     retry_target: TestMilestone
     max_retries: 5
     fallback_target: EscalateMilestone
+    # Turn-limit commit-if-green guard (#406). The fix loop is the node that
+    # actually reached green at turn 47 in run 634a2527ff56 and then burned the
+    # budget on read-only `git status` — without this verifier its breach
+    # classified operator_decision and the green fix was abandoned uncommitted.
+    # Exit 0 → verified_green → the verified_green edge below commits the tree.
+    params:
+      verify_command: sh .ai/build/verify.sh
     prompt:
       FIRST, in one turn, read .ai/build/build-context.md for orientation — it
       holds an architecture map and a one-entry-per-milestone log (files touched
@@ -2327,6 +2324,14 @@ workflow BuildProduct
     VerifyMilestone -> FixMilestone  when ctx.outcome = fail
     VerifyMilestone -> EscalateMilestone
     MarkMilestoneDone -> PickNextMilestone  restart: true
+    # #406: a turn-limit breach that reached a GREEN tree (verify_command exit 0)
+    # classifies verified_green (outcome=success). Commit the finished work via
+    # the same durable-persistence node the #318 commit_advance path uses, then
+    # re-verify through TestMilestone. Narrow `= verified_green` so a normal
+    # (non-breach) fix carries no turn_breach_class and still falls through to
+    # the warm restart loop below; a pathological/non-green breach has no commit
+    # edge and reaches EscalateMilestone via fallback_target (strict-fail).
+    FixMilestone -> CommitIfDirty  when ctx.turn_breach_class = verified_green  restart: true
     FixMilestone -> TestMilestone  restart: true
 
     # Milestone escalation — human decides per-milestone

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -2193,16 +2193,39 @@ workflow BuildProduct
   human EscalateMilestone
     label: "Milestone stuck — pick how to proceed"
     mode: freeform
+    # #407: `mark done` is FIRST and the default so the unattended path (freeform
+    # labels[0] fallback + default_choice) preserves work — it NEVER discards.
+    # `abandon` is demoted to the destructive last resort. The "Verify currently"
+    # block surfaces the live build/verify output that routed here so a green,
+    # passing tree is never thrown away by an operator who wasn't told it passes
+    # (run 634a2527ff56 abandoned a green build). A green-at-breach turn limit no
+    # longer even reaches this gate — #406 routes it to CommitIfDirty — but other
+    # paths (a Verify false-positive over passing tests, an escalate sentinel)
+    # can still land here on a green tree, so the state must be shown.
     default: mark done
     prompt:
       The build loop hit a wall on the current milestone.
       The agent tried to fix it but couldn't get tests to pass.
 
+      READ "Verify currently" at the END of this prompt before choosing. If it
+      shows PASS the tree is GREEN — do NOT abandon; pick **mark done** (or
+      **accept** to ship). Abandoning a passing tree discards finished work.
+
       Options:
-      - **mark done**: Override the test failure — you've verified the milestone is complete. Continues to the next milestone.
-      - **retry**: Re-implement this milestone from scratch. Does NOT re-plan.
+      - **mark done** (default; chosen automatically for unattended runs): Override the failure — you've confirmed the milestone is complete. Commits/continues to the next milestone. Preserves work.
+      - **retry**: Re-implement this milestone from scratch. Does NOT re-plan. Preserves prior commits.
       - **accept**: Stop building more milestones and ship what exists — but still run the full cross-review, final build/test, and spec-compliance gates first (does NOT skip verification).
-      - **abandon**: Kill the pipeline immediately.
+      - **abandon**: DESTRUCTIVE LAST RESORT. Kill the pipeline immediately and discard uncommitted work. Only pick this if "Verify currently" is FAIL and the build is genuinely unsalvageable.
+
+      ---
+      ## Verify currently
+
+      Tail of the most recent build/verify output (64KB cap) that routed here —
+      the live milestone state. A green `tests-pass` / passing build means the
+      tree is COMPLETE; a failure or `escalate` marker means it is not. Delimited
+      under its own heading — never interpolated mid-sentence.
+
+      ${ctx.tool_stdout}
 
   human EscalateReview
     label: "Review flagged issues — pick how to proceed"

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -269,10 +269,15 @@ workflow BuildProduct
       # lives here, exactly as it did inline in TestMilestone (mirrors the
       # ci-probe.sh single-place discipline above).
       cat > .ai/build/verify.sh <<'VERIFY_EOF'
-      # Source nothing — run this directly (`sh .ai/build/verify.sh`). Exit code:
+      # Run this directly (`sh .ai/build/verify.sh`) — do NOT source it. It
+      # sources .ai/build/ci-probe.sh internally for the project CI gate. Exit:
       #   0  green: build + every detected stack's tests + project CI gate pass
-      #   2  Makefile present but `make` not installed (environment; escalate)
-      #   1  build/test/CI failure (normal fix-loop failure)
+      #   2  Makefile present but `make` not installed (environment; escalate) —
+      #      RESERVED for that env-missing case ONLY. TestMilestone routes exit 2
+      #      straight to `escalate`, so no language test runner's exit may reach it.
+      #   1  any build/test/CI failure (normal fix-loop failure). Every non-zero
+      #      TEST-runner exit collapses to 1 below (a runner exiting 2 — e.g. a
+      #      pytest collection error — must NOT masquerade as the make-missing 2).
       set -eu
       TEST_EXIT=0
 
@@ -283,8 +288,11 @@ workflow BuildProduct
       fi
 
       # Run EVERY detected stack, not just the first match (issue #305).
-      # Failures accumulate into TEST_EXIT so a later passing stack can't mask an
-      # earlier failing one. `go build` stays unguarded: under set -eu a Go
+      # Each runner's non-zero exit collapses to TEST_EXIT=1 (NOT $?) so a runner
+      # that legitimately exits 2 (e.g. a pytest collection error) can't be
+      # mistaken for the make-missing escalate (exit 2) reserved below (PR #411).
+      # The 1 is sticky: once a stack fails a later passing stack can't reset it,
+      # so failures still can't be masked. `go build` stays unguarded: under set -eu a Go
       # compile failure aborts immediately (exit 1, normal fix-loop failure).
       # Milestone-scoped Go test target (issue #392): scope `go test` to the
       # packages this milestone changed since .ai/build/milestone-start-sha; the
@@ -312,19 +320,19 @@ workflow BuildProduct
         fi
         if [ -n "$SKIP_PATTERN" ]; then
           echo "--- skipping known failures: $SKIP_PATTERN ---"
-          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET -skip "$SKIP_PATTERN" 2>&1 || TEST_EXIT=1
         else
-          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=$?
+          go test $GO_TEST_TARGET 2>&1 || TEST_EXIT=1
         fi
       fi
       if [ -f package.json ]; then
-        npm test 2>&1 || TEST_EXIT=$?
+        npm test 2>&1 || TEST_EXIT=1
       fi
       if [ -f pyproject.toml ]; then
-        uv run pytest 2>&1 || TEST_EXIT=$?
+        uv run pytest 2>&1 || TEST_EXIT=1
       fi
       if [ -f Cargo.toml ]; then
-        cargo test 2>&1 || TEST_EXIT=$?
+        cargo test 2>&1 || TEST_EXIT=1
       fi
       if [ ! -f go.mod ] && [ ! -f package.json ] && [ ! -f pyproject.toml ] && [ ! -f Cargo.toml ]; then
         echo "no known build system — skipping tests"
@@ -340,7 +348,9 @@ workflow BuildProduct
         exit 2
       fi
       if [ "$CI_RC" -ne 0 ]; then
-        TEST_EXIT="$CI_RC"
+        # Non-2 CI failure → normal fix-loop failure (exit 2 already handled above
+        # and is reserved for make-missing). Collapse to 1, never propagate raw.
+        TEST_EXIT=1
       fi
       exit "$TEST_EXIT"
       VERIFY_EOF
@@ -946,33 +956,45 @@ workflow BuildProduct
       # `go build -o <name>` drops an executable into the tree (Go binaries have
       # no fixed extension, so Setup's static .gitignore seed can't catch them);
       # `git add -A` would commit it and Verify then FAILs the milestone for
-      # out-of-scope work. Gitignore any UNTRACKED, executable, BINARY,
-      # non-empty file before staging — real source (text) and executable shell
-      # scripts (text) survive; only opaque binaries are filtered. Binary-ness
-      # comes from git itself: `git diff --no-index --numstat /dev/null <f>`
-      # reports `-` in the added-lines column for a binary file, a number for
-      # text. Using git (already required by this node) avoids depending on a
-      # GNU-only `grep -I`, whose unrecognized-flag failure mode would mis-ignore
-      # real source. The `[ -s ]` guard keeps an empty placeholder from being
-      # mistaken for an artifact. Listing comes from git's own untracked-not-
-      # ignored set, so nothing already tracked or ignored is touched. Newline-
-      # delimited read (POSIX sh — tracker runs tool nodes under dash, where
-      # `read -d ''` is illegal); git quotes any pathname with embedded newlines,
-      # so such a name simply fails the `[ -x ]` test and is left for `git add
-      # -A` rather than mis-ignored. The `-- "$f"` end-of-options separator on the
-      # diff keeps a leading-dash artifact name (e.g. `-weird`) from being parsed
-      # as switches (which would error, yield empty, miss the `-` case, and leak
-      # the binary into `git add -A`). The pattern is sed-escaped before being
-      # written so gitignore metacharacters (`* ? [ ] \ ! #`) in an LLM-influenced
-      # artifact name match the literal path only, never a broader source set.
-      git ls-files --others --exclude-standard \
-        | while IFS= read -r f; do
-            [ -x "$f" ] && [ -s "$f" ] || continue
-            case "$(git diff --no-index --numstat /dev/null -- "$f" 2>/dev/null | cut -f1)" in
-              -) printf '/%s\n' "$(printf '%s' "$f" | sed 's/[][*?\\!#]/\\&/g')" >> .gitignore ;;
-            esac
-          done
-      sort -u .gitignore -o .gitignore 2>/dev/null || true
+      # out-of-scope work. Exclude any UNTRACKED, executable, BINARY, non-empty
+      # file before staging — real source (text) and executable shell scripts
+      # (text) survive; only opaque binaries are filtered. The exclusion goes to
+      # the LOCAL, untracked .git/info/exclude — NOT the tracked .gitignore (PR
+      # #411): a runtime write to the tracked .gitignore is itself an out-of-scope
+      # tree change VerifyMilestone would FAIL, defeating the point of skipping
+      # the artifact. Same .git/info/exclude treatment .tracker/ (Setup) and the
+      # turn-override dir (ContinueWithMoreTurns) already get. Binary-ness comes
+      # from git itself: `git diff --no-index --numstat /dev/null <f>` reports `-`
+      # in the added-lines column for a binary file, a number for text. Using git
+      # (already required by this node) avoids depending on a GNU-only `grep -I`,
+      # whose unrecognized-flag failure mode would mis-ignore real source. The
+      # `[ -s ]` guard keeps an empty placeholder from being mistaken for an
+      # artifact. Listing comes from git's own untracked-not-excluded set (it
+      # already honors .git/info/exclude), so nothing already tracked or excluded
+      # is touched and re-runs are idempotent. Newline-delimited read (POSIX sh —
+      # tracker runs tool nodes under dash, where `read -d ''` is illegal); git
+      # quotes any pathname with embedded newlines, so such a name simply fails
+      # the `[ -x ]` test and is left for `git add -A` rather than mis-excluded.
+      # The `-- "$f"` end-of-options separator on the diff keeps a leading-dash
+      # artifact name (e.g. `-weird`) from being parsed as switches (which would
+      # error, yield empty, miss the `-` case, and leak the binary into `git add
+      # -A`). The pattern is sed-escaped before being written so gitignore
+      # metacharacters (`* ? [ ] \ ! #`) in an LLM-influenced artifact name match
+      # the literal path only, never a broader source set; grep -qxF keeps the
+      # append idempotent.
+      GITDIR=$(git rev-parse --git-dir 2>/dev/null || true)
+      if [ -n "$GITDIR" ]; then
+        mkdir -p "$GITDIR/info"
+        git ls-files --others --exclude-standard \
+          | while IFS= read -r f; do
+              [ -x "$f" ] && [ -s "$f" ] || continue
+              case "$(git diff --no-index --numstat /dev/null -- "$f" 2>/dev/null | cut -f1)" in
+                -) PAT="/$(printf '%s' "$f" | sed 's/[][*?\\!#]/\\&/g')"
+                   grep -qxF "$PAT" "$GITDIR/info/exclude" 2>/dev/null \
+                     || printf '%s\n' "$PAT" >> "$GITDIR/info/exclude" ;;
+              esac
+            done
+      fi
 
       if [ -n "$(git status --porcelain)" ]; then
         git add -A
@@ -2465,14 +2487,30 @@ workflow BuildProduct
     # the same durable-persistence node the #318 commit_advance path uses, then
     # re-verify through TestMilestone. Narrow `= verified_green` so a normal
     # (non-breach) fix carries no turn_breach_class and still falls through to
-    # the warm restart loop below. NOTE: adding this conditional edge makes
-    # FixMilestone `hasAnyConditionalEdge`, which disables engine strict-fail on
-    # this node — so a pathological/non-green breach no longer escalates via
-    # fallback_target. Instead it falls through the unconditional TestMilestone
-    # edge below, which deterministically re-runs verify.sh on the (still non-
-    # green) tree, increments the on-disk fix-attempt counter, and escalates to
-    # EscalateMilestone once that counter exceeds its cap (bounded, counter-
-    # driven escalation; no infinite loop, no work loss).
+    # the warm restart loop below.
+    #
+    # PR #411 (Codex P1): turn_breach_class is STICKY in context, so a
+    # verified_green value left by an EARLIER milestone's breach could route a
+    # later NORMAL fail (outcome=fail) down the commit edge and checkpoint a
+    # non-green tree. The ideal guard is a compound `verified_green AND
+    # outcome=success`, but compound conditions are unavailable on this path —
+    # dippin rejects `&&` (DIP010) and tracker's edge evaluator can't parse the
+    # `and` keyword (it splits only on `&&`/`||`). Instead we exploit first-match
+    # edge ordering (selectByCondition returns the first matching edge in
+    # declaration order): a `when ctx.outcome = fail -> TestMilestone` edge
+    # declared BEFORE the commit edge short-circuits EVERY fail back to re-verify,
+    # so a stale verified_green class can never commit a non-green tree. Only a
+    # genuine green breach (outcome=success) falls past it to the commit edge.
+    #
+    # NOTE: these conditional edges make FixMilestone `hasAnyConditionalEdge`,
+    # which disables engine strict-fail on this node — so a pathological/non-green
+    # breach no longer escalates via fallback_target. Instead its outcome=fail
+    # routes it (via the first edge below) to TestMilestone, which deterministically
+    # re-runs verify.sh on the (still non-green) tree, increments the on-disk
+    # fix-attempt counter, and escalates to EscalateMilestone once that counter
+    # exceeds its cap (bounded, counter-driven escalation; no infinite loop, no
+    # work loss).
+    FixMilestone -> TestMilestone  when ctx.outcome = fail  restart: true
     FixMilestone -> CommitIfDirty  when ctx.turn_breach_class = verified_green  restart: true
     FixMilestone -> TestMilestone  restart: true
 

--- a/pipeline/build_product_artifact_hygiene_test.go
+++ b/pipeline/build_product_artifact_hygiene_test.go
@@ -1,0 +1,102 @@
+// ABOUTME: #405 guards for the build_product dogfood cascade (run 634a2527ff56):
+// ABOUTME: build artifacts must never be swept into a checkpoint commit.
+package pipeline
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// gitInit makes dir a committable git repo with one initial commit, so a
+// CommitIfDirty runtime test exercises the real `git status`/`git add -A`
+// path. Returns the dir for chaining.
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; skipping CommitIfDirty runtime test")
+	}
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.name", "test"},
+		{"config", "user.email", "test@test.local"},
+		{"commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		c := exec.Command("git", args...)
+		c.Dir = dir
+		if b, err := c.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, b)
+		}
+	}
+}
+
+// gitTracked returns the newline-joined list of files tracked at HEAD.
+func gitTracked(t *testing.T, dir string) string {
+	t.Helper()
+	c := exec.Command("git", "ls-tree", "-r", "--name-only", "HEAD")
+	c.Dir = dir
+	b, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git ls-tree: %v\n%s", err, b)
+	}
+	return string(b)
+}
+
+// TestBuildProductCommitIfDirtySkipsBinaryArtifact pins #405 AC1: a compiled,
+// arbitrary-named binary dropped into the tree by a test (Go `go build -o
+// goblin .` — Go binaries have no fixed extension, so the static .gitignore
+// seed can't catch them) must NOT be swept into a checkpoint commit. In run
+// 634a2527ff56 `git add -A` committed `goblin`, and VerifyMilestone then FAILed
+// the milestone for out-of-scope work. CommitIfDirty must gitignore the
+// untracked executable binary instead of committing it.
+func TestBuildProductCommitIfDirtySkipsBinaryArtifact(t *testing.T) {
+	dir := setupRunDir(t)
+	gitInit(t, dir)
+	// A real source file (text) — must be committed.
+	mustWrite(t, filepath.Join(dir, "main.go"), "package main\nfunc main() {}\n")
+	// A compiled binary artifact (NUL bytes → binary, +x) — must be skipped.
+	bin := filepath.Join(dir, "goblin")
+	if err := os.WriteFile(bin, []byte("\x7fELF\x00\x00\x00binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out, code := runToolCmd(t, toolCmd(t, "CommitIfDirty"), dir, append(os.Environ(), "HOME="+t.TempDir()))
+	if code != 0 {
+		t.Fatalf("CommitIfDirty exit=%d:\n%s", code, out)
+	}
+
+	tracked := gitTracked(t, dir)
+	if !strings.Contains(tracked, "main.go") {
+		t.Errorf("main.go (real source) was not committed:\n%s", tracked)
+	}
+	if strings.Contains(tracked, "goblin") {
+		t.Errorf("compiled `goblin` binary was committed into the checkpoint — Verify will FAIL the milestone for out-of-scope work (issue #405 AC1):\n%s", tracked)
+	}
+	gi, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if !strings.Contains(string(gi), "goblin") {
+		t.Errorf("CommitIfDirty did not gitignore the untracked binary artifact:\n%s", gi)
+	}
+}
+
+// TestBuildProductSetupSeedsGitignoreBuildOutputs pins #405: the scaffold step
+// must seed .gitignore with the detected toolchain's build outputs, not just
+// `.ai/`. In run 634a2527ff56 the scaffold seeded only `.ai/`, so a compiled
+// `goblin` binary was untracked, swept into a CommitIfDirty checkpoint by
+// `git add -A`, and then FAILed by VerifyMilestone as out-of-scope work.
+// A seeded build-output pattern (e.g. `*.test`) makes `git add -A` skip the
+// artifact by construction.
+func TestBuildProductSetupSeedsGitignoreBuildOutputs(t *testing.T) {
+	cmd := toolCmd(t, "Setup")
+	if !strings.Contains(cmd, ".gitignore") {
+		t.Fatal("Setup no longer seeds .gitignore (issue #405)")
+	}
+	// `node_modules` is on the issue's expected build-output list and appears
+	// nowhere in Setup today (a `*.test`-style anchor collides with the unrelated
+	// reference-scan exclusion globs), so it is a clean signal the seed grew
+	// beyond the lone `.ai/` entry into toolchain-appropriate build outputs.
+	if !strings.Contains(cmd, "node_modules") {
+		t.Error("Setup .gitignore seed covers only `.ai/`, not the toolchain's build outputs — a compiled artifact gets swept into a checkpoint commit and FAILs Verify (issue #405)")
+	}
+}

--- a/pipeline/build_product_artifact_hygiene_test.go
+++ b/pipeline/build_product_artifact_hygiene_test.go
@@ -74,9 +74,16 @@ func TestBuildProductCommitIfDirtySkipsBinaryArtifact(t *testing.T) {
 	if strings.Contains(tracked, "goblin") {
 		t.Errorf("compiled `goblin` binary was committed into the checkpoint — Verify will FAIL the milestone for out-of-scope work (issue #405 AC1):\n%s", tracked)
 	}
-	gi, _ := os.ReadFile(filepath.Join(dir, ".gitignore"))
-	if !strings.Contains(string(gi), "goblin") {
-		t.Errorf("CommitIfDirty did not gitignore the untracked binary artifact:\n%s", gi)
+	// PR #411 finding #2: the runtime binary-artifact exclusion must go to the
+	// LOCAL, untracked .git/info/exclude — NOT the tracked .gitignore. A runtime
+	// write to the tracked .gitignore is itself an out-of-scope tree change that
+	// VerifyMilestone would FAIL, defeating the purpose of skipping the binary.
+	excl, _ := os.ReadFile(filepath.Join(dir, ".git", "info", "exclude"))
+	if !strings.Contains(string(excl), "goblin") {
+		t.Errorf("CommitIfDirty did not exclude the untracked binary artifact via .git/info/exclude:\n%s", excl)
+	}
+	if gi, err := os.ReadFile(filepath.Join(dir, ".gitignore")); err == nil && strings.Contains(string(gi), "goblin") {
+		t.Errorf("CommitIfDirty wrote the binary-artifact ignore into the TRACKED .gitignore — that runtime tree mutation is itself out-of-scope work VerifyMilestone FAILs (PR #411 finding #2):\n%s", gi)
 	}
 }
 

--- a/pipeline/build_product_escalation_test.go
+++ b/pipeline/build_product_escalation_test.go
@@ -1,0 +1,30 @@
+// ABOUTME: #407 guard for the build_product dogfood cascade (run 634a2527ff56):
+// ABOUTME: the milestone-escalation gate must surface the live verify result.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// nodePrompt returns the resolved prompt text for an agent/human node.
+func nodePrompt(t *testing.T, g *Graph, id string) string {
+	t.Helper()
+	n, ok := g.Nodes[id]
+	if !ok {
+		t.Fatalf("%s node missing from build_product graph", id)
+	}
+	return n.Attrs["prompt"]
+}
+
+// TestBuildProductEscalateMilestoneSurfacesVerifyState pins #407 AC1: the
+// milestone-escalation gate must show the live verify result. In run
+// 634a2527ff56 the operator was offered `abandon` on a green, passing tree with
+// no indication the milestone verify currently PASSES, and discarded a finished
+// build. The prompt must headline the live verify state.
+func TestBuildProductEscalateMilestoneSurfacesVerifyState(t *testing.T) {
+	p := nodePrompt(t, loadBuildProduct(t), "EscalateMilestone")
+	if !strings.Contains(strings.ToLower(p), "verify currently") {
+		t.Error("EscalateMilestone prompt does not surface the live verify result — a green tree can be abandoned without the operator being told it passes (issue #407 AC1)")
+	}
+}

--- a/pipeline/build_product_escalation_test.go
+++ b/pipeline/build_product_escalation_test.go
@@ -27,4 +27,17 @@ func TestBuildProductEscalateMilestoneSurfacesVerifyState(t *testing.T) {
 	if !strings.Contains(strings.ToLower(p), "verify currently") {
 		t.Error("EscalateMilestone prompt does not surface the live verify result — a green tree can be abandoned without the operator being told it passes (issue #407 AC1)")
 	}
+	// The heading alone is hollow: the ${ctx.tool_stdout} interpolation is the
+	// mechanism that actually injects the live verify output under it (this is a
+	// prompt, where LLM-origin ctx.* keys are allowed). Without it the operator
+	// sees an empty "Verify currently" section — exactly the regression #407
+	// exists to prevent.
+	if !strings.Contains(p, "${ctx.tool_stdout}") {
+		t.Error("EscalateMilestone prompt has the \"Verify currently\" heading but no ${ctx.tool_stdout} interpolation — the live verify state is never actually surfaced (issue #407 AC1)")
+	}
+	// abandon must stay demoted to a FAIL-gated last resort so a green tree is
+	// not offered as a casual default choice.
+	if !strings.Contains(p, "LAST RESORT") {
+		t.Error("EscalateMilestone prompt no longer demotes `abandon` to a LAST RESORT — a green tree can be abandoned as a first-class option (issue #407)")
+	}
 }

--- a/pipeline/build_product_fixmilestone_breach_test.go
+++ b/pipeline/build_product_fixmilestone_breach_test.go
@@ -1,0 +1,79 @@
+// ABOUTME: Phase-0 RED guards for #406 — the #303/#297 turn-limit commit-if-green
+// ABOUTME: guard must apply to the FixMilestone fix-loop node, not just Implement.
+package pipeline
+
+import "testing"
+
+// Case study run 634a2527ff56: FixMilestone repaired every VerifyMilestone
+// finding and reached a fully green tree at turn 47, then burned turns 48–50 on
+// read-only `git status` and hit the 50-turn limit. The breach classified as
+// `operator_decision` (NOT `verified_green`) because FixMilestone carries no
+// `verify_command`, so the breach verifier never ran — and FixMilestone's only
+// edge (`-> TestMilestone restart: true`, plus the EscalateMilestone fallback)
+// has no commit-if-green path. The green fix was abandoned uncommitted; HEAD
+// stayed at the broken pre-fix state. These tests pin the fix.
+
+// TestBuildProductFixMilestoneCarriesVerifyCommand pins #406 AC2: "the breach
+// classifier records verify: PASS when the milestone verify command succeeds at
+// breach time." That can only happen if the fix-loop node actually carries a
+// verify_command for resolveBreachVerifier to run — without one, every breach
+// degrades to operator_decision. The guard is meant for "every agent node that
+// can mutate the tree," so the original Implement node must carry it too (its
+// existing commit-on-success breach path is dead without a verifier).
+func TestBuildProductFixMilestoneCarriesVerifyCommand(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	for _, id := range []string{"FixMilestone", "Implement"} {
+		n, ok := g.Nodes[id]
+		if !ok {
+			t.Fatalf("%s node missing from build_product.dip", id)
+		}
+		if vc := n.AgentConfig(g.Attrs).VerifyCommand; vc == "" {
+			t.Errorf("%s resolves empty verify_command — a turn breach can never classify verified_green, so a green tree is adjudicated as a failure (issue #406 AC2)", id)
+		}
+	}
+}
+
+// TestBuildProductFixMilestoneGreenBreachCommits pins #406 AC1: "a FixMilestone
+// node that exhausts its turn budget with a green verify command results in a
+// committed tree (durable ref), not a dirty working tree." A verified_green
+// breach sets ctx.turn_breach_class = verified_green (and outcome = success); a
+// narrow conditional edge keyed on that class must route to the commit-on-success
+// node (CommitIfDirty — the same durable-persistence mechanism used for the
+// #318 OperatorDecision commit_advance path), which then continues the loop.
+func TestBuildProductFixMilestoneGreenBreachCommits(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if !hasEdgeWithCondition(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
+		t.Error("FixMilestone has no `ctx.turn_breach_class = verified_green` edge to CommitIfDirty — a green-at-breach fix is left uncommitted and abandoned (issue #406 AC1)")
+	}
+	// commit_advance/green-breach must continue the milestone, not dead-end.
+	if !hasEdgeTo(g, "CommitIfDirty", "TestMilestone") {
+		t.Error("CommitIfDirty must continue to TestMilestone so a committed green-breach fix re-verifies and advances (issue #406)")
+	}
+}
+
+// TestBuildProductFixMilestoneNormalLoopPreserved is a regression guard: the
+// narrow verified_green edge must NOT disturb FixMilestone's ordinary fix→retest
+// loop. A normal success (agent committed + DONE, no breach) carries no
+// turn_breach_class, so it must still fall through to the warm TestMilestone
+// restart edge.
+func TestBuildProductFixMilestoneNormalLoopPreserved(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if !hasEdgeAttr(g, "FixMilestone", "TestMilestone", "", "restart", "true") {
+		t.Error("FixMilestone lost its unconditional `-> TestMilestone restart: true` loop edge — normal (non-breach) fixes would no longer re-verify (issue #406 regression)")
+	}
+}
+
+// TestBuildProductFixMilestonePathologicalStillEscalates is a regression guard:
+// a pathological / non-green breach (turn_breach_class != verified_green) must
+// still reach EscalateMilestone via the resolved fallback_target, so a looping
+// fix agent still stops rather than committing a non-green tree (issue #296/#303).
+func TestBuildProductFixMilestonePathologicalStillEscalates(t *testing.T) {
+	g := loadBuildProduct(t)
+
+	if got := resolveFallback(g, g.Nodes["FixMilestone"]); got != "EscalateMilestone" {
+		t.Errorf("FixMilestone resolved fallback = %q, want EscalateMilestone — a non-green breach must still escalate (issue #296/#303)", got)
+	}
+}

--- a/pipeline/build_product_fixmilestone_breach_test.go
+++ b/pipeline/build_product_fixmilestone_breach_test.go
@@ -68,12 +68,34 @@ func TestBuildProductFixMilestoneNormalLoopPreserved(t *testing.T) {
 
 // TestBuildProductFixMilestonePathologicalStillEscalates is a regression guard:
 // a pathological / non-green breach (turn_breach_class != verified_green) must
-// still reach EscalateMilestone via the resolved fallback_target, so a looping
-// fix agent still stops rather than committing a non-green tree (issue #296/#303).
+// still reach EscalateMilestone (issue #296/#303). NOTE the routing layer is
+// subtle here: adding the verified_green conditional edge makes FixMilestone
+// `hasAnyConditionalEdge`, which DISABLES engine strict-fail on this node — so a
+// non-green breach no longer escalates via the fallback_target attr. It instead
+// falls through the unconditional `-> TestMilestone restart: true` edge, and
+// TestMilestone re-runs verify.sh, increments the on-disk fix-attempt counter,
+// and escalates to EscalateMilestone once the counter is exhausted. This test
+// pins that actual bounded route, not merely the (now-dead-for-this-case)
+// fallback_target attribute.
 func TestBuildProductFixMilestonePathologicalStillEscalates(t *testing.T) {
 	g := loadBuildProduct(t)
 
-	if got := resolveFallback(g, g.Nodes["FixMilestone"]); got != "EscalateMilestone" {
-		t.Errorf("FixMilestone resolved fallback = %q, want EscalateMilestone — a non-green breach must still escalate (issue #296/#303)", got)
+	// The verified_green edge is what disables strict-fail; if it were ever
+	// removed, the assertions below would mis-describe the routing.
+	if !hasEdgeWithCondition(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
+		t.Fatal("FixMilestone lost its verified_green conditional edge — strict-fail analysis below no longer applies (issue #406)")
+	}
+
+	// A non-green breach (outcome=fail, turn_breach_class != verified_green)
+	// has no matching conditional edge, so it falls through the unconditional
+	// TestMilestone loop edge rather than escalating via fallback_target.
+	if !hasEdgeAttr(g, "FixMilestone", "TestMilestone", "", "restart", "true") {
+		t.Error("FixMilestone lost its unconditional `-> TestMilestone restart: true` fall-through — a non-green breach would have no bounded escalation path (issue #296/#303)")
+	}
+
+	// TestMilestone is where the bounded, counter-driven escalation actually
+	// fires once the on-disk fix-attempt counter is exhausted.
+	if !hasEdgeWithCondition(g, "TestMilestone", "EscalateMilestone", "ctx.tool_stdout contains escalate") {
+		t.Error("TestMilestone has no counter-driven `-> EscalateMilestone` edge — a non-green breach looping through FixMilestone would never stop (issue #296/#303)")
 	}
 }

--- a/pipeline/build_product_fixmilestone_breach_test.go
+++ b/pipeline/build_product_fixmilestone_breach_test.go
@@ -2,7 +2,22 @@
 // ABOUTME: guard must apply to the FixMilestone fix-loop node, not just Implement.
 package pipeline
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
+
+// hasEdgeConditionContaining reports whether the node has an outgoing edge to
+// the target whose condition contains the given substring (tolerant of compound
+// `&&`/`||` conditions and dippin's whitespace normalization).
+func hasEdgeConditionContaining(g *Graph, from, to, sub string) bool {
+	for _, e := range g.OutgoingEdges(from) {
+		if e.To == to && strings.Contains(e.Condition, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 // Case study run 634a2527ff56: FixMilestone repaired every VerifyMilestone
 // finding and reached a fully green tree at turn 47, then burned turns 48–50 on
@@ -44,8 +59,32 @@ func TestBuildProductFixMilestoneCarriesVerifyCommand(t *testing.T) {
 func TestBuildProductFixMilestoneGreenBreachCommits(t *testing.T) {
 	g := loadBuildProduct(t)
 
-	if !hasEdgeWithCondition(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
+	if !hasEdgeConditionContaining(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
 		t.Error("FixMilestone has no `ctx.turn_breach_class = verified_green` edge to CommitIfDirty — a green-at-breach fix is left uncommitted and abandoned (issue #406 AC1)")
+	}
+	// PR #411 finding #3 (Codex P1): turn_breach_class is STICKY in context, so a
+	// verified_green value left by an EARLIER milestone's breach could route a
+	// later NORMAL fail (outcome=fail) down the commit edge and checkpoint a
+	// non-green tree. A compound `verified_green AND outcome=success` guard is
+	// unavailable (dippin rejects `&&`; tracker's evaluator can't parse `and`), so
+	// the fix exploits first-match edge ordering: a `when ctx.outcome = fail ->
+	// TestMilestone` edge declared BEFORE the verified_green commit edge
+	// short-circuits every fail back to re-verify. Assert both the edge exists and
+	// that it precedes the commit edge.
+	if !hasEdgeWithCondition(g, "FixMilestone", "TestMilestone", "ctx.outcome = fail") {
+		t.Error("FixMilestone has no `ctx.outcome = fail -> TestMilestone` short-circuit edge — a stale verified_green class could commit a non-green tree on a normal fail (PR #411 finding #3)")
+	}
+	failIdx, commitIdx := -1, -1
+	for i, e := range g.OutgoingEdges("FixMilestone") {
+		if e.To == "TestMilestone" && e.Condition == "ctx.outcome = fail" && failIdx == -1 {
+			failIdx = i
+		}
+		if e.To == "CommitIfDirty" && strings.Contains(e.Condition, "verified_green") {
+			commitIdx = i
+		}
+	}
+	if failIdx == -1 || commitIdx == -1 || failIdx > commitIdx {
+		t.Errorf("the `ctx.outcome = fail -> TestMilestone` short-circuit must be declared BEFORE the verified_green commit edge (first-match ordering is the guard) — failIdx=%d commitIdx=%d (PR #411 finding #3)", failIdx, commitIdx)
 	}
 	// commit_advance/green-breach must continue the milestone, not dead-end.
 	if !hasEdgeTo(g, "CommitIfDirty", "TestMilestone") {
@@ -82,7 +121,7 @@ func TestBuildProductFixMilestonePathologicalStillEscalates(t *testing.T) {
 
 	// The verified_green edge is what disables strict-fail; if it were ever
 	// removed, the assertions below would mis-describe the routing.
-	if !hasEdgeWithCondition(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
+	if !hasEdgeConditionContaining(g, "FixMilestone", "CommitIfDirty", "ctx.turn_breach_class = verified_green") {
 		t.Fatal("FixMilestone lost its verified_green conditional edge — strict-fail analysis below no longer applies (issue #406)")
 	}
 

--- a/pipeline/build_product_milestone_gate_test.go
+++ b/pipeline/build_product_milestone_gate_test.go
@@ -64,16 +64,13 @@ func TestBuildProductIssue392AcceptDoesNotBypassVerification(t *testing.T) {
 // later milestone's pre-seeded package is red. The whole-tree suite still runs
 // at FinalBuild before anything ships.
 //
-// This is a string-level guard because the gate logic lives inline in the .dip
-// tool command; issue #398 tracks extracting it to a bats-testable script file,
-// at which point this becomes a real script test.
+// This is a string-level guard. As of #406 the gate logic lives in the shared
+// .ai/build/verify.sh script (written by Setup, delegated to by TestMilestone
+// and the Implement/FixMilestone breach verify_command) — a single source of
+// truth — so the guard reads that extracted script, not TestMilestone's thin
+// wrapper.
 func TestBuildProductIssue392MilestoneScopedTestGate(t *testing.T) {
-	g := loadBuildProduct(t)
-	n, ok := g.Nodes["TestMilestone"]
-	if !ok {
-		t.Fatal("TestMilestone node missing from build_product.dip (issue #392)")
-	}
-	cmd := n.ToolConfig().Command
+	cmd := extractHeredoc(t, toolCmd(t, "Setup"), ".ai/build/verify.sh", "VERIFY_EOF")
 	for _, marker := range []string{"milestone-start-sha", "GO_TEST_TARGET"} {
 		if !strings.Contains(cmd, marker) {
 			t.Errorf("TestMilestone command no longer references %q — the milestone-scoped go test gate may have reverted to whole-tree (issue #392)", marker)

--- a/pipeline/build_product_quality_gate_test.go
+++ b/pipeline/build_product_quality_gate_test.go
@@ -112,11 +112,17 @@ func TestQualityGateRc2OnlyMakeMissing(t *testing.T) {
 
 // Test 7 — regression-pin: the gate stays CENTRALIZED. Both callers must still
 // source ci-probe.sh and call run_project_ci_gate (one helper, two callers — no
-// duplicated gate logic in the caller bodies).
+// duplicated gate logic in the caller bodies). As of #406 the per-milestone
+// caller is the shared .ai/build/verify.sh (written by Setup, run by
+// TestMilestone and the Implement/FixMilestone breach verify_command), so the
+// guard reads that extracted script in place of TestMilestone's thin wrapper.
 func TestQualityGateStaysCentralized(t *testing.T) {
 	g := loadBuildProduct(t)
-	for _, id := range []string{"TestMilestone", "FinalBuild"} {
-		cmd := g.Nodes[id].Attrs["tool_command"]
+	gateCallers := map[string]string{
+		"verify.sh":  extractHeredoc(t, toolCmd(t, "Setup"), ".ai/build/verify.sh", "VERIFY_EOF"),
+		"FinalBuild": g.Nodes["FinalBuild"].Attrs["tool_command"],
+	}
+	for id, cmd := range gateCallers {
 		if !strings.Contains(cmd, ". .ai/build/ci-probe.sh") {
 			t.Errorf("%s no longer sources ci-probe.sh (#299)", id)
 		}

--- a/pipeline/build_product_test_contract_test.go
+++ b/pipeline/build_product_test_contract_test.go
@@ -1,0 +1,39 @@
+// ABOUTME: #409 guards for the build_product dogfood cascade (run 634a2527ff56):
+// ABOUTME: Implement and VerifyMilestone share one test-verifies-contract rubric.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildProductImplementSharesTestContractRubric pins #409 AC2: Implement and
+// VerifyMilestone must reference one shared test-verifies-contract rubric. The
+// named anchor TEST-VERIFIES-CONTRACT already heads VerifyMilestone's check 4;
+// Implement must cite the same rubric so it is graded against the same standard.
+func TestBuildProductImplementSharesTestContractRubric(t *testing.T) {
+	g := loadBuildProduct(t)
+	if !strings.Contains(nodePrompt(t, g, "VerifyMilestone"), "TEST-VERIFIES-CONTRACT") {
+		t.Fatal("VerifyMilestone lost its TEST-VERIFIES-CONTRACT rubric anchor (issue #409 precondition)")
+	}
+	if !strings.Contains(nodePrompt(t, g, "Implement"), "TEST-VERIFIES-CONTRACT") {
+		t.Error("Implement does not reference the shared TEST-VERIFIES-CONTRACT rubric — it is graded against a weaker standard than VerifyMilestone, guaranteeing a Verify FAIL + fix loop (issue #409 AC2)")
+	}
+}
+
+// TestBuildProductTestShapeContractEnforced pins #409 AC1: when a milestone's
+// done-when names a concrete test SHAPE ("built binary" smoke test, subprocess,
+// real `gh`), both Implement and VerifyMilestone must enforce that the test
+// actually uses that harness — not a weaker in-process call. In run
+// 634a2527ff56 Implement shipped a smoke test that called `runWithSignal()`
+// in-process instead of spawning the built binary; it passed Implement's
+// done-when but FAILed Verify, forcing a costly fix loop to invent the whole
+// subprocess injection seam.
+func TestBuildProductTestShapeContractEnforced(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"Implement", "VerifyMilestone"} {
+		if !strings.Contains(strings.ToLower(nodePrompt(t, g, id)), "built binary") {
+			t.Errorf("%s does not enforce the test-shape contract (a \"built binary\" smoke test must spawn the binary, not call it in-process) — Implement and Verify diverge on the test harness standard (issue #409 AC1)", id)
+		}
+	}
+}

--- a/pipeline/build_product_test_runner_test.go
+++ b/pipeline/build_product_test_runner_test.go
@@ -275,6 +275,38 @@ func TestMilestoneFirstStackFailureStillRunsLater(t *testing.T) {
 	}
 }
 
+// PR #411 finding #1 (Codex/Copilot/CodeRabbit consensus): verify.sh exit code 2
+// is RESERVED for "Makefile present but `make` not installed" — TestMilestone
+// routes exit 2 straight to `escalate`. A language test runner can legitimately
+// exit 2 (pytest collection error, an arbitrary npm script), which must NOT be
+// mistaken for that env-missing escalate. verify.sh must collapse every non-zero
+// TEST runner exit to 1, reserving 2 for the CI/Makefile path. Run the extracted
+// verify.sh directly so the assertion pins the source of the exit code.
+func TestVerifyScriptCollapsesTestRunnerExit2(t *testing.T) {
+	dir := setupRunDir(t, "package.json")
+	verify := extractHeredoc(t, toolCmd(t, "Setup"), ".ai/build/verify.sh", "VERIFY_EOF")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, code := runToolCmd(t, verify, dir, stackEnv(t, stubLog, "STUB_NPM_EXIT=2"))
+	if code == 0 {
+		t.Fatalf("npm test failed (exit 2) but verify.sh exited 0:\n%s", out)
+	}
+	if code == 2 {
+		t.Errorf("npm test exited 2 (a legitimate test-runner failure) but verify.sh propagated exit 2, which TestMilestone treats as `make` missing → escalate; a normal fixable failure gets falsely escalated (PR #411 finding #1):\n%s", out)
+	}
+}
+
+// PR #411 finding #1 at the routing layer: a test runner exiting 2 must route to
+// the fix loop (no sentinel), never to EscalateMilestone via the `escalate`
+// sentinel that exit 2 (`make` missing) would emit.
+func TestMilestoneTestRunnerExit2DoesNotFalselyEscalate(t *testing.T) {
+	dir := setupRunDir(t, "package.json")
+	stubLog := filepath.Join(t.TempDir(), "stub.log")
+	out, _ := runToolCmd(t, toolCmd(t, "TestMilestone"), dir, stackEnv(t, stubLog, "STUB_NPM_EXIT=2"))
+	if strings.Contains(out, "escalate") {
+		t.Errorf("a test runner exiting 2 falsely escalated (the `escalate` sentinel is reserved for `make` missing / fix-loop exhaustion) instead of routing to the fix loop (PR #411 finding #1):\n%s", out)
+	}
+}
+
 // No stack files → the no-build-system notice still prints and the node passes.
 func TestMilestoneNoStackNoticePreserved(t *testing.T) {
 	dir := setupRunDir(t)

--- a/pipeline/build_product_test_runner_test.go
+++ b/pipeline/build_product_test_runner_test.go
@@ -66,9 +66,39 @@ func stackEnv(t *testing.T, stubLog string, extra ...string) []string {
 	return append(env, extra...)
 }
 
+// extractHeredoc returns the body of the `<<'EOF' … EOF` heredoc written into
+// `path` by `cmd`, i.e. the bytes between `cat > <path> <<'<term>'` and the
+// terminator line. Used to provision the SAME .ai/build/verify.sh that Setup
+// writes at runtime, so the TestMilestone suite exercises the real shared gate
+// (issue #406 — single source of truth) instead of a hand-copied duplicate.
+func extractHeredoc(t *testing.T, cmd, path, term string) string {
+	t.Helper()
+	open := "cat > " + path + " <<'" + term + "'"
+	lines := strings.Split(cmd, "\n")
+	start := -1
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == open {
+			start = i + 1
+			break
+		}
+	}
+	if start == -1 {
+		t.Fatalf("heredoc opener %q not found in tool_command", open)
+	}
+	for i := start; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == term {
+			return strings.Join(lines[start:i], "\n") + "\n"
+		}
+	}
+	t.Fatalf("heredoc terminator %q not found after opener", term)
+	return ""
+}
+
 // setupRunDir creates a workdir with the .ai scaffolding both tool nodes
-// expect: a no-op ci-probe.sh (the #299 gate is covered by its own suite)
-// and the milestones dir TestMilestone writes its attempt counter into.
+// expect: a no-op ci-probe.sh (the #299 gate is covered by its own suite),
+// the .ai/build/verify.sh shared green-gate extracted from Setup (the script
+// TestMilestone now delegates to — issue #406), and the milestones dir
+// TestMilestone writes its attempt counter into.
 func setupRunDir(t *testing.T, stackFiles ...string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -79,6 +109,8 @@ func setupRunDir(t *testing.T, stackFiles ...string) string {
 	}
 	mustWrite(t, filepath.Join(dir, ".ai/build/ci-probe.sh"),
 		"run_project_ci_gate() { return \"${STUB_CI_RC:-0}\"; }\n")
+	mustWrite(t, filepath.Join(dir, ".ai/build/verify.sh"),
+		extractHeredoc(t, toolCmd(t, "Setup"), ".ai/build/verify.sh", "VERIFY_EOF"))
 	for _, f := range stackFiles {
 		mustWrite(t, filepath.Join(dir, f), "{}\n")
 	}

--- a/pipeline/build_product_verify_severity_test.go
+++ b/pipeline/build_product_verify_severity_test.go
@@ -1,0 +1,21 @@
+// ABOUTME: #408 guard for the build_product dogfood cascade (run 634a2527ff56):
+// ABOUTME: VerifyMilestone needs an ADR-aware WARN severity tier.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildProductVerifyMilestoneHasWarnTier pins #408: VerifyMilestone's
+// findings must carry a severity tier with a WARN level, so a behaviorally-
+// equivalent deviation that an `.ai/decisions/` ADR documents (and whose tests
+// pass) downgrades from FAIL to WARN instead of triggering an expensive fix
+// loop. In run 634a2527ff56 a `signal.Notify`-vs-`signal.NotifyContext` prose
+// identifier mismatch hard-FAILed behaviorally-correct, fully-tested code.
+func TestBuildProductVerifyMilestoneHasWarnTier(t *testing.T) {
+	p := nodePrompt(t, loadBuildProduct(t), "VerifyMilestone")
+	if !strings.Contains(p, "WARN") {
+		t.Error("VerifyMilestone has no WARN severity tier — an ADR-documented, behaviorally-verified deviation from a prose-named identifier hard-FAILs instead of warning (issue #408)")
+	}
+}


### PR DESCRIPTION
## Why

Dogfood case study — `build_product` run `634a2527ff56` — discarded a finished, green build. One failure cascaded: the turn-limit guard never committed a green fix, build artifacts polluted checkpoints and tripped Verify, the escalation gate offered `abandon` without showing the tree was passing, and Verify hard-FAILed behaviorally-correct code over a prose identifier. This super-PR fixes the whole chain in `examples/build_product.dip`, one commit per issue, each with a failing-test-first guard.

## Commits (one per issue)

- **#406** — `commit turn-limit green fixes instead of abandoning them`. The commit-if-green breach guard (#297/#303) never fired on the fix loop because no `verify_command` was wired, so a green-at-breach tree classified `operator_decision` and was abandoned. Wire **one shared green gate**: Setup writes `.ai/build/verify.sh` (relocated verbatim from the old inline TestMilestone gate — single source of truth); TestMilestone is a thin RC→sentinel wrapper; Implement and FixMilestone set `params: verify_command: sh .ai/build/verify.sh`; a `FixMilestone -> CommitIfDirty when ctx.turn_breach_class = verified_green` edge (restart:true) commits the green tree before escalating.
- **#405** — `keep build artifacts out of checkpoint commits`. Setup seeds `.gitignore` with toolchain build outputs (not just `.ai/`); CommitIfDirty gitignores any untracked, executable, binary file (git-native `git diff --no-index --numstat` detection) before `git add -A`, so a compiled `goblin` no longer FAILs Verify as out-of-scope work.
- **#407** — `surface live verify state at milestone escalation`. EscalateMilestone defaults to `mark done` (preserves work on the unattended path), demotes `abandon` to a FAIL-gated last resort, and adds a `${ctx.tool_stdout}` "Verify currently" section so a green tree is never thrown away uninformed.
- **#408** — `add ADR-aware WARN tier to VerifyMilestone spec check`. Check 3 gains a three-tier severity system. A prose-named identifier that differs from the spec but whose behavioral tests are green **and** is documented in a `.ai/decisions/` ADR now WARNs instead of hard-FAILing. WARN is reserved for that case; scope/behavior/test-contract violations stay categorical FAILs.
- **#409** — `make Implement self-apply Verify's test-contract rubric`. Implement now runs the same `TEST-VERIFIES-CONTRACT` rubric VerifyMilestone grades against, including a test-shape rule: a "built binary" smoke test must spawn the built binary, not call an unexported function in-process — and builds the plumbing up front rather than deferring to a fix loop.

## Tests (failing-first per change type)

Go graph-structure + runtime tool-command guards, one file per issue:
`build_product_fixmilestone_breach_test.go` (#406), `build_product_artifact_hygiene_test.go` (#405), `build_product_escalation_test.go` (#407), `build_product_verify_severity_test.go` (#408), `build_product_test_contract_test.go` (#409). The #392 milestone-scoped and #233 centralized-CI-gate regression guards now read the extracted `verify.sh`.

## Verification

- `dippin doctor examples/build_product.dip` → **Grade A (90/100)**, maintained throughout
- `dippin simulate -all-paths` on both `build_product` pipelines → 100 paths enumerated, clean
- `go test ./... -short` green; `go test ./pipeline/ -race` green
- All five commits passed the full pre-commit gate suite (coverage, complexity, tests, lint, format) — no `--no-verify`

## Not in scope

- **#306** deferred to a follow-up PR (per prior decision).
- **#353** (review fan-out cost) assessed and excluded — its changes (engine-enforced per-node cost ceiling, per-backend context budgeting, fan-out→escalation routing redesign) are non-trivial and design-first, not a small add-on.

Closes #405
Closes #406
Closes #407
Closes #408
Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784912820&installation_id=131176874&pr_number=411&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F411&signature=496356b61abfd5530ca5ac9b381f350c382ab96cf91d008578abd16c8e0a9238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a shared verification gate script for consistent build/test checks across milestones.

- **Bug Fixes**
  - Hardened commit behavior to skip newly created compiled/untracked binaries and broaden build-output ignore coverage.
  - Updated escalation and breach routing to surface live verification output, make “abandon” a last resort, and ensure verified-green work is committed then re-validated.
  - Refined verification severity (ADR deviations now WARN) and enforced smoke-test “test shape”/contract rules with improved exit-code handling.

- **Tests**
  - Expanded pipeline tests for artifact hygiene, centralized gate usage, contract/routing correctness, and verify severity/exit-code behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->