### PR TITLE
engine: opt-in content-hash node-output memoization (#421)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the node re-runs live rather than replaying a stored failure into routing.
   A node declaring `writable_paths` is an **unconditional** hard
   miss — it always re-runs and is never replayed, with no warning (a by-design
-  policy skip, not a key-computation failure). Such a node mutates and reads the
+  policy skip, not a key-computation failure). The miss is keyed on attr
+  **presence**, not a non-empty value, mirroring `AgentConfig.WritablePathsSet`
+  and the fs-jail gate — so the adapter's `writable_paths: ""` bypass-defense
+  sentinel still refuses memoization (#425 review). Such a node mutates and reads the
   agent's session `working_dir`, but tracker can only fingerprint the ARTIFACT
   repo (`<artifactDir>/<runID>`), a different directory — so any content
   fingerprint would prove nothing about the tree the agent actually read/wrote

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   file edits that the prior staged-blob listing missed); the persisted
   `MemoEntry` now carries the `PreferredLabel`/`SuggestedNextNodes` routing hints
   so a replayed node follows the same edge the original did; and replayed trace
-  entries are stamped with a real timestamp.
+  entries are stamped with a real timestamp. Second review round: the worktree
+  fingerprint now fails closed on an unexpected `read-tree HEAD` error (only a
+  genuinely missing HEAD proceeds with an empty index — otherwise a tracked
+  deletion could yield a stale fingerprint / false cache hit); and the replay
+  Outcome deep-copies its `ContextUpdates`/`SuggestedNextNodes` so downstream
+  mutation can never corrupt the persisted memo record.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   genuinely missing HEAD proceeds with an empty index — otherwise a tracked
   deletion could yield a stale fingerprint / false cache hit); and the replay
   Outcome deep-copies its `ContextUpdates`/`SuggestedNextNodes` so downstream
-  mutation can never corrupt the persisted memo record.
+  mutation can never corrupt the persisted memo record; and the replay path now
+  threads the run's `ctx` (instead of `context.Background()`) into `finishNode`
+  so cancellation/deadlines still apply and a non-success memo record from a
+  corrupted/hand-edited checkpoint routes through the same ctx-aware tail.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Opt-in content-hash node-output memoization (#421).** Annotate an agent
+  node with `params: { memoize: true }` and a loop-restart that re-enters the
+  already-green node with identical resolved inputs now REPLAYS the stored
+  successful outcome instead of re-running the handler. The memo key is a
+  SHA-256 over the node's resolved attrs (post-interpolation prompt/command)
+  and the bare-namespace context it reads — including the `last_response` and
+  `human_response` prompt inputs injected into every agent prompt, which are
+  hashed unconditionally so an intervening node's new critique invalidates the
+  replay. Memoization is **agent-node-only**. A node declaring `writable_paths`
+  has working-tree side effects and **requires a working-tree fingerprint to
+  replay**: without a live git repo (or on a fingerprint error) it is a hard
+  cache miss and re-runs, never replaying on an unproven tree. Any input change
+  yields a different key and re-runs the node. Only successful outcomes are
+  memoized (failures never replay), the memo table is persisted in
+  `checkpoint.json` so replay survives resume. Off by default: a `.dip` file
+  lacking the attr has byte-identical behavior and writes no `memo_entries`.
+  Emits `node_memo_replayed` on a replay.
+
 ## [0.40.2] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   memoized (failures never replay), the memo table is persisted in
   `checkpoint.json` so replay survives resume. Off by default: a `.dip` file
   lacking the attr has byte-identical behavior and writes no `memo_entries`.
-  Emits `node_memo_replayed` on a replay.
+  Emits `node_memo_replayed` on a replay. Review hardening: the memo key now
+  re-includes a bare key the node self-aliased on a prior pass once an
+  intervening node OVERWRITES it (so replay can't serve stale output against a
+  changed input); the `writable_paths` tree fingerprint now hashes actual
+  worktree CONTENT via a throwaway-index `write-tree` (catching unstaged/untracked
+  file edits that the prior staged-blob listing missed); the persisted
+  `MemoEntry` now carries the `PreferredLabel`/`SuggestedNextNodes` routing hints
+  so a replayed node follows the same edge the original did; and replayed trace
+  entries are stamped with a real timestamp.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `human_response` prompt inputs injected into every agent prompt, which are
   hashed unconditionally so an intervening node's new critique invalidates the
   replay. Memoization is **agent-node-only**. A node declaring `writable_paths`
-  has working-tree side effects and **requires a working-tree fingerprint to
-  replay**: without a live git repo (or on a fingerprint error) it is a hard
-  cache miss and re-runs, never replaying on an unproven tree. Any input change
+  has working-tree side effects and is **never memoized** — an unconditional hard
+  cache miss, so it always re-runs (see the third review-round note below for why).
+  Any input change
   yields a different key and re-runs the node. Only successful outcomes are
   memoized (failures never replay), the memo table is persisted in
   `checkpoint.json` so replay survives resume. Off by default: a `.dip` file
@@ -41,7 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mutation can never corrupt the persisted memo record; and the replay path now
   threads the run's `ctx` (instead of `context.Background()`) into `finishNode`
   so cancellation/deadlines still apply and a non-success memo record from a
-  corrupted/hand-edited checkpoint routes through the same ctx-aware tail.
+  corrupted/hand-edited checkpoint routes through the same ctx-aware tail. Third
+  review round: a `writable_paths` node is now an **unconditional** hard miss
+  rather than replaying on an artifact-repo tree fingerprint. The fingerprint was
+  taken from `s.gitRepo` — the artifact repo at `<artifactDir>/<runID>`, a
+  different directory than the agent's session `working_dir` where `writable_paths`
+  actually takes effect — so it proved nothing about the tree the agent read/wrote
+  and could have replayed against a changed working tree. Until tracker can
+  fingerprint the agent's real `working_dir`, side-effecting nodes are simply not
+  memoizable (the `TreeFingerprint` helper is retained as the building block for
+  that follow-up).
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   timestamp; the replay Outcome deep-copies its `ContextUpdates`/`SuggestedNextNodes`
   so downstream mutation can never corrupt the persisted memo record; and the
   replay path threads the run's `ctx` (instead of `context.Background()`) into
-  `finishNode` so cancellation/deadlines still apply and a non-success memo
-  record from a corrupted/hand-edited checkpoint routes through the same
-  ctx-aware tail. A node declaring `writable_paths` is an **unconditional** hard
+  `finishNode` so cancellation/deadlines still apply; and the replay lookup now
+  enforces the "failures never replay" contract on the READ side too — a
+  non-success memo record (only reachable via a corrupted/hand-edited checkpoint,
+  since the store site is gated on `OutcomeSuccess`) is treated as a cache miss
+  and the node re-runs live rather than replaying a stored failure into routing.
+  A node declaring `writable_paths` is an **unconditional** hard
   miss — it always re-runs and is never replayed, with no warning (a by-design
   policy skip, not a key-computation failure). Such a node mutates and reads the
   agent's session `working_dir`, but tracker can only fingerprint the ARTIFACT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hashed unconditionally so an intervening node's new critique invalidates the
   replay. Memoization is **agent-node-only**. A node declaring `writable_paths`
   has working-tree side effects and is **never memoized** — an unconditional hard
-  cache miss, so it always re-runs (see the third review-round note below for why).
+  cache miss, so it always re-runs (see the `writable_paths` note below for why).
   Any input change
   yields a different key and re-runs the node. Only successful outcomes are
   memoized (failures never replay), the memo table is persisted in
@@ -28,29 +28,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Emits `node_memo_replayed` on a replay. Review hardening: the memo key now
   re-includes a bare key the node self-aliased on a prior pass once an
   intervening node OVERWRITES it (so replay can't serve stale output against a
-  changed input); the `writable_paths` tree fingerprint now hashes actual
-  worktree CONTENT via a throwaway-index `write-tree` (catching unstaged/untracked
-  file edits that the prior staged-blob listing missed); the persisted
-  `MemoEntry` now carries the `PreferredLabel`/`SuggestedNextNodes` routing hints
-  so a replayed node follows the same edge the original did; and replayed trace
-  entries are stamped with a real timestamp. Second review round: the worktree
-  fingerprint now fails closed on an unexpected `read-tree HEAD` error (only a
-  genuinely missing HEAD proceeds with an empty index — otherwise a tracked
-  deletion could yield a stale fingerprint / false cache hit); and the replay
-  Outcome deep-copies its `ContextUpdates`/`SuggestedNextNodes` so downstream
-  mutation can never corrupt the persisted memo record; and the replay path now
-  threads the run's `ctx` (instead of `context.Background()`) into `finishNode`
-  so cancellation/deadlines still apply and a non-success memo record from a
-  corrupted/hand-edited checkpoint routes through the same ctx-aware tail. Third
-  review round: a `writable_paths` node is now an **unconditional** hard miss
-  rather than replaying on an artifact-repo tree fingerprint. The fingerprint was
-  taken from `s.gitRepo` — the artifact repo at `<artifactDir>/<runID>`, a
-  different directory than the agent's session `working_dir` where `writable_paths`
-  actually takes effect — so it proved nothing about the tree the agent read/wrote
-  and could have replayed against a changed working tree. Until tracker can
-  fingerprint the agent's real `working_dir`, side-effecting nodes are simply not
-  memoizable (the `TreeFingerprint` helper is retained as the building block for
-  that follow-up).
+  changed input); the persisted `MemoEntry` now carries the
+  `PreferredLabel`/`SuggestedNextNodes` routing hints so a replayed node follows
+  the same edge the original did; replayed trace entries are stamped with a real
+  timestamp; the replay Outcome deep-copies its `ContextUpdates`/`SuggestedNextNodes`
+  so downstream mutation can never corrupt the persisted memo record; and the
+  replay path threads the run's `ctx` (instead of `context.Background()`) into
+  `finishNode` so cancellation/deadlines still apply and a non-success memo
+  record from a corrupted/hand-edited checkpoint routes through the same
+  ctx-aware tail. A node declaring `writable_paths` is an **unconditional** hard
+  miss — it always re-runs and is never replayed, with no warning (a by-design
+  policy skip, not a key-computation failure). Such a node mutates and reads the
+  agent's session `working_dir`, but tracker can only fingerprint the ARTIFACT
+  repo (`<artifactDir>/<runID>`), a different directory — so any content
+  fingerprint would prove nothing about the tree the agent actually read/wrote
+  and could replay against a changed working tree. Until tracker can fingerprint
+  the agent's real `working_dir`, side-effecting nodes are simply not memoizable
+  (the `TreeFingerprint` helper is retained as the building block for that
+  follow-up, but is not used in the memo key today).
 - **Sleep-aware budgets (#422, part A).** Opt-in `BudgetLimits.SleepAware` (CLI
   `--sleep-aware-budget`) excludes OS-suspend spans — e.g. a suspended laptop —
   from `max_wall_time` and `stall_timeout` accounting, so a machine that sleeps

--- a/pipeline/checkpoint.go
+++ b/pipeline/checkpoint.go
@@ -74,11 +74,16 @@ type Checkpoint struct {
 
 // MemoEntry is the JSON-tagged, serializable projection of a successful Outcome
 // (which has no JSON tags) persisted in the checkpoint for memoization (#421).
-// Only Status + ContextUpdates are replayed; other Outcome fields are routing
-// or accounting artifacts that the replay path does not need.
+// Status, ContextUpdates, and the routing hints (PreferredLabel,
+// SuggestedNextNodes) are replayed — the hints are required so a memoized node
+// that selected its next edge via them replays onto the SAME path the original
+// execution took (#425 review). Other Outcome fields are accounting artifacts
+// the replay path does not need.
 type MemoEntry struct {
-	Status         string            `json:"status"`
-	ContextUpdates map[string]string `json:"context_updates,omitempty"`
+	Status             string            `json:"status"`
+	ContextUpdates     map[string]string `json:"context_updates,omitempty"`
+	PreferredLabel     string            `json:"preferred_label,omitempty"`
+	SuggestedNextNodes []string          `json:"suggested_next_nodes,omitempty"`
 }
 
 // ensureSet lazily initializes the completed set from the slice.
@@ -198,7 +203,16 @@ func (cp *Checkpoint) PutMemo(key string, o *Outcome) {
 	for k, v := range o.ContextUpdates {
 		cu[k] = v
 	}
-	cp.MemoEntries[key] = MemoEntry{Status: o.Status, ContextUpdates: cu}
+	var snn []string
+	if len(o.SuggestedNextNodes) > 0 {
+		snn = append(snn, o.SuggestedNextNodes...)
+	}
+	cp.MemoEntries[key] = MemoEntry{
+		Status:             o.Status,
+		ContextUpdates:     cu,
+		PreferredLabel:     o.PreferredLabel,
+		SuggestedNextNodes: snn,
+	}
 }
 
 // GetMemo returns the stored outcome projection for a key, if any (#421).

--- a/pipeline/checkpoint.go
+++ b/pipeline/checkpoint.go
@@ -59,9 +59,26 @@ type Checkpoint struct {
 	// checkpoints (absent = "no overrides happened").
 	ValidationOverrides []OverrideDetail `json:"validation_overrides,omitempty"`
 
+	// MemoEntries maps a content-hash memo key to a stored SUCCESSFUL outcome
+	// projection (#421). Deliberately NOT cleared by clearDownstream — replay
+	// must survive loop restarts; a changed input yields a different key and
+	// misses naturally. The map round-trips natively through JSON (no derived
+	// set to rebuild, unlike completedSet). omitempty keeps pre-feature
+	// checkpoints byte-identical (default-off acceptance criterion).
+	MemoEntries map[string]MemoEntry `json:"memo_entries,omitempty"`
+
 	// completedSet provides O(1) lookup for IsCompleted. It is rebuilt from
 	// CompletedNodes on deserialization and kept in sync by MarkCompleted.
 	completedSet map[string]bool `json:"-"`
+}
+
+// MemoEntry is the JSON-tagged, serializable projection of a successful Outcome
+// (which has no JSON tags) persisted in the checkpoint for memoization (#421).
+// Only Status + ContextUpdates are replayed; other Outcome fields are routing
+// or accounting artifacts that the replay path does not need.
+type MemoEntry struct {
+	Status         string            `json:"status"`
+	ContextUpdates map[string]string `json:"context_updates,omitempty"`
 }
 
 // ensureSet lazily initializes the completed set from the slice.
@@ -168,6 +185,29 @@ func (cp *Checkpoint) ClearCompleted(nodeID string) {
 			break
 		}
 	}
