### PR TITLE
docs(site): add v0.40.1 changelog entry and bump latest pointer

### DIFF
--- a/site/content/_index.html
+++ b/site/content/_index.html
@@ -48,7 +48,7 @@ jsonld:
       Three agent backends &mdash; <strong>native</strong> (Anthropic / OpenAI / Gemini / OpenAI-compat),
       <strong>Claude&nbsp;Code</strong> (subscription auth, file editing, terminal),
       and <strong>ACP</strong> (claude-agent-acp&nbsp;/ codex-acp&nbsp;/ gemini --acp). Mix per node.
-      &middot; Latest: <a href="changelog.html#v0-40-0">v0.40.0</a>
+      &middot; Latest: <a href="changelog.html#v0-40-1">v0.40.1</a>
     </p>
   </section>
 

--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,6 +28,7 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
+    <a href="#v0-40-1">v0.40.1</a>
     <a href="#v0-40-0">v0.40.0</a>
     <a href="#v0-39-1">v0.39.1</a>
     <a href="#v0-39-0">v0.39.0</a>
@@ -75,6 +76,30 @@ jsonld:
     <a href="#v0-9-x">v0.9.x</a>
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
+
+  <!-- ═══ v0.40.1 ═══ -->
+  <section class="glass" id="v0-40-1" style="border-left: 3px solid var(--orange-600);">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.40.1" style="color: inherit; text-decoration: none;">v0.40.1</a></h2>
+      <span class="badge">2026-06-24</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.40.1" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">
+      <strong><code>build_product</code> dogfood hardening &mdash; a single super-PR fixing a real case-study
+      cascade (run <code>634a2527ff56</code>) where a finished, green build was discarded.</strong> Five fixes
+      plus the automated-review hardening pass; no breaking changes; core embedded workflows hold their A
+      grades on <code>dippin doctor</code>.
+    </p>
+    <h4>Fixed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong>Turn-limit green fix no longer abandoned uncommitted</strong> (<a href="https://github.com/2389-research/tracker/issues/406">#406</a>). The <code>commit-if-green</code> breach guard (<a href="https://github.com/2389-research/tracker/issues/303">#303</a>/<a href="https://github.com/2389-research/tracker/issues/297">#297</a>) never fired on the <code>Implement</code>/<code>FixMilestone</code> fix loop because no <code>verify_command</code> was wired, so a breach with a passing tree classified as <code>operator_decision</code> instead of <code>verified_green</code>. Fixed with one shared green gate: <code>Setup</code> writes <code>.ai/build/verify.sh</code>, <code>TestMilestone</code> delegates to it, and the fix-loop nodes set <code>verify_command: sh .ai/build/verify.sh</code>; a <code>FixMilestone -&gt; CommitIfDirty when ctx.turn_breach_class = verified_green</code> edge commits the green tree before escalating.</li>
+      <li><strong>Build artifacts no longer swept into checkpoint commits</strong> (<a href="https://github.com/2389-research/tracker/issues/405">#405</a>). <code>Setup</code> seeds <code>.gitignore</code> with toolchain build outputs (not just <code>.ai/</code>), and <code>CommitIfDirty</code> detects untracked executable binaries (git-native <code>git diff --no-index --numstat</code> binary check) and gitignores them instead of committing &mdash; a compiled binary like <code>goblin</code> no longer FAILs Verify as out-of-scope work.</li>
+      <li><strong>Escalation no longer discards green trees silently</strong> (<a href="https://github.com/2389-research/tracker/issues/407">#407</a>). <code>EscalateMilestone</code> surfaces the live verify result (<code>${ctx.tool_stdout}</code>), defaults to "mark done" to preserve finished work on the unattended path, and reframes <code>abandon</code> as a destructive last resort.</li>
+      <li><strong>Behaviorally-correct code no longer FAILed over prose identifiers</strong> (<a href="https://github.com/2389-research/tracker/issues/408">#408</a>). <code>VerifyMilestone</code> gains an ADR-aware three-tier severity system (FAIL / WARN / PASS): a prose-named identifier that differs from the spec wording but whose behavioral tests are green and which is documented in a <code>.ai/decisions/</code> ADR now WARNs instead of hard-FAILing. Scope, unmet-behavior, and test-contract violations remain categorical FAILs.</li>
+      <li><strong>Tests that pass but don't verify the contract</strong> (<a href="https://github.com/2389-research/tracker/issues/409">#409</a>). <code>Implement</code> self-applies the same <code>TEST-VERIFIES-CONTRACT</code> rubric <code>VerifyMilestone</code> grades against, including a test-shape rule: a "built binary" smoke test must spawn the built binary, not call an unexported function in-process.</li>
+      <li><strong>PR <a href="https://github.com/2389-research/tracker/pull/411">#411</a> review hardening</strong> (automated multi-bot review of the super-PR). <code>verify.sh</code> collapses every non-zero language-test-runner exit to <code>1</code>, reserving exit <code>2</code> strictly for the "<code>make</code> present but not installed" escalation (a pytest collection error exiting <code>2</code> no longer masquerades as the env-missing escalate); <code>CommitIfDirty</code> writes the runtime binary-artifact ignore to the local, untracked <code>.git/info/exclude</code> rather than the tracked <code>.gitignore</code>, so the skip itself is not an out-of-scope tree change; and the <code>FixMilestone</code> green-breach commit edge is guarded by a <code>when ctx.outcome = fail -&gt; TestMilestone</code> short-circuit declared ahead of it, so a stale (sticky) <code>verified_green</code> class from an earlier milestone can no longer checkpoint a non-green tree on a normal fail.</li>
+    </ul>
+  </section>
 
   <!-- ═══ v0.40.0 ═══ -->
   <section class="glass" id="v0-40-0" style="border-left: 3px solid var(--orange-600);">


### PR DESCRIPTION
Sync the website with the published **v0.40.1** release (`build_product` dogfood hardening — #405–#409 plus the PR #411 automated-review hardening pass).

## Changes
- New `#v0-40-1` changelog section in `site/content/changelog.html` (Fixed-only, mirroring `CHANGELOG.md`).
- TOC link for v0.40.1.
- Home-page "Latest" pointer bumped `v0.40.0` → `v0.40.1` in `site/content/_index.html`.

Deploy is automatic via `.github/workflows/docs.yml` on merge to `main` (publishes `site/public/` to `gh-pages`). Mirrors the v0.40.0 site sync (#404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784922336&installation_id=131176874&pr_number=413&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F413&signature=39a80c0b938d0fb8cd69e621330af4409aa3359fec9ec2e5d8f968adfd2fa507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new v0.40.1 changelog entry and linked it from the version list.
  * Updated the “Latest” hero link to point to v0.40.1.

* **Bug Fixes**
  * Improved build and verification behavior with stronger gating and clearer escalation/verification handling.
  * Fixed handling of build artifacts and added review-related hardening updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->