### PR TITLE
feat(budget): sleep-aware wall/stall budgets (#422 part A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`Check` runs only at node boundaries, so anchoring on it would silently drop
   the entire first node); `Pause()` is idempotent (a double `Pause` records the
   window once); and an in-flight pause (Pause without Resume) is now subtracted
-  from both wall and stall accounting, so neither trips mid-pause.
+  from both wall and stall accounting, so neither trips mid-pause. `anchorMono`
+  no longer initializes the stall progress baseline (`monoProgress`): that
+  baseline is derived solely in `sleepAwareStall`, which clamps the last-progress
+  mark up to the run-start anchor — covering "no progress yet", pre-run progress,
+  and genuine post-anchor progress without the risk of overwriting a real
+  progress mark with the (later) anchor time and undercounting stall (#426
+  review).
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sleep-aware accounting; engine wiring around blocking gate waits is a
   follow-up. Default behavior is byte-identical when the flag is absent: the
   wall-clock path is used and suspend time is still counted (strict semantics
-  preserved).
+  preserved). Review fixes (#422): the sleep-aware monotonic baseline now
+  anchors at run start (first `Check`), not guard construction, so pre-run awake
+  idle is excluded from `max_wall_time` and the initial `stall_timeout`;
+  `Pause()` is idempotent (a double `Pause` records the window once); and an
+  in-flight pause (Pause without Resume) is now subtracted from both wall and
+  stall accounting, so neither trips mid-pause.
 
 ### Notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sleep-aware budgets (#422, part A).** Opt-in `BudgetLimits.SleepAware` (CLI
+  `--sleep-aware-budget`) excludes OS-suspend spans — e.g. a suspended laptop —
+  from `max_wall_time` and `stall_timeout` accounting, so a machine that sleeps
+  mid-run no longer spuriously trips `OutcomeBudgetExceeded` on resume. The
+  exclusion is driven by the monotonic clock (Linux `CLOCK_MONOTONIC`, which is
+  frozen during OS suspend but advances during genuine work) — there is **no**
+  wall-delta threshold, so genuine long-running nodes are still budgeted: a 70m
+  node correctly trips a 1h `max_wall_time`, and a 90m no-progress hang correctly
+  trips a 30m `stall_timeout`. `BudgetGuard` now takes a clock exposing both a
+  wall reading and a monotonic elapsed reading. New `BudgetGuard.Pause()` /
+  `Resume()` subtract an explicit awake-idle window (e.g. a human gate) from
+  sleep-aware accounting; engine wiring around blocking gate waits is a
+  follow-up. Default behavior is byte-identical when the flag is absent: the
+  wall-clock path is used and suspend time is still counted (strict semantics
+  preserved).
+
+### Notes
+
+- `sleep_aware_budget` is read from `graph.Attrs` by `ResolveBudgetLimits` for
+  parity with the other budget keys, but dippin-lang v0.43.0 has no `defaults:`
+  field or pass-through that delivers a bare `sleep_aware_budget` attribute to
+  the graph (verified: `dippin doctor` rejects it as an unknown defaults field).
+  The opt-in surface for operators is therefore the `--sleep-aware-budget` CLI
+  flag / `Config.Budget.SleepAware`, not a `.dip` attribute, until a future
+  dippin-lang release exposes a generic workflow-attr pass-through.
+- **#422 part B (AC3) is a tracked follow-up, not in this release.** Sub-node
+  turn checkpointing — letting a long-running agent node resume mid-node from
+  its last turn boundary with conversation/episode state intact — requires
+  net-new serialization of `agent.Session` in-memory state (`messages`,
+  `episodeLog`, turn counter), provider message round-trip fidelity tests, a
+  working-tree SHA capture/restore, a `pipeline/checkpoint.go` schema extension,
+  and an engine + `CodergenHandler` resume path. That is ~300–700 LOC across 4+
+  files with medium-high state-corruption risk, so it is deferred per the
+  scope decision. See "#422 follow-up" in the PR description.
+
 ## [0.40.2] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   follow-up. Default behavior is byte-identical when the flag is absent: the
   wall-clock path is used and suspend time is still counted (strict semantics
   preserved). Review fixes (#422): the sleep-aware monotonic baseline now
-  anchors at run start (first `Check`), not guard construction, so pre-run awake
-  idle is excluded from `max_wall_time` and the initial `stall_timeout`;
-  `Pause()` is idempotent (a double `Pause` records the window once); and an
-  in-flight pause (Pause without Resume) is now subtracted from both wall and
-  stall accounting, so neither trips mid-pause.
+  anchors at TRUE run start — the engine calls `BudgetGuard.AnchorRunStart()`
+  before the first node executes, not guard construction and not the first
+  `Check` — so pre-run awake idle is excluded from `max_wall_time` and the
+  initial `stall_timeout` while the FIRST node's runtime is still counted
+  (`Check` runs only at node boundaries, so anchoring on it would silently drop
+  the entire first node); `Pause()` is idempotent (a double `Pause` records the
+  window once); and an in-flight pause (Pause without Resume) is now subtracted
+  from both wall and stall accounting, so neither trips mid-pause.
 
 ### Notes
 

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -284,6 +284,7 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 		MaxTotalTokens: cfg.maxTokens,
 		MaxCostCents:   cfg.maxCostCents,
 		MaxWallTime:    cfg.maxWallTime,
+		SleepAware:     cfg.sleepAware,
 	}
 	activeRunParams = maps.Clone(cfg.params)
 	activeEffectiveRunParams = nil
@@ -308,15 +309,8 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 	// through Config without touching os.Environ. The CLI uses os.Setenv because
 	// run/runTUI have fixed signatures that can't be extended without breaking tests.
 	// Per-provider *_BASE_URL env vars always win over TRACKER_GATEWAY_URL.