+}
+
+// PutMemo records a successful outcome under the given content-hash key (#421).
+// ContextUpdates is deep-copied so a later pctx mutation cannot retroactively
+// corrupt the stored record.
+func (cp *Checkpoint) PutMemo(key string, o *Outcome) {
+	if cp.MemoEntries == nil {
+		cp.MemoEntries = make(map[string]MemoEntry)
+	}
+	cu := make(map[string]string, len(o.ContextUpdates))
+	for k, v := range o.ContextUpdates {
+		cu[k] = v
+	}
+	cp.MemoEntries[key] = MemoEntry{Status: o.Status, ContextUpdates: cu}
+}
+
+// GetMemo returns the stored outcome projection for a key, if any (#421).
+func (cp *Checkpoint) GetMemo(key string) (MemoEntry, bool) {
+	if cp.MemoEntries == nil {
+		return MemoEntry{}, false
+	}
+	e, ok := cp.MemoEntries[key]
+	return e, ok
 }
 
 // SaveCheckpoint writes the checkpoint to disk as JSON, creating directories as needed.

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -475,8 +475,14 @@ func (e *Engine) replayMemoizedNode(s *runState, currentNodeID string, node, exe
 		Message:   fmt.Sprintf("memoize: replayed prior successful outcome for node %q", currentNodeID),
 	})
 
-	outcome := &Outcome{Status: rec.Status, ContextUpdates: rec.ContextUpdates}
+	outcome := &Outcome{
+		Status:             rec.Status,
+		ContextUpdates:     rec.ContextUpdates,
+		PreferredLabel:     rec.PreferredLabel,
+		SuggestedNextNodes: rec.SuggestedNextNodes,
+	}
 	traceEntry := TraceEntry{
+		Timestamp:   time.Now(),
 		NodeID:      currentNodeID,
 		HandlerName: "<memoized>",
 		Status:      rec.Status,

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -361,22 +361,20 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 // iteration. When the node opted in and its resolved-input hash matches a prior
 // successful execution (in this run or a resumed checkpoint), it returns the
 // replayed loopResult; otherwise it records the pending key (for the store
-// site) and returns nil so the handler runs. An uncertain key (hash error)
-// warns and runs live — never replays on an uncertain key.
+// site) and returns nil so the handler runs. A node that opted in but is not
+// memoizable (computeMemoKey ok=false) simply runs the handler live — that is a
+// deterministic, by-design hard miss (currently only writable_paths side
+// effects), never a runtime computation failure, so it is NOT warned about
+// (#425 review). The conservative "never replay on an uncertain key" contract
+// is enforced inside computeMemoKey, which returns ok=false rather than a
+// best-guess key.
 func (e *Engine) maybeReplayMemoized(ctx context.Context, s *runState, currentNodeID string, node, execNode *Node, preHumanResponse string) *loopResult {
 	if !memoizeEnabled(execNode) {
 		return nil
 	}
 	key, ok := e.computeMemoKey(s, execNode)
 	if !ok {
-		e.emit(PipelineEvent{
-			Type:      EventWarning,
-			Timestamp: time.Now(),
-			RunID:     s.runID,
-			NodeID:    currentNodeID,
-			Message:   fmt.Sprintf("memoize: could not compute memo key for node %q; running handler", currentNodeID),
-		})
-		return nil
+		return nil // not memoizable (policy hard miss) — run the handler live
 	}
 	s.pendingMemoKey = key
 	rec, hit := s.cp.GetMemo(key)

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -381,6 +381,15 @@ func (e *Engine) maybeReplayMemoized(ctx context.Context, s *runState, currentNo
 	if !hit {
 		return nil
 	}
+	// Only successful outcomes are ever stored (PutMemo is gated on
+	// OutcomeSuccess), but enforce the "failures never replay" contract on the
+	// read side too: a non-success record can only come from a corrupted or
+	// hand-edited checkpoint, so treat it as a miss and re-run the node live
+	// rather than replaying a stored failure into the routing decision (#425
+	// review).
+	if rec.Status != string(OutcomeSuccess) {
+		return nil
+	}
 	lr := e.replayMemoizedNode(ctx, s, currentNodeID, node, execNode, rec, preHumanResponse)
 	return &lr
 }

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -233,26 +233,43 @@ func (e *Engine) Run(ctx context.Context) (*EngineResult, error) {
 		currentNodeID = s.cp.CurrentNode
 	}
 
-	resumeVisited := make(map[string]bool)
+	if result, err, done := e.runLoop(ctx, s, currentNodeID); !done {
+		return result, err
+	}
 
+	return e.buildSuccessResult(s), nil
+}
+
+// runLoop drives the main node-processing loop. It returns (result, err, false)
+// when a node iteration produced a terminal result (return) — the caller
+// returns it directly; it returns (nil, nil, true) when the loop broke on a
+// successful exit, signaling the caller to build the success result.
+func (e *Engine) runLoop(ctx context.Context, s *runState, currentNodeID string) (*EngineResult, error, bool) {
+	resumeVisited := make(map[string]bool)
 	for {
 		if err := ctx.Err(); err != nil {
-			return e.cancelledResult(s, err)
+			result, cerr := e.cancelledResult(s, err)
+			return result, cerr, false
 		}
 
 		lr := e.processNode(ctx, s, currentNodeID, resumeVisited)
 		switch lr.action {
 		case loopReturn:
-			return lr.result, lr.err
+			return lr.result, lr.err, false
 		case loopBreak:
-			goto done
+			return nil, nil, true
 		case loopContinue:
 			currentNodeID = lr.nextNodeID
-			continue
 		}
 	}
+}
 
-done:
+// buildSuccessResult emits the completion event and assembles the terminal
+// success EngineResult. Terminal-status rule: a success exit becomes
+// validation_overridden if any override fired during the run. Failure paths
+// return fail/budget regardless of override presence; only this success path
+// flips.
+func (e *Engine) buildSuccessResult(s *runState) *EngineResult {
 	s.trace.EndTime = time.Now()
 
 	e.emit(PipelineEvent{
@@ -262,9 +279,6 @@ done:
 		Message:   "pipeline completed",
 	})
 
-	// Terminal-status rule: a success exit becomes validation_overridden if
-	// any override fired during the run. Failure paths return fail/budget
-	// regardless of override presence; only this success path flips.
 	status := OutcomeSuccess
 	if len(s.validationOverrides) > 0 {
 		status = OutcomeValidationOverridden
@@ -277,7 +291,7 @@ done:
 		Trace:               s.trace,
 		Usage:               s.trace.AggregateUsage(),
 		ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
-	}, nil
+	}
 }
 
 // processNode handles a single iteration of the main engine loop.
@@ -312,6 +326,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	s.pctx.Set(ContextKeyOutcome, "")
 	s.pctx.Set(ContextKeyPreferredLabel, "")
 	s.pctx.Set(ContextKeySuggestedNextNodes, "")
+	s.pendingMemoKey = ""
 
 	// #352 item 2: human_response is one-shot. Record the value visible to
 	// this node so it can be cleared after the first prompt-consuming node
@@ -320,37 +335,89 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 
 	execNode := e.prepareExecNode(node, s)
 
-	outcome, traceEntry, err := e.executeNode(ctx, s, currentNodeID, execNode)
-	if err != nil {
-		// Preserve any dirty (possibly green) tree before this terminal handler
-		// error halts the run (#302) — e.g. a tool/agent that wrote files then
-		// died, or a cancellation mid-write. No-op on a clean tree. executeNode
-		// already appended this node's trace entry, so mirror the recorded ref
-		// onto it after the helper sets it on our local copy.
-		e.commitWIPBeforeRouting(s, currentNodeID, &traceEntry)
-		if traceEntry.WIPRef != "" && len(s.trace.Entries) > 0 {
-			s.trace.Entries[len(s.trace.Entries)-1].WIPRef = traceEntry.WIPRef
-		}
-		// Scope any keys written before the error so checkpoints and downstream
-		// nodes can still access this node's partial output via the scoped namespace.
-		s.pctx.ScopeToNode(currentNodeID)
-		e.saveCheckpoint(s.cp, s.pctx, s.runID)
-		s.trace.EndTime = time.Now()
-		return loopResult{
-			action: loopReturn,
-			result: &EngineResult{
-				RunID:               s.runID,
-				Status:              OutcomeFail,
-				CompletedNodes:      s.cp.CompletedNodes,
-				Context:             s.pctx.Snapshot(),
-				Trace:               s.trace,
-				Usage:               s.trace.AggregateUsage(),
-				ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
-			},
-			err: fmt.Errorf("handler error at node %q: %w", currentNodeID, err),
-		}
+	// #421: opt-in node-output memoization — replay a prior successful outcome
+	// when resolved inputs match, without invoking the handler. Returns a
+	// non-nil result only when a replay actually fires.
+	if lr := e.maybeReplayMemoized(s, currentNodeID, node, execNode, preHumanResponse); lr != nil {
+		return *lr
 	}
 
+	outcome, traceEntry, err := e.executeNode(ctx, s, currentNodeID, execNode)
+	if err != nil {
+		return e.handleNodeError(s, currentNodeID, &traceEntry, err)
+	}
+
+	return e.finishNode(ctx, s, currentNodeID, node, execNode, outcome, &traceEntry, preHumanResponse)
+}
+
+// maybeReplayMemoized handles the #421 memoization lookup at the top of a node
+// iteration. When the node opted in and its resolved-input hash matches a prior
+// successful execution (in this run or a resumed checkpoint), it returns the
+// replayed loopResult; otherwise it records the pending key (for the store
+// site) and returns nil so the handler runs. An uncertain key (hash error)
+// warns and runs live — never replays on an uncertain key.
+func (e *Engine) maybeReplayMemoized(s *runState, currentNodeID string, node, execNode *Node, preHumanResponse string) *loopResult {
+	if !memoizeEnabled(execNode) {
+		return nil
+	}
+	key, ok := e.computeMemoKey(s, execNode)
+	if !ok {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    currentNodeID,
+			Message:   fmt.Sprintf("memoize: could not compute memo key for node %q; running handler", currentNodeID),
+		})
+		return nil
+	}
+	s.pendingMemoKey = key
+	rec, hit := s.cp.GetMemo(key)
+	if !hit {
+		return nil
+	}
+	lr := e.replayMemoizedNode(s, currentNodeID, node, execNode, rec, preHumanResponse)
+	return &lr
+}
+
+// handleNodeError builds the terminal-fail loopResult for a handler error,
+// preserving any dirty (possibly green) tree before the run halts (#302).
+func (e *Engine) handleNodeError(s *runState, currentNodeID string, traceEntry *TraceEntry, err error) loopResult {
+	// Preserve any dirty (possibly green) tree before this terminal handler
+	// error halts the run (#302) — e.g. a tool/agent that wrote files then
+	// died, or a cancellation mid-write. No-op on a clean tree. executeNode
+	// already appended this node's trace entry, so mirror the recorded ref
+	// onto it after the helper sets it on our local copy.
+	e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
+	if traceEntry.WIPRef != "" && len(s.trace.Entries) > 0 {
+		s.trace.Entries[len(s.trace.Entries)-1].WIPRef = traceEntry.WIPRef
+	}
+	// Scope any keys written before the error so checkpoints and downstream
+	// nodes can still access this node's partial output via the scoped namespace.
+	s.pctx.ScopeToNode(currentNodeID)
+	e.saveCheckpoint(s.cp, s.pctx, s.runID)
+	s.trace.EndTime = time.Now()
+	return loopResult{
+		action: loopReturn,
+		result: &EngineResult{
+			RunID:               s.runID,
+			Status:              OutcomeFail,
+			CompletedNodes:      s.cp.CompletedNodes,
+			Context:             s.pctx.Snapshot(),
+			Trace:               s.trace,
+			Usage:               s.trace.AggregateUsage(),
+			ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
+		},
+		err: fmt.Errorf("handler error at node %q: %w", currentNodeID, err),
+	}
+}
+
+// finishNode runs the shared post-handler tail: apply outcome, scope, drain
+// steering, retry/human-response handling, status, and edge advance. Extracted
+// from processActiveNode so the memoization replay path (replayMemoizedNode)
+// reuses the IDENTICAL tail without re-invoking the handler (#421), and to keep
+// processActiveNode under the complexity gate.
+func (e *Engine) finishNode(ctx context.Context, s *runState, currentNodeID string, node, execNode *Node, outcome *Outcome, traceEntry *TraceEntry, preHumanResponse string) loopResult {
 	e.applyOutcome(s, currentNodeID, outcome)
 
 	// Copy every key written during this node's execution into the per-node
@@ -370,7 +437,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	e.drainSteering(s)
 
 	if outcome.Status == string(OutcomeRetry) {
-		return e.processRetryOutcome(ctx, s, currentNodeID, execNode, &traceEntry)
+		return e.processRetryOutcome(ctx, s, currentNodeID, execNode, traceEntry)
 	}
 
 	// After the retry check: a retrying node re-executes and must still see
@@ -379,11 +446,45 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 
 	e.handleOutcomeStatus(s, currentNodeID, outcome.Status)
 
-	if currentNodeID == e.graph.ExitNode {
-		return e.processExitNode(s, currentNodeID, outcome.Status, &traceEntry)
+	// #421: memoize ONLY successful outcomes (never replay a failure). Reached
+	// only when this node opted in and a key was computed (pendingMemoKey set);
+	// the retry path returned above, so fail/unknown never reach here as success.
+	if s.pendingMemoKey != "" && outcome.Status == string(OutcomeSuccess) {
+		s.cp.PutMemo(s.pendingMemoKey, outcome)
 	}
 
-	return e.advanceToNextNode(s, currentNodeID, &traceEntry)
+	if currentNodeID == e.graph.ExitNode {
+		return e.processExitNode(s, currentNodeID, outcome.Status, traceEntry)
+	}
+
+	return e.advanceToNextNode(s, currentNodeID, traceEntry)
+}
+
+// replayMemoizedNode replays a stored successful outcome (#421) instead of
+// invoking the handler: it synthesizes the Outcome + a marker trace entry and
+// runs the SAME post-handler tail (finishNode) as a live execution, so edge
+// routing, scoping, and checkpointing are identical. The handler is never
+// called, so a node memoized on a prior pass keeps its handler call count flat
+// across re-entries (acceptance criterion 1).
+func (e *Engine) replayMemoizedNode(s *runState, currentNodeID string, node, execNode *Node, rec MemoEntry, preHumanResponse string) loopResult {
+	e.emit(PipelineEvent{
+		Type:      EventNodeMemoReplayed,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    currentNodeID,
+		Message:   fmt.Sprintf("memoize: replayed prior successful outcome for node %q", currentNodeID),
+	})
+
+	outcome := &Outcome{Status: rec.Status, ContextUpdates: rec.ContextUpdates}
+	traceEntry := TraceEntry{
+		NodeID:      currentNodeID,
+		HandlerName: "<memoized>",
+		Status:      rec.Status,
+	}
+	// pendingMemoKey is already set to this node's key; PutMemo on the replay is
+	// an idempotent no-op (same key, same record), so finishNode's store branch
+	// is harmless here.
+	return e.finishNode(context.Background(), s, currentNodeID, node, execNode, outcome, &traceEntry, preHumanResponse)
 }
 
 // consumesHumanResponse reports whether executing the node feeds pipeline

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -475,12 +475,11 @@ func (e *Engine) replayMemoizedNode(s *runState, currentNodeID string, node, exe
 		Message:   fmt.Sprintf("memoize: replayed prior successful outcome for node %q", currentNodeID),
 	})
 
