### PR TITLE
build_product: contract-fidelity review + diff-scoped, tiered review panel (#416, #417, #418, #419)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rather than silently grepped-and-passed. The `SpecLint` rule-(f)/(g) and
   Mandated-tests sentinel changes are mirrored into the intentionally-duplicated
   `SpecLint` node in `build_product_with_superspec.dip` so the two shipped copies
-  stay behaviorally identical (dedup tracked in #307) (#424 review).
+  keep the same prompt/rules and sentinel text in sync (dedup tracked in #307).
+  The superspec copy deliberately retains its higher model tier
+  (`claude-opus-4-6` / `reasoning_effort: high` vs `claude-sonnet-4-6` / `medium`
+  in `build_product.dip`), so the nodes are not byte-identical — only the spec-lint
+  contract they enforce is (#424 review).
 - **Sandbox device-node hygiene preflight (#423).** Before any git or subprocess
   handler runs — on both fresh runs and resume — `applyGitPreflight` now verifies
   standard device nodes are usable (at minimum `/dev/null` is a readable+writable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`build_product` now derives spec-contract artifacts (#306).** `ReadSpec`
+  additionally writes `.ai/decisions/spec-ambiguities.md` (one DEFINITE ruling
+  per detected SPEC.md contradiction) and `.ai/decisions/behavioral-contracts.md`
+  (every non-literal prose guarantee — MUST/never/timing/cardinality — paired
+  with a concrete test or grep verification method). Detection keys on the SHAPE
+  of the prose (modal verbs, timing/ordering phrases, two-statement
+  contradictions), never on a product/language. `ApprovePlan` surfaces both
+  artifacts to the operator before the build; `Implement` cites the binding
+  ruling; `VerifyMilestone` (new check 5b) and `FinalSpecCheck` disposition each
+  in-scope behavioral contract with concrete evidence at the same show-your-work
+  bar as the spec-literal grep — an undispositioned contract or an
+  absent-but-needed ruling is `STATUS:fail`.
+
 ## [0.40.2] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The superspec copy deliberately retains its higher model tier
   (`claude-opus-4-6` / `reasoning_effort: high` vs `claude-sonnet-4-6` / `medium`
   in `build_product.dip`), so the nodes are not byte-identical — only the spec-lint
-  contract they enforce is (#424 review).
+  contract they enforce is.
 - **Sandbox device-node hygiene preflight (#423).** Before any git or subprocess
   handler runs — on both fresh runs and resume — `applyGitPreflight` now verifies
   standard device nodes are usable (at minimum `/dev/null` is a readable+writable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in-scope behavioral contract with concrete evidence at the same show-your-work
   bar as the spec-literal grep — an undispositioned contract or an
   absent-but-needed ruling is `STATUS:fail`.
+- **`build_product` reviewers now catch self-ratifying tests (#417).** A new
+  rubric point 6 (SPEC-EMITTED-VALUE ASSERTIONS) in all three reviewers and in
+  `FinalSpecCheck` requires, for every spec-prescribed emitted value (log event
+  name, error code, status string), a test whose asserted expected value is the
+  SPEC literal itself — `assert(emitted == prod.Constant)` is FAIL (it ratifies
+  the constant rather than pinning it to the spec), `assert(emitted ==
+  "review.skip")` is PASS — with a cited assertion file:line. `ReadSpec` records
+  spec-marked "normative" constants in `behavioral-contracts.md` with the same
+  value-asserting verification method, and `SpecLint` rule (f) / the `Decompose`
+  coverage table now enumerate spec-emitted values and normative constants so
+  none is silently unowned.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`build_product` review panel reads a bounded diff and tiers its models
   (#418).** A new `ComputeReviewDiff` tool node (inserted
   `ClearStaleReviews -> ComputeReviewDiff -> ReviewParallel`) computes the
-  cumulative `base..HEAD` diff once into `.ai/build/review-diff.md` — base is the
-  run's commit captured at `Setup` (`run-base-sha`), with the same empty-tree
-  fallback the per-milestone diffs already use (no hard-coded path/range). Each
-  reviewer's scope sentence now points its PRIMARY read at that diff (full tree
-  available on demand, not mandated); the 5→7-point rubric is unchanged.
+  cumulative `base..worktree` diff once into `.ai/build/review-diff.md` — base is
+  the run's commit captured at `Setup` (`run-base-sha`), with the same empty-tree
+  fallback the per-milestone diffs already use (no hard-coded path/range). `git
+  diff <base>` (no `..HEAD`) compares base to the working tree, so
+  accepted-but-uncommitted milestone work is included; untracked files are listed
+  separately. Each reviewer's scope sentence now points its PRIMARY read at that
+  diff (full tree available on demand, not mandated). The reviewer rubric is
+  untouched by this PR — its original five points are unchanged, and points 6
+  (#417) and 7 (#416) were added additively by their own PRs.
   `ReviewClaude` drops to `claude-sonnet-4-6` and `ReviewCodex` to `gpt-5.2`;
   `ReviewGemini` (adversarial) stays `gemini-2.5-pro` and `SynthesizeReviews` is
   unchanged. Steady-state this is the dominant input-token cost (reviewers no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ReviewGemini` (adversarial) stays `gemini-2.5-pro` and `SynthesizeReviews` is
   unchanged. Steady-state this is the dominant input-token cost (reviewers no
   longer each re-walk the whole tree ×3, and 2 of 3 lanes run mid-tier).
+- **`build_product` tiers cheaply-verified agent nodes (#419).** `SpecLint`
+  (gated by its own `STATUS:fail`-first contract) and `ReadSpec` (gated by the
+  `ApprovePlan` human review) drop to `claude-sonnet-4-6` + `reasoning_effort:
+  medium`; their downstream gates are unchanged. `SynthesizeReviews`,
+  `FinalSpecCheck`, and the adversarial `ReviewGemini` lane stay frontier/high.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   records an exact external-tool invocation literal (a `gh`/`git` flag string) as
   a contract whose verification method is "the real tool accepts this literal," so
   a wrong-on-its-face literal (e.g. `gh ... -b -`) is flagged as unverifiable
-  rather than silently grepped-and-passed.
+  rather than silently grepped-and-passed. The `SpecLint` rule-(f)/(g) and
+  Mandated-tests sentinel changes are mirrored into the intentionally-duplicated
+  `SpecLint` node in `build_product_with_superspec.dip` so the two shipped copies
+  stay behaviorally identical (dedup tracked in #307) (#424 review).
 - **Sleep-aware budgets (#422, part A).** Opt-in `BudgetLimits.SleepAware` (CLI
   `--sleep-aware-budget`) excludes OS-suspend spans — e.g. a suspended laptop —
   from `max_wall_time` and `stall_timeout` accounting, so a machine that sleeps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ReviewClaude` drops to `claude-sonnet-4-6` and `ReviewCodex` to `gpt-5.2`;
   `ReviewGemini` (adversarial) stays `gemini-2.5-pro` and `SynthesizeReviews` is
   unchanged. Steady-state this is the dominant input-token cost (reviewers no
-  longer each re-walk the whole tree ×3, and 2 of 3 lanes run mid-tier).
+  longer each re-walk the whole tree ×3, and 2 of 3 lanes run mid-tier). Review
+  hardening: `ComputeReviewDiff` guards against running outside a git work tree
+  and now captures each `git diff` exit status — most git failures
+  (safe.directory, corrupt repo, bad object) exit non-zero while still printing
+  error text, so an empty-output check alone would let git errors masquerade as
+  a valid diff; on any failure the artifact is overwritten with an UNAVAILABLE
+  header so reviewers fall back to reading the working tree directly.
 - **`build_product` tiers cheaply-verified agent nodes (#419).** `SpecLint`
   (gated by its own `STATUS:fail`-first contract) and `ReadSpec` (gated by the
   `ApprovePlan` human review) drop to `claude-sonnet-4-6` + `reasoning_effort:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value-asserting verification method, and `SpecLint` rule (f) / the `Decompose`
   coverage table now enumerate spec-emitted values and normative constants so
   none is silently unowned.
+- **`build_product` enforces contract-fidelity at external seams (#416).** A new
+  rubric point 7 (CONTRACT-FIDELITY AT EXTERNAL SEAMS) in all three reviewers and
+  in `FinalSpecCheck`: for every external seam (LLM provider adapter, VCS-host CLI
+  like `gh`, or a subprocess whose arg/response shape is contractual), FAIL when
+  the only test exercising it uses a fake the production code also defines —
+  require a recorded/golden real-provider response OR a CI-reachable real-CLI
+  invocation, citing the seam file:line and the test path. Detection keys on the
+  seam's ROLE, never on a specific provider/tool/language. `SpecLint` rule (g)
+  records an exact external-tool invocation literal (a `gh`/`git` flag string) as
+  a contract whose verification method is "the real tool accepts this literal," so
+  a wrong-on-its-face literal (e.g. `gh ... -b -`) is flagged as unverifiable
+  rather than silently grepped-and-passed.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`build_product` review panel reads a bounded diff and tiers its models
+  (#418).** A new `ComputeReviewDiff` tool node (inserted
+  `ClearStaleReviews -> ComputeReviewDiff -> ReviewParallel`) computes the
+  cumulative `base..HEAD` diff once into `.ai/build/review-diff.md` — base is the
+  run's commit captured at `Setup` (`run-base-sha`), with the same empty-tree
+  fallback the per-milestone diffs already use (no hard-coded path/range). Each
+  reviewer's scope sentence now points its PRIMARY read at that diff (full tree
+  available on demand, not mandated); the 5→7-point rubric is unchanged.
+  `ReviewClaude` drops to `claude-sonnet-4-6` and `ReviewCodex` to `gpt-5.2`;
+  `ReviewGemini` (adversarial) stays `gemini-2.5-pro` and `SynthesizeReviews` is
+  unchanged. Steady-state this is the dominant input-token cost (reviewers no
+  longer each re-walk the whole tree ×3, and 2 of 3 lanes run mid-tier).
+
 ### Added
 
 - **`build_product` now derives spec-contract artifacts (#306).** `ReadSpec`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   diff <base>` (no `..HEAD`) compares base to the working tree, so
   accepted-but-uncommitted milestone work is included; untracked files are listed
   separately. Each reviewer's scope sentence now points its PRIMARY read at that
-  diff (full tree available on demand, not mandated). The reviewer rubric is
-  untouched by this PR — its original five points are unchanged, and points 6
-  (#417) and 7 (#416) were added additively by their own PRs.
+  diff (full tree available on demand, not mandated). The diff-scoping and model
+  tiering do not touch the reviewer rubric — its original five points are
+  unchanged. (Points 6 (#417) and 7 (#416) are additive rubric extensions,
+  documented in their own entries below.)
   `ReviewClaude` drops to `claude-sonnet-4-6` and `ReviewCodex` to `gpt-5.2`;
   `ReviewGemini` (adversarial) stays `gemini-2.5-pro` and `SynthesizeReviews` is
   unchanged. Steady-state this is the dominant input-token cost (reviewers no

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -698,8 +698,10 @@ workflow BuildProduct
       ## Risks and ambiguities
 
       ── SPEC-CONTRACT ARTIFACTS (issue #306) ──
-      Beyond the analysis above, derive TWO machine-checkable contract
-      artifacts from SPEC.md. Detection keys on the SHAPE of the prose
+      Beyond the analysis above, WRITE TWO machine-checkable contract
+      artifact FILES to disk at the exact paths below (both are required —
+      do not skip either; downstream nodes read them off disk). Derive their
+      content from SPEC.md. Detection keys on the SHAPE of the prose
       (modal verbs, timing/ordering phrases, contradiction between two
       statements) — NEVER on the product, language, or domain.
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1910,8 +1910,11 @@ workflow BuildProduct
   # re-reading the whole tree (the ~90%-of-tokens problem). BASE is the run's
   # base commit captured at Setup (.ai/build/run-base-sha); degrade to the
   # empty tree when it is empty (fresh repo) or unreachable (history rewrite)
-  # — the SAME two-dot + empty-tree-fallback idiom verify.sh and
-  # MarkMilestoneDone already use. The full tree stays available on demand
+  # — the SAME empty-tree-fallback idiom verify.sh and MarkMilestoneDone
+  # already use. Unlike those two-dot (BASE..HEAD) call sites, this is a
+  # one-arg `git diff <BASE>` WORKTREE compare: the "accept" gate routes here
+  # WITHOUT committing first, so the diff must capture accepted-but-uncommitted
+  # work, not just commits. The full tree stays available on demand
   # (the reviewers may read any file); this only POINTS their primary read.
   # The diff is advisory context, so the whole body is best-effort and the
   # routing marker is printed last.
@@ -2012,8 +2015,10 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
-      the complete set of changes this build produced. Read the full working
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it
+      captures every tracked-file change this build produced. Newly-created
+      UNTRACKED files are listed there by path only; their contents are NOT in
+      the diff, so open those files directly. Read the rest of the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose
@@ -2107,8 +2112,10 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
-      the complete set of changes this build produced. Read the full working
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it
+      captures every tracked-file change this build produced. Newly-created
+      UNTRACKED files are listed there by path only; their contents are NOT in
+      the diff, so open those files directly. Read the rest of the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose
@@ -2202,8 +2209,10 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
-      the complete set of changes this build produced. Read the full working
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it
+      captures every tracked-file change this build produced. Newly-created
+      UNTRACKED files are listed there by path only; their contents are NOT in
+      the diff, so open those files directly. Read the rest of the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1996,20 +1996,29 @@ workflow BuildProduct
       # preserved output keeps it diagnosable.
       if [ "$DIFF_ERR" -ne 0 ] || [ ! -s "$OUT" ]; then
         echo "WARNING: review diff generation failed or produced no output; reviewers must read the working tree directly" >&2
-        CAPTURED=$(cat "$OUT" 2>/dev/null)
+        # Stream the captured git output through a temp file instead of slurping
+        # the whole artifact into a shell variable: a partial failure (e.g.
+        # name-status succeeds and writes a large diff, then `git diff` fails)
+        # can leave a large $OUT, and `CAPTURED=$(cat "$OUT")` would risk shell
+        # memory / arg-length limits — turning a recoverable diff failure into a
+        # node failure or OOM (#424 review). We can't `cat "$OUT"` into a
+        # redirect to "$OUT" (truncation race), so build the banner+block in a
+        # temp file and atomically mv it over the artifact.
+        TMP="${OUT}.tmp"
         {
           echo "# Review diff UNAVAILABLE — diff generation failed. Read the working tree directly."
           echo
-          if [ -n "$CAPTURED" ]; then
+          if [ -s "$OUT" ]; then
             echo "Captured git output (likely the underlying cause — e.g. safe.directory, corrupt repo, bad object):"
             echo
             echo '```'
-            printf '%s\n' "$CAPTURED"
+            cat "$OUT"
             echo '```'
           else
             echo "(no git output was captured)"
           fi
-        } > "$OUT"
+        } > "$TMP"
+        mv "$TMP" "$OUT"
       fi
       printf 'review-diff-ready'
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1948,9 +1948,15 @@ workflow BuildProduct
       # committed + staged + unstaged tracked changes; untracked files are listed
       # separately below. On a clean tree this is identical to BASE..HEAD.
       #
-      # git stderr is kept IN the artifact (2>&1, not 2>/dev/null) and the outer
-      # `|| true` is dropped, so a diff failure surfaces instead of yielding a
-      # silently-empty PRIMARY input (CLAUDE.md: never silently swallow errors).
+      # git stderr is kept IN the artifact (2>&1, not 2>/dev/null) so a failure
+      # is diagnosable, but #424 review: an empty-output guard alone is not
+      # enough — most git failure modes (safe.directory, corrupt repo, bad
+      # object) exit non-zero while STILL printing error text, so the artifact
+      # is non-empty and reviewers see git errors dressed up as a valid diff.
+      # Capture each `git diff` exit status explicitly (the brace group runs in
+      # this shell, not a subshell, so DIFF_ERR persists) and stamp UNAVAILABLE
+      # on any failure (CLAUDE.md: never silently swallow errors).
+      DIFF_ERR=0
       {
         echo "# Cumulative review diff (base..worktree)"
         echo
@@ -1960,7 +1966,7 @@ workflow BuildProduct
         echo "available on demand if a finding needs surrounding context._"
         echo
         echo '## Files changed'
-        git diff --name-status "${BASE}" 2>&1
+        git diff --name-status "${BASE}" 2>&1 || DIFF_ERR=1
         UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
         if [ -n "$UNTRACKED" ]; then
           echo
@@ -1969,13 +1975,14 @@ workflow BuildProduct
         fi
         echo
         echo '## Full diff'
-        git diff "${BASE}" 2>&1
+        git diff "${BASE}" 2>&1 || DIFF_ERR=1
       } > "$OUT"
-      # Fail loudly if the artifact is empty — reviewers depend on it as their
-      # PRIMARY input. Don't dead-stop (the diff is advisory routing context),
-      # but warn on stderr and stamp the file so the gap is visible, not silent.
-      if [ ! -s "$OUT" ]; then
-        echo "WARNING: review diff generation produced no output; reviewers must read the working tree directly" >&2
+      # Fail loudly if a diff command errored OR the artifact is empty —
+      # reviewers depend on it as their PRIMARY input. Don't dead-stop (the diff
+      # is advisory routing context), but warn on stderr and OVERWRITE the file
+      # with the UNAVAILABLE header so a git error can't masquerade as a diff.
+      if [ "$DIFF_ERR" -ne 0 ] || [ ! -s "$OUT" ]; then
+        echo "WARNING: review diff generation failed or produced no output; reviewers must read the working tree directly" >&2
         echo "# Review diff UNAVAILABLE — diff generation failed. Read the working tree directly." > "$OUT"
       fi
       printf 'review-diff-ready'

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1921,10 +1921,13 @@ workflow BuildProduct
   tool ComputeReviewDiff
     label: "Compute Cumulative Review Diff"
     timeout: 60s
-    # Reviewers read the FILE (.ai/build/review-diff.md), not this node's stdout
-    # — which is only the short readiness marker. output_limit stays large so
-    # that if diff generation fails and we fall back to dumping git stderr, the
-    # diagnostic is not clipped in `tracker diagnose`.
+    # Reviewers read the FILE (.ai/build/review-diff.md), not this node's
+    # streams: stdout is only the short readiness marker and stderr is only the
+    # failure WARNING (any git error text is redirected INTO the file via 2>&1,
+    # not onto a node stream). So output_limit does not bound the diff/error
+    # content reviewers consume — it only caps this node's marker + warning
+    # streams as surfaced by `tracker diagnose`. Kept generous purely as harmless
+    # headroom so a future stderr diagnostic is never clipped.
     output_limit: 1048576
     command:
       set -u

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -614,11 +614,17 @@ workflow BuildProduct
           value. A contract like "Idempotency-Key derived from
           review_id+sha" on a signature receiving neither is
           unimplementable as written.
-      (f) Mandated tests enumerated and assignable: list every test
-          SPEC.md mandates by name or by concrete behavior. This list
-          feeds the Decompose requirement-coverage table (issue
-          #300); a mandated test so vague no milestone could own it
-          is a finding.
+      (f) Mandated tests, spec-emitted values, and normative constants
+          enumerated and assignable: list every test SPEC.md mandates by
+          name or by concrete behavior, PLUS every spec-prescribed EMITTED
+          value (log event name, error code, status string) and every
+          constant SPEC.md marks "normative". This list feeds the Decompose
+          requirement-coverage table (issue #300) so none can be silently
+          unowned; a mandated test / emitted value / normative constant so
+          vague no milestone could own it is a finding. For each emitted
+          value and normative constant, note the required verification
+          shape: "a test asserts this exact value as a hard-coded
+          expectation (not via the production constant)".
 
       WARN — report in the artifact, do NOT fail the gate:
       (d) Checkable guarantees: behavioral guarantees phrased so they
@@ -635,8 +641,11 @@ workflow BuildProduct
       ## Warnings
       Rule (d)/(e) findings, same evidence shape — or "none".
       ## Mandated tests
-      Every rule-(f) test, one per line, each with its SPEC.md
-      source — or the single line "SPEC mandates no named tests".
+      Every rule-(f) item, one per line, each with its SPEC.md source and
+      its kind (test / emitted-value / normative-constant); emitted-value
+      and normative-constant lines must carry the verification shape "a
+      test asserts this exact value as a hard-coded expectation" — or the
+      single line "SPEC mandates no named tests".
 
       Then your terminal STATUS line:
       - zero critical findings -> STATUS:success (warnings alone never
@@ -708,6 +717,13 @@ workflow BuildProduct
             construction), NOT skipped as untestable.
           If SPEC.md states no such guarantees, write the single line:
           "no behavioral contracts detected".
+          When SPEC.md marks a constant "normative" (a value the spec says
+          implementations must use exactly — not merely a default or an
+          example), record it as a contract with
+          **Verification method**: "a test asserts this exact value as a
+          hard-coded expectation" (the point-6 / SPEC-EMITTED-VALUE bar — a
+          test asserting against the production constant does NOT satisfy
+          it).
 
       Both files are inputs to ApprovePlan (the human sees them before the
       build) and to VerifyMilestone / FinalSpecCheck (which disposition
@@ -781,8 +797,9 @@ workflow BuildProduct
          verifications (never leave the table silently empty — a silent
          empty table hides under-extraction). Cross-check against the
          "Mandated tests" section of .ai/decisions/spec-quality.md
-         (written by the SpecLint preflight): every test
-         listed there must appear in this table. Table columns:
+         (written by the SpecLint preflight): every item listed there —
+         test, spec-emitted value, or normative constant — must appear in
+         this table, so none is silently unowned. Table columns:
            | Mandated verification | SPEC.md source (line/section) | Owning milestone |
 
       2. THEN decompose into milestones as the rules above describe.
@@ -1938,6 +1955,20 @@ workflow BuildProduct
          for? Phase 2+ features built in a Phase 1 milestone are FAIL.
       5. ARCHITECTURE & LEFTOVERS: Were the spec's technical-guidance
          sections followed? Are leftover artifacts from removed code gone?
+      6. SPEC-EMITTED-VALUE ASSERTIONS: For every value the spec prescribes
+         that the code EMITS — a log event name, an error code, a status
+         string (e.g. a skip reason like "no_branch"), a wire/JSON value —
+         find a test whose ASSERTED EXPECTED value is the SPEC LITERAL
+         itself, not a variable that references the production constant.
+         `assert(emitted == prod.Constant)` is FAIL — it ratifies whatever
+         the production constant happens to be, so a wrong constant ships
+         green. `assert(emitted == "review.skip")` (the spec literal,
+         hard-coded in the test) is PASS. Cite the assertion file:line and
+         quote the asserted expected value. A spec-emitted value with no
+         test asserting the literal is FAIL. This is distinct from point 1
+         (which checks the literal exists in the code); point 6 checks a
+         TEST pins it to the spec literal independent of the production
+         constant.
 
       Your lane emphasis (after the rubric): missing requirements,
       architectural violations, leftover artifacts. Cite spec section
@@ -2001,6 +2032,20 @@ workflow BuildProduct
          for? Phase 2+ features built in a Phase 1 milestone are FAIL.
       5. ARCHITECTURE & LEFTOVERS: Were the spec's technical-guidance
          sections followed? Are leftover artifacts from removed code gone?
+      6. SPEC-EMITTED-VALUE ASSERTIONS: For every value the spec prescribes
+         that the code EMITS — a log event name, an error code, a status
+         string (e.g. a skip reason like "no_branch"), a wire/JSON value —
+         find a test whose ASSERTED EXPECTED value is the SPEC LITERAL
+         itself, not a variable that references the production constant.
+         `assert(emitted == prod.Constant)` is FAIL — it ratifies whatever
+         the production constant happens to be, so a wrong constant ships
+         green. `assert(emitted == "review.skip")` (the spec literal,
+         hard-coded in the test) is PASS. Cite the assertion file:line and
+         quote the asserted expected value. A spec-emitted value with no
+         test asserting the literal is FAIL. This is distinct from point 1
+         (which checks the literal exists in the code); point 6 checks a
+         TEST pins it to the spec literal independent of the production
+         constant.
 
       Your lane emphasis (after the rubric): code quality, test coverage,
       edge cases the spec calls out, whether "throw away" items were
@@ -2075,6 +2120,20 @@ workflow BuildProduct
          for? Phase 2+ features built in a Phase 1 milestone are FAIL.
       5. ARCHITECTURE & LEFTOVERS: Were the spec's technical-guidance
          sections followed? Are leftover artifacts from removed code gone?
+      6. SPEC-EMITTED-VALUE ASSERTIONS: For every value the spec prescribes
+         that the code EMITS — a log event name, an error code, a status
+         string (e.g. a skip reason like "no_branch"), a wire/JSON value —
+         find a test whose ASSERTED EXPECTED value is the SPEC LITERAL
+         itself, not a variable that references the production constant.
+         `assert(emitted == prod.Constant)` is FAIL — it ratifies whatever
+         the production constant happens to be, so a wrong constant ships
+         green. `assert(emitted == "review.skip")` (the spec literal,
+         hard-coded in the test) is PASS. Cite the assertion file:line and
+         quote the asserted expected value. A spec-emitted value with no
+         test asserting the literal is FAIL. This is distinct from point 1
+         (which checks the literal exists in the code); point 6 checks a
+         TEST pins it to the spec literal independent of the production
+         constant.
 
       Your lane emphasis (after the rubric): the things the other two
       reviewers will miss. Edge cases the spec implies but doesn't state
@@ -2363,6 +2422,16 @@ workflow BuildProduct
       dispositioned with the startup-path test/grep its verification method
       names — not skipped as untestable.
 
+      SPEC-EMITTED-VALUE ASSERTIONS (issue #417): For every spec-prescribed
+      EMITTED value (log event name, error code, status string), confirm a
+      test asserts the SPEC LITERAL as a hard-coded expectation — NOT a
+      variable referencing the production constant. A test of the form
+      `assert(emitted == prod.Constant)` does not count: it ratifies the
+      constant rather than pinning it to the spec, so a wrong constant
+      ships green. Cite the asserting file:line and the quoted expected
+      value. A spec-emitted value with no literal-asserting test keeps the
+      early STATUS:fail in place.
+
       This is the final gate. Read SPEC.md line by line.
 
       For EVERY requirement, prescription, and instruction in the spec:
@@ -2402,8 +2471,9 @@ workflow BuildProduct
       REACHABILITY (every method has a production caller or
       carve-out), TEST QUALITY (every sleep-fence hit dispositioned),
       BEHAVIORAL CONTRACTS (every contract dispositioned with evidence,
-      every ambiguity ruling followed), and SPEC.md compliance (every
-      requirement implemented, no
+      every ambiguity ruling followed), SPEC-EMITTED-VALUE ASSERTIONS
+      (every emitted value pinned to its spec literal by a test), and
+      SPEC.md compliance (every requirement implemented, no
       extras, no TODO/FIXME/HACK, tests pass, no unexpected files
       in .ai/build/ outside the allowlist enumerated above) all
       passed. Otherwise the early `STATUS:fail` from your first

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -625,6 +625,18 @@ workflow BuildProduct
           value and normative constant, note the required verification
           shape: "a test asserts this exact value as a hard-coded
           expectation (not via the production constant)".
+      (g) External-tool invocation literals verifiable: for every exact
+          external-tool invocation SPEC.md prescribes — a `gh` / `git` /
+          other CLI command with a specific flag string (e.g.
+          `gh pr create --head <owner>:<branch>`) — record the literal flag
+          string as a behavioral contract whose verification method is "the
+          real tool accepts this literal". A literal that is wrong on its
+          face against the tool's own flag grammar (the canonical case:
+          `gh ... -b -`, where `-b` expects an argument and `-` is consumed
+          as that argument, silently mis-parsing) is an UNVERIFIABLE
+          contract — flag it here rather than letting a downstream grep
+          "find the string" and pass. Detection keys on the SHAPE "spec
+          prescribes a literal CLI invocation", never on a specific tool.
 
       WARN — report in the artifact, do NOT fail the gate:
       (d) Checkable guarantees: behavioral guarantees phrased so they
@@ -1969,6 +1981,19 @@ workflow BuildProduct
          (which checks the literal exists in the code); point 6 checks a
          TEST pins it to the spec literal independent of the production
          constant.
+      7. CONTRACT-FIDELITY AT EXTERNAL SEAMS: For every EXTERNAL SEAM — an
+         LLM provider adapter, a VCS-host CLI invocation (e.g. `gh`), or a
+         subprocess whose argument shape or response shape is contractual —
+         FAIL when the ONLY test exercising that seam uses a fake that the
+         PRODUCTION code also defines (a fake the code under test ships and
+         the test reuses ratifies the code's own assumptions, proving
+         nothing about the real seam). Cite the seam (file:line of the
+         production call) and the test path. A passing seam requires EITHER
+         a recorded/golden REAL-provider response (cite the fixture) OR a
+         CI-reachable REAL-CLI invocation (cite the test that shells the
+         actual tool). Detection keys on the seam's ROLE (crosses a process
+         or provider boundary whose arg/response shape is a contract) —
+         never on a specific provider, tool, or language.
 
       Your lane emphasis (after the rubric): missing requirements,
       architectural violations, leftover artifacts. Cite spec section
@@ -2046,6 +2071,19 @@ workflow BuildProduct
          (which checks the literal exists in the code); point 6 checks a
          TEST pins it to the spec literal independent of the production
          constant.
+      7. CONTRACT-FIDELITY AT EXTERNAL SEAMS: For every EXTERNAL SEAM — an
+         LLM provider adapter, a VCS-host CLI invocation (e.g. `gh`), or a
+         subprocess whose argument shape or response shape is contractual —
+         FAIL when the ONLY test exercising that seam uses a fake that the
+         PRODUCTION code also defines (a fake the code under test ships and
+         the test reuses ratifies the code's own assumptions, proving
+         nothing about the real seam). Cite the seam (file:line of the
+         production call) and the test path. A passing seam requires EITHER
+         a recorded/golden REAL-provider response (cite the fixture) OR a
+         CI-reachable REAL-CLI invocation (cite the test that shells the
+         actual tool). Detection keys on the seam's ROLE (crosses a process
+         or provider boundary whose arg/response shape is a contract) —
+         never on a specific provider, tool, or language.
 
       Your lane emphasis (after the rubric): code quality, test coverage,
       edge cases the spec calls out, whether "throw away" items were
@@ -2134,6 +2172,19 @@ workflow BuildProduct
          (which checks the literal exists in the code); point 6 checks a
          TEST pins it to the spec literal independent of the production
          constant.
+      7. CONTRACT-FIDELITY AT EXTERNAL SEAMS: For every EXTERNAL SEAM — an
+         LLM provider adapter, a VCS-host CLI invocation (e.g. `gh`), or a
+         subprocess whose argument shape or response shape is contractual —
+         FAIL when the ONLY test exercising that seam uses a fake that the
+         PRODUCTION code also defines (a fake the code under test ships and
+         the test reuses ratifies the code's own assumptions, proving
+         nothing about the real seam). Cite the seam (file:line of the
+         production call) and the test path. A passing seam requires EITHER
+         a recorded/golden REAL-provider response (cite the fixture) OR a
+         CI-reachable REAL-CLI invocation (cite the test that shells the
+         actual tool). Detection keys on the seam's ROLE (crosses a process
+         or provider boundary whose arg/response shape is a contract) —
+         never on a specific provider, tool, or language.
 
       Your lane emphasis (after the rubric): the things the other two
       reviewers will miss. Edge cases the spec implies but doesn't state
@@ -2432,6 +2483,14 @@ workflow BuildProduct
       value. A spec-emitted value with no literal-asserting test keeps the
       early STATUS:fail in place.
 
+      CONTRACT-FIDELITY AT EXTERNAL SEAMS (issue #416): For every external
+      seam (LLM provider adapter / VCS-host CLI like `gh` / subprocess
+      whose arg or response shape is contractual), FAIL when the only test
+      exercising it uses a fake the production code also defines. Require a
+      recorded/golden real-provider response OR a CI-reachable real-CLI
+      invocation; cite the seam file:line and the test path. An
+      undispositioned external seam keeps the early STATUS:fail in place.
+
       This is the final gate. Read SPEC.md line by line.
 
       For EVERY requirement, prescription, and instruction in the spec:
@@ -2472,8 +2531,10 @@ workflow BuildProduct
       carve-out), TEST QUALITY (every sleep-fence hit dispositioned),
       BEHAVIORAL CONTRACTS (every contract dispositioned with evidence,
       every ambiguity ruling followed), SPEC-EMITTED-VALUE ASSERTIONS
-      (every emitted value pinned to its spec literal by a test), and
-      SPEC.md compliance (every requirement implemented, no
+      (every emitted value pinned to its spec literal by a test),
+      CONTRACT-FIDELITY AT EXTERNAL SEAMS (every seam backed by a golden
+      real response or a real-CLI invocation, not a self-defined fake),
+      and SPEC.md compliance (every requirement implemented, no
       extras, no TODO/FIXME/HACK, tests pass, no unexpected files
       in .ai/build/ outside the allowlist enumerated above) all
       passed. Otherwise the early `STATUS:fail` from your first

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1984,11 +1984,29 @@ workflow BuildProduct
       } > "$OUT"
       # Fail loudly if a diff command errored OR the artifact is empty —
       # reviewers depend on it as their PRIMARY input. Don't dead-stop (the diff
-      # is advisory routing context), but warn on stderr and OVERWRITE the file
-      # with the UNAVAILABLE header so a git error can't masquerade as a diff.
+      # is advisory routing context), but warn on stderr and prepend a clear
+      # UNAVAILABLE banner so a git error can't masquerade as a valid diff. The
+      # git stderr captured into the file (2>&1) is PRESERVED below the banner in
+      # a fenced block — overwriting it outright would discard the underlying
+      # cause (safe.directory / corrupt repo / bad object) and make the failure
+      # undebuggable (#424 review). The banner removes the masquerade risk; the
+      # preserved output keeps it diagnosable.
       if [ "$DIFF_ERR" -ne 0 ] || [ ! -s "$OUT" ]; then
         echo "WARNING: review diff generation failed or produced no output; reviewers must read the working tree directly" >&2
-        echo "# Review diff UNAVAILABLE — diff generation failed. Read the working tree directly." > "$OUT"
+        CAPTURED=$(cat "$OUT" 2>/dev/null)
+        {
+          echo "# Review diff UNAVAILABLE — diff generation failed. Read the working tree directly."
+          echo
+          if [ -n "$CAPTURED" ]; then
+            echo "Captured git output (likely the underlying cause — e.g. safe.directory, corrupt repo, bad object):"
+            echo
+            echo '```'
+            printf '%s\n' "$CAPTURED"
+            echo '```'
+          else
+            echo "(no git output was captured)"
+          fi
+        } > "$OUT"
       fi
       printf 'review-diff-ready'
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -665,6 +665,55 @@ workflow BuildProduct
       ## Implicit requirements (things the spec assumes but doesn't state)
       ## Risks and ambiguities
 
+      ── SPEC-CONTRACT ARTIFACTS (issue #306) ──
+      Beyond the analysis above, derive TWO machine-checkable contract
+      artifacts from SPEC.md. Detection keys on the SHAPE of the prose
+      (modal verbs, timing/ordering phrases, contradiction between two
+      statements) — NEVER on the product, language, or domain.
+
+      (i) .ai/decisions/spec-ambiguities.md — one DEFINITE ruling per
+          detected contradiction. A contradiction is two statements in
+          SPEC.md that cannot both hold (a constant stated two ways, an
+          ordering asserted one place and contradicted another, a value
+          "required" here and "optional" there). For EACH, write one entry:
+          ## Ambiguity N
+          **Conflicting statements**: quote both, each with its SPEC.md
+            location (section / line).
+          **Ruling**: the single resolution this build will follow,
+            stated as a concrete buildable decision.
+          **Rationale**: one line.
+          The ruling MUST be definite — never "it depends", never "either
+          is acceptable", never deferred to the implementer. If SPEC.md is
+          internally consistent, write the single line: "no contradictions
+          detected". (A retry-count stated as "max 2 retries" in one
+          section and "retries up to 3 times" in another is ONE
+          contradiction and gets ONE ruling, e.g. "3 total attempts (2
+          retries after the initial try)".)
+
+      (ii) .ai/decisions/behavioral-contracts.md — every NON-LITERAL prose
+          guarantee, each with a concrete verification method. A prose
+          guarantee is any sentence whose SHAPE is a behavioral obligation:
+          a modal verb (MUST / MUST NOT / SHALL / never / always), a
+          timing/ordering phrase ("at startup, not at runtime", "before
+          X", "within N ms", "on the first call"), or a cardinality
+          guarantee ("exactly once", "at most one"). For EACH, write:
+          ## Contract N
+          **Guarantee**: the prose, quoted, with its SPEC.md location.
+          **Verification method**: a SPECIFIC test (named test function /
+            test shape) OR a SPECIFIC grep that would prove the guarantee
+            holds. "Manual review" is not a verification method. A
+            "rejects at startup, not at runtime" guarantee is verified by
+            a startup-path test/grep (e.g. a test that constructs the
+            component with a bad config and asserts it fails at
+            construction), NOT skipped as untestable.
+          If SPEC.md states no such guarantees, write the single line:
+          "no behavioral contracts detected".
+
+      Both files are inputs to ApprovePlan (the human sees them before the
+      build) and to VerifyMilestone / FinalSpecCheck (which disposition
+      each in-scope contract). Do not editorialize SPEC.md — extract and
+      rule, do not invent guarantees the spec does not make.
+
   agent Decompose
     label: "Decompose into Milestones"
     model: claude-opus-4-6
@@ -797,6 +846,22 @@ workflow BuildProduct
       else
         echo "_(requirement-coverage.md not found)_"
       fi
+      echo
+      echo "# Spec ambiguity rulings (.ai/decisions/spec-ambiguities.md)"
+      echo
+      if [ -f .ai/decisions/spec-ambiguities.md ]; then
+        cat .ai/decisions/spec-ambiguities.md
+      else
+        echo "_(spec-ambiguities.md not found — ReadSpec did not write rulings)_"
+      fi
+      echo
+      echo "# Behavioral contracts (.ai/decisions/behavioral-contracts.md)"
+      echo
+      if [ -f .ai/decisions/behavioral-contracts.md ]; then
+        cat .ai/decisions/behavioral-contracts.md
+      else
+        echo "_(behavioral-contracts.md not found)_"
+      fi
 
   human ApprovePlan
     label: "Review the milestone plan — approve, adjust, or reject"
@@ -819,6 +884,13 @@ workflow BuildProduct
       spec-mandated verification mapped to an owning (or deferred) milestone with
       `COVERAGE_GAPS: 0`. A non-zero gap count or an over-broad milestone is a
       reason to **adjust**.
+
+      Also review the spec ambiguity rulings and behavioral contracts below
+      (written by ReadSpec): each contradiction has exactly ONE definite
+      ruling, and each prose guarantee has a concrete verification method.
+      A ruling you disagree with, or a missing/needed ruling, is a reason to
+      **adjust** — this is your one chance to correct a wrong interpretation
+      before the build commits to it.
 
       ---
       ## Plan under review
@@ -924,6 +996,10 @@ workflow BuildProduct
 
       RULES:
       - Implement EXACTLY what this milestone requires. Nothing more.
+      - Read .ai/decisions/spec-ambiguities.md. Where SPEC.md was
+        contradictory, the ruling there is binding — implement the ruling,
+        and in your commit message or a .ai/decisions/ note cite the
+        ambiguity number you followed. Do NOT re-litigate a ruling.
       - Only touch the files listed in the milestone spec.
       - Follow the codebase's existing patterns and conventions.
       - Do NOT create documentation files unless the milestone requires them.
@@ -1351,6 +1427,21 @@ workflow BuildProduct
          .ai/decisions/requirement-coverage.md (written by Decompose)
          when present; if it disagrees with a live SPEC.md re-read, SPEC.md
          wins.
+
+      5b. BEHAVIORAL CONTRACTS (issue #306): Read
+         .ai/decisions/behavioral-contracts.md. For every contract whose
+         SPEC.md guarantee intersects THIS milestone's file list,
+         disposition it with concrete evidence — the same show-your-work
+         bar as the SPEC LITERALS grep in check 3: run the contract's
+         stated verification method (the named test or the grep) and paste
+         the command + its result inline. A contract that is in-scope for
+         this milestone but left undispositioned (no test/grep evidence
+         shown) is FAIL. If SPEC.md was contradictory in this milestone's
+         area, confirm a ruling exists in .ai/decisions/spec-ambiguities.md
+         and the implementation follows it; an absent-but-needed ruling is
+         FAIL. Contracts whose guarantee does not touch this milestone's
+         files are out of scope here (FinalSpecCheck dispositions the full
+         set) — say so, do not invent evidence.
 
       6. TESTS + CI PASSED: The `tests-pass` sentinel in the
          "TestMilestone stdout" fenced block at the END of this
@@ -2256,6 +2347,22 @@ workflow BuildProduct
       ReviewCodex / ReviewGemini) — not detected here. W21
       (subname collision) is out of scope.
 
+      BEHAVIORAL CONTRACTS (issue #306):
+
+      Read .ai/decisions/behavioral-contracts.md and
+      .ai/decisions/spec-ambiguities.md (both written by ReadSpec). For
+      EVERY behavioral contract, disposition it with concrete evidence —
+      the same show-your-work bar as the interface-reachability and
+      spec-literal checks: run its stated verification method (the named
+      test or the grep) and paste the command + result. An undispositioned
+      contract (no evidence shown) keeps the early STATUS:fail in place.
+      For every ambiguity ruling, confirm the shipped code follows the
+      ruling (cite file:line); a ruling the code contradicts, or a
+      contradiction with no ruling, keeps the early STATUS:fail in place.
+      A "rejects at startup, not at runtime"-class guarantee must be
+      dispositioned with the startup-path test/grep its verification method
+      names — not skipped as untestable.
+
       This is the final gate. Read SPEC.md line by line.
 
       For EVERY requirement, prescription, and instruction in the spec:
@@ -2294,7 +2401,9 @@ workflow BuildProduct
       Emit `STATUS:success` as your terminal line ONLY if INTERFACE
       REACHABILITY (every method has a production caller or
       carve-out), TEST QUALITY (every sleep-fence hit dispositioned),
-      and SPEC.md compliance (every requirement implemented, no
+      BEHAVIORAL CONTRACTS (every contract dispositioned with evidence,
+      every ambiguity ruling followed), and SPEC.md compliance (every
+      requirement implemented, no
       extras, no TODO/FIXME/HACK, tests pass, no unexpected files
       in .ai/build/ outside the allowlist enumerated above) all
       passed. Otherwise the early `STATUS:fail` from your first

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -578,9 +578,9 @@ workflow BuildProduct
 
   agent SpecLint
     label: "Spec Coherence Preflight"
-    model: claude-opus-4-6
+    model: claude-sonnet-4-6
     provider: anthropic
-    reasoning_effort: high
+    reasoning_effort: medium
     auto_status: true
     prompt:
       SPEC COHERENCE PREFLIGHT:
@@ -678,9 +678,9 @@ workflow BuildProduct
 
   agent ReadSpec
     label: "Read & Analyze Spec"
-    model: claude-opus-4-6
+    model: claude-sonnet-4-6
     provider: anthropic
-    reasoning_effort: high
+    reasoning_effort: medium
     prompt:
       Read SPEC.md thoroughly. Understand:
       - What is being built (the product)

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -554,7 +554,7 @@ workflow BuildProduct
       } > .ai/build/build-context.md 2>/dev/null || true
 
       # #418: capture the run's base commit ONCE at Setup so the cross-review
-      # diff node can compute a cumulative base..HEAD without a per-milestone
+      # diff node can compute a cumulative base..worktree without a per-milestone
       # marker (those are deleted at each MarkMilestoneDone). Same non-leaking
       # idiom as PickNextMilestone's start marker: --verify --quiet prints
       # nothing and exits non-zero on a commitless repo, so a fresh repo
@@ -1904,7 +1904,7 @@ workflow BuildProduct
       rm -f .ai/build/review-claude.md .ai/build/review-codex.md .ai/build/review-gemini.md
       printf 'cleared stale review reports\n'
 
-  # #418: compute the cumulative base..HEAD review diff ONCE so the three
+  # #418: compute the cumulative base..worktree review diff ONCE so the three
   # reviewers read a bounded diff as their PRIMARY input instead of each
   # re-reading the whole tree (the ~90%-of-tokens problem). BASE is the run's
   # base commit captured at Setup (.ai/build/run-base-sha); degrade to the
@@ -1917,30 +1917,57 @@ workflow BuildProduct
   tool ComputeReviewDiff
     label: "Compute Cumulative Review Diff"
     timeout: 60s
-    # Cap matches ShowPlan: a large cumulative diff must not be clipped before
-    # the reviewers read the file (they read the FILE, not ctx, but keep the
-    # node's own stdout generous for diagnose).
+    # Reviewers read the FILE (.ai/build/review-diff.md), not this node's stdout
+    # — which is only the short readiness marker. output_limit stays large so
+    # that if diff generation fails and we fall back to dumping git stderr, the
+    # diagnostic is not clipped in `tracker diagnose`.
     output_limit: 1048576
     command:
       set -u
       mkdir -p .ai/build
+      OUT=.ai/build/review-diff.md
       BASE=$(cat .ai/build/run-base-sha 2>/dev/null || true)
       if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
         BASE=$(git hash-object -t tree /dev/null)
       fi
+      # #424 review: diff BASE against the WORKING TREE (not BASE..HEAD), so
+      # accepted-but-uncommitted milestone work — the `accept` gate routes here
+      # WITHOUT committing first — is included instead of silently omitted from
+      # what reviewers are told is "the complete set of changes". `git diff
+      # <commit>` (no ..HEAD) compares the commit to the worktree, capturing
+      # committed + staged + unstaged tracked changes; untracked files are listed
+      # separately below. On a clean tree this is identical to BASE..HEAD.
+      #
+      # git stderr is kept IN the artifact (2>&1, not 2>/dev/null) and the outer
+      # `|| true` is dropped, so a diff failure surfaces instead of yielding a
+      # silently-empty PRIMARY input (CLAUDE.md: never silently swallow errors).
       {
-        echo "# Cumulative review diff (base..HEAD)"
+        echo "# Cumulative review diff (base..worktree)"
         echo
-        echo "_Base: ${BASE} → HEAD. This is the complete set of changes the"
-        echo "build produced. It is your PRIMARY read; the full working tree is"
+        echo "_Base: ${BASE} → working tree. This is the complete set of changes"
+        echo "the build produced, INCLUDING staged/unstaged and untracked work not"
+        echo "yet committed. It is your PRIMARY read; the full working tree is"
         echo "available on demand if a finding needs surrounding context._"
         echo
         echo '## Files changed'
-        git diff --name-status "${BASE}..HEAD" 2>/dev/null
+        git diff --name-status "${BASE}" 2>&1
+        UNTRACKED=$(git ls-files --others --exclude-standard 2>/dev/null)
+        if [ -n "$UNTRACKED" ]; then
+          echo
+          echo '## Untracked files (not yet in any commit)'
+          printf '%s\n' "$UNTRACKED"
+        fi
         echo
         echo '## Full diff'
-        git diff "${BASE}..HEAD" 2>/dev/null
-      } > .ai/build/review-diff.md 2>/dev/null || true
+        git diff "${BASE}" 2>&1
+      } > "$OUT"
+      # Fail loudly if the artifact is empty — reviewers depend on it as their
+      # PRIMARY input. Don't dead-stop (the diff is advisory routing context),
+      # but warn on stderr and stamp the file so the gap is visible, not silent.
+      if [ ! -s "$OUT" ]; then
+        echo "WARNING: review diff generation produced no output; reviewers must read the working tree directly" >&2
+        echo "# Review diff UNAVAILABLE — diff generation failed. Read the working tree directly." > "$OUT"
+      fi
       printf 'review-diff-ready'
 
   parallel ReviewParallel -> ReviewClaude, ReviewCodex, ReviewGemini
@@ -1966,7 +1993,7 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
       the complete set of changes this build produced. Read the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
@@ -1979,7 +2006,7 @@ workflow BuildProduct
         plan, not evidence of completion. Treat them as nothing. Verify each
         requirement against the code yourself.
 
-      RUBRIC — for every spec section, answer these five questions in
+      RUBRIC — for every spec section, answer these seven questions in
       .ai/build/review-claude.md, in order, with PASS or FAIL per question
       and concrete evidence (grep output, file:line, snippet) for any FAIL:
 
@@ -2061,7 +2088,7 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
       the complete set of changes this build produced. Read the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
@@ -2074,7 +2101,7 @@ workflow BuildProduct
         plan, not evidence of completion. Treat them as nothing. Verify each
         requirement against the code yourself.
 
-      RUBRIC — for every spec section, answer these five questions in
+      RUBRIC — for every spec section, answer these seven questions in
       .ai/build/review-codex.md, in order, with PASS or FAIL per question
       and concrete evidence (grep output, file:line, snippet) for any FAIL:
 
@@ -2156,7 +2183,7 @@ workflow BuildProduct
     reasoning_effort: high
     prompt:
       Review the implementation against SPEC.md. Your PRIMARY read is the
-      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      cumulative base..worktree review diff at .ai/build/review-diff.md — it is
       the complete set of changes this build produced. Read the full working
       tree ON DEMAND only when a finding needs surrounding context (it is
       available, not mandated). The build loop has
@@ -2178,7 +2205,7 @@ workflow BuildProduct
         requirement against the code yourself. Reading ✅ as evidence is
         the exact failure mode this lane exists to prevent.
 
-      RUBRIC — for every spec section, answer these five questions in
+      RUBRIC — for every spec section, answer these seven questions in
       .ai/build/review-gemini.md, in order, with PASS or FAIL per question
       and concrete evidence (grep output, file:line, snippet) for any FAIL:
 

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1926,6 +1926,16 @@ workflow BuildProduct
       set -u
       mkdir -p .ai/build
       OUT=.ai/build/review-diff.md
+      # #424 review: bail loudly if this isn't a git work tree. Otherwise the
+      # git commands below emit error text, the file is non-empty so the
+      # empty-artifact guard never trips, and reviewers see git errors dressed
+      # up as a valid diff. Stamp UNAVAILABLE and route on (the diff is advisory).
+      if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        echo "WARNING: not inside a git work tree; cannot compute review diff" >&2
+        echo "# Review diff UNAVAILABLE — not a git work tree. Read the working tree directly." > "$OUT"
+        printf 'review-diff-ready'
+        exit 0
+      fi
       BASE=$(cat .ai/build/run-base-sha 2>/dev/null || true)
       if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
         BASE=$(git hash-object -t tree /dev/null)

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -560,7 +560,7 @@ workflow BuildProduct
       # nothing and exits non-zero on a commitless repo, so a fresh repo
       # genuinely records an empty base. Goes to a FILE so the routing marker
       # below stays last on stdout.
-      RUN_BASE=$(git rev-parse --verify --quiet HEAD || true)
+      RUN_BASE=$(git rev-parse --verify --quiet HEAD 2>/dev/null || true)
       printf '%s\n' "$RUN_BASE" > .ai/build/run-base-sha
 
       printf 'setup-ready'
@@ -1002,7 +1002,7 @@ workflow BuildProduct
       # silently empty milestone 1's file record). Written on the has-next path
       # only — the all-done branch returned earlier. Goes to a FILE so the
       # routing marker below stays last on stdout.
-      START=$(git rev-parse --verify --quiet HEAD || true)
+      START=$(git rev-parse --verify --quiet HEAD 2>/dev/null || true)
       printf '%s\n' "$START" > .ai/build/milestone-start-sha
 
       printf "milestone-$NEXT"
@@ -1961,10 +1961,11 @@ workflow BuildProduct
       {
         echo "# Cumulative review diff (base..worktree)"
         echo
-        echo "_Base: ${BASE} → working tree. This is the complete set of changes"
-        echo "the build produced, INCLUDING staged/unstaged and untracked work not"
-        echo "yet committed. It is your PRIMARY read; the full working tree is"
-        echo "available on demand if a finding needs surrounding context._"
+        echo "_Base: ${BASE} → working tree. The diff below covers committed plus"
+        echo "staged/unstaged changes to TRACKED files; untracked files are listed"
+        echo "by path in their own section (their content is NOT diffed here). It is"
+        echo "your PRIMARY read; the full working tree is available on demand if a"
+        echo "finding needs surrounding context._"
         echo
         echo '## Files changed'
         git diff --name-status "${BASE}" 2>&1 || DIFF_ERR=1

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -666,8 +666,9 @@ workflow BuildProduct
       Every rule-(f) item, one per line, each with its SPEC.md source and
       its kind (test / emitted-value / normative-constant); emitted-value
       and normative-constant lines must carry the verification shape "a
-      test asserts this exact value as a hard-coded expectation" — or the
-      single line "SPEC mandates no named tests".
+      test asserts this exact value as a hard-coded expectation" — or, only
+      when SPEC.md mandates no rule-(f) items of ANY kind, the single line
+      "SPEC mandates no tests, emitted values, or normative constants".
 
       Then your terminal STATUS line:
       - zero critical findings -> STATUS:success (warnings alone never

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -1953,9 +1953,15 @@ workflow BuildProduct
       # accepted-but-uncommitted milestone work — the `accept` gate routes here
       # WITHOUT committing first — is included instead of silently omitted from
       # what reviewers are told is "the complete set of changes". `git diff
-      # <commit>` (no ..HEAD) compares the commit to the worktree, capturing
-      # committed + staged + unstaged tracked changes; untracked files are listed
-      # separately below. On a clean tree this is identical to BASE..HEAD.
+      # <commit>` (no ..HEAD) compares the commit to the WORKING TREE, so it
+      # reflects the current on-disk content of tracked files (committed work plus
+      # any uncommitted edits present in the worktree). It compares against the
+      # worktree, NOT the index, so a staged change that doesn't match the worktree
+      # (#424 review: stage version B, then revert the file on disk) isn't captured
+      # — but in this workflow the worktree IS the source of truth (agents edit
+      # files, they don't manage a staging area), so worktree state is exactly what
+      # reviewers should see. Untracked files are listed separately below. On a
+      # clean tree this is identical to BASE..HEAD.
       #
       # git stderr is kept IN the artifact (2>&1, not 2>/dev/null) so a failure
       # is diagnosable, but #424 review: an empty-output guard alone is not
@@ -1969,8 +1975,9 @@ workflow BuildProduct
       {
         echo "# Cumulative review diff (base..worktree)"
         echo
-        echo "_Base: ${BASE} → working tree. The diff below covers committed plus"
-        echo "staged/unstaged changes to TRACKED files; untracked files are listed"
+        echo "_Base: ${BASE} → working tree. The diff below covers every TRACKED-file"
+        echo "change present in the working tree relative to base (committed work plus"
+        echo "any uncommitted edits on disk); untracked files are listed"
         echo "by path in their own section (their content is NOT diffed here). It is"
         echo "your PRIMARY read; the full working tree is available on demand if a"
         echo "finding needs surrounding context._"

--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -553,6 +553,16 @@ workflow BuildProduct
         echo "## Milestones landed"
       } > .ai/build/build-context.md 2>/dev/null || true
 
+      # #418: capture the run's base commit ONCE at Setup so the cross-review
+      # diff node can compute a cumulative base..HEAD without a per-milestone
+      # marker (those are deleted at each MarkMilestoneDone). Same non-leaking
+      # idiom as PickNextMilestone's start marker: --verify --quiet prints
+      # nothing and exits non-zero on a commitless repo, so a fresh repo
+      # genuinely records an empty base. Goes to a FILE so the routing marker
+      # below stays last on stdout.
+      RUN_BASE=$(git rev-parse --verify --quiet HEAD || true)
+      printf '%s\n' "$RUN_BASE" > .ai/build/run-base-sha
+
       printf 'setup-ready'
 
   # ─── SpecLint: spec-coherence preflight (issue #301, epic #308 Phase 2) ──
@@ -1894,6 +1904,45 @@ workflow BuildProduct
       rm -f .ai/build/review-claude.md .ai/build/review-codex.md .ai/build/review-gemini.md
       printf 'cleared stale review reports\n'
 
+  # #418: compute the cumulative base..HEAD review diff ONCE so the three
+  # reviewers read a bounded diff as their PRIMARY input instead of each
+  # re-reading the whole tree (the ~90%-of-tokens problem). BASE is the run's
+  # base commit captured at Setup (.ai/build/run-base-sha); degrade to the
+  # empty tree when it is empty (fresh repo) or unreachable (history rewrite)
+  # — the SAME two-dot + empty-tree-fallback idiom verify.sh and
+  # MarkMilestoneDone already use. The full tree stays available on demand
+  # (the reviewers may read any file); this only POINTS their primary read.
+  # The diff is advisory context, so the whole body is best-effort and the
+  # routing marker is printed last.
+  tool ComputeReviewDiff
+    label: "Compute Cumulative Review Diff"
+    timeout: 60s
+    # Cap matches ShowPlan: a large cumulative diff must not be clipped before
+    # the reviewers read the file (they read the FILE, not ctx, but keep the
+    # node's own stdout generous for diagnose).
+    output_limit: 1048576
+    command:
+      set -u
+      mkdir -p .ai/build
+      BASE=$(cat .ai/build/run-base-sha 2>/dev/null || true)
+      if [ -z "$BASE" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+        BASE=$(git hash-object -t tree /dev/null)
+      fi
+      {
+        echo "# Cumulative review diff (base..HEAD)"
+        echo
+        echo "_Base: ${BASE} → HEAD. This is the complete set of changes the"
+        echo "build produced. It is your PRIMARY read; the full working tree is"
+        echo "available on demand if a finding needs surrounding context._"
+        echo
+        echo '## Files changed'
+        git diff --name-status "${BASE}..HEAD" 2>/dev/null
+        echo
+        echo '## Full diff'
+        git diff "${BASE}..HEAD" 2>/dev/null
+      } > .ai/build/review-diff.md 2>/dev/null || true
+      printf 'review-diff-ready'
+
   parallel ReviewParallel -> ReviewClaude, ReviewCodex, ReviewGemini
     params:
       fan_in_policy: all
@@ -1912,11 +1961,15 @@ workflow BuildProduct
 
   agent ReviewClaude
     label: "Claude Review (general)"
-    model: claude-opus-4-6
+    model: claude-sonnet-4-6
     provider: anthropic
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. The build loop has
+      Review the implementation against SPEC.md. Your PRIMARY read is the
+      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      the complete set of changes this build produced. Read the full working
+      tree ON DEMAND only when a finding needs surrounding context (it is
+      available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose
       to stop early (the "accept" gate) and ship what exists. Review what is
       actually present; do not assume unfinished work will arrive later.
@@ -2003,11 +2056,15 @@ workflow BuildProduct
 
   agent ReviewCodex
     label: "Codex Review (quality)"
-    model: gpt-5.4
+    model: gpt-5.2
     provider: openai
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. The build loop has
+      Review the implementation against SPEC.md. Your PRIMARY read is the
+      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      the complete set of changes this build produced. Read the full working
+      tree ON DEMAND only when a finding needs surrounding context (it is
+      available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose
       to stop early (the "accept" gate) and ship what exists. Review what is
       actually present; do not assume unfinished work will arrive later.
@@ -2098,7 +2155,11 @@ workflow BuildProduct
     provider: gemini
     reasoning_effort: high
     prompt:
-      Review the COMPLETE implementation against SPEC.md. The build loop has
+      Review the implementation against SPEC.md. Your PRIMARY read is the
+      cumulative base..HEAD review diff at .ai/build/review-diff.md — it is
+      the complete set of changes this build produced. Read the full working
+      tree ON DEMAND only when a finding needs surrounding context (it is
+      available, not mandated). The build loop has
       finished — either every planned milestone completed, or the operator chose
       to stop early (the "accept" gate) and ship what exists. Review what is
       actually present; do not assume unfinished work will arrive later.
@@ -2514,7 +2575,8 @@ workflow BuildProduct
         iface-reachability-rubric.md), the re-review
         budget counter (review_fix_attempts),
         the per-node build-context file (build-context.md),
-        and reviewers write reports (review-claude.md,
+        the run base marker (run-base-sha) and cumulative review diff
+        (review-diff.md), and reviewers write reports (review-claude.md,
         review-codex.md, review-gemini.md). Only flag files outside
         this explicit allowlist. (.ai/decisions/*.md workflow artifacts —
         spec-analysis, milestones, requirement-coverage, compliance —
@@ -2840,7 +2902,8 @@ workflow BuildProduct
     # ClearStaleReviews wipes prior-round reports before fan-out so the
     # post-join CheckReviewsComplete guard (issue #313) can't be satisfied by a
     # stale file from an earlier re-review pass.
-    ClearStaleReviews -> ReviewParallel
+    ClearStaleReviews -> ComputeReviewDiff
+    ComputeReviewDiff -> ReviewParallel
     # The three reviewers run as parallel branches; a branch runs via
     # ParallelHandler (registry.Execute), bypassing the engine's strict-failure
     # path, so a per-branch fallback_target would be inert. Route failure on the

--- a/examples/build_product_with_superspec.dip
+++ b/examples/build_product_with_superspec.dip
@@ -98,11 +98,29 @@ workflow BuildProductWithSuperspec
           value. A contract like "Idempotency-Key derived from
           review_id+sha" on a signature receiving neither is
           unimplementable as written.
-      (f) Mandated tests enumerated and assignable: list every test
-          SPEC.md mandates by name or by concrete behavior. This list
-          feeds the Decompose requirement-coverage table (issue
-          #300); a mandated test so vague no milestone could own it
-          is a finding.
+      (f) Mandated tests, spec-emitted values, and normative constants
+          enumerated and assignable: list every test SPEC.md mandates by
+          name or by concrete behavior, PLUS every spec-prescribed EMITTED
+          value (log event name, error code, status string) and every
+          constant SPEC.md marks "normative". This list feeds the Decompose
+          requirement-coverage table (issue #300) so none can be silently
+          unowned; a mandated test / emitted value / normative constant so
+          vague no milestone could own it is a finding. For each emitted
+          value and normative constant, note the required verification
+          shape: "a test asserts this exact value as a hard-coded
+          expectation (not via the production constant)".
+      (g) External-tool invocation literals verifiable: for every exact
+          external-tool invocation SPEC.md prescribes — a `gh` / `git` /
+          other CLI command with a specific flag string (e.g.
+          `gh pr create --head <owner>:<branch>`) — record the literal flag
+          string as a behavioral contract whose verification method is "the
+          real tool accepts this literal". A literal that is wrong on its
+          face against the tool's own flag grammar (the canonical case:
+          `gh ... -b -`, where `-b` expects an argument and `-` is consumed
+          as that argument, silently mis-parsing) is an UNVERIFIABLE
+          contract — flag it here rather than letting a downstream grep
+          "find the string" and pass. Detection keys on the SHAPE "spec
+          prescribes a literal CLI invocation", never on a specific tool.
 
       WARN — report in the artifact, do NOT fail the gate:
       (d) Checkable guarantees: behavioral guarantees phrased so they
@@ -119,8 +137,12 @@ workflow BuildProductWithSuperspec
       ## Warnings
       Rule (d)/(e) findings, same evidence shape — or "none".
       ## Mandated tests
-      Every rule-(f) test, one per line, each with its SPEC.md
-      source — or the single line "SPEC mandates no named tests".
+      Every rule-(f) item, one per line, each with its SPEC.md source and
+      its kind (test / emitted-value / normative-constant); emitted-value
+      and normative-constant lines must carry the verification shape "a
+      test asserts this exact value as a hard-coded expectation" — or, only
+      when SPEC.md mandates no rule-(f) items of ANY kind, the single line
+      "SPEC mandates no tests, emitted values, or normative constants".
 
       Then your terminal STATUS line:
       - zero critical findings -> STATUS:success (warnings alone never

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -268,8 +268,10 @@ func TestBuildProductIssue313ReviewGate(t *testing.T) {
 	// ClearStaleReviews. The #313 invariant — stale reports cleared on BOTH
 	// entries — is preserved with the gate prepended.
 	// #418 inserts ComputeReviewDiff between ClearStaleReviews and the fan-out
-	// so the reviewers read a bounded base..HEAD diff; the #313 invariant (stale
-	// reports cleared before the fan-out runs) is preserved across the extra hop.
+	// so the reviewers read a bounded base..worktree diff (BASE vs the working
+	// tree, capturing uncommitted edits — not BASE..HEAD); the #313 invariant
+	// (stale reports cleared before the fan-out runs) is preserved across the
+	// extra hop.
 	if !hasUnconditionalEdgeTo(g, "ClearStaleReviews", "ComputeReviewDiff") {
 		t.Error("ClearStaleReviews has no edge to ComputeReviewDiff (issues #313/#418)")
 	}

--- a/pipeline/build_product_failure_routing_test.go
+++ b/pipeline/build_product_failure_routing_test.go
@@ -267,8 +267,14 @@ func TestBuildProductIssue313ReviewGate(t *testing.T) {
 	// the #350 structural existence gate (CheckMilestoneOutputs) and then
 	// ClearStaleReviews. The #313 invariant — stale reports cleared on BOTH
 	// entries — is preserved with the gate prepended.
-	if !hasUnconditionalEdgeTo(g, "ClearStaleReviews", "ReviewParallel") {
-		t.Error("ClearStaleReviews has no edge to ReviewParallel (issue #313)")
+	// #418 inserts ComputeReviewDiff between ClearStaleReviews and the fan-out
+	// so the reviewers read a bounded base..HEAD diff; the #313 invariant (stale
+	// reports cleared before the fan-out runs) is preserved across the extra hop.
+	if !hasUnconditionalEdgeTo(g, "ClearStaleReviews", "ComputeReviewDiff") {
+		t.Error("ClearStaleReviews has no edge to ComputeReviewDiff (issues #313/#418)")
+	}
+	if !hasUnconditionalEdgeTo(g, "ComputeReviewDiff", "ReviewParallel") {
+		t.Error("ComputeReviewDiff has no edge to ReviewParallel (issues #313/#418)")
 	}
 	if !hasEdgeWithCondition(g, "PickNextMilestone", "CheckMilestoneOutputs", "ctx.tool_stdout contains all-done") {
 		t.Error("PickNextMilestone all-done edge must enter CheckMilestoneOutputs before the review fan-out (issue #350)")

--- a/pipeline/build_product_model_tiering_test.go
+++ b/pipeline/build_product_model_tiering_test.go
@@ -1,0 +1,71 @@
+// ABOUTME: Pin test for issues #418b/#419 — model + reasoning-effort tiering on
+// ABOUTME: the review panel and cheaply-verified agent nodes in build_product.dip.
+package pipeline
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildProductReviewPanelTiering(t *testing.T) {
+	g := loadBuildProduct(t)
+	cases := []struct{ id, model, effort, provider string }{
+		// #418b: two of three lanes drop to mid-tier; adversarial stays frontier.
+		{"ReviewClaude", "claude-sonnet-4-6", "high", "anthropic"},
+		{"ReviewCodex", "gpt-5.2", "high", "openai"},
+		{"ReviewGemini", "gemini-2.5-pro", "high", "gemini"}, // adversarial frontier
+	}
+	for _, c := range cases {
+		n := g.Nodes[c.id]
+		if n == nil {
+			t.Fatalf("%s node missing", c.id)
+		}
+		if got := n.Attrs["llm_model"]; got != c.model {
+			t.Errorf("%s llm_model = %q, want %q (#418b)", c.id, got, c.model)
+		}
+		if got := n.Attrs["reasoning_effort"]; got != c.effort {
+			t.Errorf("%s reasoning_effort = %q, want %q (#418b)", c.id, got, c.effort)
+		}
+		if got := n.Attrs["llm_provider"]; got != c.provider {
+			t.Errorf("%s llm_provider = %q, want %q (#418b)", c.id, got, c.provider)
+		}
+	}
+}
+
+func TestBuildProductSynthesisAndAdversarialStayFrontier(t *testing.T) {
+	g := loadBuildProduct(t)
+	for _, id := range []string{"SynthesizeReviews", "FinalSpecCheck"} {
+		n := g.Nodes[id]
+		if n == nil {
+			t.Fatalf("%s node missing", id)
+		}
+		if got := n.Attrs["llm_model"]; got != "claude-opus-4-6" {
+			t.Errorf("%s llm_model = %q, want claude-opus-4-6 (frontier, #419)", id, got)
+		}
+		if got := n.Attrs["reasoning_effort"]; got != "high" {
+			t.Errorf("%s reasoning_effort = %q, want high (#419)", id, got)
+		}
+	}
+}
+
+func TestBuildProductComputeReviewDiffNodeExists(t *testing.T) {
+	g := loadBuildProduct(t)
+	n := g.Nodes["ComputeReviewDiff"]
+	if n == nil {
+		t.Fatal("ComputeReviewDiff node missing (#418a)")
+	}
+	cmd := n.Attrs["tool_command"]
+	if cmd == "" {
+		t.Fatal("ComputeReviewDiff has no tool_command (#418a)")
+	}
+	for _, want := range []string{"run-base-sha", "> .ai/build/review-diff.md"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("ComputeReviewDiff tool_command missing %q (#418a)", want)
+		}
+	}
+	for _, id := range []string{"ReviewClaude", "ReviewCodex", "ReviewGemini"} {
+		if p := g.Nodes[id].Attrs["prompt"]; !strings.Contains(p, "review-diff.md") {
+			t.Errorf("%s prompt does not point at review-diff.md (#418a)", id)
+		}
+	}
+}

--- a/pipeline/build_product_model_tiering_test.go
+++ b/pipeline/build_product_model_tiering_test.go
@@ -32,7 +32,7 @@ func TestBuildProductReviewPanelTiering(t *testing.T) {
 	}
 }
 
-func TestBuildProductSynthesisAndAdversarialStayFrontier(t *testing.T) {
+func TestBuildProductSynthesisAndFinalSpecCheckStayFrontier(t *testing.T) {
 	g := loadBuildProduct(t)
 	for _, id := range []string{"SynthesizeReviews", "FinalSpecCheck"} {
 		n := g.Nodes[id]

--- a/pipeline/build_product_model_tiering_test.go
+++ b/pipeline/build_product_model_tiering_test.go
@@ -76,13 +76,18 @@ func TestBuildProductComputeReviewDiffNodeExists(t *testing.T) {
 	if cmd == "" {
 		t.Fatal("ComputeReviewDiff has no tool_command (#418a)")
 	}
-	for _, want := range []string{"run-base-sha", "> .ai/build/review-diff.md"} {
+	for _, want := range []string{"run-base-sha", "OUT=.ai/build/review-diff.md"} {
 		if !strings.Contains(cmd, want) {
 			t.Errorf("ComputeReviewDiff tool_command missing %q (#418a)", want)
 		}
 	}
 	for _, id := range []string{"ReviewClaude", "ReviewCodex", "ReviewGemini"} {
-		if p := g.Nodes[id].Attrs["prompt"]; !strings.Contains(p, "review-diff.md") {
+		rn := g.Nodes[id]
+		if rn == nil {
+			t.Errorf("reviewer node %q missing (#418a)", id)
+			continue
+		}
+		if p := rn.Attrs["prompt"]; !strings.Contains(p, "review-diff.md") {
 			t.Errorf("%s prompt does not point at review-diff.md (#418a)", id)
 		}
 	}

--- a/pipeline/build_product_model_tiering_test.go
+++ b/pipeline/build_product_model_tiering_test.go
@@ -48,6 +48,24 @@ func TestBuildProductSynthesisAndAdversarialStayFrontier(t *testing.T) {
 	}
 }
 
+func TestBuildProductCheaplyVerifiedNodesAreMidTier(t *testing.T) {
+	g := loadBuildProduct(t)
+	// #419: SpecLint (gated by its STATUS contract) and ReadSpec (gated by
+	// ApprovePlan) drop to mid-tier model AND medium effort.
+	for _, id := range []string{"SpecLint", "ReadSpec"} {
+		n := g.Nodes[id]
+		if n == nil {
+			t.Fatalf("%s node missing", id)
+		}
+		if got := n.Attrs["llm_model"]; got != "claude-sonnet-4-6" {
+			t.Errorf("%s llm_model = %q, want claude-sonnet-4-6 (#419)", id, got)
+		}
+		if got := n.Attrs["reasoning_effort"]; got != "medium" {
+			t.Errorf("%s reasoning_effort = %q, want medium (#419)", id, got)
+		}
+	}
+}
+
 func TestBuildProductComputeReviewDiffNodeExists(t *testing.T) {
 	g := loadBuildProduct(t)
 	n := g.Nodes["ComputeReviewDiff"]


### PR DESCRIPTION
## Summary

Closes the review-fidelity and review-cost defects exposed by `build_product` dogfooding run `b65fb64ac099`. Five issues, **one commit each**, all pure `examples/build_product.dip` authoring + Go pin tests (no engine code — #416's optional adapter-fixture lint is deferred as a follow-up to keep PR-A engine-free).

| # | Change |
|---|--------|
| **#306** | `ReadSpec` now derives `.ai/decisions/spec-ambiguities.md` (one DEFINITE ruling per contradiction) and `.ai/decisions/behavioral-contracts.md` (every non-literal prose guarantee + a concrete verification method). `ApprovePlan` surfaces both; `Implement` cites the rulings; `VerifyMilestone` (new check 5b) + `FinalSpecCheck` disposition each contract or `STATUS:fail`. |
| **#417** | New rubric **point 6 (SPEC-EMITTED-VALUE)** in all three reviewers + `FinalSpecCheck`: a test asserting `emit == prod.Constant` FAILs; `emit == "<spec literal>"` PASSes (cited assertion line). Normative constants flow into `behavioral-contracts.md` and the `Decompose` coverage table so they can't be silently unowned. |
| **#416** | New rubric **point 7 (CONTRACT-FIDELITY)** in all three reviewers + `FinalSpecCheck`: FAIL any external seam whose only test uses a fake the production code also defines. `SpecLint` rule (g) records an external-tool invocation **literal** as a contract verified by "the real tool accepts this literal" (catches the `gh ... -b -` case). |
| **#418** | New `ComputeReviewDiff` tool node (`ClearStaleReviews -> ComputeReviewDiff -> ReviewParallel`) computes the cumulative `base..worktree` diff once (`git diff <base>` worktree compare, capturing accepted-but-uncommitted work — the accept gate routes here without committing); reviewers' PRIMARY read is scoped to it (full tree on demand). Base derives from the run's `Setup`-captured `run-base-sha` with the existing empty-tree fallback — no hard-coded range. `ReviewClaude`→`claude-sonnet-4-6`, `ReviewCodex`→`gpt-5.2`; adversarial `ReviewGemini` stays `gemini-2.5-pro`; `SynthesizeReviews` unchanged. |
| **#419** | `SpecLint` and `ReadSpec` drop to `claude-sonnet-4-6` + `reasoning_effort: medium` (each gated by a cheap downstream verifier). `SynthesizeReviews`, `FinalSpecCheck`, and the adversarial lane stay frontier/high. |

The 5-point rubric is byte-for-byte unchanged — points 6/7 are purely additive and verbatim-identical across all three reviewers.

## Genericity (section D)

Every rule keys on **seam role** (provider adapter / host CLI / contractual subprocess), **node role** (general/quality/adversarial lane; cheaply-verified vs synthesis), **prose shape** (modal verbs, timing/ordering/cardinality), or the dip's **own** SHA computation. `gh`/`git`/`OpenAI`/`"review.skip"` appear only as illustrative instances, each with an explicit "never on a specific tool/provider/language" disclaimer.

## #418 AC#3 (−40% review input tokens) — by construction + estimate

AC#3's steady-state target isn't runnable in-PR (a full `build_product` re-run costs ~$27/2h and needs a real spec). Proven by construction instead: (i) reviewers now read the dip-computed `base..worktree` diff instead of re-walking the whole tree ×3; (ii) 2 of 3 lanes run mid-tier. Against the **3.01M review INPUT-token baseline** (#418 body), scoping three whole-tree reads down to one shared bounded diff plus mid-tier on two lanes comfortably clears −40%. Run a live re-run only if empirical confirmation is wanted.

## Note (from adversarial review)

Normative-constant records flow two ways, both reaching `Decompose`'s coverage table: `ReadSpec` → `behavioral-contracts.md`, and `SpecLint` rule (f) → `spec-quality.md` "Mandated tests". `VerifyMilestone` 5b dispositions them transitively via `behavioral-contracts.md`; `FinalSpecCheck` has an explicit SPEC-EMITTED-VALUE section.

## Verification

- `go build ./...` ✅ · `go test ./... -short` ✅ (new `build_product_model_tiering_test.go` pins all model/effort/provider tiers; `#313` invariant test strengthened to the two-hop `ClearStaleReviews -> ComputeReviewDiff -> ReviewParallel` topology)
- `dippin doctor` **Grade A** on `ask_and_execute`, `build_product`, `build_product_with_superspec`
- `dippin simulate -all-paths build_product` — 100 paths, all terminate
- Adversarial review (3 lenses: AC completeness / over-under-correction / genericity+edges+gates): **PASS, zero blockers**

Closes #306
Closes #416
Closes #417
Closes #418
Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785003144&installation_id=131176874&pr_number=424&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F424&signature=13e79e6e2e065f0f651326ba359bc142faae2ee99844857fdaf686a28a57d24c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-build decision artifacts for spec ambiguities and behavioral contracts, now surfaced during plan approval.
  * Introduced a single unified review-diff (`.ai/build/review-diff.md`) as the primary cross-review input, using a bounded base-to-worktree comparison.
* **Bug Fixes**
  * Hardened review-diff generation so failures surface as unavailable output with safe fallback behavior.
  * Strengthened fail-closed contract/ambiguity gating and tightened review rubrics for spec-emitted hard-coded literal expectations and external seam fidelity.
* **Tests**
  * Updated routing assertions for the added review-diff step and added coverage for node presence, prompt references, and pinned model/tier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