-	if cfg.gatewayURL != "" {
-		if err := os.Setenv("TRACKER_GATEWAY_URL", cfg.gatewayURL); err != nil {
-			return fmt.Errorf("set TRACKER_GATEWAY_URL: %w", err)
-		}
-	}
-	if cfg.gatewayKind != "" {
-		if err := os.Setenv("TRACKER_GATEWAY_KIND", cfg.gatewayKind); err != nil {
-			return fmt.Errorf("set TRACKER_GATEWAY_KIND: %w", err)
-		}
+	if err := applyGatewayEnv(cfg); err != nil {
+		return err
 	}
 
 	if err := printRunPreamble(cfg); err != nil {
@@ -338,6 +332,23 @@ func executeRun(cfg runConfig, deps commandDeps) error {
 	activeResumeInfo = resume
 
 	return selectAndRunMode(cfg, deps, resume.CheckpointPath)
+}
+
+// applyGatewayEnv sets the TRACKER_GATEWAY_* env vars from cfg before any
+// provider constructor runs (see the timing note in executeRun). Per-provider
+// *_BASE_URL env vars still win over TRACKER_GATEWAY_URL downstream.
+func applyGatewayEnv(cfg runConfig) error {
+	if cfg.gatewayURL != "" {
+		if err := os.Setenv("TRACKER_GATEWAY_URL", cfg.gatewayURL); err != nil {
+			return fmt.Errorf("set TRACKER_GATEWAY_URL: %w", err)
+		}
+	}
+	if cfg.gatewayKind != "" {
+		if err := os.Setenv("TRACKER_GATEWAY_KIND", cfg.gatewayKind); err != nil {
+			return fmt.Errorf("set TRACKER_GATEWAY_KIND: %w", err)
+		}
+	}
+	return nil
 }
 
 // printRunPreamble prints backend and autopilot status messages and validates persona.

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -147,22 +147,7 @@ func parseRunFlags(args []string, cfg runConfig) (runConfig, error) {
 	}
 	cfg.pipelineFile = positional[0]
 
-	if err := validateBackend(cfg.backend); err != nil {
-		return cfg, err
-	}
-	if err := validateBudgetLimits(cfg); err != nil {
-		return cfg, err
-	}
-	if err := validateWebhookFlags(cfg); err != nil {
-		return cfg, err
-	}
-	if err := validateToolSafetyFlags(cfg); err != nil {
-		return cfg, err
-	}
-	if err := validateGitFlag(cfg); err != nil {
-		return cfg, err
-	}
-	if err := validateGatewayKind(cfg.gatewayKind); err != nil {
+	if err := validateRunConfig(cfg); err != nil {
 		return cfg, err
 	}
 	// Normalize the "auto" alias to empty so downstream comparisons stay simple.
@@ -170,6 +155,27 @@ func parseRunFlags(args []string, cfg runConfig) (runConfig, error) {
 		cfg.git = ""
 	}
 	return cfg, nil
+}
+
+// validateRunConfig runs the run-mode flag validators in order, returning the
+// first error. Extracted from parseRunFlags to keep its complexity bounded.
+func validateRunConfig(cfg runConfig) error {
+	if err := validateBackend(cfg.backend); err != nil {
+		return err
+	}
+	if err := validateBudgetLimits(cfg); err != nil {
+		return err
+	}
+	if err := validateWebhookFlags(cfg); err != nil {
+		return err
+	}
+	if err := validateToolSafetyFlags(cfg); err != nil {
+		return err
+	}
+	if err := validateGitFlag(cfg); err != nil {
+		return err
+	}
+	return validateGatewayKind(cfg.gatewayKind)
 }
 
 // validateBudgetLimits returns an error if any budget limit is negative.
@@ -241,6 +247,7 @@ func newRunFlagSet(progName string, cfg *runConfig) *flag.FlagSet {
 	fs.IntVar(&cfg.maxTokens, "max-tokens", 0, "Halt if total tokens across the run exceed this value (0 = no limit)")
 	fs.IntVar(&cfg.maxCostCents, "max-cost", 0, "Halt if total cost in cents exceeds this value (0 = no limit)")
 	fs.DurationVar(&cfg.maxWallTime, "max-wall-time", 0, "Halt if pipeline wall time exceeds this duration (0 = no limit)")
+	fs.BoolVar(&cfg.sleepAware, "sleep-aware-budget", false, "Exclude detected suspend spans (e.g. a closed laptop) from wall-time and stall budgets")
 	fs.BoolVar(&cfg.failOnOverride, "fail-on-override", false, "Exit code 2 if the run terminates via validation_overridden (default: exit 0)")
 	fs.Var(paramMapFlag{target: &cfg.params}, "param", "Override workflow param (repeatable): key=value")
 	fs.StringVar(&cfg.gatewayURL, "gateway-url", "", "Cloudflare AI Gateway root URL (per-provider *_BASE_URL env vars override this)")

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -31,6 +31,7 @@ type runConfig struct {
 	maxTokens    int           // halt if total tokens exceed this value (0 = no limit)
 	maxCostCents int           // halt if total cost in cents exceeds this value (0 = no limit)
 	maxWallTime  time.Duration // halt if wall time exceeds this duration (0 = no limit)
+	sleepAware   bool          // opt-in: exclude detected suspend spans from wall/stall budgets (#422)
 	// failOnOverride causes the CLI to exit with code 2 (not 0) when the run
 	// terminates as pipeline.OutcomeValidationOverridden. Default false keeps
 	// validation_overridden a success-equivalent exit, matching IsSuccess().
@@ -129,36 +130,49 @@ func main() {
 		cfg.workdir = resolveMainWorkDir()
 	}
 
+	if err := runCommand(cfg); err != nil {
+		exitWithError(err)
+	}
+}
+
+// runCommand performs the non-jail-exec, post-flag-parse work: an optional
+// pre-run update check, command execution, and a post-success update hint.
+// Returns the command's error (handled by exitWithError in main).
+func runCommand(cfg runConfig) error {
 	if cfg.mode == modeRun {
 		maybeCheckForUpdate()
 	}
 
-	err = executeCommand(cfg, commandDeps{})
+	err := executeCommand(cfg, commandDeps{})
 
 	// Only nag about updates after a successful run — on failure the error
-	// (printed below) is the headline, and the hint's ≤2s wait just delays it.
+	// (printed by exitWithError) is the headline, and the hint's ≤2s wait
+	// just delays it.
 	if cfg.mode == modeRun && err == nil {
 		printUpdateHint()
 	}
+	return err
+}
 
-	if err != nil {
-		var doctorWarn *DoctorWarningsError
-		if errors.As(err, &doctorWarn) {
-			// exit 2 = doctor finished with warnings but no failures
-			os.Exit(2)
-		}
-		// --fail-on-override turns a validation_overridden run-mode terminal
-		// status into exit 2 (distinct from generic fail=1, doctor-warning=2
-		// only applies to `tracker doctor` so the two exit-2 codepaths can't
-		// both fire on the same invocation). The detailed stderr message was
-		// already printed by interpretRunResult (spec-format with gate ID and
-		// preferred label), so we don't re-print the bare sentinel here.
-		if errors.Is(err, pipeline.ErrValidationOverridden) {
-			os.Exit(2)
-		}
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
+// exitWithError maps a command error to the process exit code and exits.
+// It never returns.
+func exitWithError(err error) {
+	var doctorWarn *DoctorWarningsError
+	if errors.As(err, &doctorWarn) {
+		// exit 2 = doctor finished with warnings but no failures
+		os.Exit(2)
 	}
+	// --fail-on-override turns a validation_overridden run-mode terminal
+	// status into exit 2 (distinct from generic fail=1, doctor-warning=2
+	// only applies to `tracker doctor` so the two exit-2 codepaths can't
+	// both fire on the same invocation). The detailed stderr message was
+	// already printed by interpretRunResult (spec-format with gate ID and
+	// preferred label), so we don't re-print the bare sentinel here.
+	if errors.Is(err, pipeline.ErrValidationOverridden) {
+		os.Exit(2)
+	}
+	fmt.Fprintf(os.Stderr, "error: %v\n", err)
+	os.Exit(1)
 }
 
 // handleFlagsError prints usage or error and exits for flag parsing failures.

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -234,17 +234,20 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 // the first Check (the fallback for direct-Check callers). Pre-run AWAKE idle
 // between NewBudgetGuard and the anchor is excluded (F1). Idempotent; called only
 // on the sleep-aware path.
+//
+// It deliberately does NOT touch monoProgress: the stall baseline is derived in
+// sleepAwareStall, which clamps lastProgress up to monoAnchor. That clamp covers
+// every case — no progress yet (monoProgress == 0 < anchor → anchor), pre-run
+// progress (monoProgress < anchor → anchor), and genuine post-anchor progress
+// (monoProgress > anchor → used as-is). Initializing monoProgress here would only
+// risk overwriting a real progress mark with the (later) anchor time, undercounting
+// stall.
 func (g *BudgetGuard) anchorMono() {
 	mono := g.clk.Mono()
 	g.mu.Lock()
 	if !g.monoAnchored {
 		g.monoAnchor = mono
 		g.monoAnchored = true
-		// If no NotifyProgress has fired yet, anchor the stall baseline here too.
-		// A NotifyProgress that already ran records its own (clamped at read time).
-		if g.monoProgress < mono {
-			g.monoProgress = mono
-		}
 	}
 	g.mu.Unlock()
 }

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"math"
+	"sync"
 	"sync/atomic"
 	"time"
 )
@@ -15,9 +16,15 @@ type BudgetLimits struct {
 	MaxCostCents   int
 	MaxWallTime    time.Duration
 	StallTimeout   time.Duration // abort when no node completes for this wall-clock span
+	// SleepAware, when true, excludes detected wall-clock discontinuities (e.g.
+	// a suspended laptop) from MaxWallTime and StallTimeout accounting. Opt-in;
+	// the zero value preserves today's strict semantics (suspend counted).
+	SleepAware bool
 }
 
-// IsZero reports whether every limit is unset.
+// IsZero reports whether every limit is unset. SleepAware is intentionally
+// excluded: a SleepAware-only config has no ceiling to enforce, so it must
+// still yield a nil guard (sleep-awareness without a budget is a no-op).
 func (l BudgetLimits) IsZero() bool {
 	return l.MaxTotalTokens == 0 && l.MaxCostCents == 0 && l.MaxWallTime == 0 && l.StallTimeout == 0
 }
@@ -56,22 +63,67 @@ type BudgetBreach struct {
 	Message string
 }
 
+// clock abstracts the system clock. Now() is the wall clock (timestamps and the
+// default-path elapsed/stall accounting). Mono() is a monotonic elapsed reading
+// since clock creation: on Linux it is CLOCK_MONOTONIC, which does NOT advance
+// during OS suspend but DOES advance during genuine work — the only reliable
+// suspend discriminator. Tests inject a clock whose Now() and Mono() advance
+// independently to simulate suspend (wall jumps, mono frozen) versus work.
+type clock interface {
+	Now() time.Time      // wall clock
+	Mono() time.Duration // monotonic elapsed since creation; frozen during OS suspend
+}
+
+type realClock struct{ start time.Time }
+
+// newRealClock captures a start instant whose monotonic reading anchors Mono().
+func newRealClock() *realClock { return &realClock{start: time.Now()} }
+
+func (c *realClock) Now() time.Time { return time.Now() }
+
+// Mono returns monotonic elapsed since construction. time.Since uses the
+// monotonic reading embedded in the start time.Time, so OS suspend is excluded
+// for free on Linux.
+func (c *realClock) Mono() time.Duration { return time.Since(c.start) }
+
 // BudgetGuard evaluates BudgetLimits against a UsageSummary snapshot and a run
 // start time. The zero value is not usable; construct via NewBudgetGuard.
 type BudgetGuard struct {
 	limits     BudgetLimits
-	progressAt atomic.Int64 // UnixNano of last node completion; written by NotifyProgress
+	progressAt atomic.Int64 // UnixNano of last node completion (default-path stall)
+
+	clk        clock         // time source; defaults to realClock
+	sleepAware bool          // opt-in: drive wall/stall off Mono() so suspend is excluded
+	monoStart  time.Duration // Mono() at construction (sleep-aware elapsed baseline)
+
+	// mu guards the sleep-aware accounting fields below: they must move together
+	// (a paused window and its accumulated span) for correctness. A slept-laptop
+	// guard is not a hot path, so a mutex over atomics is acceptable.
+	mu               sync.Mutex
+	monoProgress     time.Duration // Mono() at last NotifyProgress (sleep-aware stall)
+	pausedMono       time.Duration // Mono() at Pause(); 0 = not paused
+	pausedDuration   time.Duration // accumulated explicit awake-idle span (since run start)
+	pausedAtProgress time.Duration // pausedDuration snapshot at last NotifyProgress
 }
 
 // NewBudgetGuard constructs a BudgetGuard with the given limits. Returns nil
 // when limits.IsZero() so callers can use the nil-guard pattern to skip checks
 // when no limits are configured.
 func NewBudgetGuard(limits BudgetLimits) *BudgetGuard {
+	return newBudgetGuardWithClock(limits, newRealClock())
+}
+
+// newBudgetGuardWithClock is the clock-injecting constructor used by tests to
+// simulate suspend gaps. Production code goes through NewBudgetGuard (realClock).
+func newBudgetGuardWithClock(limits BudgetLimits, clk clock) *BudgetGuard {
 	if limits.IsZero() {
 		return nil
 	}
-	g := &BudgetGuard{limits: limits}
-	g.progressAt.Store(time.Now().UnixNano())
+	g := &BudgetGuard{limits: limits, clk: clk, sleepAware: limits.SleepAware}
+	g.progressAt.Store(g.clk.Now().UnixNano())
+	mono := g.clk.Mono()
+	g.monoStart = mono
+	g.monoProgress = mono
 	return g
 }
 
@@ -82,7 +134,46 @@ func (g *BudgetGuard) NotifyProgress() {
 	if g == nil {
 		return
 	}
-	g.progressAt.Store(time.Now().UnixNano())
+	g.progressAt.Store(g.clk.Now().UnixNano())
+	if g.sleepAware {
+		mono := g.clk.Mono()
+		g.mu.Lock()
+		g.monoProgress = mono
+		g.pausedAtProgress = g.pausedDuration
+		g.mu.Unlock()
+	}
+}
+
+// Pause records the start of an explicit awake-idle window. Resume subtracts the
+// bracketed span from sleep-aware wall and stall accounting. This is the opt-in
+// API for awake idle the operator does not want counted (e.g. a blocking human
+// gate); OS suspend is handled automatically by the monotonic clock and needs no
+// Pause. Engine wiring (around blocking human-gate waits) is a follow-up. Safe
+// on nil and from concurrent goroutines.
+func (g *BudgetGuard) Pause() {
+	if g == nil {
+		return
+	}
+	mono := g.clk.Mono()
+	g.mu.Lock()
+	g.pausedMono = mono
+	g.mu.Unlock()
+}
+
+// Resume closes the window opened by Pause, folding the bracketed monotonic span
+// into the accumulated paused duration. Safe on nil; a Resume without a prior
+// Pause is a no-op.
+func (g *BudgetGuard) Resume() {
+	if g == nil {
+		return
+	}
+	mono := g.clk.Mono()
+	g.mu.Lock()
+	if g.pausedMono != 0 {
+		g.pausedDuration += mono - g.pausedMono
+		g.pausedMono = 0
+	}
+	g.mu.Unlock()
 }
 
 // Check reports whether the given usage snapshot breaches any configured
@@ -95,19 +186,62 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	if breach := g.checkUsage(usage); breach.Kind != BudgetOK {
 		return breach
 	}
-	if g.limits.MaxWallTime > 0 && time.Since(started) > g.limits.MaxWallTime {
+	if breach := g.checkWall(started); breach.Kind != BudgetOK {
+		return breach
+	}
+	return g.checkStall(started)
+}
+
+// checkWall evaluates MaxWallTime. Default path uses wall elapsed (byte-identical
+// to today). Sleep-aware path uses monotonic elapsed minus the explicit paused
+// span: monotonic is frozen during OS suspend (so a slept laptop is excluded
+// with no threshold) but advances during genuine work (so a long node correctly
+// trips).
+func (g *BudgetGuard) checkWall(started time.Time) BudgetBreach {
+	if g.limits.MaxWallTime <= 0 {
+		return BudgetBreach{Kind: BudgetOK}
+	}
+	var elapsed time.Duration
+	if g.sleepAware {
+		g.mu.Lock()
+		paused := g.pausedDuration
+		g.mu.Unlock()
+		elapsed = g.clk.Mono() - g.monoStart - paused
+	} else {
+		elapsed = g.clk.Now().Sub(started)
+	}
+	if elapsed > g.limits.MaxWallTime {
 		return BudgetBreach{Kind: BudgetWallTime, Message: "max_wall_time exceeded"}
 	}
-	if g.limits.StallTimeout > 0 {
-		// Clamp to started so pre-run idle time (between NewBudgetGuard and
-		// Run()) does not consume the stall window before the first node fires.
+	return BudgetBreach{Kind: BudgetOK}
+}
+
+// checkStall evaluates StallTimeout against the time since last progress. Default
+// path uses wall clock; sleep-aware path uses monotonic-since-progress minus the
+// explicit paused span (suspend excluded, genuine hangs still trip).
+func (g *BudgetGuard) checkStall(started time.Time) BudgetBreach {
+	if g.limits.StallTimeout <= 0 {
+		return BudgetBreach{Kind: BudgetOK}
+	}
+	var stall time.Duration
+	if g.sleepAware {
+		g.mu.Lock()
+		sinceProgress := g.clk.Mono() - g.monoProgress
+		pausedSinceProgress := g.pausedDuration - g.pausedAtProgress
+		g.mu.Unlock()
+		stall = sinceProgress - pausedSinceProgress
+	} else {
+		now := g.clk.Now()
+		// Clamp to started so pre-run idle time (between NewBudgetGuard and Run())
+		// does not consume the stall window before the first node fires.
 		lastProgress := time.Unix(0, g.progressAt.Load())
 		if lastProgress.Before(started) {
 			lastProgress = started
 		}
-		if time.Since(lastProgress) > g.limits.StallTimeout {
-			return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
-		}
+		stall = now.Sub(lastProgress)
+	}
+	if stall > g.limits.StallTimeout {
+		return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
 	}
 	return BudgetBreach{Kind: BudgetOK}
 }

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -99,13 +99,18 @@ type BudgetGuard struct {
 	// (a paused window and its accumulated span) for correctness. A slept-laptop
 	// guard is not a hot path, so a mutex over atomics is acceptable.
 	mu sync.Mutex
-	// monoAnchor is the monotonic baseline for sleep-aware wall/stall accounting,
-	// anchored lazily on the FIRST Check call (run start, right after the first
-	// node) — NOT at construction. A guard built before the run starts must not
-	// charge pre-run AWAKE idle against MaxWallTime or the initial StallTimeout
-	// (mirrors the default path, which measures from `started`).
+	// monoAnchor is the monotonic baseline for sleep-aware wall/stall accounting.
+	// The engine anchors it at TRUE run start via AnchorRunStart — before the
+	// first node executes — so the first node's runtime is counted (Check runs
+	// only at node boundaries, so anchoring on the first Check would exclude the
+	// entire first node). It is NOT anchored at construction: a guard built
+	// before the run starts must not charge pre-run AWAKE idle against
+	// MaxWallTime or the initial StallTimeout (this mirrors the default path,
+	// which measures from `started`). For direct-Check callers that never call
+	// AnchorRunStart (unit tests, embedded uses), the first Check anchors lazily
+	// as a fallback.
 	monoAnchor       time.Duration
-	monoAnchored     bool          // monoAnchor has been set by the first Check
+	monoAnchored     bool          // monoAnchor has been set (by AnchorRunStart or the first Check)
 	monoProgress     time.Duration // Mono() at last NotifyProgress (sleep-aware stall)
 	pausedMono       time.Duration // Mono() at Pause(); -1 = not paused
 	pausedDuration   time.Duration // accumulated explicit awake-idle span (since run start)
@@ -132,9 +137,24 @@ func newBudgetGuardWithClock(limits BudgetLimits, clk clock) *BudgetGuard {
 	g := &BudgetGuard{limits: limits, clk: clk, sleepAware: limits.SleepAware}
 	g.progressAt.Store(g.clk.Now().UnixNano())
 	g.pausedMono = pauseSentinelNone
-	// monoAnchor/monoProgress are left unset here and anchored lazily on the first
-	// Check (run start), so pre-run AWAKE idle is excluded (F1).
+	// monoAnchor/monoProgress are left unset here and anchored at TRUE run start
+	// by AnchorRunStart (or lazily on the first Check as a fallback), so pre-run
+	// AWAKE idle is excluded (F1) while the first node's runtime is still counted.
 	return g
+}
+
+// AnchorRunStart fixes the sleep-aware monotonic baseline at the TRUE run start
+// — before the first node executes. The engine calls this once, right after the
+// run begins, so the first node's runtime is charged against MaxWallTime and the
+// initial StallTimeout. BudgetGuard.Check runs only at node boundaries (after a
+// node completes), so relying on the first Check to anchor would silently exclude
+// the entire first node's runtime (#426 review). Idempotent and safe on nil;
+// no-op off the sleep-aware path.
+func (g *BudgetGuard) AnchorRunStart() {
+	if g == nil || !g.sleepAware {
+		return
+	}
+	g.anchorMono()
 }
 
 // NotifyProgress resets the stall clock. Call after each node completes
@@ -209,10 +229,11 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	return g.checkStall(started)
 }
 
-// anchorMono lazily fixes the sleep-aware monotonic baseline at run start — the
-// first Check call, which the engine issues right after the first node — so
-// pre-run AWAKE idle between NewBudgetGuard and the run is excluded (F1). Called
-// only on the sleep-aware path.
+// anchorMono fixes the sleep-aware monotonic baseline once, on whichever comes
+// first: AnchorRunStart (the engine's TRUE run start, before the first node) or
+// the first Check (the fallback for direct-Check callers). Pre-run AWAKE idle
+// between NewBudgetGuard and the anchor is excluded (F1). Idempotent; called only
+// on the sleep-aware path.
 func (g *BudgetGuard) anchorMono() {
 	mono := g.clk.Mono()
 	g.mu.Lock()

--- a/pipeline/budget.go
+++ b/pipeline/budget.go
@@ -92,19 +92,29 @@ type BudgetGuard struct {
 	limits     BudgetLimits
 	progressAt atomic.Int64 // UnixNano of last node completion (default-path stall)
 
-	clk        clock         // time source; defaults to realClock
-	sleepAware bool          // opt-in: drive wall/stall off Mono() so suspend is excluded
-	monoStart  time.Duration // Mono() at construction (sleep-aware elapsed baseline)
+	clk        clock // time source; defaults to realClock
+	sleepAware bool  // opt-in: drive wall/stall off Mono() so suspend is excluded
 
 	// mu guards the sleep-aware accounting fields below: they must move together
 	// (a paused window and its accumulated span) for correctness. A slept-laptop
 	// guard is not a hot path, so a mutex over atomics is acceptable.
-	mu               sync.Mutex
+	mu sync.Mutex
+	// monoAnchor is the monotonic baseline for sleep-aware wall/stall accounting,
+	// anchored lazily on the FIRST Check call (run start, right after the first
+	// node) — NOT at construction. A guard built before the run starts must not
+	// charge pre-run AWAKE idle against MaxWallTime or the initial StallTimeout
+	// (mirrors the default path, which measures from `started`).
+	monoAnchor       time.Duration
+	monoAnchored     bool          // monoAnchor has been set by the first Check
 	monoProgress     time.Duration // Mono() at last NotifyProgress (sleep-aware stall)
-	pausedMono       time.Duration // Mono() at Pause(); 0 = not paused
+	pausedMono       time.Duration // Mono() at Pause(); -1 = not paused
 	pausedDuration   time.Duration // accumulated explicit awake-idle span (since run start)
 	pausedAtProgress time.Duration // pausedDuration snapshot at last NotifyProgress
 }
+
+// pauseSentinelNone marks "not currently paused". A zero value is a legitimate
+// Mono() reading at run start, so 0 cannot mean "not paused"; use -1.
+const pauseSentinelNone time.Duration = -1
 
 // NewBudgetGuard constructs a BudgetGuard with the given limits. Returns nil
 // when limits.IsZero() so callers can use the nil-guard pattern to skip checks
@@ -121,9 +131,9 @@ func newBudgetGuardWithClock(limits BudgetLimits, clk clock) *BudgetGuard {
 	}
 	g := &BudgetGuard{limits: limits, clk: clk, sleepAware: limits.SleepAware}
 	g.progressAt.Store(g.clk.Now().UnixNano())
-	mono := g.clk.Mono()
-	g.monoStart = mono
-	g.monoProgress = mono
+	g.pausedMono = pauseSentinelNone
+	// monoAnchor/monoProgress are left unset here and anchored lazily on the first
+	// Check (run start), so pre-run AWAKE idle is excluded (F1).
 	return g
 }
 
@@ -156,7 +166,11 @@ func (g *BudgetGuard) Pause() {
 	}
 	mono := g.clk.Mono()
 	g.mu.Lock()
-	g.pausedMono = mono
+	// Idempotent (F2): only record the pause baseline when not already paused, so a
+	// double Pause does not overwrite (and under-count) the in-flight span.
+	if g.pausedMono == pauseSentinelNone {
+		g.pausedMono = mono
+	}
 	g.mu.Unlock()
 }
 
@@ -169,9 +183,9 @@ func (g *BudgetGuard) Resume() {
 	}
 	mono := g.clk.Mono()
 	g.mu.Lock()
-	if g.pausedMono != 0 {
+	if g.pausedMono != pauseSentinelNone {
 		g.pausedDuration += mono - g.pausedMono
-		g.pausedMono = 0
+		g.pausedMono = pauseSentinelNone
 	}
 	g.mu.Unlock()
 }
@@ -183,6 +197,9 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	if g == nil {
 		return BudgetBreach{Kind: BudgetOK}
 	}
+	if g.sleepAware {
+		g.anchorMono()
+	}
 	if breach := g.checkUsage(usage); breach.Kind != BudgetOK {
 		return breach
 	}
@@ -192,21 +209,55 @@ func (g *BudgetGuard) Check(usage *UsageSummary, started time.Time) BudgetBreach
 	return g.checkStall(started)
 }
 
+// anchorMono lazily fixes the sleep-aware monotonic baseline at run start — the
+// first Check call, which the engine issues right after the first node — so
+// pre-run AWAKE idle between NewBudgetGuard and the run is excluded (F1). Called
+// only on the sleep-aware path.
+func (g *BudgetGuard) anchorMono() {
+	mono := g.clk.Mono()
+	g.mu.Lock()
+	if !g.monoAnchored {
+		g.monoAnchor = mono
+		g.monoAnchored = true
+		// If no NotifyProgress has fired yet, anchor the stall baseline here too.
+		// A NotifyProgress that already ran records its own (clamped at read time).
+		if g.monoProgress < mono {
+			g.monoProgress = mono
+		}
+	}
+	g.mu.Unlock()
+}
+
+// pausedSpanLocked returns the accumulated paused duration plus any in-flight
+// pause window (Pause without a matching Resume). Callers must hold g.mu.
+func (g *BudgetGuard) pausedSpanLocked(now time.Duration) time.Duration {
+	paused := g.pausedDuration
+	if g.pausedMono != pauseSentinelNone {
+		paused += now - g.pausedMono
+	}
+	return paused
+}
+
 // checkWall evaluates MaxWallTime. Default path uses wall elapsed (byte-identical
-// to today). Sleep-aware path uses monotonic elapsed minus the explicit paused
-// span: monotonic is frozen during OS suspend (so a slept laptop is excluded
-// with no threshold) but advances during genuine work (so a long node correctly
-// trips).
+// to today). Sleep-aware path uses monotonic elapsed (from the run-start anchor)
+// minus the paused span — including any in-flight pause window (F3): monotonic is
+// frozen during OS suspend (so a slept laptop is excluded with no threshold) but
+// advances during genuine work (so a long node correctly trips).
 func (g *BudgetGuard) checkWall(started time.Time) BudgetBreach {
 	if g.limits.MaxWallTime <= 0 {
 		return BudgetBreach{Kind: BudgetOK}
 	}
 	var elapsed time.Duration
 	if g.sleepAware {
+		now := g.clk.Mono()
 		g.mu.Lock()
-		paused := g.pausedDuration
+		paused := g.pausedSpanLocked(now)
+		anchor := g.monoAnchor
 		g.mu.Unlock()
-		elapsed = g.clk.Mono() - g.monoStart - paused
+		elapsed = now - anchor - paused
+		if elapsed < 0 {
+			elapsed = 0
+		}
 	} else {
 		elapsed = g.clk.Now().Sub(started)
 	}
@@ -218,32 +269,58 @@ func (g *BudgetGuard) checkWall(started time.Time) BudgetBreach {
 
 // checkStall evaluates StallTimeout against the time since last progress. Default
 // path uses wall clock; sleep-aware path uses monotonic-since-progress minus the
-// explicit paused span (suspend excluded, genuine hangs still trip).
+// paused span — including any in-flight pause window (F4), and clamping the
+// progress baseline to the run-start anchor so pre-run idle cannot consume the
+// stall window (the default path's "clamp to started" semantics).
 func (g *BudgetGuard) checkStall(started time.Time) BudgetBreach {
 	if g.limits.StallTimeout <= 0 {
 		return BudgetBreach{Kind: BudgetOK}
 	}
 	var stall time.Duration
 	if g.sleepAware {
-		g.mu.Lock()
-		sinceProgress := g.clk.Mono() - g.monoProgress
-		pausedSinceProgress := g.pausedDuration - g.pausedAtProgress
-		g.mu.Unlock()
-		stall = sinceProgress - pausedSinceProgress
+		stall = g.sleepAwareStall()
 	} else {
-		now := g.clk.Now()
-		// Clamp to started so pre-run idle time (between NewBudgetGuard and Run())
-		// does not consume the stall window before the first node fires.
-		lastProgress := time.Unix(0, g.progressAt.Load())
-		if lastProgress.Before(started) {
-			lastProgress = started
-		}
-		stall = now.Sub(lastProgress)
+		stall = g.defaultStall(started)
 	}
 	if stall > g.limits.StallTimeout {
 		return BudgetBreach{Kind: BudgetStall, Message: "stall_timeout exceeded"}
 	}
 	return BudgetBreach{Kind: BudgetOK}
+}
+
+// sleepAwareStall computes monotonic-since-progress minus the paused span
+// (including any in-flight pause window, F4), clamping the progress baseline to
+// the run-start anchor so pre-run idle cannot consume the stall window.
+func (g *BudgetGuard) sleepAwareStall() time.Duration {
+	now := g.clk.Mono()
+	g.mu.Lock()
+	// Clamp the progress baseline to the run-start anchor: progress recorded
+	// before run start (NotifyProgress called pre-Check) must not let pre-run
+	// idle accrue against the stall window.
+	lastProgress := g.monoProgress
+	if lastProgress < g.monoAnchor {
+		lastProgress = g.monoAnchor
+	}
+	pausedSinceProgress := g.pausedSpanLocked(now) - g.pausedAtProgress
+	g.mu.Unlock()
+	stall := now - lastProgress - pausedSinceProgress
+	if stall < 0 {
+		stall = 0
+	}
+	return stall
+}
+
+// defaultStall computes wall-clock since last progress, clamped to the run start
+// (byte-identical to the original default path).
+func (g *BudgetGuard) defaultStall(started time.Time) time.Duration {
+	now := g.clk.Now()
+	// Clamp to started so pre-run idle time (between NewBudgetGuard and Run())
+	// does not consume the stall window before the first node fires.
+	lastProgress := time.Unix(0, g.progressAt.Load())
+	if lastProgress.Before(started) {
+		lastProgress = started
+	}
+	return now.Sub(lastProgress)
 }
 
 // checkUsage evaluates token and cost limits against a usage snapshot.

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -346,6 +346,49 @@ func TestBudgetGuard_SleepAware_PreRunIdleNotChargedToStall(t *testing.T) {
 	}
 }
 
+// F1 (#426 review): the engine anchors the baseline at TRUE run start via
+// AnchorRunStart — BEFORE the first node runs — so a long first node counts
+// toward MaxWallTime, while pre-run AWAKE idle is still excluded. Check fires
+// only at node boundaries, so anchoring on the first Check would silently drop
+// the entire first node's runtime. This proves both halves at once.
+func TestBudgetGuard_SleepAware_AnchorRunStartCountsFirstNodeExcludesPreRunIdle(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	// 50m awake idle between construction and run start — must NOT be charged.
+	fc.advanceWork(50 * time.Minute)
+	started := fc.Now()
+	g.AnchorRunStart() // engine anchors here, before the first node executes
+
+	// 40m first node, no intervening Check (Check runs only after a node). 40m
+	// since run start, well under 1h → OK (pre-run idle excluded).
+	fc.advanceWork(40 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("40m first node (90m since construction): got %v, want BudgetOK (pre-run idle excluded)", b.Kind)
+	}
+	// 25m more genuine work → 65m since run start → trips (first node counted).
+	fc.advanceWork(25 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
+		t.Fatalf("65m since run start: got %v, want BudgetWallTime (first node runtime must count)", b.Kind)
+	}
+}
+
+// F1 (#426 review): the same first-node accounting applies to StallTimeout — a
+// first node that hangs with no progress must trip the stall even though Check
+// hasn't run yet, because AnchorRunStart seeded the stall baseline at run start.
+func TestBudgetGuard_SleepAware_AnchorRunStartFirstNodeStall(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
+	started := fc.Now()
+	g.AnchorRunStart() // before the first node; no NotifyProgress yet
+
+	// First node hangs 40m with no progress → stall trips (first node counts).
+	fc.advanceWork(40 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetStall {
+		t.Fatalf("40m hung first node: got %v, want BudgetStall (first node must count)", b.Kind)
+	}
+}
+
 // F2: Pause is idempotent. A double Pause before a single Resume must subtract
 // the bracketed span exactly once (not zero, not double). pausedMono is recorded
 // only on the first Pause; the second is a no-op.

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -152,6 +152,7 @@ func TestBudgetGuard_SleepAware_WallExcludesSuspend(t *testing.T) {
 	fc := newFakeClock()
 	started := fc.Now()
 	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, started) // anchor monotonic baseline at run start (F1)
 
 	fc.advanceWork(10 * time.Minute)
 	if b := g.Check(nil, started); b.Kind != BudgetOK {
@@ -171,6 +172,7 @@ func TestBudgetGuard_SleepAware_GenuineLongWorkTripsWall(t *testing.T) {
 	fc := newFakeClock()
 	started := fc.Now()
 	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, started) // anchor monotonic baseline at run start (F1)
 
 	// One long node: 70m of genuine work with no intervening Check (Check runs
 	// only at node boundaries). Monotonic advances the full 70m.
@@ -187,6 +189,7 @@ func TestBudgetGuard_SleepAware_GenuineLongWorkMultiSpanTripsWall(t *testing.T) 
 	fc := newFakeClock()
 	started := fc.Now()
 	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, started) // anchor monotonic baseline at run start (F1)
 
 	tripped := false
 	for i := 0; i < 10; i++ {
@@ -209,6 +212,7 @@ func TestBudgetGuard_SleepAware_GenuineHangTripsStall(t *testing.T) {
 	started := fc.Now()
 	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
 	g.NotifyProgress()
+	g.Check(nil, started) // anchor monotonic baseline at run start (F1)
 
 	fc.advanceWork(90 * time.Minute) // genuine no-progress hang
 	if b := g.Check(nil, started); b.Kind != BudgetStall {
@@ -261,6 +265,7 @@ func TestBudgetGuard_PauseResume_SubtractsSpan(t *testing.T) {
 	fc := newFakeClock()
 	started := fc.Now()
 	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, started) // anchor monotonic baseline at run start (F1)
 
 	fc.advanceWork(50 * time.Minute)
 	g.Pause()
@@ -300,5 +305,112 @@ func TestBudgetGuard_DefaultOff_WallTripsOnElapsed(t *testing.T) {
 	fc.advanceWork(time.Hour) // genuine 70m elapsed
 	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
 		t.Fatalf("after 70m genuine elapsed: got %v, want BudgetWallTime", b.Kind)
+	}
+}
+
+// F1: a guard constructed BEFORE the run starts must not charge pre-run AWAKE
+// idle against MaxWallTime — the monotonic baseline anchors at the first Check
+// (run start), so 50m of awake idle before the run does not consume the hour.
+func TestBudgetGuard_SleepAware_PreRunIdleNotChargedToWall(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	// Construction-to-run-start gap: 50m of awake idle (mono advances) before the
+	// run begins. The engine's first Check marks run start here.
+	fc.advanceWork(50 * time.Minute)
+	started := fc.Now()
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("at run start with 50m pre-run idle: got %v, want BudgetOK", b.Kind)
+	}
+	// 30m of genuine in-run work — total since run start is 30m, well under 1h.
+	fc.advanceWork(30 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("30m in-run (80m since construction): got %v, want BudgetOK (pre-run idle excluded)", b.Kind)
+	}
+}
+
+// F1: pre-run AWAKE idle must not consume the initial StallTimeout either — the
+// stall baseline clamps to the run-start anchor.
+func TestBudgetGuard_SleepAware_PreRunIdleNotChargedToStall(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
+
+	fc.advanceWork(50 * time.Minute) // pre-run awake idle, no NotifyProgress yet
+	started := fc.Now()
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("at run start with 50m pre-run idle: got %v, want BudgetOK (stall clamped to run start)", b.Kind)
+	}
+	fc.advanceWork(10 * time.Minute) // 10m since run start, under 30m
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("10m in-run: got %v, want BudgetOK", b.Kind)
+	}
+}
+
+// F2: Pause is idempotent. A double Pause before a single Resume must subtract
+// the bracketed span exactly once (not zero, not double). pausedMono is recorded
+// only on the first Pause; the second is a no-op.
+func TestBudgetGuard_PauseResume_DoublePauseIdempotent(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, fc.Now()) // anchor at run start
+
+	fc.advanceWork(40 * time.Minute)
+	g.Pause()                        // pause baseline = mono at 40m
+	fc.advanceWork(2 * time.Minute)  // a second Pause arrives mid-window
+	g.Pause()                        // must NOT overwrite the 40m baseline (F2)
+	fc.advanceWork(28 * time.Minute) // total paused span = 30m (40m -> 70m)
+	g.Resume()
+	// Effective elapsed = 70m mono - 30m paused = 40m. Under 1h.
+	fc.advanceWork(15 * time.Minute) // effective 55m
+	if b := g.Check(nil, fc.Now()); b.Kind != BudgetOK {
+		t.Fatalf("effective 55m after idempotent double-pause: got %v, want BudgetOK", b.Kind)
+	}
+	// Now advance 10m: correct accounting (30m subtracted once) -> effective 65m,
+	// which must TRIP. The F2 bug (second Pause overwrites baseline at 42m, so
+	// only 28m is subtracted) -> effective 67m, which also trips — so a trip here
+	// does not distinguish. The distinguishing observation is the boundary BELOW:
+	// with the span subtracted exactly once, effective 59m must still be OK; the
+	// over-subtraction bug (if Pause had instead added spans) would read lower.
+	fc.advanceWork(4 * time.Minute) // correct effective 59m, still under 1h
+	if b := g.Check(nil, fc.Now()); b.Kind != BudgetOK {
+		t.Fatalf("effective 59m: got %v, want BudgetOK (span subtracted exactly once)", b.Kind)
+	}
+	fc.advanceWork(2 * time.Minute) // correct effective 61m -> must trip
+	if b := g.Check(nil, fc.Now()); b.Kind != BudgetWallTime {
+		t.Fatalf("effective 61m: got %v, want BudgetWallTime", b.Kind)
+	}
+}
+
+// F3: while currently paused (Pause without Resume), the in-flight pause window
+// must be subtracted from wall accounting — MaxWallTime must NOT trip mid-pause
+// even when the paused span alone exceeds the limit.
+func TestBudgetGuard_PauseResume_WallNotTrippedWhilePaused(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+	g.Check(nil, fc.Now()) // anchor at run start
+
+	fc.advanceWork(10 * time.Minute)
+	g.Pause()
+	fc.advanceWork(2 * time.Hour) // long awake idle while paused — exceeds 1h alone
+	// Still paused (no Resume): the in-flight span must be excluded (F3).
+	if b := g.Check(nil, fc.Now()); b.Kind != BudgetOK {
+		t.Fatalf("mid-pause wall: got %v, want BudgetOK (in-flight pause span not subtracted, F3)", b.Kind)
+	}
+}
+
+// F4: while currently paused, the in-flight pause window must be subtracted from
+// stall accounting — StallTimeout must NOT trip mid-pause even when the paused
+// span alone exceeds the timeout.
+func TestBudgetGuard_PauseResume_StallNotTrippedWhilePaused(t *testing.T) {
+	fc := newFakeClock()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
+	g.NotifyProgress()
+	g.Check(nil, fc.Now()) // anchor at run start
+
+	fc.advanceWork(5 * time.Minute)
+	g.Pause()
+	fc.advanceWork(2 * time.Hour) // long awake idle while paused — exceeds 30m alone
+	if b := g.Check(nil, fc.Now()); b.Kind != BudgetOK {
+		t.Fatalf("mid-pause stall: got %v, want BudgetOK (in-flight pause span not subtracted, F4)", b.Kind)
 	}
 }

--- a/pipeline/budget_test.go
+++ b/pipeline/budget_test.go
@@ -120,3 +120,185 @@ func TestBudgetGuard_StallTimeout_OnlyLimitIsStall(t *testing.T) {
 		t.Fatal("NewBudgetGuard with StallTimeout should not return nil")
 	}
 }
+
+// fakeClock is an injectable clock whose wall and monotonic readings advance
+// INDEPENDENTLY. advanceWall() simulates an OS suspend (wall jumps, monotonic
+// frozen — as CLOCK_MONOTONIC behaves on Linux). advanceWork() simulates
+// genuine elapsed work (both advance together). This independence is what makes
+// suspend-vs-work distinguishable and testable.
+type fakeClock struct {
+	wall time.Time
+	mono time.Duration
+}
+
+func (f *fakeClock) Now() time.Time      { return f.wall }
+func (f *fakeClock) Mono() time.Duration { return f.mono }
+
+// advanceWork advances both wall and monotonic clocks — genuine elapsed time.
+func (f *fakeClock) advanceWork(d time.Duration) {
+	f.wall = f.wall.Add(d)
+	f.mono += d
+}
+
+// advanceWall advances only the wall clock — an OS suspend, during which
+// CLOCK_MONOTONIC does not tick.
+func (f *fakeClock) advanceWall(d time.Duration) { f.wall = f.wall.Add(d) }
+
+func newFakeClock() *fakeClock { return &fakeClock{wall: time.Unix(1_000_000, 0)} }
+
+// T_SuspendExcludedWall: sleep-aware, MaxWallTime=1h; monotonic advances 10m
+// while wall jumps 17h (suspend) -> BudgetOK (suspend excluded by Mono freeze).
+func TestBudgetGuard_SleepAware_WallExcludesSuspend(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	fc.advanceWork(10 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("after 10m work: got %v, want BudgetOK", b.Kind)
+	}
+	// 17h suspend: wall jumps but monotonic is frozen — must be excluded.
+	fc.advanceWall(17 * time.Hour)
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("after 17h suspend: got %v, want BudgetOK (suspend excluded)", b.Kind)
+	}
+}
+
+// T_GenuineLongWorkStillTripsWall: sleep-aware, MaxWallTime=1h; monotonic
+// advances 70m of genuine work (the blocker — a long node must NOT be
+// misclassified as suspend) -> BudgetWallTime. MUST trip.
+func TestBudgetGuard_SleepAware_GenuineLongWorkTripsWall(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	// One long node: 70m of genuine work with no intervening Check (Check runs
+	// only at node boundaries). Monotonic advances the full 70m.
+	fc.advanceWork(70 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
+		t.Fatalf("after 70m genuine work: got %v, want BudgetWallTime", b.Kind)
+	}
+}
+
+// T_GenuineLongWorkMultiSpan: same as above but several >5m node spans with a
+// Check between each — the old >5m inter-Check threshold would have excluded
+// every span; monotonic accounting correctly accrues them.
+func TestBudgetGuard_SleepAware_GenuineLongWorkMultiSpanTripsWall(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	tripped := false
+	for i := 0; i < 10; i++ {
+		fc.advanceWork(8 * time.Minute) // each node runs 8m (> old 5m threshold)
+		if b := g.Check(nil, started); b.Kind == BudgetWallTime {
+			tripped = true
+			break
+		}
+	}
+	if !tripped {
+		t.Fatalf("80m of genuine 8m-node work never tripped MaxWallTime=1h")
+	}
+}
+
+// T_GenuineHangStillTripsStall: sleep-aware, StallTimeout=30m; monotonic
+// advances 90m with NO NotifyProgress (a genuine hang) -> BudgetStall. MUST
+// trip — catching this hang is StallTimeout's whole purpose.
+func TestBudgetGuard_SleepAware_GenuineHangTripsStall(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
+	g.NotifyProgress()
+
+	fc.advanceWork(90 * time.Minute) // genuine no-progress hang
+	if b := g.Check(nil, started); b.Kind != BudgetStall {
+		t.Fatalf("after 90m genuine hang: got %v, want BudgetStall", b.Kind)
+	}
+}
+
+// T_SuspendExcludedStall: sleep-aware, StallTimeout=30m; after NotifyProgress
+// the wall jumps 17h but monotonic advances ~0 (suspend) -> BudgetOK.
+func TestBudgetGuard_SleepAware_StallExcludesSuspend(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute, SleepAware: true}, fc)
+	g.NotifyProgress() // last progress = now (mono)
+
+	fc.advanceWall(17 * time.Hour) // suspend: wall jumps, mono frozen
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("sleep-aware stall after 17h suspend: got %v, want BudgetOK", b.Kind)
+	}
+}
+
+// AC1 control: same suspend with sleep-awareness OFF must trip wall (proves
+// the strict default still fires and the exclusion is load-bearing).
+func TestBudgetGuard_SleepUnaware_WallTripsOnSuspend(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour}, fc)
+
+	fc.advanceWall(17 * time.Hour)
+	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
+		t.Fatalf("sleep-unaware after 17h: got %v, want BudgetWallTime", b.Kind)
+	}
+}
+
+func TestBudgetGuard_SleepUnaware_StallTripsOnSuspend(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{StallTimeout: 30 * time.Minute}, fc)
+	g.NotifyProgress()
+
+	fc.advanceWall(17 * time.Hour)
+	if b := g.Check(nil, started); b.Kind != BudgetStall {
+		t.Fatalf("sleep-unaware stall after 17h: got %v, want BudgetStall", b.Kind)
+	}
+}
+
+// T_PauseResumeSubtractsSpan (AC2): an explicit Pause then Resume across a span
+// of genuine awake-idle work subtracts that span from wall and stall accounting.
+func TestBudgetGuard_PauseResume_SubtractsSpan(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour, SleepAware: true}, fc)
+
+	fc.advanceWork(50 * time.Minute)
+	g.Pause()
+	fc.advanceWork(17 * time.Minute) // explicit awake-idle span (mono advances)
+	g.Resume()
+	fc.advanceWork(5 * time.Minute) // effective elapsed = 55m
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("effective 55m: got %v, want BudgetOK", b.Kind)
+	}
+	fc.advanceWork(4 * time.Minute) // effective elapsed = 59m
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("effective 59m: got %v, want BudgetOK", b.Kind)
+	}
+	fc.advanceWork(4 * time.Minute) // effective elapsed = 63m
+	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
+		t.Fatalf("effective 63m: got %v, want BudgetWallTime", b.Kind)
+	}
+}
+
+func TestBudgetGuard_PauseResume_NilSafe(t *testing.T) {
+	var g *BudgetGuard
+	g.Pause()  // must not panic
+	g.Resume() // must not panic
+}
+
+// T_DefaultOffUnchanged (AC4): default constructor (no SleepAware) behaves
+// exactly as today — a genuine elapsed beyond MaxWallTime still trips.
+func TestBudgetGuard_DefaultOff_WallTripsOnElapsed(t *testing.T) {
+	fc := newFakeClock()
+	started := fc.Now()
+	g := newBudgetGuardWithClock(BudgetLimits{MaxWallTime: time.Hour}, fc)
+
+	fc.advanceWork(10 * time.Minute)
+	if b := g.Check(nil, started); b.Kind != BudgetOK {
+		t.Fatalf("after 10m: got %v, want BudgetOK", b.Kind)
+	}
+	fc.advanceWork(time.Hour) // genuine 70m elapsed
+	if b := g.Check(nil, started); b.Kind != BudgetWallTime {
+		t.Fatalf("after 70m genuine elapsed: got %v, want BudgetWallTime", b.Kind)
+	}
+}

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -228,6 +228,13 @@ func (e *Engine) Run(ctx context.Context) (*EngineResult, error) {
 		Message:   "pipeline started",
 	})
 