-	outcome := &Outcome{
-		Status:             rec.Status,
-		ContextUpdates:     rec.ContextUpdates,
-		PreferredLabel:     rec.PreferredLabel,
-		SuggestedNextNodes: rec.SuggestedNextNodes,
-	}
+	// Deep-copy the reference-typed fields so the replay Outcome (and the
+	// s.lastOutcome copy applyOutcome makes from it) can never mutate the
+	// checkpoint memo record backing rec — the record must stay immutable
+	// across replays.
+	outcome := memoOutcome(rec)
 	traceEntry := TraceEntry{
 		Timestamp:   time.Now(),
 		NodeID:      currentNodeID,

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -338,7 +338,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 	// #421: opt-in node-output memoization — replay a prior successful outcome
 	// when resolved inputs match, without invoking the handler. Returns a
 	// non-nil result only when a replay actually fires.
-	if lr := e.maybeReplayMemoized(s, currentNodeID, node, execNode, preHumanResponse); lr != nil {
+	if lr := e.maybeReplayMemoized(ctx, s, currentNodeID, node, execNode, preHumanResponse); lr != nil {
 		return *lr
 	}
 
@@ -356,7 +356,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 // replayed loopResult; otherwise it records the pending key (for the store
 // site) and returns nil so the handler runs. An uncertain key (hash error)
 // warns and runs live — never replays on an uncertain key.
-func (e *Engine) maybeReplayMemoized(s *runState, currentNodeID string, node, execNode *Node, preHumanResponse string) *loopResult {
+func (e *Engine) maybeReplayMemoized(ctx context.Context, s *runState, currentNodeID string, node, execNode *Node, preHumanResponse string) *loopResult {
 	if !memoizeEnabled(execNode) {
 		return nil
 	}
@@ -376,7 +376,7 @@ func (e *Engine) maybeReplayMemoized(s *runState, currentNodeID string, node, ex
 	if !hit {
 		return nil
 	}
-	lr := e.replayMemoizedNode(s, currentNodeID, node, execNode, rec, preHumanResponse)
+	lr := e.replayMemoizedNode(ctx, s, currentNodeID, node, execNode, rec, preHumanResponse)
 	return &lr
 }
 
@@ -466,7 +466,7 @@ func (e *Engine) finishNode(ctx context.Context, s *runState, currentNodeID stri
 // routing, scoping, and checkpointing are identical. The handler is never
 // called, so a node memoized on a prior pass keeps its handler call count flat
 // across re-entries (acceptance criterion 1).
-func (e *Engine) replayMemoizedNode(s *runState, currentNodeID string, node, execNode *Node, rec MemoEntry, preHumanResponse string) loopResult {
+func (e *Engine) replayMemoizedNode(ctx context.Context, s *runState, currentNodeID string, node, execNode *Node, rec MemoEntry, preHumanResponse string) loopResult {
 	e.emit(PipelineEvent{
 		Type:      EventNodeMemoReplayed,
 		Timestamp: time.Now(),
@@ -488,8 +488,12 @@ func (e *Engine) replayMemoizedNode(s *runState, currentNodeID string, node, exe
 	}
 	// pendingMemoKey is already set to this node's key; PutMemo on the replay is
 	// an idempotent no-op (same key, same record), so finishNode's store branch
-	// is harmless here.
-	return e.finishNode(context.Background(), s, currentNodeID, node, execNode, outcome, &traceEntry, preHumanResponse)
+	// is harmless here. Thread the run's ctx (not context.Background) so any
+	// cancellation/deadline still applies — and so a non-success memo record
+	// (e.g. a hand-edited/corrupted checkpoint) routes through ctx-aware
+	// finishNode work correctly rather than dropping the run's context (#425
+	// review).
+	return e.finishNode(ctx, s, currentNodeID, node, execNode, outcome, &traceEntry, preHumanResponse)
 }
 
 // consumesHumanResponse reports whether executing the node feeds pipeline

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -272,10 +272,11 @@ type runState struct {
 
 	// pendingMemoKey is the content-hash memo key (#421) computed for the node
 	// currently executing, threaded from the lookup site to the store site so
-	// the tree fingerprint is computed once per entry and the store uses the
-	// exact key the lookup did. Empty when the node did not opt into memoize
-	// or the key could not be computed — neither GetMemo nor PutMemo is reached
-	// in that case (default-off guarantee). Reset at the top of processActiveNode.
+	// the memo key is computed once per entry and the store uses the exact key
+	// the lookup did. Empty when the node did not opt into memoize or is not
+	// memoizable (e.g. writable_paths side effects → unconditional hard miss) —
+	// neither GetMemo nor PutMemo is reached in that case (default-off
+	// guarantee). Reset at the top of processActiveNode.
 	pendingMemoKey string
 }
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -269,6 +269,14 @@ type runState struct {
 	// as read-only here. Mutating those fields through s.lastOutcome would
 	// silently corrupt the handler's outcome value (and vice versa).
 	lastOutcome Outcome
+
+	// pendingMemoKey is the content-hash memo key (#421) computed for the node
+	// currently executing, threaded from the lookup site to the store site so
+	// the tree fingerprint is computed once per entry and the store uses the
+	// exact key the lookup did. Empty when the node did not opt into memoize
+	// or the key could not be computed — neither GetMemo nor PutMemo is reached
+	// in that case (default-off guarantee). Reset at the top of processActiveNode.
+	pendingMemoKey string
 }
 
 // appendOverride appends an OverrideDetail to BOTH the in-memory hot-path
@@ -311,22 +319,7 @@ func (e *Engine) initRunState(ctx context.Context) (*runState, error) {
 	// copied into the first node's scoped namespace when ScopeToNode is called.
 	pctx.ClearDirty()
 
-	// Initialize git artifact repo if requested and an artifact dir is set.
-	var gitRepo *gitArtifactRepo
-	if e.gitArtifacts && e.artifactDir != "" {
-		repoDir := filepath.Join(e.artifactDir, runID)
-		gitRepo = newGitArtifactRepo(repoDir, runID)
-		if err := gitRepo.Init(); err != nil {
-			// Best-effort: emit a warning and continue without git tracking.
-			e.emit(PipelineEvent{
-				Type:      EventWarning,
-				Timestamp: time.Now(),
-				RunID:     runID,
-				Message:   fmt.Sprintf("git artifact init failed (continuing without git tracking): %v", err),
-			})
-			gitRepo = nil
-		}
-	}
+	gitRepo := e.initGitRepo(runID)
 
 	// Seed the in-memory sticky list from any prior checkpoint so a resumed
 	// run preserves overrides that fired before the kill / SIGINT. The cp
@@ -346,6 +339,28 @@ func (e *Engine) initRunState(ctx context.Context) (*runState, error) {
 		gitRepo:             gitRepo,
 		validationOverrides: stickyOverrides,
 	}, nil
+}
+
+// initGitRepo initializes the git artifact repo when git artifacts are enabled
+// and an artifact dir is set. Best-effort: an Init failure emits a warning and
+// returns nil so the run continues without git tracking. Extracted from
+// initRunState to keep it under the complexity gate; behavior is unchanged.
+func (e *Engine) initGitRepo(runID string) *gitArtifactRepo {
+	if !e.gitArtifacts || e.artifactDir == "" {
+		return nil
+	}
+	repoDir := filepath.Join(e.artifactDir, runID)
+	gitRepo := newGitArtifactRepo(repoDir, runID)
+	if err := gitRepo.Init(); err != nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     runID,
+			Message:   fmt.Sprintf("git artifact init failed (continuing without git tracking): %v", err),
+		})
+		return nil
+	}
+	return gitRepo
 }
 
 // buildInitialContext creates a PipelineContext seeded with graph and initial context values.
@@ -595,6 +610,17 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 	traceEntry.Stats = outcome.Stats
 	traceEntry.ChildUsage = outcome.ChildUsage
 
+	e.emitOutcomeAnomalies(s, currentNodeID, &outcome)
+
+	return &outcome, traceEntry, nil
+}
+
+// emitOutcomeAnomalies surfaces structured audit events for any anomaly fields
+// the handler populated on a successful (non-error) outcome: tool-output
+// truncation (#208), marker_grep no-match (#210), missing route sentinel
+// (#212), and auto_status missing STATUS (#346). Extracted from executeNode to
+// keep it under the complexity gate; behavior is unchanged.
+func (e *Engine) emitOutcomeAnomalies(s *runState, currentNodeID string, outcome *Outcome) {
 	// Surface tool-output truncation as structured events so `tracker
 	// diagnose`, the TUI activity log, and NDJSON consumers can correlate
 	// routing misses with dropped output (issue #208). One event per
@@ -621,20 +647,12 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 	// was invalid (author error), an empty Error means the regex was
 	// fine but matched nothing in the captured stdout.
 	if outcome.MissingMarker != nil {
-		var msg string
-		if outcome.MissingMarker.Error != "" {
-			msg = fmt.Sprintf("tool node %q: marker_grep regex %q failed to compile: %s — failing node to avoid silent fallback",
-				currentNodeID, outcome.MissingMarker.Pattern, outcome.MissingMarker.Error)
-		} else {
-			msg = fmt.Sprintf("tool node %q: marker_grep %q matched nothing in captured stdout — failing node to avoid silent fallback",
-				currentNodeID, outcome.MissingMarker.Pattern)
-		}
 		e.emit(PipelineEvent{
 			Type:      EventToolMarkerMissing,
 			Timestamp: time.Now(),
 			RunID:     s.runID,
 			NodeID:    currentNodeID,
-			Message:   msg,
+			Message:   markerMissingMessage(currentNodeID, outcome.MissingMarker),
 			Marker:    outcome.MissingMarker,
 		})
 	}
@@ -660,25 +678,38 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 	// this is the audit-trail companion so the TUI and `tracker diagnose`
 	// can surface the anomaly instead of it registering as a silent verdict.
 	if outcome.MissingStatus != nil {
-		var msg string
-		if outcome.MissingStatus.FailClosed {
-			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
-				currentNodeID)
-		} else {
-			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — the STATUS verdict defaulted to success (legacy behavior; the node's final status may still differ, e.g. on a declared-writes failure; mark the node goal_gate: true to fail closed)",
-				currentNodeID)
-		}
 		e.emit(PipelineEvent{
 			Type:       EventAutoStatusMissing,
 			Timestamp:  time.Now(),
 			RunID:      s.runID,
 			NodeID:     currentNodeID,
-			Message:    msg,
+			Message:    autoStatusMissingMessage(currentNodeID, outcome.MissingStatus),
 			AutoStatus: outcome.MissingStatus,
 		})
 	}
+}
 
-	return &outcome, traceEntry, nil
+// markerMissingMessage builds the EventToolMarkerMissing message. A populated
+// Error means the regex itself failed to compile (author error); an empty Error
+// means the regex was valid but matched nothing in the captured stdout (#210).
+func markerMissingMessage(nodeID string, m *MarkerDetail) string {
+	if m.Error != "" {
+		return fmt.Sprintf("tool node %q: marker_grep regex %q failed to compile: %s — failing node to avoid silent fallback",
+			nodeID, m.Pattern, m.Error)
+	}
+	return fmt.Sprintf("tool node %q: marker_grep %q matched nothing in captured stdout — failing node to avoid silent fallback",
+		nodeID, m.Pattern)
+}
+
+// autoStatusMissingMessage builds the EventAutoStatusMissing message, branching
+// on whether the gate failed closed or defaulted to legacy success (#346).
+func autoStatusMissingMessage(nodeID string, d *AutoStatusDetail) string {
+	if d.FailClosed {
+		return fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
+			nodeID)
+	}
+	return fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — the STATUS verdict defaulted to success (legacy behavior; the node's final status may still differ, e.g. on a declared-writes failure; mark the node goal_gate: true to fail closed)",
+		nodeID)
 }
 
 // applyOutcome merges handler outcome into pipeline context and emits the decision_outcome event.
@@ -925,40 +956,7 @@ func (e *Engine) handleOutcomeStatus(s *runState, currentNodeID string, status s
 func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus string, traceEntry *TraceEntry) (bool, string, *EngineResult) {
 	target, gateNodeID, retry, unsatisfied := e.goalGateRetryTarget(s.cp, s.nodeOutcomes)
 	if retry {
-		// A pending re-entry (target == the gate itself, flagged by a prior
-		// redirect) completes that redirect's retry cycle — the budget was
-		// charged when the redirect fired, so it is not charged again here.
-		// It cannot loop: the gate executes next, clearing the pending flag.
-		reentry := s.cp.IsGateRecheckPending(gateNodeID) && target == gateNodeID
-		gateNode := e.nodeOrDefault(gateNodeID)
-		msg := fmt.Sprintf("goal-gate recheck: re-entering %q so the gate re-judges the current tree (attempt %d/%d)",
-			gateNodeID, s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
-		if !reentry {
-			s.cp.IncrementRetry(gateNodeID)
-			msg = fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
-				gateNodeID, target,
-				s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
-		}
-		e.emit(PipelineEvent{
-			Type:      EventStageRetrying,
-			Timestamp: time.Now(),
-			RunID:     s.runID,
-			NodeID:    gateNodeID,
-			Message:   msg,
-		})
-		traceEntry.EdgeTo = target
-		s.trace.AddEntry(*traceEntry)
-		e.emitGitCommit(s, currentNodeID, traceEntry)
-		// #348 defect 1: the redirect's clearDownstream below may remove the
-		// gate from CompletedNodes while the executed path routes around it
-		// to the exit. Mark the gate recheck-pending so it stays visible to
-		// this check and the next retry re-enters at the gate itself; the
-		// flag clears when the gate actually re-executes (applyOutcome).
-		s.cp.SetGateRecheckPending(gateNodeID)
-		e.clearDownstream(target, s.cp)
-		s.cp.CurrentNode = target
-		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
-		return false, target, nil
+		return e.handleGoalGateRetry(s, currentNodeID, traceEntry, target, gateNodeID)
 	}
 	// Fallback/escalation: target is set but not a retry (one-time redirect).
 	if unsatisfied && target != "" {
@@ -1015,6 +1013,50 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 	}
 	e.budgetGuard.NotifyProgress()
 	return true, "", nil
+}
+
+// handleGoalGateRetry processes a goal-gate retry redirect at the exit node:
+// it increments the retry counter (unless this is a pending re-entry that
+// completes a prior redirect's cycle), emits the retry event, records the trace
+// edge, marks the gate recheck-pending (#348 defect 1), clears downstream, and
+// checkpoints. Returns (false, target, nil) so the caller advances to target.
+// Extracted from handleExitNode to keep it under the complexity gate; behavior
+// is unchanged.
+func (e *Engine) handleGoalGateRetry(s *runState, currentNodeID string, traceEntry *TraceEntry, target, gateNodeID string) (bool, string, *EngineResult) {
+	// A pending re-entry (target == the gate itself, flagged by a prior
+	// redirect) completes that redirect's retry cycle — the budget was
+	// charged when the redirect fired, so it is not charged again here.
+	// It cannot loop: the gate executes next, clearing the pending flag.
+	reentry := s.cp.IsGateRecheckPending(gateNodeID) && target == gateNodeID
+	gateNode := e.nodeOrDefault(gateNodeID)
+	msg := fmt.Sprintf("goal-gate recheck: re-entering %q so the gate re-judges the current tree (attempt %d/%d)",
+		gateNodeID, s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+	if !reentry {
+		s.cp.IncrementRetry(gateNodeID)
+		msg = fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
+			gateNodeID, target,
+			s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+	}
+	e.emit(PipelineEvent{
+		Type:      EventStageRetrying,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    gateNodeID,
+		Message:   msg,
+	})
+	traceEntry.EdgeTo = target
+	s.trace.AddEntry(*traceEntry)
+	e.emitGitCommit(s, currentNodeID, traceEntry)
+	// #348 defect 1: the redirect's clearDownstream below may remove the
+	// gate from CompletedNodes while the executed path routes around it
+	// to the exit. Mark the gate recheck-pending so it stays visible to
+	// this check and the next retry re-enters at the gate itself; the
+	// flag clears when the gate actually re-executes (applyOutcome).
+	s.cp.SetGateRecheckPending(gateNodeID)
+	e.clearDownstream(target, s.cp)
+	s.cp.CurrentNode = target
+	e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
+	return false, target, nil
 }
 
 // handleLoopRestart processes a loop-back to an already-completed node.

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -105,6 +105,12 @@ const (
 	// field so external consumers that only watch DecisionEdge can still
 	// identify the traversal as an override.
 	EventValidationOverridden PipelineEventType = "validation_overridden"
+
+	// EventNodeMemoReplayed fires when a memoize:true node is re-entered with
+	// identical hashed inputs and its prior successful outcome is replayed
+	// instead of re-invoking the handler (#421). Stage-level (NodeID = the
+	// replayed node).
+	EventNodeMemoReplayed PipelineEventType = "node_memo_replayed"
 )
 
 // EdgePriorityOverride identifies an edge selected at advanceToNextNode

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -239,6 +239,28 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 	return ref, nil
 }
 
+// TreeFingerprint returns a conservative content hash of the working tree for
+// node-output memoization (#421): the porcelain status (staged + unstaged +
+// untracked drift) concatenated with the index's per-path mode+blob-SHA. This
+// is MORE conservative than `git write-tree` (index-only) — it also reflects
+// untracked/unstaged changes a side-effecting handler would observe, so any
+// drift between two entries of a memoized node invalidates the memo key.
+//
+// Reuses r.git so the #399 GIT_DIR-leak guard (gitSafeEnv) applies. Any git
+// error is returned (not swallowed): the caller treats it as a cache miss and
+// runs the handler rather than replaying on an uncertain key.
+func (r *gitArtifactRepo) TreeFingerprint() (string, error) {
+	status, err := r.git("status", "--porcelain=v1", "-z")
+	if err != nil {
+		return "", fmt.Errorf("git status for tree fingerprint: %w\n%s", err, status)
+	}
+	index, err := r.git("ls-files", "-s", "-z")
+	if err != nil {
+		return "", fmt.Errorf("git ls-files for tree fingerprint: %w\n%s", err, index)
+	}
+	return status + "\x00" + index, nil
+}
+
 // git runs a git command in r.dir with a sanitized environment.
 // Returns combined output and any error.
 func (r *gitArtifactRepo) git(args ...string) (string, error) {

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -240,33 +240,71 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 }
 
 // TreeFingerprint returns a conservative content hash of the working tree for
-// node-output memoization (#421): the porcelain status (staged + unstaged +
-// untracked drift) concatenated with the index's per-path mode+blob-SHA. This
-// is MORE conservative than `git write-tree` (index-only) — it also reflects
-// untracked/unstaged changes a side-effecting handler would observe, so any
-// drift between two entries of a memoized node invalidates the memo key.
+// node-output memoization (#421): the porcelain status (path + status markers)
+// concatenated with a tree object SHA that hashes the actual CONTENT of every
+// tracked-modified AND untracked file. The content tree is built in a throwaway
+// index so the real index is never touched (side-effect-free). This closes the
+// #425-review gap where `ls-files -s` only reflected STAGED blobs, so an
+// intervening node that modified an unstaged-tracked or untracked file without
+// changing its path/status produced an identical fingerprint and could replay
+// stale output against a different worktree.
 //
-// Reuses r.git so the #399 GIT_DIR-leak guard (gitSafeEnv) applies. Any git
-// error is returned (not swallowed): the caller treats it as a cache miss and
-// runs the handler rather than replaying on an uncertain key.
+// Reuses r.git/gitEnv so the #399 GIT_DIR-leak guard (gitSafeEnv) applies. Any
+// git error is returned (not swallowed): the caller treats it as a cache miss
+// and runs the handler rather than replaying on an uncertain key.
 func (r *gitArtifactRepo) TreeFingerprint() (string, error) {
 	status, err := r.git("status", "--porcelain=v1", "-z")
 	if err != nil {
 		return "", fmt.Errorf("git status for tree fingerprint: %w\n%s", err, status)
 	}
-	index, err := r.git("ls-files", "-s", "-z")
+	tree, err := r.worktreeContentTree()
 	if err != nil {
-		return "", fmt.Errorf("git ls-files for tree fingerprint: %w\n%s", err, index)
+		return "", err
 	}
-	return status + "\x00" + index, nil
+	return status + "\x00" + tree, nil
+}
+
+// worktreeContentTree stages the FULL worktree (tracked-modified + untracked,
+// honoring .gitignore) into a throwaway index seeded from HEAD, then returns the
+// resulting tree object SHA — a content hash over actual file bytes, with
+// deletions reflected. The real index is never touched; the dangling blob/tree
+// objects it writes are unreferenced and reclaimed by git gc (same posture as
+// `git stash create`). Used only by TreeFingerprint.
+func (r *gitArtifactRepo) worktreeContentTree() (string, error) {
+	tmpDir, err := os.MkdirTemp("", "tracker-memo-index-")
+	if err != nil {
+		return "", fmt.Errorf("temp index dir for tree fingerprint: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	env := append(gitSafeEnv(), "GIT_INDEX_FILE="+filepath.Join(tmpDir, "index"))
+	// Seed from HEAD so a deleted-but-tracked file registers as a removal. A repo
+	// with no commits yet has no HEAD — that's fine, the index just starts empty.
+	if out, err := r.gitEnv(env, "read-tree", "HEAD"); err != nil {
+		_ = out // no HEAD yet — proceed with an empty index
+	}
+	if out, err := r.gitEnv(env, "add", "-A"); err != nil {
+		return "", fmt.Errorf("git add -A (temp index) for tree fingerprint: %w\n%s", err, out)
+	}
+	tree, err := r.gitEnv(env, "write-tree")
+	if err != nil {
+		return "", fmt.Errorf("git write-tree (temp index) for tree fingerprint: %w\n%s", err, tree)
+	}
+	return strings.TrimSpace(tree), nil
 }
 
 // git runs a git command in r.dir with a sanitized environment.
 // Returns combined output and any error.
 func (r *gitArtifactRepo) git(args ...string) (string, error) {
+	return r.gitEnv(gitSafeEnv(), args...)
+}
+
+// gitEnv runs a git command in r.dir with an explicit environment (already
+// sanitized by the caller). Used by TreeFingerprint to inject a throwaway
+// GIT_INDEX_FILE without touching the real index.
+func (r *gitArtifactRepo) gitEnv(env []string, args ...string) (string, error) {
 	cmdArgs := append([]string{"-C", r.dir}, args...)
 	cmd := exec.Command("git", cmdArgs...) //nolint:gosec // controlled args
-	cmd.Env = gitSafeEnv()
+	cmd.Env = env
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -239,15 +239,19 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 	return ref, nil
 }
 
-// TreeFingerprint returns a conservative content hash of the working tree for
-// node-output memoization (#421): the porcelain status (path + status markers)
-// concatenated with a tree object SHA that hashes the actual CONTENT of every
-// tracked-modified AND untracked file. The content tree is built in a throwaway
-// index so the real index is never touched (side-effect-free). This closes the
-// #425-review gap where `ls-files -s` only reflected STAGED blobs, so an
-// intervening node that modified an unstaged-tracked or untracked file without
-// changing its path/status produced an identical fingerprint and could replay
-// stale output against a different worktree.
+// TreeFingerprint returns a conservative content hash of the working tree: the
+// porcelain status (path + status markers) concatenated with a tree object SHA
+// that hashes the actual CONTENT of every tracked-modified AND untracked file.
+// The content tree is built in a throwaway index so the real index is never
+// touched (side-effect-free).
+//
+// NOTE: the current memoization path (#421) does NOT use this. A `writable_paths`
+// node is an unconditional hard miss in computeMemoKey, and this fingerprint is
+// taken from the ARTIFACT repo (`<artifactDir>/<runID>`) — a different directory
+// than the agent's session `working_dir` where side effects actually land — so
+// it could not validate a side-effecting node's inputs anyway. TreeFingerprint
+// is retained as the building block for a future fingerprint of the agent's real
+// `working_dir`; until that lands it is unused by the memo key.
 //
 // Reuses r.git/gitEnv so the #399 GIT_DIR-leak guard (gitSafeEnv) applies. Any
 // git error is returned (not swallowed): the caller treats it as a cache miss

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -279,8 +279,14 @@ func (r *gitArtifactRepo) worktreeContentTree() (string, error) {
 	env := append(gitSafeEnv(), "GIT_INDEX_FILE="+filepath.Join(tmpDir, "index"))
 	// Seed from HEAD so a deleted-but-tracked file registers as a removal. A repo
 	// with no commits yet has no HEAD — that's fine, the index just starts empty.
+	// But fail closed on any OTHER read-tree failure: silently proceeding with an
+	// empty index would make `git add -A` miss tracked deletions and yield a stale
+	// fingerprint (a false cache hit) instead of the required miss.
 	if out, err := r.gitEnv(env, "read-tree", "HEAD"); err != nil {
-		_ = out // no HEAD yet — proceed with an empty index
+		if _, headErr := r.gitEnv(env, "rev-parse", "--verify", "HEAD"); headErr == nil {
+			return "", fmt.Errorf("git read-tree HEAD (temp index) for tree fingerprint: %w\n%s", err, out)
+		}
+		// no HEAD yet — proceed with an empty index
 	}
 	if out, err := r.gitEnv(env, "add", "-A"); err != nil {
 		return "", fmt.Errorf("git add -A (temp index) for tree fingerprint: %w\n%s", err, out)

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -280,6 +280,35 @@ func (r *gitArtifactRepo) TreeFingerprint() (string, error) {
 // deletions reflected. The real index is never touched; the dangling blob/tree
 // objects it writes are unreferenced and reclaimed by git gc (same posture as
 // `git stash create`). Used only by TreeFingerprint.
+// seedTreeIndexFromHEAD populates the temp index (selected via GIT_INDEX_FILE in
+// env) from HEAD so a deleted-but-tracked file later registers as a removal under
+// `git add -A`. Probe HEAD FIRST so we can tell "truly unborn" (no commits
+// anywhere) from "HEAD exists but is unreadable/corrupt": only the unborn case may
+// proceed with an empty index. Every other failure must fail closed — silently
+// proceeding would make `git add -A` miss tracked deletions and yield a stale
+// fingerprint (a false cache hit) instead of the required miss.
+func (r *gitArtifactRepo) seedTreeIndexFromHEAD(env []string) error {
+	if _, headErr := r.gitEnv(env, "rev-parse", "--verify", "HEAD"); headErr != nil {
+		// HEAD did not resolve. Distinguish a truly-unborn repo (no commits at all)
+		// from a corrupt/unreadable HEAD: if any commit is reachable, HEAD is broken,
+		// so fail closed rather than fingerprint against an empty index.
+		out, err := r.gitEnv(env, "rev-list", "-n", "1", "--all")
+		if err != nil {
+			return fmt.Errorf("git rev-list --all probe for tree fingerprint: %w\n%s", err, out)
+		}
+		if strings.TrimSpace(out) != "" {
+			return fmt.Errorf("git HEAD unresolved but commits exist (corrupt HEAD?) for tree fingerprint: %w", headErr)
+		}
+		// no commits anywhere — truly unborn, proceed with an empty index
+		return nil
+	}
+	// HEAD resolves — read-tree must succeed; any error is hard.
+	if out, err := r.gitEnv(env, "read-tree", "HEAD"); err != nil {
+		return fmt.Errorf("git read-tree HEAD (temp index) for tree fingerprint: %w\n%s", err, out)
+	}
+	return nil
+}
+
 func (r *gitArtifactRepo) worktreeContentTree() (string, error) {
 	tmpDir, err := os.MkdirTemp("", "tracker-memo-index-")
 	if err != nil {
@@ -287,16 +316,8 @@ func (r *gitArtifactRepo) worktreeContentTree() (string, error) {
 	}
 	defer os.RemoveAll(tmpDir)
 	env := append(gitSafeEnv(), "GIT_INDEX_FILE="+filepath.Join(tmpDir, "index"))
-	// Seed from HEAD so a deleted-but-tracked file registers as a removal. A repo
-	// with no commits yet has no HEAD — that's fine, the index just starts empty.
-	// But fail closed on any OTHER read-tree failure: silently proceeding with an
-	// empty index would make `git add -A` miss tracked deletions and yield a stale
-	// fingerprint (a false cache hit) instead of the required miss.
-	if out, err := r.gitEnv(env, "read-tree", "HEAD"); err != nil {
-		if _, headErr := r.gitEnv(env, "rev-parse", "--verify", "HEAD"); headErr == nil {
-			return "", fmt.Errorf("git read-tree HEAD (temp index) for tree fingerprint: %w\n%s", err, out)
-		}
-		// no HEAD yet — proceed with an empty index
+	if err := r.seedTreeIndexFromHEAD(env); err != nil {
+		return "", err
 	}
 	if out, err := r.gitEnv(env, "add", "-A"); err != nil {
 		return "", fmt.Errorf("git add -A (temp index) for tree fingerprint: %w\n%s", err, out)

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -92,7 +92,7 @@ func (e *Engine) computeMemoKey(s *runState, execNode *Node) (string, bool) {
 	// fingerprint the agent's real working_dir, side-effecting nodes are not
 	// memoizable (CLAUDE.md: over-invalidate, never replay stale).
 	//
-	// Keyed on attr PRESENCE, not non-emptiness, to mirror AgentConfig's
+	// Keyed on attr PRESENCE, not non-emptiness, to mirror AgentNodeConfig's
 	// WritablePathsSet (node_config.go) and the jail gate (codergen_jail.go): the
 	// adapter can emit writable_paths:"" as a bypass-defense sentinel (an empty
 	// glob set jails the node to nothing rather than silently dropping the

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -1,0 +1,168 @@
+// ABOUTME: Opt-in content-hash node-output memoization (#421).
+// ABOUTME: Replays a prior successful outcome when a loop-restart re-enters a node with identical inputs.
+package pipeline
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"sort"
+	"strings"
+)
+
+// memoizeEnabled reports whether a node opted in to output memoization via the
+// generic `memoize: true` param (surfaced through node.Attrs without a
+// dippin-lang field — see the agent Params pass-through in dippin_adapter.go).
+// Truthy is exactly "true" (case-insensitive, trimmed); any other value
+// (absent, "false", "1") is off. Default-off is an acceptance criterion: a
+// .dip file lacking the attr never reaches the memo lookup or store sites.
+func memoizeEnabled(execNode *Node) bool {
+	return strings.EqualFold(strings.TrimSpace(execNode.Attrs["memoize"]), "true")
+}
+
+// writeLP writes a length-prefixed string into the hash buffer: a uint32
+// big-endian length followed by the raw bytes. The length prefix prevents
+// concatenation collisions (e.g. "a"+"bc" hashing the same as "ab"+"c").
+func writeLP(h interface{ Write([]byte) (int, error) }, s string) {
+	var lenbuf [4]byte
+	binary.BigEndian.PutUint32(lenbuf[:], uint32(len(s)))
+	_, _ = h.Write(lenbuf[:])
+	_, _ = h.Write([]byte(s))
+}
+
+// computeMemoKey returns a SHA-256 hex digest over the node's RESOLVED inputs,
+// and ok=false on any condition that makes a replay unsafe (memoize disabled,
+// or a hashing input could not be obtained). When ok=false the caller treats
+// the node as a cache MISS and runs the handler — we never replay on an
+// uncertain key (CLAUDE.md: never silently swallow / never replay stale).
+//
+// The digest is computed over a length-prefixed buffer in this FIXED order.
+// Document changes here and bump the "v1" recipe tag to auto-invalidate.
+//
+//  1. "v1"                 — recipe-version tag.
+//  2. execNode.ID          — scopes the key to this node.
+//  3. execNode.Handler     — handler identity.
+//  4. execNode.Attrs        — every entry, sorted by key, each writeLP(k)+writeLP(v).
+//     These are POST-stylesheet, POST-ExpandGraphVariables, POST-ExpandPromptVariables
+//     (prepareExecNode), so the interpolated `prompt`/`command` already embeds
+//     every upstream ctx.* value it referenced via ${...}.
+//  5. bare-namespace ctx snapshot — every context key WITHOUT a "node." prefix,
+//     EXCLUDING the three routing-scratch keys reset immediately before execution
+//     (outcome, preferred_label, suggested_next_nodes — they are reset to "" so
+//     excluding them is a documented no-op). Sorted, each writeLP(k)+writeLP(v).
+//     Rationale: ${...} interpolation only captures ctx values literally embedded
+//     in an attr; a handler can READ context (last_response, tool_stdout, ...) it
+//     was never templated with. Over-hashing the bare namespace makes ANY upstream
+//     drift invalidate — conservative by design (over-invalidate, never replay stale).
+//  6. tree fingerprint     — REQUIRED when the node declares writable_paths (an
+//     agent with working-tree side effects). writeLP("tree")+writeLP(sha). If no
+//     git repo is active (s.gitRepo == nil) or the tree hash ERRORS, return
+//     ok=false (hard miss) — never replay a side-effecting node whose tree input
+//     cannot be proven unchanged.
+//
+// The opt-in contract: by setting memoize:true the operator asserts the node is
+// a pure function of these hashed inputs. Non-deterministic output (timestamps,
+// LLM variance) is the operator's responsibility, not the engine's.
+func (e *Engine) computeMemoKey(s *runState, execNode *Node) (string, bool) {
+	if !memoizeEnabled(execNode) {
+		return "", false
+	}
+
+	h := sha256.New()
+	writeLP(h, "v1")
+	writeLP(h, execNode.ID)
+	writeLP(h, execNode.Handler)
+	hashSortedMap(h, execNode.Attrs)                      // 4. resolved attrs
+	hashSortedMap(h, memoizableContext(s.pctx, execNode)) // 5. bare ctx inputs
+
+	// 6. tree fingerprint for side-effecting agents (writable_paths). A node that
+	// declares writable_paths has working-tree side effects, so a usable tree
+	// fingerprint is REQUIRED to prove its tree input is unchanged before replay.
+	// If no git repo is active (s.gitRepo == nil — the default tracker run /
+	// library Run config, since WithGitArtifacts has no production callers) or
+	// the fingerprint errors, return ok=false (hard miss → handler re-runs).
+	// Never replay a side-effecting node when its tree input cannot be proven
+	// unchanged (CLAUDE.md: over-invalidate, never replay stale).
+	if strings.TrimSpace(execNode.Attrs["writable_paths"]) != "" {
+		if s.gitRepo == nil {
+			return "", false
+		}
+		sha, err := s.gitRepo.TreeFingerprint()
+		if err != nil {
+			// Uncertain key — hard miss, never replay. Caller emits a warning.
+			return "", false
+		}
+		writeLP(h, "tree")
+		writeLP(h, sha)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), true
+}
+
+// hashSortedMap writes a map into the hash buffer in key-sorted order, each
+// entry as writeLP(k)+writeLP(v), so map iteration order never affects the key.
+func hashSortedMap(h interface{ Write([]byte) (int, error) }, m map[string]string) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		writeLP(h, k)
+		writeLP(h, m[k])
+	}
+}
+
+// memoizableContext returns the subset of the bare-namespace context that is a
+// genuine INPUT to execNode (step 5 of computeMemoKey). It excludes:
+//   - per-node scoped keys (node.* prefix),
+//   - routing-scratch keys reset before execution (outcome, preferred_label,
+//     suggested_next_nodes),
+//   - bare keys this node itself wrote on a prior entry. After a node runs its
+//     dirty bare keys are aliased to node.<id>.<key> (ScopeToNode); on loop
+//     re-entry those bare values linger, so hashing them would fold the node's
+//     OWN output into its input key and defeat replay. A bare key K is treated
+//     as a self-output (skipped) when node.<execNode.ID>.K exists in the
+//     snapshot. Upstream keys never carry this node's prefix, so they survive —
+//     conservative on inputs, blind only to self-outputs.
+//
+// EXCEPTION — ContextKeyLastResponse and ContextKeyHumanResponse are ALWAYS
+// hashed, even when this node wrote them on a prior entry. InjectPipelineContext
+// appends these two bare keys to EVERY agent prompt at runtime (FidelityFull,
+// the default), so they are genuine prompt INPUTS, not merely self-outputs. In a
+// build->review--fail-->build loop an intervening node overwrites bare
+// last_response with a new critique that becomes part of build's resolved prompt
+// on re-entry; the self-output exclusion would otherwise drop it and replay a
+// stale outcome. Hashing them unconditionally is the conservative direction: a
+// node that loops directly to itself with its own lingering last_response now
+// re-runs (miss) rather than risk a stale replay (over-invalidate, never replay
+// stale).
+func memoizableContext(pctx *PipelineContext, execNode *Node) map[string]string {
+	snap := pctx.Snapshot()
+	selfScopePrefix := "node." + execNode.ID + "."
+	out := make(map[string]string, len(snap))
+	for k, v := range snap {
+		if isMemoizableContextKey(k, selfScopePrefix, snap) {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// isMemoizableContextKey reports whether bare context key k is a genuine input
+// to hash (see memoizableContext). It rejects node-scoped keys, routing-scratch
+// keys, and self-outputs — but ContextKeyLastResponse / ContextKeyHumanResponse
+// are always accepted (the EXCEPTION: they are injected prompt inputs).
+func isMemoizableContextKey(k, selfScopePrefix string, snap map[string]string) bool {
+	if strings.HasPrefix(k, "node.") {
+		return false
+	}
+	if k == ContextKeyOutcome || k == ContextKeyPreferredLabel || k == ContextKeySuggestedNextNodes {
+		return false
+	}
+	if k == ContextKeyLastResponse || k == ContextKeyHumanResponse {
+		return true
+	}
+	_, isSelfOutput := snap[selfScopePrefix+k]
+	return !isSelfOutput
+}

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -73,24 +73,26 @@ func (e *Engine) computeMemoKey(s *runState, execNode *Node) (string, bool) {
 		return "", false
 	}
 
+	// 6. writable_paths side effects: an UNCONDITIONAL hard miss, checked BEFORE
+	// any hashing so a side-effecting node mistakenly marked memoize:true costs no
+	// snapshot/hash work. The node mutates and reads the agent's session
+	// working_dir, but tracker has no fingerprint of that tree — s.gitRepo is the
+	// ARTIFACT repo (<artifactDir>/<runID>), a different directory than the agent's
+	// working tree, so its fingerprint proves nothing about what the agent
+	// read/wrote. Replaying on it could fire against a changed working tree (the
+	// stale-replay class this feature prevents, #425 review). Until we can
+	// fingerprint the agent's real working_dir, side-effecting nodes are not
+	// memoizable (CLAUDE.md: over-invalidate, never replay stale).
+	if strings.TrimSpace(execNode.Attrs["writable_paths"]) != "" {
+		return "", false
+	}
+
 	h := sha256.New()
 	writeLP(h, "v1")
 	writeLP(h, execNode.ID)
 	writeLP(h, execNode.Handler)
 	hashSortedMap(h, execNode.Attrs)                      // 4. resolved attrs
 	hashSortedMap(h, memoizableContext(s.pctx, execNode)) // 5. bare ctx inputs
-
-	// 6. writable_paths side effects: an UNCONDITIONAL hard miss. The node mutates
-	// and reads the agent's session working_dir, but tracker has no fingerprint of
-	// that tree — s.gitRepo is the ARTIFACT repo (<artifactDir>/<runID>), a different
-	// directory than the agent's working tree, so its fingerprint proves nothing
-	// about what the agent read/wrote. Replaying on it could fire against a changed
-	// working tree (the stale-replay class this feature prevents, #425 review).
-	// Until we can fingerprint the agent's real working_dir, side-effecting nodes
-	// are not memoizable (CLAUDE.md: over-invalidate, never replay stale).
-	if strings.TrimSpace(execNode.Attrs["writable_paths"]) != "" {
-		return "", false
-	}
 
 	return hex.EncodeToString(h.Sum(nil)), true
 }

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -83,7 +83,14 @@ func (e *Engine) computeMemoKey(s *runState, execNode *Node) (string, bool) {
 	// stale-replay class this feature prevents, #425 review). Until we can
 	// fingerprint the agent's real working_dir, side-effecting nodes are not
 	// memoizable (CLAUDE.md: over-invalidate, never replay stale).
-	if strings.TrimSpace(execNode.Attrs["writable_paths"]) != "" {
+	//
+	// Keyed on attr PRESENCE, not non-emptiness, to mirror AgentConfig's
+	// WritablePathsSet (node_config.go) and the jail gate (codergen_jail.go): the
+	// adapter can emit writable_paths:"" as a bypass-defense sentinel (an empty
+	// glob set jails the node to nothing rather than silently dropping the
+	// signal), so a present-but-empty value must still be treated as a
+	// side-effecting node and refused memoization (#425 review).
+	if _, ok := execNode.Attrs["writable_paths"]; ok {
 		return "", false
 	}
 

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -118,13 +118,17 @@ func hashSortedMap(h interface{ Write([]byte) (int, error) }, m map[string]strin
 //   - per-node scoped keys (node.* prefix),
 //   - routing-scratch keys reset before execution (outcome, preferred_label,
 //     suggested_next_nodes),
-//   - bare keys this node itself wrote on a prior entry. After a node runs its
-//     dirty bare keys are aliased to node.<id>.<key> (ScopeToNode); on loop
-//     re-entry those bare values linger, so hashing them would fold the node's
-//     OWN output into its input key and defeat replay. A bare key K is treated
-//     as a self-output (skipped) when node.<execNode.ID>.K exists in the
-//     snapshot. Upstream keys never carry this node's prefix, so they survive —
-//     conservative on inputs, blind only to self-outputs.
+//   - bare keys this node itself wrote on a prior entry AND that still hold that
+//     written value. After a node runs its dirty bare keys are aliased to
+//     node.<id>.<key> (ScopeToNode); on loop re-entry those bare values linger,
+//     so hashing them would fold the node's OWN output into its input key and
+//     defeat replay. A bare key K is treated as a self-output (skipped) ONLY
+//     when node.<execNode.ID>.K exists AND the current bare K equals it. If an
+//     intervening node overwrote bare K with a DIFFERENT value before a loop
+//     restart, K is now a genuine changed INPUT and is hashed — otherwise the
+//     node could replay stale output against changed input (#425 review).
+//     Upstream keys never carry this node's prefix, so they survive — blind only
+//     to unchanged self-outputs.
 //
 // EXCEPTION — ContextKeyLastResponse and ContextKeyHumanResponse are ALWAYS
 // hashed, even when this node wrote them on a prior entry. InjectPipelineContext
@@ -142,7 +146,7 @@ func memoizableContext(pctx *PipelineContext, execNode *Node) map[string]string 
 	selfScopePrefix := "node." + execNode.ID + "."
 	out := make(map[string]string, len(snap))
 	for k, v := range snap {
-		if isMemoizableContextKey(k, selfScopePrefix, snap) {
+		if isMemoizableContextKey(k, v, selfScopePrefix, snap) {
 			out[k] = v
 		}
 	}
@@ -153,7 +157,7 @@ func memoizableContext(pctx *PipelineContext, execNode *Node) map[string]string 
 // to hash (see memoizableContext). It rejects node-scoped keys, routing-scratch
 // keys, and self-outputs — but ContextKeyLastResponse / ContextKeyHumanResponse
 // are always accepted (the EXCEPTION: they are injected prompt inputs).
-func isMemoizableContextKey(k, selfScopePrefix string, snap map[string]string) bool {
+func isMemoizableContextKey(k, v, selfScopePrefix string, snap map[string]string) bool {
 	if strings.HasPrefix(k, "node.") {
 		return false
 	}
@@ -163,6 +167,12 @@ func isMemoizableContextKey(k, selfScopePrefix string, snap map[string]string) b
 	if k == ContextKeyLastResponse || k == ContextKeyHumanResponse {
 		return true
 	}
-	_, isSelfOutput := snap[selfScopePrefix+k]
-	return !isSelfOutput
+	scoped, selfAliased := snap[selfScopePrefix+k]
+	if !selfAliased {
+		return true // never this node's output — a genuine upstream input
+	}
+	// Self-aliased on a prior pass. Skip it as stale self-output ONLY while the
+	// bare value is unchanged; if an intervening node overwrote it, it is now a
+	// genuine changed input and must be hashed (#425 review).
+	return v != scoped
 }

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -153,6 +153,30 @@ func memoizableContext(pctx *PipelineContext, execNode *Node) map[string]string 
 	return out
 }
 
+// memoOutcome rebuilds a replay Outcome from a stored MemoEntry, deep-copying
+// the reference-typed fields (ContextUpdates map, SuggestedNextNodes slice) so
+// the replay path and anything it hands the Outcome to (e.g. s.lastOutcome via
+// applyOutcome) can never mutate the checkpoint memo record (#425 review).
+func memoOutcome(rec MemoEntry) *Outcome {
+	var ctxUpdates map[string]string
+	if rec.ContextUpdates != nil {
+		ctxUpdates = make(map[string]string, len(rec.ContextUpdates))
+		for k, v := range rec.ContextUpdates {
+			ctxUpdates[k] = v
+		}
+	}
+	var suggested []string
+	if rec.SuggestedNextNodes != nil {
+		suggested = append([]string(nil), rec.SuggestedNextNodes...)
+	}
+	return &Outcome{
+		Status:             rec.Status,
+		ContextUpdates:     ctxUpdates,
+		PreferredLabel:     rec.PreferredLabel,
+		SuggestedNextNodes: suggested,
+	}
+}
+
 // isMemoizableContextKey reports whether bare context key k is a genuine input
 // to hash (see memoizableContext). It rejects node-scoped keys, routing-scratch
 // keys, and self-outputs — but ContextKeyLastResponse / ContextKeyHumanResponse

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -54,11 +54,16 @@ func writeLP(h interface{ Write([]byte) (int, error) }, s string) {
 //     in an attr; a handler can READ context (last_response, tool_stdout, ...) it
 //     was never templated with. Over-hashing the bare namespace makes ANY upstream
 //     drift invalidate — conservative by design (over-invalidate, never replay stale).
-//  6. tree fingerprint     — REQUIRED when the node declares writable_paths (an
-//     agent with working-tree side effects). writeLP("tree")+writeLP(sha). If no
-//     git repo is active (s.gitRepo == nil) or the tree hash ERRORS, return
-//     ok=false (hard miss) — never replay a side-effecting node whose tree input
-//     cannot be proven unchanged.
+//  6. writable_paths side effects — a node that declares writable_paths is an
+//     UNCONDITIONAL hard miss (ok=false → handler re-runs). Such a node reads and
+//     mutates the agent's SESSION working_dir, but tracker cannot currently
+//     fingerprint that tree: s.gitRepo is the ARTIFACT repo (<artifactDir>/<runID>),
+//     a DIFFERENT directory that holds stage artifacts and node-outcome commits —
+//     not the agent's working tree. Fingerprinting it would prove nothing about
+//     what the agent actually read/wrote, so a replay could fire against a changed
+//     working tree — the exact stale-replay class this feature prevents (#425
+//     review). Until we can fingerprint the agent's real working_dir, side-effecting
+//     nodes are simply not memoizable.
 //
 // The opt-in contract: by setting memoize:true the operator asserts the node is
 // a pure function of these hashed inputs. Non-deterministic output (timestamps,
@@ -75,25 +80,16 @@ func (e *Engine) computeMemoKey(s *runState, execNode *Node) (string, bool) {
 	hashSortedMap(h, execNode.Attrs)                      // 4. resolved attrs
 	hashSortedMap(h, memoizableContext(s.pctx, execNode)) // 5. bare ctx inputs
 
-	// 6. tree fingerprint for side-effecting agents (writable_paths). A node that
-	// declares writable_paths has working-tree side effects, so a usable tree
-	// fingerprint is REQUIRED to prove its tree input is unchanged before replay.
-	// If no git repo is active (s.gitRepo == nil — the default tracker run /
-	// library Run config, since WithGitArtifacts has no production callers) or
-	// the fingerprint errors, return ok=false (hard miss → handler re-runs).
-	// Never replay a side-effecting node when its tree input cannot be proven
-	// unchanged (CLAUDE.md: over-invalidate, never replay stale).
+	// 6. writable_paths side effects: an UNCONDITIONAL hard miss. The node mutates
+	// and reads the agent's session working_dir, but tracker has no fingerprint of
+	// that tree — s.gitRepo is the ARTIFACT repo (<artifactDir>/<runID>), a different
+	// directory than the agent's working tree, so its fingerprint proves nothing
+	// about what the agent read/wrote. Replaying on it could fire against a changed
+	// working tree (the stale-replay class this feature prevents, #425 review).
+	// Until we can fingerprint the agent's real working_dir, side-effecting nodes
+	// are not memoizable (CLAUDE.md: over-invalidate, never replay stale).
 	if strings.TrimSpace(execNode.Attrs["writable_paths"]) != "" {
-		if s.gitRepo == nil {
-			return "", false
-		}
-		sha, err := s.gitRepo.TreeFingerprint()
-		if err != nil {
-			// Uncertain key — hard miss, never replay. Caller emits a warning.
-			return "", false
-		}
-		writeLP(h, "tree")
-		writeLP(h, sha)
+		return "", false
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), true

--- a/pipeline/memoize.go
+++ b/pipeline/memoize.go
@@ -16,8 +16,16 @@ import (
 // Truthy is exactly "true" (case-insensitive, trimmed); any other value
 // (absent, "false", "1") is off. Default-off is an acceptance criterion: a
 // .dip file lacking the attr never reaches the memo lookup or store sites.
+//
+// Memoization is agent-node-only by contract. The `memoize` attr only reaches
+// node.Attrs for agent nodes via the dippin adapter's Params pass-through, but
+// a DOT graph or a programmatic Graph could set it on any handler — so enforce
+// the codergen scope here rather than relying on the adapter. Replaying a
+// tool/wait.human/conditional node would skip a side-effecting or
+// non-deterministic handler (#425 review).
 func memoizeEnabled(execNode *Node) bool {
-	return strings.EqualFold(strings.TrimSpace(execNode.Attrs["memoize"]), "true")
+	return execNode.Handler == "codergen" &&
+		strings.EqualFold(strings.TrimSpace(execNode.Attrs["memoize"]), "true")
 }
 
 // writeLP writes a length-prefixed string into the hash buffer: a uint32

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -1,0 +1,551 @@
+// ABOUTME: Tests for opt-in content-hash node-output memoization (#421).
+// ABOUTME: Covers replay-on-restart, input-change invalidation, checkpoint round-trip, and default-off.
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// memoLoopGraph builds: s -> work -> check --(fail)--> work ; check --(success)--> end.
+// `work` is the candidate node; `check` fails on its first attempt to force one
+// loop restart that clears + re-enters `work`, then succeeds.
+func memoLoopGraph(name string, workMemoize bool) *Graph {
+	g := NewGraph(name)
+	g.Attrs["max_restarts"] = "3"
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	work := &Node{ID: "work", Shape: "box", Label: "Work"}
+	if workMemoize {
+		work.Attrs = map[string]string{"memoize": "true"}
+	}
+	g.AddNode(work)
+	g.AddNode(&Node{ID: "check", Shape: "diamond", Label: "Check"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+
+	g.AddEdge(&Edge{From: "s", To: "work"})
+	g.AddEdge(&Edge{From: "work", To: "check"})
+	g.AddEdge(&Edge{From: "check", To: "end", Condition: "outcome=success"})
+	g.AddEdge(&Edge{From: "check", To: "work", Condition: "outcome=fail"})
+	return g
+}
+
+// failOnceCheckHandler returns a conditional handler that fails on its first
+// call and succeeds thereafter, driving exactly one restart.
+func failOnceCheckHandler(mu *sync.Mutex, attempts *int) *testHandler {
+	return &testHandler{
+		name: "conditional",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			mu.Lock()
+			*attempts++
+			a := *attempts
+			mu.Unlock()
+			if a == 1 {
+				return Outcome{Status: string(OutcomeFail), ContextUpdates: map[string]string{"outcome": "fail"}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"outcome": "success"}}, nil
+		},
+	}
+}
+
+// AC1: a memoize:true node re-entered via a restart edge with identical hashed
+// inputs replays its prior outcome WITHOUT invoking the handler.
+func TestMemoReplaySkipsHandlerOnRestart(t *testing.T) {
+	g := memoLoopGraph("memo_ac1", true)
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	workCalls := 0
+	checkAttempts := 0
+
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				workCalls++
+				mu.Unlock()
+				return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"work_out": "v1"}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	reg.Register(failOnceCheckHandler(&mu, &checkAttempts))
+
+	engine := NewEngine(g, reg)
+	result, err := engine.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if result.Status != OutcomeSuccess {
+		t.Fatalf("expected success, got %q", result.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// `work` is entered twice (initial + after restart) but the second entry
+	// must be a memo replay → handler invoked exactly once.
+	if workCalls != 1 {
+		t.Errorf("AC1: expected work handler called exactly 1 time across 2 entries, got %d", workCalls)
+	}
+	if checkAttempts != 2 {
+		t.Errorf("expected check to run twice, got %d", checkAttempts)
+	}
+	// The replayed ContextUpdates must be re-applied so downstream sees work_out.
+	if v, ok := result.Context["work_out"]; !ok || v != "v1" {
+		t.Errorf("AC1: expected replayed work_out=v1 in context, got %q (ok=%v)", v, ok)
+	}
+}
+
+// AC2(i): changing a bare ctx value the node hashes invalidates the memo and re-runs.
+func TestMemoInvalidatesOnChangedCtxInput(t *testing.T) {
+	g := memoLoopGraph("memo_ac2_ctx", true)
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	workCalls := 0
+	checkAttempts := 0
+
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				workCalls++
+				mu.Unlock()
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	// check fails first time AND mutates a bare ctx key so work's hashed input
+	// changes between its two entries → memo miss → handler re-runs.
+	reg.Register(&testHandler{
+		name: "conditional",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			mu.Lock()
+			checkAttempts++
+			a := checkAttempts
+			mu.Unlock()
+			if a == 1 {
+				return Outcome{Status: string(OutcomeFail), ContextUpdates: map[string]string{"outcome": "fail", "drift": "changed"}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"outcome": "success"}}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if workCalls != 2 {
+		t.Errorf("AC2(ctx): expected work handler to re-run (2 calls) after ctx drift, got %d", workCalls)
+	}
+}
+
+// AC2(ii): changing an interpolated prompt (different resolved attr) invalidates.
+func TestMemoInvalidatesOnChangedPrompt(t *testing.T) {
+	g := NewGraph("memo_ac2_prompt")
+	g.Attrs["max_restarts"] = "3"
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	// work's prompt interpolates a ctx var that changes between entries.
+	g.AddNode(&Node{ID: "work", Shape: "box", Label: "Work", Attrs: map[string]string{
+		"memoize": "true",
+		"prompt":  "do ${ctx.knob}",
+	}})
+	g.AddNode(&Node{ID: "check", Shape: "diamond", Label: "Check"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "work"})
+	g.AddEdge(&Edge{From: "work", To: "check"})
+	g.AddEdge(&Edge{From: "check", To: "end", Condition: "outcome=success"})
+	g.AddEdge(&Edge{From: "check", To: "work", Condition: "outcome=fail"})
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	workCalls := 0
+	checkAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				workCalls++
+				mu.Unlock()
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	reg.Register(&testHandler{
+		name: "conditional",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			mu.Lock()
+			checkAttempts++
+			a := checkAttempts
+			mu.Unlock()
+			if a == 1 {
+				return Outcome{Status: string(OutcomeFail), ContextUpdates: map[string]string{"outcome": "fail", "knob": "two"}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"outcome": "success"}}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if workCalls != 2 {
+		t.Errorf("AC2(prompt): expected work to re-run (2 calls) after prompt drift, got %d", workCalls)
+	}
+}
+
+// AC3: the memo table survives a checkpoint serialize -> deserialize -> replay.
+func TestMemoSurvivesCheckpointRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cpPath := filepath.Join(dir, "cp.json")
+
+	// First run: linear s -> work -> end. work is memoized and succeeds once.
+	g := NewGraph("memo_ac3")
+	g.AddNode(&Node{ID: "s", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "work", Shape: "box", Label: "Work", Attrs: map[string]string{"memoize": "true"}})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "s", To: "work"})
+	g.AddEdge(&Edge{From: "work", To: "end"})
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	calls := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				calls++
+				mu.Unlock()
+				return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"work_out": "persisted"}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg, WithCheckpointPath(cpPath))
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+
+	// Verify the memo entry was persisted to disk.
+	cp, err := LoadCheckpoint(cpPath)
+	if err != nil {
+		t.Fatalf("load checkpoint: %v", err)
+	}
+	if len(cp.MemoEntries) != 1 {
+		t.Fatalf("AC3: expected 1 persisted memo entry, got %d", len(cp.MemoEntries))
+	}
+
+	// Force re-execution of work on resume by clearing it from completed, then
+	// resume from a fresh engine that loads the checkpoint. The memo table must
+	// replay work WITHOUT invoking the handler.
+	cp.ClearCompleted("work")
+	cp.CurrentNode = "work"
+	if err := SaveCheckpoint(cp, cpPath); err != nil {
+		t.Fatalf("save mutated checkpoint: %v", err)
+	}
+
+	mu.Lock()
+	callsBeforeResume := calls
+	mu.Unlock()
+
+	engine2 := NewEngine(g, reg, WithCheckpointPath(cpPath))
+	result2, err := engine2.Run(context.Background())
+	if err != nil {
+		t.Fatalf("run 2 (resume): %v", err)
+	}
+	if result2.Status != OutcomeSuccess {
+		t.Fatalf("resume expected success, got %q", result2.Status)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != callsBeforeResume {
+		t.Errorf("AC3: expected NO new handler calls on resume (pure memo replay), got %d new", calls-callsBeforeResume)
+	}
+	if v := result2.Context["work_out"]; v != "persisted" {
+		t.Errorf("AC3: expected replayed work_out=persisted from deserialized memo, got %q", v)
+	}
+}
+
+// AC4: off by default — a node WITHOUT the attr re-runs each entry and writes
+// no memo_entries to the checkpoint.
+func TestMemoOffByDefault(t *testing.T) {
+	dir := t.TempDir()
+	cpPath := filepath.Join(dir, "cp.json")
+	g := memoLoopGraph("memo_ac4", false) // no memoize attr
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	workCalls := 0
+	checkAttempts := 0
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				workCalls++
+				mu.Unlock()
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	reg.Register(failOnceCheckHandler(&mu, &checkAttempts))
+
+	engine := NewEngine(g, reg, WithCheckpointPath(cpPath))
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	mu.Lock()
+	if workCalls != 2 {
+		t.Errorf("AC4: expected work to run each entry (2 calls) with no memoize, got %d", workCalls)
+	}
+	mu.Unlock()
+
+	// The on-disk checkpoint must have no memo_entries key (omitempty proves
+	// zero serialization footprint when the feature is off).
+	data, err := os.ReadFile(cpPath)
+	if err != nil {
+		t.Fatalf("read checkpoint: %v", err)
+	}
+	if strings.Contains(string(data), "memo_entries") {
+		t.Errorf("AC4: checkpoint must not contain memo_entries when feature is off:\n%s", data)
+	}
+}
+
+// Unit: computeMemoKey determinism, sensitivity, anti-collision, and disabled.
+func TestComputeMemoKey(t *testing.T) {
+	g := NewGraph("memo_unit")
+	e := NewEngine(g, newTestRegistry())
+
+	mkState := func(ctxVals map[string]string) *runState {
+		pctx := NewPipelineContext()
+		for k, v := range ctxVals {
+			pctx.Set(k, v)
+		}
+		return &runState{pctx: pctx, cp: &Checkpoint{}}
+	}
+
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{"memoize": "true", "prompt": "abc"}}
+
+	s := mkState(map[string]string{"a": "1"})
+	k1, ok1 := e.computeMemoKey(s, node)
+	if !ok1 {
+		t.Fatal("expected ok=true for memoize node")
+	}
+	// Identical inputs → identical key.
+	k1b, _ := e.computeMemoKey(mkState(map[string]string{"a": "1"}), node)
+	if k1 != k1b {
+		t.Errorf("expected identical key for identical inputs, got %q vs %q", k1, k1b)
+	}
+	// Changed ctx → different key.
+	k2, _ := e.computeMemoKey(mkState(map[string]string{"a": "2"}), node)
+	if k1 == k2 {
+		t.Error("expected different key when ctx value changes")
+	}
+	// Changed attr → different key.
+	node2 := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{"memoize": "true", "prompt": "xyz"}}
+	k3, _ := e.computeMemoKey(mkState(map[string]string{"a": "1"}), node2)
+	if k1 == k3 {
+		t.Error("expected different key when attr changes")
+	}
+	// Disabled → ok=false.
+	plain := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{"prompt": "abc"}}
+	if _, ok := e.computeMemoKey(mkState(nil), plain); ok {
+		t.Error("expected ok=false when memoize is not set")
+	}
+	// Length-prefix anti-collision: ctx {"a":"bc"} vs {"ab":"c"} must differ.
+	ka, _ := e.computeMemoKey(mkState(map[string]string{"a": "bc"}), node)
+	kb, _ := e.computeMemoKey(mkState(map[string]string{"ab": "c"}), node)
+	if ka == kb {
+		t.Error("length-prefix anti-collision failed: distinct ctx maps hashed equal")
+	}
+	// Routing-scratch keys are excluded — setting them must not change the key.
+	withScratch := mkState(map[string]string{"a": "1", ContextKeyOutcome: "success", ContextKeyPreferredLabel: "x"})
+	ks, _ := e.computeMemoKey(withScratch, node)
+	if ks != k1 {
+		t.Error("routing-scratch keys must be excluded from the memo key")
+	}
+}
+
+// Verify MemoEntry round-trips through JSON.
+func TestMemoEntryJSONRoundTrip(t *testing.T) {
+	cp := &Checkpoint{RunID: "r"}
+	cp.PutMemo("k", &Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"x": "y"}})
+	data, err := json.Marshal(cp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var loaded Checkpoint
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rec, ok := loaded.GetMemo("k")
+	if !ok {
+		t.Fatal("expected memo entry after round-trip")
+	}
+	if rec.Status != string(OutcomeSuccess) || rec.ContextUpdates["x"] != "y" {
+		t.Errorf("memo entry corrupted: %+v", rec)
+	}
+}
+
+// AC2(iii): for a writable_paths agent backed by a live repo, a working-tree
+// change between entries flips the tree fingerprint and thus the memo key.
+func TestMemoKeyTreeFingerprintSensitivity(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	repo := newGitArtifactRepo(dir, "treerun01")
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+
+	g := NewGraph("memo_tree")
+	e := NewEngine(g, newTestRegistry())
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
+		"memoize":        "true",
+		"writable_paths": "out/**",
+	}}
+	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}, gitRepo: repo}
+
+	k1, ok := e.computeMemoKey(s, node)
+	if !ok {
+		t.Fatal("expected ok=true with live repo")
+	}
+
+	// Mutate the working tree.
+	if err := os.WriteFile(filepath.Join(dir, "newfile.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	k2, ok := e.computeMemoKey(s, node)
+	if !ok {
+		t.Fatal("expected ok=true after tree change")
+	}
+	if k1 == k2 {
+		t.Error("AC2(tree): expected memo key to change after working-tree mutation")
+	}
+}
+
+// A tree-fingerprint error yields a cache miss (ok=false), not a stale replay.
+func TestMemoKeyTreeFingerprintErrorIsMiss(t *testing.T) {
+	g := NewGraph("memo_tree_err")
+	e := NewEngine(g, newTestRegistry())
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
+		"memoize":        "true",
+		"writable_paths": "out/**",
+	}}
+	// gitRepo points at a non-existent dir → git status fails → ok=false.
+	badRepo := newGitArtifactRepo(filepath.Join(t.TempDir(), "does-not-exist"), "bad")
+	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}, gitRepo: badRepo}
+
+	if _, ok := e.computeMemoKey(s, node); ok {
+		t.Error("expected ok=false (cache miss) when tree fingerprint errors")
+	}
+}
+
+// BLOCKER 1 (run-b65fb64 shape): work writes bare last_response on entry 1
+// (so node.work.last_response gets aliased — the old self-output exclusion would
+// drop last_response from the key). The intervening check node OVERWRITES bare
+// last_response with a NEW critique before work re-enters. Because last_response
+// is a genuine InjectPipelineContext prompt INPUT, the memo key MUST change and
+// work MUST re-run — handler called TWICE, not once.
+func TestMemoInvalidatesOnChangedInjectedLastResponse(t *testing.T) {
+	g := memoLoopGraph("memo_b1", true)
+
+	reg := newTestRegistry()
+	var mu sync.Mutex
+	workCalls := 0
+	checkAttempts := 0
+
+	reg.Register(&testHandler{
+		name: "codergen",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == "work" {
+				mu.Lock()
+				workCalls++
+				mu.Unlock()
+				// work writes bare last_response — on scope it aliases to
+				// node.work.last_response, the trigger for the old self-output bug.
+				return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{
+					ContextKeyLastResponse: "work output",
+				}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		},
+	})
+	// check fails first time and overwrites bare last_response with a NEW critique,
+	// genuinely changing work's resolved prompt input on re-entry.
+	reg.Register(&testHandler{
+		name: "conditional",
+		executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			mu.Lock()
+			checkAttempts++
+			a := checkAttempts
+			mu.Unlock()
+			if a == 1 {
+				return Outcome{Status: string(OutcomeFail), ContextUpdates: map[string]string{
+					"outcome":              "fail",
+					ContextKeyLastResponse: "review critique: fix X",
+				}}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess), ContextUpdates: map[string]string{"outcome": "success"}}, nil
+		},
+	})
+
+	engine := NewEngine(g, reg)
+	if _, err := engine.Run(context.Background()); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if workCalls != 2 {
+		t.Errorf("B1: expected work to re-run (2 calls) after intervening node changed bare last_response, got %d", workCalls)
+	}
+}
+
+// BLOCKER 2: a memoize:true node declaring writable_paths run WITHOUT a git repo
+// (the default tracker run / library Run config — WithGitArtifacts has no
+// production callers). With no tree fingerprint available there is no way to
+// prove the working tree is unchanged, so computeMemoKey MUST return ok=false
+// (hard miss) rather than replay a side-effecting node on a stale tree.
+func TestMemoKeyWritablePathsRequiresTreeFingerprint(t *testing.T) {
+	g := NewGraph("memo_b2")
+	e := NewEngine(g, newTestRegistry())
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
+		"memoize":        "true",
+		"writable_paths": "out/**",
+	}}
+	// Default config: gitRepo is nil (WithGitArtifacts not wired into production).
+	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}}
+
+	if _, ok := e.computeMemoKey(s, node); ok {
+		t.Error("B2: expected ok=false (cache miss) for a writable_paths node with no tree fingerprint")
+	}
+}
+
+// PutMemo must deep-copy ContextUpdates so later mutation cannot corrupt it.
+func TestPutMemoDeepCopiesContextUpdates(t *testing.T) {
+	cp := &Checkpoint{}
+	cu := map[string]string{"x": "v1"}
+	cp.PutMemo("k", &Outcome{Status: string(OutcomeSuccess), ContextUpdates: cu})
+	cu["x"] = "mutated"
+	rec, _ := cp.GetMemo("k")
+	if rec.ContextUpdates["x"] != "v1" {
+		t.Errorf("expected stored record to be insulated from caller mutation, got %q", rec.ContextUpdates["x"])
+	}
+}

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -634,3 +634,29 @@ func TestPutMemoDeepCopiesContextUpdates(t *testing.T) {
 		t.Errorf("expected stored record to be insulated from caller mutation, got %q", rec.ContextUpdates["x"])
 	}
 }
+
+// memoOutcome must deep-copy the reference-typed fields so mutating the replay
+// Outcome cannot reach back into the checkpoint memo record (#425 review).
+func TestMemoOutcomeIsolatesRecordFromMutation(t *testing.T) {
+	rec := MemoEntry{
+		Status:             string(OutcomeSuccess),
+		ContextUpdates:     map[string]string{"x": "v1"},
+		PreferredLabel:     "approve",
+		SuggestedNextNodes: []string{"join"},
+	}
+	out := memoOutcome(rec)
+	// Mutate every reference field on the replay Outcome.
+	out.ContextUpdates["x"] = "mutated"
+	out.ContextUpdates["y"] = "added"
+	out.SuggestedNextNodes[0] = "elsewhere"
+
+	if rec.ContextUpdates["x"] != "v1" {
+		t.Errorf("record ContextUpdates corrupted: x=%q, want v1", rec.ContextUpdates["x"])
+	}
+	if _, ok := rec.ContextUpdates["y"]; ok {
+		t.Error("record ContextUpdates gained a key from replay mutation")
+	}
+	if rec.SuggestedNextNodes[0] != "join" {
+		t.Errorf("record SuggestedNextNodes corrupted: [0]=%q, want join", rec.SuggestedNextNodes[0])
+	}
+}

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -398,6 +398,39 @@ func TestComputeMemoKey(t *testing.T) {
 	}
 }
 
+// A non-success memo record (only reachable via a corrupted or hand-edited
+// checkpoint, since PutMemo is gated on OutcomeSuccess at the call site) must be
+// treated as a cache MISS — the "failures never replay" contract is enforced on
+// the read side too, not just the write side (#425 review).
+func TestMemoNonSuccessRecordIsNotReplayed(t *testing.T) {
+	g := NewGraph("memo_nonsuccess")
+	e := NewEngine(g, newTestRegistry())
+
+	pctx := NewPipelineContext()
+	pctx.Set("a", "1")
+	s := &runState{pctx: pctx, cp: &Checkpoint{}}
+
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{"memoize": "true", "prompt": "abc"}}
+	key, ok := e.computeMemoKey(s, node)
+	if !ok {
+		t.Fatal("expected a memoizable key for the memoize node")
+	}
+	// Inject a stored FAILURE under the exact key the node will compute.
+	s.cp.PutMemo(key, &Outcome{Status: string(OutcomeFail), ContextUpdates: map[string]string{"work_out": "stale"}})
+	if _, hit := s.cp.GetMemo(key); !hit {
+		t.Fatal("precondition: the fail record must be present under the computed key")
+	}
+
+	lr := e.maybeReplayMemoized(context.Background(), s, "work", node, node, "")
+	if lr != nil {
+		t.Errorf("a non-success memo record must be a cache miss (nil loopResult, re-run live), got %+v", lr)
+	}
+	// The key must still be recorded so a fresh successful run can store under it.
+	if s.pendingMemoKey != key {
+		t.Errorf("pendingMemoKey = %q, want the computed key %q (store site must still fire on the live re-run)", s.pendingMemoKey, key)
+	}
+}
+
 // Verify MemoEntry round-trips through JSON.
 func TestMemoEntryJSONRoundTrip(t *testing.T) {
 	cp := &Checkpoint{RunID: "r"}

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"testing"
 )
@@ -318,12 +317,18 @@ func TestMemoOffByDefault(t *testing.T) {
 	mu.Unlock()
 
 	// The on-disk checkpoint must have no memo_entries key (omitempty proves
-	// zero serialization footprint when the feature is off).
+	// zero serialization footprint when the feature is off). Parse into a generic
+	// map and assert key absence rather than substring-matching the raw JSON, which
+	// could false-positive on the value of an unrelated field.
 	data, err := os.ReadFile(cpPath)
 	if err != nil {
 		t.Fatalf("read checkpoint: %v", err)
 	}
-	if strings.Contains(string(data), "memo_entries") {
+	var cp map[string]any
+	if err := json.Unmarshal(data, &cp); err != nil {
+		t.Fatalf("unmarshal checkpoint: %v\n%s", err, data)
+	}
+	if _, ok := cp["memo_entries"]; ok {
 		t.Errorf("AC4: checkpoint must not contain memo_entries when feature is off:\n%s", data)
 	}
 }

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -552,7 +552,7 @@ func TestMemoKeyWritablePathsAlwaysMissesWithLiveRepo(t *testing.T) {
 // A PRESENT-but-EMPTY writable_paths attr (writable_paths:"") is still a hard
 // miss. The adapter emits that sentinel as a bypass-defense (an empty glob set
 // jails the node to nothing rather than dropping the signal), and the jail keys
-// on presence via AgentConfig.WritablePathsSet — so memoization must too, or a
+// on presence via AgentNodeConfig.WritablePathsSet — so memoization must too, or a
 // side-effecting node could be replayed (#425 review).
 func TestMemoKeyWritablePathsEmptyStillMisses(t *testing.T) {
 	g := NewGraph("memo_tree_empty")

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -549,6 +549,25 @@ func TestMemoKeyWritablePathsAlwaysMissesWithLiveRepo(t *testing.T) {
 	}
 }
 
+// A PRESENT-but-EMPTY writable_paths attr (writable_paths:"") is still a hard
+// miss. The adapter emits that sentinel as a bypass-defense (an empty glob set
+// jails the node to nothing rather than dropping the signal), and the jail keys
+// on presence via AgentConfig.WritablePathsSet — so memoization must too, or a
+// side-effecting node could be replayed (#425 review).
+func TestMemoKeyWritablePathsEmptyStillMisses(t *testing.T) {
+	g := NewGraph("memo_tree_empty")
+	e := NewEngine(g, newTestRegistry())
+	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
+		"memoize":        "true",
+		"writable_paths": "",
+	}}
+	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}}
+
+	if _, ok := e.computeMemoKey(s, node); ok {
+		t.Error("expected ok=false (hard miss) for a present-but-empty writable_paths node")
+	}
+}
+
 // BLOCKER 1 (run-b65fb64 shape): work writes bare last_response on entry 1
 // (so node.work.last_response gets aliased — the old self-output exclusion would
 // drop last_response from the key). The intervening check node OVERWRITES bare

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -381,6 +381,21 @@ func TestComputeMemoKey(t *testing.T) {
 	if ks != k1 {
 		t.Error("routing-scratch keys must be excluded from the memo key")
 	}
+
+	// #425 review (Codex P1): a bare key this node self-aliased on a prior pass
+	// is skipped ONLY while unchanged. An UNCHANGED self-output (bare == scoped)
+	// must not affect the key; an OVERWRITTEN one (bare != scoped) is a genuine
+	// changed input and MUST change the key, else replay is stale.
+	unchangedSelf := mkState(map[string]string{"a": "1", "selfk": "out", "node.work.selfk": "out"})
+	kSelf, _ := e.computeMemoKey(unchangedSelf, node)
+	if kSelf != k1 {
+		t.Error("unchanged self-output bare key must be excluded from the memo key")
+	}
+	overwrittenSelf := mkState(map[string]string{"a": "1", "selfk": "REWRITTEN", "node.work.selfk": "out"})
+	kOver, _ := e.computeMemoKey(overwrittenSelf, node)
+	if kOver == kSelf {
+		t.Error("overwritten self-output (bare != scoped) must change the memo key, not replay stale")
+	}
 }
 
 // Verify MemoEntry round-trips through JSON.
