### PR TITLE
docs(site): sync website to v0.40.2

### DIFF
--- a/site/content/_index.html
+++ b/site/content/_index.html
@@ -48,7 +48,7 @@ jsonld:
       Three agent backends &mdash; <strong>native</strong> (Anthropic / OpenAI / Gemini / OpenAI-compat),
       <strong>Claude&nbsp;Code</strong> (subscription auth, file editing, terminal),
       and <strong>ACP</strong> (claude-agent-acp&nbsp;/ codex-acp&nbsp;/ gemini --acp). Mix per node.
-      &middot; Latest: <a href="changelog.html#v0-40-1">v0.40.1</a>
+      &middot; Latest: <a href="changelog.html#v0-40-2">v0.40.2</a>
     </p>
   </section>
 

--- a/site/content/changelog.html
+++ b/site/content/changelog.html
@@ -28,6 +28,7 @@ jsonld:
   </section>
 
   <nav class="page-toc" aria-label="Versions">
+    <a href="#v0-40-2">v0.40.2</a>
     <a href="#v0-40-1">v0.40.1</a>
     <a href="#v0-40-0">v0.40.0</a>
     <a href="#v0-39-1">v0.39.1</a>
@@ -76,6 +77,28 @@ jsonld:
     <a href="#v0-9-x">v0.9.x</a>
     <a href="#v0-8-0">v0.8.0</a>
   </nav>
+
+  <!-- ═══ v0.40.2 ═══ -->
+  <section class="glass" id="v0-40-2" style="border-left: 3px solid var(--orange-600);">
+    <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+      <h2 style="margin: 0;"><a href="https://github.com/2389-research/tracker/releases/tag/v0.40.2" style="color: inherit; text-decoration: none;">v0.40.2</a></h2>
+      <span class="badge">2026-06-24</span>
+      <a href="https://github.com/2389-research/tracker/releases/tag/v0.40.2" style="font-size: 0.8rem; color: var(--orange-600);">release notes &rarr;</a>
+    </div>
+    <p style="color: var(--text-secondary); margin-bottom: 1rem;">
+      <strong>Human gates now display their authored <code>prompt:</code> body, and <code>build_product</code>'s
+      plan-approval gate finally shows the actual plan.</strong> One fix, one behavioral change; no breaking
+      changes; core embedded workflows hold their A grades on <code>dippin doctor</code>.
+    </p>
+    <h4>Fixed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong>Human gates now display their <code>prompt:</code> body, not just the <code>label:</code>.</strong> The <code>wait.human</code> handler built the gate prompt from <code>node.Label</code> alone and silently dropped <code>node.Attrs["prompt"]</code> for freeform/choice/yes_no modes. Every human gate that authored a multi-line <code>prompt:</code> &mdash; including v0.40.1's <code>EscalateMilestone</code> "Verify currently" block (<a href="https://github.com/2389-research/tracker/issues/407">#407</a>) and the new <code>ApprovePlan</code> plan review &mdash; was therefore showing only its one-line label at runtime, and any <code>${ctx.tool_stdout}</code> / <code>${ctx.*}</code> interpolation the gate relied on to surface live state never rendered. <code>resolveHumanPrompt</code> now appends the expanded prompt body to the label; label-only gates are unchanged. (Surfaced by automated review of the <a href="https://github.com/2389-research/tracker/pull/414">#414</a> super-PR; the prior <a href="https://github.com/2389-research/tracker/issues/407">#407</a> test only asserted the attribute's content, never that it was displayed.)</li>
+    </ul>
+    <h4>Changed</h4>
+    <ul style="margin-left: 1.5rem; color: var(--text-secondary); margin-bottom: 1rem;">
+      <li><strong><code>build_product</code> plan-approval gate now shows the actual plan.</strong> The <code>ApprovePlan</code> human gate previously displayed only its one-line label, so an operator had no plan to review and could only rubber-stamp <code>approve</code>. A new <code>ShowPlan</code> tool node cats <code>.ai/decisions/milestones.md</code> (the milestone plan) and <code>.ai/decisions/requirement-coverage.md</code> (the spec-coverage table, with the <code>COVERAGE_GAPS</code> count) into <code>ctx.tool_stdout</code> (with a 1MB <code>output_limit</code> so a large plan isn't clipped), and <code>ApprovePlan</code> interpolates it under a <code>## Plan under review</code> heading &mdash; rendering the full plan in the fullscreen review modal. <code>Decompose</code> success now routes <code>-&gt; ShowPlan -&gt; ApprovePlan</code>; the approve/adjust/reject routes are unchanged.</li>
+    </ul>
+  </section>
 
   <!-- ═══ v0.40.1 ═══ -->
   <section class="glass" id="v0-40-1" style="border-left: 3px solid var(--orange-600);">


### PR DESCRIPTION
Adds the v0.40.2 changelog section to the website and bumps the home-page "Latest" pointer to v0.40.2, mirroring the released CHANGELOG entry.

- **changelog.html**: new `#v0-40-2` section (Fixed: human gates display their `prompt:` body; Changed: `build_product` `ApprovePlan` surfaces the actual plan via `ShowPlan`) + TOC link.
- **_index.html**: `Latest:` pointer v0.40.1 → v0.40.2.

Follows the v0.40.1 site-sync precedent (#413). Deploys via `.github/workflows/docs.yml` on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784927840&installation_id=131176874&pr_number=415&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F415&signature=09c998d34ff37d630a4d4752e8abc5d9f401e525634292414f5c7340effdf0e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the latest changelog link to point to the newest release.
  * Added a new release entry for **v0.40.2** with summary, fixes, and changes.
  * Added a table-of-contents link for quicker access to the new release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->