+	// Anchor the sleep-aware budget baseline at TRUE run start — before the first
+	// node executes — so the first node's runtime counts toward MaxWallTime and
+	// the initial StallTimeout. Check runs only at node boundaries, so the first
+	// Check (after the first node) would otherwise be the anchor (#426). No-op off
+	// the sleep-aware path and safe on a nil guard.
+	e.budgetGuard.AnchorRunStart()
+
 	currentNodeID := e.graph.StartNode
 	if s.cp.CurrentNode != "" {
 		currentNodeID = s.cp.CurrentNode
@@ -262,9 +269,14 @@ done:
 		Message:   "pipeline completed",
 	})
 
-	// Terminal-status rule: a success exit becomes validation_overridden if
-	// any override fired during the run. Failure paths return fail/budget
-	// regardless of override presence; only this success path flips.
+	return e.successResult(s), nil
+}
+
+// successResult builds the terminal EngineResult for a normal run completion.
+// Terminal-status rule: a success exit becomes validation_overridden if any
+// override fired during the run. Failure paths return fail/budget regardless of
+// override presence; only this success path flips.
+func (e *Engine) successResult(s *runState) *EngineResult {
 	status := OutcomeSuccess
 	if len(s.validationOverrides) > 0 {
 		status = OutcomeValidationOverridden
@@ -277,7 +289,7 @@ done:
 		Trace:               s.trace,
 		Usage:               s.trace.AggregateUsage(),
 		ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
-	}, nil
+	}
 }
 
 // processNode handles a single iteration of the main engine loop.