@@ -401,6 +416,76 @@ func TestMemoEntryJSONRoundTrip(t *testing.T) {
 	}
 	if rec.Status != string(OutcomeSuccess) || rec.ContextUpdates["x"] != "y" {
 		t.Errorf("memo entry corrupted: %+v", rec)
+	}
+}
+
+// #425 review (CodeRabbit): a memoized node that selected its next edge via
+// PreferredLabel / SuggestedNextNodes must replay onto the SAME path. Verify
+// both routing hints survive PutMemo + a JSON checkpoint round-trip.
+func TestMemoEntryPersistsRoutingHints(t *testing.T) {
+	cp := &Checkpoint{RunID: "r"}
+	cp.PutMemo("k", &Outcome{
+		Status:             string(OutcomeSuccess),
+		PreferredLabel:     "approve",
+		SuggestedNextNodes: []string{"join", "fanin"},
+	})
+	data, err := json.Marshal(cp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var loaded Checkpoint
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	rec, ok := loaded.GetMemo("k")
+	if !ok {
+		t.Fatal("expected memo entry after round-trip")
+	}
+	if rec.PreferredLabel != "approve" {
+		t.Errorf("PreferredLabel not persisted: got %q", rec.PreferredLabel)
+	}
+	if len(rec.SuggestedNextNodes) != 2 || rec.SuggestedNextNodes[0] != "join" || rec.SuggestedNextNodes[1] != "fanin" {
+		t.Errorf("SuggestedNextNodes not persisted: got %v", rec.SuggestedNextNodes)
+	}
+}
+
+// #425 review (Codex P2): TreeFingerprint must reflect actual worktree CONTENT,
+// not just staged blobs. A content change to an existing tracked file that is
+// neither staged nor changes its status marker must still flip the fingerprint.
+func TestTreeFingerprintDetectsUnstagedTrackedContentChange(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	repo := newGitArtifactRepo(dir, "unstaged01")
+	if err := repo.Init(); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Commit a tracked file so it lives in HEAD and the index.
+	path := filepath.Join(dir, "tracked.txt")
+	if err := os.WriteFile(path, []byte("original"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if out, err := repo.git("add", "tracked.txt"); err != nil {
+		t.Fatalf("add: %v\n%s", err, out)
+	}
+	if out, err := repo.git("commit", "-m", "seed"); err != nil {
+		t.Fatalf("commit: %v\n%s", err, out)
+	}
+
+	fp1, err := repo.TreeFingerprint()
+	if err != nil {
+		t.Fatalf("fingerprint 1: %v", err)
+	}
+	// Modify the tracked file in the worktree WITHOUT staging — `ls-files -s`
+	// (the old impl) would still show the committed blob and miss this.
+	if err := os.WriteFile(path, []byte("CHANGED-UNSTAGED"), 0o644); err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	fp2, err := repo.TreeFingerprint()
+	if err != nil {
+		t.Fatalf("fingerprint 2: %v", err)
+	}
+	if fp1 == fp2 {
+		t.Error("expected fingerprint to change on an unstaged tracked-file content change")
 	}
 }
 

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -568,6 +568,26 @@ func TestMemoKeyWritablePathsEmptyStillMisses(t *testing.T) {
 	}
 }
 
+// Memoization is agent-node-only by contract. A non-codergen node carrying
+// memoize:true (only reachable via a DOT/programmatic Graph — the dippin
+// adapter surfaces the attr for agent nodes only) must be a hard miss so a
+// side-effecting/non-deterministic handler is never replayed (#425 review).
+func TestMemoKeyNonAgentNodeNeverMemoizes(t *testing.T) {
+	g := NewGraph("memo_non_agent")
+	e := NewEngine(g, newTestRegistry())
+	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}}
+
+	for _, handler := range []string{"tool", "wait.human", "conditional"} {
+		node := &Node{ID: "n", Handler: handler, Attrs: map[string]string{
+			"memoize": "true",
+			"prompt":  "abc",
+		}}
+		if _, ok := e.computeMemoKey(s, node); ok {
+			t.Errorf("handler %q: expected ok=false (hard miss) — memoization is agent-node-only", handler)
+		}
+	}
+}
+
 // BLOCKER 1 (run-b65fb64 shape): work writes bare last_response on entry 1
 // (so node.work.last_response gets aliased — the old self-output exclusion would
 // drop last_response from the key). The intervening check node OVERWRITES bare