--- a/tracker.go
+++ b/tracker.go
@@ -511,34 +511,57 @@ func ResolveBudgetLimits(cfg pipeline.BudgetLimits, graph *pipeline.Graph) pipel
 		return cfg
 	}
 	if cfg.MaxTotalTokens == 0 {
-		if v, ok := graph.Attrs["max_total_tokens"]; ok {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxTotalTokens = n
-			}
-		}
+		cfg.MaxTotalTokens = positiveIntAttr(graph, "max_total_tokens")
 	}
 	if cfg.MaxCostCents == 0 {
-		if v, ok := graph.Attrs["max_cost_cents"]; ok {
-			if n, err := strconv.Atoi(v); err == nil && n > 0 {
-				cfg.MaxCostCents = n
-			}
-		}
+		cfg.MaxCostCents = positiveIntAttr(graph, "max_cost_cents")
 	}
 	if cfg.MaxWallTime == 0 {
-		if v, ok := graph.Attrs["max_wall_time"]; ok {
-			if d, err := time.ParseDuration(v); err == nil && d > 0 {
-				cfg.MaxWallTime = d
-			}
-		}
+		cfg.MaxWallTime = positiveDurationAttr(graph, "max_wall_time")
 	}
 	if cfg.StallTimeout == 0 {
-		if v, ok := graph.Attrs["stall_timeout"]; ok {
-			if d, err := time.ParseDuration(v); err == nil && d > 0 {
-				cfg.StallTimeout = d
-			}
-		}
+		cfg.StallTimeout = positiveDurationAttr(graph, "stall_timeout")
+	}
+	// Opt-in sleep-awareness (#422). A bool can't use the == 0 zero gate, so a
+	// Config value of true wins; otherwise consult the attr. A malformed bool
+	// falls through to the default (off) — it does not silently mis-enable.
+	if !cfg.SleepAware {
+		cfg.SleepAware = boolAttr(graph, "sleep_aware_budget")
 	}
 	return cfg
+}
+
+// positiveIntAttr returns the positive int value of graph.Attrs[key], or 0 when
+// absent, unparseable, or non-positive (leaving the caller's field unchanged).
+func positiveIntAttr(graph *pipeline.Graph, key string) int {
+	if v, ok := graph.Attrs[key]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
+}
+
+// positiveDurationAttr returns the positive duration value of graph.Attrs[key],
+// or 0 when absent, unparseable, or non-positive.
+func positiveDurationAttr(graph *pipeline.Graph, key string) time.Duration {
+	if v, ok := graph.Attrs[key]; ok {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return 0
+}
+
+// boolAttr returns the parsed bool value of graph.Attrs[key], or false when
+// absent or unparseable (malformed values stay default-off, never mis-enabled).
+func boolAttr(graph *pipeline.Graph, key string) bool {
+	if v, ok := graph.Attrs[key]; ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
+		}
+	}
+	return false
 }
 
 // parsePipelineSource parses a pipeline source string using the given format.
@@ -669,27 +692,39 @@ const (
 func gatewaySuffix(kind GatewayKind, provider string) (string, bool) {
 	switch kind {
 	case "", GatewayKindCFAIG:
-		switch provider {
-		case "anthropic":
-			return "/anthropic", true
-		case "openai":
-			return "/openai", true
-		case "gemini":
-			return "/google-ai-studio", true
-		case "openai-compat":
-			return "/compat", true
-		}
+		return cfAIGSuffix(provider)
 	case GatewayKindBedrock:
-		switch provider {
-		case "anthropic":
-			return "", true // Anthropic SDK appends /v1/messages itself
-		case "openai":
-			return "/v1", true
-		case "gemini":
-			return "/v1", true
-		case "openai-compat":
-			return "", false // refuse: bedrock gateway has no /compat
-		}
+		return bedrockSuffix(provider)
+	}
+	return "", false
+}
+
+// cfAIGSuffix maps a provider to its Cloudflare AI Gateway path suffix.
+func cfAIGSuffix(provider string) (string, bool) {
+	switch provider {
+	case "anthropic":
+		return "/anthropic", true
+	case "openai":
+		return "/openai", true
+	case "gemini":
+		return "/google-ai-studio", true
+	case "openai-compat":
+		return "/compat", true
+	}
+	return "", false
+}
+
+// bedrockSuffix maps a provider to its Bedrock gateway path suffix.
+func bedrockSuffix(provider string) (string, bool) {
+	switch provider {
+	case "anthropic":
+		return "", true // Anthropic SDK appends /v1/messages itself
+	case "openai":
+		return "/v1", true
+	case "gemini":
+		return "/v1", true
+	case "openai-compat":
+		return "", false // refuse: bedrock gateway has no /compat
 	}
 	return "", false
 }
@@ -700,6 +735,22 @@ func gatewaySuffix(kind GatewayKind, provider string) (string, bool) {
 // SDK-default fallback (e.g. openai-compat defaulting to openrouter.ai)
 // that contradicts the documented fail-closed semantics of #276.
 var ErrGatewayRouteRefused = errors.New("gateway route refused: kind/provider combination unsupported or unknown")
+
+// providerBaseURLEnvKey returns the per-provider *_BASE_URL env var name, or
+// "" for an unknown provider.
+func providerBaseURLEnvKey(provider string) string {
+	switch provider {
+	case "anthropic":
+		return "ANTHROPIC_BASE_URL"
+	case "openai":
+		return "OPENAI_BASE_URL"
+	case "gemini":
+		return "GEMINI_BASE_URL"
+	case "openai-compat":
+		return "OPENAI_COMPAT_BASE_URL"
+	}
+	return ""
+}
 
 // resolveProviderBaseURLWithGateway resolves the base URL for a provider,
 // consulting sources in priority order:
@@ -721,17 +772,8 @@ var ErrGatewayRouteRefused = errors.New("gateway route refused: kind/provider co
 // fallback that would otherwise leak requests (carrying the gateway
 // token) to the public default endpoint.
 func resolveProviderBaseURLWithGateway(provider, gatewayURL string, gatewayKind GatewayKind) (string, error) {
-	var envKey string
-	switch provider {
-	case "anthropic":
-		envKey = "ANTHROPIC_BASE_URL"
-	case "openai":
-		envKey = "OPENAI_BASE_URL"
-	case "gemini":
-		envKey = "GEMINI_BASE_URL"
-	case "openai-compat":
-		envKey = "OPENAI_COMPAT_BASE_URL"
-	default:
+	envKey := providerBaseURLEnvKey(provider)
+	if envKey == "" {
 		return "", nil
 	}
 	if v := os.Getenv(envKey); v != "" {

--- a/tracker_test.go
+++ b/tracker_test.go
@@ -948,6 +948,46 @@ func TestResolveBudgetLimits_ConfigWinsOverGraph(t *testing.T) {
 	}
 }
 
+// TestResolveBudgetLimits_SleepAwareAttr verifies the opt-in sleep_aware_budget
+// attr threads through ResolveBudgetLimits: absent => false (default-off, AC4),
+// "true" => true, malformed => left default-off. #422.
+func TestResolveBudgetLimits_SleepAwareAttr(t *testing.T) {
+	t.Run("absent defaults off", func(t *testing.T) {
+		graph := &pipeline.Graph{Attrs: map[string]string{"max_wall_time": "15m"}}
+		got := ResolveBudgetLimits(pipeline.BudgetLimits{}, graph)
+		if got.SleepAware {
+			t.Errorf("absent attr: SleepAware = true, want false")
+		}
+	})
+	t.Run("true enables", func(t *testing.T) {
+		graph := &pipeline.Graph{Attrs: map[string]string{
+			"max_wall_time":      "15m",
+			"sleep_aware_budget": "true",
+		}}
+		got := ResolveBudgetLimits(pipeline.BudgetLimits{}, graph)
+		if !got.SleepAware {
+			t.Errorf("attr true: SleepAware = false, want true")
+		}
+	})
+	t.Run("garbage stays off", func(t *testing.T) {
+		graph := &pipeline.Graph{Attrs: map[string]string{
+			"max_wall_time":      "15m",
+			"sleep_aware_budget": "garbage",
+		}}
+		got := ResolveBudgetLimits(pipeline.BudgetLimits{}, graph)
+		if got.SleepAware {
+			t.Errorf("garbage attr: SleepAware = true, want false")
+		}
+	})
+	t.Run("config true wins over absent attr", func(t *testing.T) {
+		graph := &pipeline.Graph{Attrs: map[string]string{"max_wall_time": "15m"}}
+		got := ResolveBudgetLimits(pipeline.BudgetLimits{SleepAware: true}, graph)
+		if !got.SleepAware {
+			t.Errorf("config SleepAware true overridden: got false")
+		}
+	})
+}
+
 // TestResolveBudgetLimits_NilGraph verifies the no-op case.
 func TestResolveBudgetLimits_NilGraph(t *testing.T) {
 	cfg := pipeline.BudgetLimits{MaxTotalTokens: 100}


### PR DESCRIPTION
## What & why

Closes #422 (part A).

During the `b65fb64ac099` dogfooding run a closed-laptop suspend (~17h) mid-run burned wall-clock and stall budget while doing **zero work**, spuriously tripping `OutcomeBudgetExceeded` on resume. `BudgetGuard` measured elapsed via `time.Since(started)` and stall via `progressAt` stored as `UnixNano` — which strips Go's monotonic reading — so the stall window absorbed the suspend gap.

## The fix — monotonic-clock accounting (opt-in, default-off)

The only reliable way to distinguish a slept laptop from a slow node is the monotonic clock: Go's monotonic reading (`CLOCK_MONOTONIC`) **freezes during OS suspend** but advances during genuine work.

- `clock` interface now exposes `Now()` (wall) + `Mono() time.Duration` (monotonic elapsed since construction). `realClock` returns `time.Since(start)` for `Mono()`. Tests inject a fake clock whose wall and monotonic readings advance **independently**.
- When `SleepAware` is on, `MaxWallTime` is driven off `Mono()`-since-start and `StallTimeout` off `Mono()`-since-last-progress. A slept laptop is excluded automatically — **no threshold, no heuristic**, and genuine long nodes are still budgeted.
- `Pause()`/`Resume()` subtract an explicit awake-idle span (mutex-guarded, nil-safe) — the opt-in API for awake idle (AC2). Engine wiring around blocking human-gate waits is a documented follow-up.
- **Default-off is byte-identical to today**: with the attr absent, wall uses `now.Sub(started)` and stall uses `time.Unix(0, progressAt)` exactly as before.

Opt-in is via `Config.Budget.SleepAware` + the `--sleep-aware-budget` CLI flag. dippin v0.43.0 rejects a `.dip`-level attr (typed `WorkflowDefaults`), so no `.dip` surface was added.

### Why no raw inter-`Check` threshold

An earlier draft used a 5-minute wall-delta-between-`Check`-calls heuristic. Adversarial review caught that `Check()` runs **only at node boundaries**, so that delta is the just-completed node's own runtime — any node > 5m was misclassified as suspend, defeating both `MaxWallTime` and (especially) `StallTimeout`. The monotonic approach eliminates that false-positive entirely. Regression tests `GenuineLongWorkTripsWall` (70m → 1h trips), `GenuineLongWorkMultiSpanTripsWall` (10×8m → trips), and `GenuineHangTripsStall` (90m → 30m stall trips) lock this in.

## Part B (AC3) — deferred

Sub-node turn checkpointing (resume an agent node mid-turn with episode state intact) is **deferred to a tracked follow-up**. `agent.Session` state (`messages`, `episodeLog`) is in-memory only with no serialization path; AC3 is ~300–700 LOC of net-new work across `agent/session.go`, a new turn-checkpoint file, `pipeline/checkpoint.go`, and engine/`CodergenHandler` resume, with unverified provider message round-trip fidelity as the core risk. It fails the "surgical, low-risk" bar, so per the workstream brief part A ships here and B splits out.

## Acceptance

- AC1 (suspend not counted) ✅ — `WallExcludesSuspend`, `StallExcludesSuspend`
- AC2 (Pause/Resume subtract span) ✅ — `PauseResume_SubtractsSpan`, `_NilSafe`
- AC3 (mid-node resume) ⏭ deferred (follow-up)
- AC4 (default unchanged) ✅ — `DefaultOff_WallTripsOnElapsed` + unmodified pre-existing tests

## Verification

- `go build ./...`, `go test ./... -short`, `go test -race ./pipeline/` — green
- `dippin doctor examples/build_product.dip` — Grade A, 90/100
- Passed a 3-lens adversarial review; the original heuristic blocker was caught and fixed, re-verified by sabotage testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785010344&installation_id=131176874&pr_number=426&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F426&signature=2ecd9d1324c93c574db3ff9b85d29e56dac9c6121a5fc35ca2e228a995cd35b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional **sleep-aware budgets** to exclude suspend time from enforcing wall-time and stall-time limits.
  * Added **`--sleep-aware-budget`** CLI flag to enable the mode.
  * Budget behavior can also be controlled via workflow attribute **`sleep_aware_budget`** (opt-in, and only treats the value `"true"` as enabled).
* **Bug Fixes**
  * Improved sleep-aware enforcement using monotonic timing so genuine long-running work still trips limits.
  * Added support for an awake-idle “paused” window so that intentional idle periods are not charged while in sleep-aware mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->