--- a/pipeline/memoize_test.go
+++ b/pipeline/memoize_test.go
@@ -489,9 +489,13 @@ func TestTreeFingerprintDetectsUnstagedTrackedContentChange(t *testing.T) {
 	}
 }
 
-// AC2(iii): for a writable_paths agent backed by a live repo, a working-tree
-// change between entries flips the tree fingerprint and thus the memo key.
-func TestMemoKeyTreeFingerprintSensitivity(t *testing.T) {
+// A writable_paths node is an UNCONDITIONAL hard miss even when a live artifact
+// repo is present. s.gitRepo is the artifact repo (<artifactDir>/<runID>), NOT
+// the agent's session working_dir, so its fingerprint proves nothing about the
+// tree the agent read/wrote — memoizing on it would risk a stale replay against
+// a changed working tree (#425 review). Until we can fingerprint the agent's
+// real working_dir, side-effecting nodes are not memoizable.
+func TestMemoKeyWritablePathsAlwaysMissesWithLiveRepo(t *testing.T) {
 	requireGit(t)
 	dir := t.TempDir()
 	repo := newGitArtifactRepo(dir, "treerun01")
@@ -507,38 +511,8 @@ func TestMemoKeyTreeFingerprintSensitivity(t *testing.T) {
 	}}
 	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}, gitRepo: repo}
 
-	k1, ok := e.computeMemoKey(s, node)
-	if !ok {
-		t.Fatal("expected ok=true with live repo")
-	}
-
-	// Mutate the working tree.
-	if err := os.WriteFile(filepath.Join(dir, "newfile.txt"), []byte("x"), 0o644); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	k2, ok := e.computeMemoKey(s, node)
-	if !ok {
-		t.Fatal("expected ok=true after tree change")
-	}
-	if k1 == k2 {
-		t.Error("AC2(tree): expected memo key to change after working-tree mutation")
-	}
-}
-
-// A tree-fingerprint error yields a cache miss (ok=false), not a stale replay.
-func TestMemoKeyTreeFingerprintErrorIsMiss(t *testing.T) {
-	g := NewGraph("memo_tree_err")
-	e := NewEngine(g, newTestRegistry())
-	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
-		"memoize":        "true",
-		"writable_paths": "out/**",
-	}}
-	// gitRepo points at a non-existent dir → git status fails → ok=false.
-	badRepo := newGitArtifactRepo(filepath.Join(t.TempDir(), "does-not-exist"), "bad")
-	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}, gitRepo: badRepo}
-
 	if _, ok := e.computeMemoKey(s, node); ok {
-		t.Error("expected ok=false (cache miss) when tree fingerprint errors")
+		t.Error("expected ok=false (hard miss) for a writable_paths node even with a live artifact repo")
 	}
 }
 
@@ -608,7 +582,7 @@ func TestMemoInvalidatesOnChangedInjectedLastResponse(t *testing.T) {
 // production callers). With no tree fingerprint available there is no way to
 // prove the working tree is unchanged, so computeMemoKey MUST return ok=false
 // (hard miss) rather than replay a side-effecting node on a stale tree.
-func TestMemoKeyWritablePathsRequiresTreeFingerprint(t *testing.T) {
+func TestMemoKeyWritablePathsMissesWithoutRepo(t *testing.T) {
 	g := NewGraph("memo_b2")
 	e := NewEngine(g, newTestRegistry())
 	node := &Node{ID: "work", Handler: "codergen", Attrs: map[string]string{
@@ -619,7 +593,7 @@ func TestMemoKeyWritablePathsRequiresTreeFingerprint(t *testing.T) {
 	s := &runState{pctx: NewPipelineContext(), cp: &Checkpoint{}}
 
 	if _, ok := e.computeMemoKey(s, node); ok {
-		t.Error("B2: expected ok=false (cache miss) for a writable_paths node with no tree fingerprint")
+		t.Error("B2: expected ok=false (hard miss) for a writable_paths node")
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #421. Adds an **opt-in, content-hash node-output memo cache** so a loop-restart that re-enters an already-green node with identical inputs **replays** the stored outcome instead of re-invoking the handler. Run `b65fb64ac099` fired 11 loop-restarts, each re-executing the cleared set via `clearDownstream`; there was no node-level memoization (the only caches — the per-session tool cache and Anthropic prompt-cache token accounting — never skip a node).

## How it works

- **Opt-in** via `params: { memoize: true }` on an agent node (read as `node.Attrs["memoize"]` through the generic params pass-through — **no dippin-lang field**, verified `dippin doctor` Grade A with the attr). Off by default: a `.dip` without the attr builds no memo table and runs the handler on every entry (AC4).
- **Memo key** = SHA-256 (length-prefixed, anti-collision) over: a recipe-version tag, node id, handler, the sorted post-interpolation `node.Attrs` (so the resolved prompt embeds every templated `ctx.*`), a filtered bare-namespace context snapshot, and (for agent nodes only) nothing more. A `writable_paths` node is an **unconditional** hard miss — never memoized, so no working-tree fingerprint enters the key (see note below). Documented verbatim in `computeMemoKey`.
- **Replay** before handler dispatch on a key hit; **store** only on `OutcomeSuccess` (failures never replay). The replay reuses the identical post-handler tail (`finishNode`), so edge routing and strict-failure semantics are untouched.
- **Persisted** in `checkpoint.json` (additive, `omitempty`), so the table survives resume (AC3); `clearDownstream` never clears it.
- **Conservative by construction**: a `writable_paths` node is always a hard cache **miss** → the handler re-runs (never replayed); more generally, any uncertainty means a miss. Never replay on an uncertain key.

## Scope: agent-node-only (documented narrowing)

`dippin v0.43.0` rejects `params:` on **tool** nodes and rejects `defaults: memoize` — so there is no `.dip` surface to opt a tool node in without a dippin-lang field (forbidden by the brief). #421 therefore ships **agent-node memoize only**; an agent that declares `writable_paths` is an unconditional hard miss (never memoized — the artifact-repo fingerprint can't validate the agent's separate `working_dir`, so side-effecting nodes always re-run; `TreeFingerprint` is retained as a building block for a future `working_dir` fingerprint but is unused by the memo key today). Tool-node opt-in is a follow-up (needs a dippin-lang `ToolConfig.Params` field). Called out in the CHANGELOG.

## Adversarial review: two blockers found and fixed

A 3-lens adversarial panel caught two **stale-replay** holes (the exact failure mode #421 must prevent); both were fixed with TDD and re-verified by an independent reviewer:

1. **Injected prompt inputs masked as self-outputs.** `InjectPipelineContext` appends bare `last_response`/`human_response` to every agent prompt; the original self-output exclusion dropped them from the key, so a `build→review→fail→build` loop replayed a stale build after the critique changed. **Fix:** those two injection keys are now hashed unconditionally (other bare self-outputs keep the exclusion). New test `TestMemoInvalidatesOnChangedInjectedLastResponse`.
2. **Tree-fingerprint was dead code in the shipping config (later superseded).** `WithGitArtifacts` has no production callers, so `s.gitRepo` is nil by default and a `writable_paths` node would have replayed without tree-drift detection. A follow-up review round made `writable_paths` an **unconditional** hard miss regardless of repo availability — the fingerprint is taken from the artifact repo (`<artifactDir>/<runID>`), a different directory than the agent's `working_dir`, so it could never validate a side-effecting node's inputs. Net shipped behavior: `writable_paths` nodes are never memoized.

**Known limitation (pre-existing, non-blocking):** under non-`FidelityFull` prompt fidelity, the compacted-context summary could in principle inject a non-`last_response` bare key that the self-output exclusion still masks. This is a narrow, pre-existing class (the demonstrated real-world loop uses `last_response`, now always hashed) and is not a regression from this change; noted for awareness.

## Verification

- `go build ./...` ✅ · `go test ./... -short` ✅ · `go test -race ./pipeline/ -run 'Memo|Restart|Checkpoint'` ✅
- Tests cover all four ACs (replay-skips-handler with call-count==1; ctx/prompt/tree invalidation; checkpoint round-trip; off-by-default) plus the two blocker-regression tests.
- `dippin doctor examples/build_product.dip` — **Grade A**; tolerates the `memoize` attr with no new lint error.
- Pre-commit hooks (gofmt, vet, build, full suite, race, coverage 85%, complexity ≤8, dippin lint) all pass (a minimal `isMemoizableContextKey` extraction kept `memoizableContext` under the complexity gate).

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785006503&installation_id=131176874&pr_number=425&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F425&signature=c028abd74bfedb31ce89858aa1397866361474bf9a2390a717f543858f3b0efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in SHA-256 content-hash memoization for node outputs (`memoize: true`), replaying prior successful outcomes on identical re-entry after restarts.
  * Memoized replays are persisted in checkpoints and emit a new `node_memo_replayed` pipeline event.
* **Bug Fixes**
  * Hardened replay correctness by invalidating on changed resolved inputs/prompts and ensuring replay follows the same routing and terminal behavior as the original run.
* **Tests**
  * Added coverage for replay-on-restart, memo invalidation rules, checkpoint persistence/round-trips, deterministic memo keying, deep-copy safety, and tree fingerprinting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
