### PR TITLE
feat(engine): sandbox device-node hygiene + git-artifact durability (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the user's enclosing repository.
   On the **terminal** never-lose-work paths (handler-error halt and failing exit
   node) an unrecoverable repo is now surfaced as a HARD signal — a new
-  `EventStageFailed` diagnostic plus an `EngineResult.WorkPreserveFailed` flag —
-  rather than degrading silently to a best-effort `EventWarning`. The original
-  node failure is never masked (`Status` stays `OutcomeFail`). **Mid-routing**
-  call sites (strict-failure pre-decision, retry-exhausted with a
-  `fallback_retry_target`) keep the warning-only behavior so the routing outcome
-  is never changed. No behavior change when devices and the artifact repo are
-  healthy.
+  dedicated `EventWorkPreserveFailed` diagnostic plus an
+  `EngineResult.WorkPreserveFailed` flag — rather than degrading silently to a
+  best-effort `EventWarning`. The signal is a distinct event type (not an extra
+  `EventStageFailed`) precisely so `tracker diagnose` does **not** count it as
+  another per-node execution attempt — emitting it as `stage_failed` would have
+  inflated the failed node's `RetryCount` / `IdenticalRetries` (#428 review).
+  The TUI adapter maps `EventWorkPreserveFailed` to the same `MsgNodeFailed`
+  failure line, so the operator still sees it. The original node failure is never
+  masked (`Status` stays `OutcomeFail`). **Mid-routing** call sites
+  (strict-failure pre-decision, retry-exhausted with a `fallback_retry_target`)
+  keep the warning-only behavior so the routing outcome is never changed. No
+  behavior change when devices and the artifact repo are healthy.
 
 ## [0.40.2] - 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Sandbox device-node hygiene preflight (#423).** Before any git or subprocess
+  handler runs — on both fresh runs and resume — `applyGitPreflight` now verifies
+  standard device nodes are usable (at minimum `/dev/null` is a readable+writable
+  character device). A suspended/restored sandbox can silently corrupt `/dev/null`
+  (e.g. it becomes unreadable or a regular file masquerading as the device),
+  which breaks git and reviewer CLIs deep mid-run; that previously surfaced only
+  as an opaque `context canceled` failure during the terminal commit. The probe
+  now fails fast with a specific, actionable diagnostic (including a `mknod`
+  remediation) instead. The probe is portability-guarded (POSIX real check,
+  Windows no-op) and injectable, so it runs ahead of and independent of the git
+  policy and never touches the host device in tests. No new behavior when
+  `/dev/null` is healthy.
+
+### Changed
+
+- **Artifact-repo health check + reattach on the never-lose-work commit path
+  (#423).** `commitWIPBeforeRouting` now probes artifact-repo availability via a
+  new `gitArtifactRepo.ensureHealthy()` before committing work-in-progress; if
+  the repo has gone unreachable post-suspend it attempts a single reattach
+  (clear the latched failure + idempotent re-`Init`, capturing the current tree).
+  On the **terminal** never-lose-work paths (handler-error halt and failing exit
+  node) an unrecoverable repo is now surfaced as a HARD signal — a new
+  `EventStageFailed` diagnostic plus an `EngineResult.WorkPreserveFailed` flag —
+  rather than degrading silently to a best-effort `EventWarning`. The original
+  node failure is never masked (`Status` stays `OutcomeFail`). **Mid-routing**
+  call sites (strict-failure pre-decision, retry-exhausted with a
+  `fallback_retry_target`) keep the warning-only behavior so the routing outcome
+  is never changed. No behavior change when devices and the artifact repo are
+  healthy.
+
 ## [0.40.2] - 2026-06-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   new `gitArtifactRepo.ensureHealthy()` before committing work-in-progress; if
   the repo has gone unreachable post-suspend it attempts a single reattach
   (clear the latched failure + idempotent re-`Init`, capturing the current tree).
+  The health probe compares `git rev-parse --show-toplevel` against the artifact
+  dir, so a nested run dir whose own `.git` was lost is treated as unhealthy
+  (and reattached) instead of silently resolving against — and committing into —
+  the user's enclosing repository.
   On the **terminal** never-lose-work paths (handler-error halt and failing exit
   node) an unrecoverable repo is now surfaced as a HARD signal — a new
   `EventStageFailed` diagnostic plus an `EngineResult.WorkPreserveFailed` flag —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EventWarning` (the mid-routing path emits the single discarded warning at its
   own site); and the device-probe remediation hint no longer presents the
   Linux-specific `mknod ... c 1 3` device numbers as if they were portable.
+  Follow-up review fixes (#428): the strict-failure mid-routing fallback site
+  (`strictFailureFallback`) now actually emits that discarded-preserve
+  `EventWarning` — it was previously dropped silently, leaving only the
+  retry-exhausted fallback branch warning; and `checkRootedHere` now includes
+  git's combined output in the `rev-parse --show-toplevel` error so a
+  repo-unavailable diagnostic stays actionable (e.g. surfaces `safe.directory`
+  or corrupt-object causes) instead of reporting a bare exit status.
 
 - **Sleep-aware budgets (#422, part A).** Opt-in `BudgetLimits.SleepAware` (CLI
   `--sleep-aware-budget`) excludes OS-suspend spans — e.g. a suspended laptop —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   masked (`Status` stays `OutcomeFail`). **Mid-routing** call sites
   (strict-failure pre-decision, retry-exhausted with a `fallback_retry_target`)
   keep the warning-only behavior so the routing outcome is never changed. No
-  behavior change when devices and the artifact repo are healthy.
+  behavior change when devices and the artifact repo are healthy. Review fixes
+  (#428): the repo-unavailable diagnostic is now emitted by the caller, not
+  inside `commitWIPBeforeRouting`, so a terminal halt logs the hard
+  `EventWorkPreserveFailed` ONCE rather than alongside a redundant
+  `EventWarning` (the mid-routing path emits the single discarded warning at its
+  own site); and the device-probe remediation hint no longer presents the
+  Linux-specific `mknod ... c 1 3` device numbers as if they were portable.
 
 - **Sleep-aware budgets (#422, part A).** Opt-in `BudgetLimits.SleepAware` (CLI
   `--sleep-aware-budget`) excludes OS-suspend spans — e.g. a suspended laptop —

--- a/cmd/tracker/device_probe.go
+++ b/cmd/tracker/device_probe.go
@@ -26,8 +26,9 @@ func checkDeviceNodes(probe func() error) error {
 	if err := probe(); err != nil {
 		return fmt.Errorf("%w: %v\n"+
 			"a suspended/restored sandbox can corrupt device nodes; git and subprocess "+
-			"handlers will fail. Restore it (e.g. `mknod -m 666 /dev/null c 1 3`) or "+
-			"restart the sandbox, then re-run", ErrDeviceNodeUnusable, err)
+			"handlers will fail. Recreate /dev/null (on Linux: `mknod -m 666 /dev/null "+
+			"c 1 3`; device numbers differ on other platforms) or restart the sandbox, "+
+			"then re-run", ErrDeviceNodeUnusable, err)
 	}
 	return nil
 }

--- a/cmd/tracker/device_probe.go
+++ b/cmd/tracker/device_probe.go
@@ -1,0 +1,33 @@
+// ABOUTME: Pre-run sandbox device-node hygiene check (#423).
+// ABOUTME: Verifies /dev/null is a usable char device before any git/subprocess handler runs.
+package main
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrDeviceNodeUnusable — a standard sandbox device node is missing or broken.
+// A suspended/restored sandbox can corrupt device nodes (e.g. /dev/null becomes
+// unreadable or a regular file), silently breaking git and subprocess handlers.
+var ErrDeviceNodeUnusable = errors.New("standard device node unusable")
+
+// defaultDeviceProbe is the injectable seam. Production uses probeDevNull;
+// tests override this package var (or pass a stub to checkDeviceNodes) so the
+// host device is never touched.
+var defaultDeviceProbe = probeDevNull
+
+// checkDeviceNodes runs the device probe and, on failure, wraps it with a
+// specific, actionable diagnostic. A nil probe resolves to defaultDeviceProbe.
+func checkDeviceNodes(probe func() error) error {
+	if probe == nil {
+		probe = defaultDeviceProbe
+	}
+	if err := probe(); err != nil {
+		return fmt.Errorf("%w: %v\n"+
+			"a suspended/restored sandbox can corrupt device nodes; git and subprocess "+
+			"handlers will fail. Restore it (e.g. `mknod -m 666 /dev/null c 1 3`) or "+
+			"restart the sandbox, then re-run", ErrDeviceNodeUnusable, err)
+	}
+	return nil
+}

--- a/cmd/tracker/device_probe_posix.go
+++ b/cmd/tracker/device_probe_posix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+// ABOUTME: POSIX real implementation of the /dev/null device probe (#423).
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// probeDevNull verifies /dev/null is a usable character device that is both
+// readable and writable. Catches the corruption class behind #423: a node that
+// became unreadable, a regular file masquerading as the device, or a vanished
+// path — any of which silently breaks git and subprocess handlers downstream.
+func probeDevNull() error {
+	const path = "/dev/null"
+	fi, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if fi.Mode()&os.ModeCharDevice == 0 {
+		return fmt.Errorf("%s is not a character device (mode %v)", path, fi.Mode())
+	}
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open %s O_RDWR: %w", path, err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte{0}); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	buf := make([]byte, 1)
+	if _, err := f.Read(buf); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	return nil
+}

--- a/cmd/tracker/device_probe_posix.go
+++ b/cmd/tracker/device_probe_posix.go
@@ -1,6 +1,8 @@
 //go:build !windows
 
-// ABOUTME: POSIX real implementation of the /dev/null device probe (#423).
+// ABOUTME: non-Windows real implementation of the /dev/null device probe (#423).
+// Build tag is !windows (mirrors device_probe_windows.go's windows-only stub); the
+// _posix filename is descriptive only — Go assigns no build meaning to it.
 package main
 
 import (

--- a/cmd/tracker/device_probe_test.go
+++ b/cmd/tracker/device_probe_test.go
@@ -52,8 +52,9 @@ func TestApplyGitPreflight_DeviceCheckedFirst(t *testing.T) {
 	g.Attrs["requires"] = "git"
 	// Force the git check on too, so a passing device probe would otherwise
 	// reach the git not-a-repo failure.
+	origPolicy := activeGitConfig.policy
 	activeGitConfig.policy = string(pipeline.GitPreflightRequire)
-	t.Cleanup(func() { activeGitConfig.policy = "" })
+	t.Cleanup(func() { activeGitConfig.policy = origPolicy })
 
 	tmp := t.TempDir() // NOT a git repo
 	err := applyGitPreflight(context.Background(), g, tmp)

--- a/cmd/tracker/device_probe_test.go
+++ b/cmd/tracker/device_probe_test.go
@@ -1,0 +1,69 @@
+// ABOUTME: Tests for the sandbox device-node hygiene preflight (#423).
+// ABOUTME: Uses a stubbed device probe so the real host /dev/null is never touched.
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// TestCheckDeviceNodes_StubBroken verifies a broken-device probe surfaces a
+// SPECIFIC diagnostic wrapping ErrDeviceNodeUnusable, mentioning the device and
+// actionable remediation — not a generic deep git error.
+func TestCheckDeviceNodes_StubBroken(t *testing.T) {
+	err := checkDeviceNodes(func() error { return errors.New("EBADF /dev/null") })
+	if err == nil {
+		t.Fatal("expected error from broken device probe, got nil")
+	}
+	if !errors.Is(err, ErrDeviceNodeUnusable) {
+		t.Fatalf("expected ErrDeviceNodeUnusable, got %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "/dev/null") {
+		t.Errorf("diagnostic missing device path: %q", msg)
+	}
+	if !strings.Contains(msg, "mknod") {
+		t.Errorf("diagnostic missing remediation hint (mknod): %q", msg)
+	}
+}
+
+// TestCheckDeviceNodes_StubHealthy verifies a healthy probe returns nil — no
+// new failure on the happy path (AC3).
+func TestCheckDeviceNodes_StubHealthy(t *testing.T) {
+	if err := checkDeviceNodes(func() error { return nil }); err != nil {
+		t.Fatalf("expected nil for healthy device, got %v", err)
+	}
+}
+
+// TestApplyGitPreflight_DeviceCheckedFirst proves the device probe runs BEFORE
+// any git-dependent probe: with a broken device stub and a requires:git workflow
+// in a non-repo dir, the returned error is the device diagnostic, NOT a git
+// not-a-repo error. This is AC1's "before the first git-dependent node".
+func TestApplyGitPreflight_DeviceCheckedFirst(t *testing.T) {
+	orig := defaultDeviceProbe
+	defaultDeviceProbe = func() error { return errors.New("simulated broken /dev/null") }
+	t.Cleanup(func() { defaultDeviceProbe = orig })
+
+	g := pipeline.NewGraph("device_first_test")
+	g.Attrs["requires"] = "git"
+	// Force the git check on too, so a passing device probe would otherwise
+	// reach the git not-a-repo failure.
+	activeGitConfig.policy = string(pipeline.GitPreflightRequire)
+	t.Cleanup(func() { activeGitConfig.policy = "" })
+
+	tmp := t.TempDir() // NOT a git repo
+	err := applyGitPreflight(context.Background(), g, tmp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrDeviceNodeUnusable) {
+		t.Fatalf("expected device error to be returned before git probe, got %v", err)
+	}
+	if errors.Is(err, pipeline.ErrGitWorkdirNotRepo) {
+		t.Fatalf("git probe ran before device check — device check is not first: %v", err)
+	}
+}

--- a/cmd/tracker/device_probe_windows.go
+++ b/cmd/tracker/device_probe_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+// ABOUTME: Windows no-op stub — the POSIX /dev/null device node does not apply (#423).
+package main
+
+// probeDevNull is a no-op on Windows: there is no POSIX /dev/null device node,
+// so the probe is skipped and the build stays green.
+func probeDevNull() error { return nil }

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -169,6 +169,15 @@ func newWebhookInterviewerFromCfg(cfg *webhookGateCfg) *handlers.WebhookIntervie
 // caller threads a signal.NotifyContext created before the LLM client
 // setup so cancellation works uniformly across preflight and engine.
 func applyGitPreflight(ctx context.Context, graph *pipeline.Graph, workdir string) error {
+	// Sandbox device-node hygiene (#423): verify standard device nodes (at
+	// minimum /dev/null is a usable char device) BEFORE any git or subprocess
+	// handler runs. A suspended/restored sandbox can corrupt /dev/null, which
+	// silently breaks git and reviewer CLIs deep mid-run. Runs ahead of (and
+	// independent of) the git policy below, since subprocess handlers depend on
+	// the device regardless of whether the workflow requires git.
+	if err := checkDeviceNodes(nil); err != nil {
+		return err
+	}
 	return pipeline.Preflight(ctx, pipeline.PreflightConfig{
 		WorkDir:        workdir,
 		Requires:       graph.RequiredDeps(),
@@ -191,14 +200,8 @@ func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	graph, subgraphs, bundleInfo, err := loadAndValidatePipeline(pipelineFile, format)
+	graph, subgraphs, bundleInfo, err := loadAndPreflightPipeline(ctx, pipelineFile, format, workdir)
 	if err != nil {
-		return err
-	}
-	if err := applyRunParamOverrides(graph); err != nil {
-		return err
-	}
-	if err := applyGitPreflight(ctx, graph, workdir); err != nil {
 		return err
 	}
 
@@ -217,27 +220,9 @@ func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool
 		defer c.Cancel()
 	}
 
-	artifactDir := activeArtifactDir
-	if artifactDir == "" {
-		artifactDir = filepath.Join(workdir, ".tracker", "runs")
-	}
-	activityLog := pipeline.NewJSONLEventHandler(artifactDir)
+	artifactDir := resolveArtifactDir(workdir)
+	activityLog := setupActivityLog(artifactDir, verbose, bundleInfo.Identity)
 	defer activityLog.Close()
-	// Raw provider streaming chunks are debugging payload — only capture
-	// them in the activity log under --verbose (#354).
-	activityLog.SetCaptureRawLLM(verbose)
-	// Stamp the .dipx bundle identity on agent/llm JSONL writes too —
-	// these bypass HandlePipelineEvent (and therefore Engine.emit and the
-	// registry's BundleIdentityStamper). Empty identity is a no-op for
-	// plain .dip runs.
-	activityLog.SetBundleIdentity(bundleInfo.Identity)
-
-	// If this resume only proceeded because --force-bundle-mismatch was
-	// passed, record the override in activity.jsonl now — the engine
-	// hasn't fired yet, so without this the audit trail would lack the
-	// signal that the run executed against a different bundle than its
-	// checkpoint claimed. No-op when no resume / no forced mismatch.
-	emitForcedBundleMismatch(activityLog, activeResumeInfo)
 
 	wireLLMTraceToLog(llmClient, activityLog)
 
@@ -263,12 +248,68 @@ func run(pipelineFile, workdir, checkpoint, format, backend string, verbose bool
 
 	result, runErr := engine.Run(ctx)
 
+	return finishRun(result, runErr, pipelineFile, artifactDir)
+}
+
+// finishRun interprets the engine result, prints the summary, and exports the
+// run bundle when a run ID is present. Extracted from run for the complexity
+// gate; returns the user-facing pipeline error.
+func finishRun(result *pipeline.EngineResult, runErr error, pipelineFile, artifactDir string) error {
 	pipelineErr := interpretRunResult(result, runErr, &runConfig{failOnOverride: activeFailOnOverride})
 	printRunSummary(result, pipelineErr, pipelineFile)
 	if result != nil && result.RunID != "" {
 		maybeExportBundle(artifactDir, result.RunID)
 	}
 	return pipelineErr
+}
+
+// loadAndPreflightPipeline loads + validates the pipeline, applies --param
+// overrides, and runs the device/git preflight. Shared prelude for run and
+// runTUI; extracted to keep both under the complexity gate.
+func loadAndPreflightPipeline(ctx context.Context, pipelineFile, format, workdir string) (*pipeline.Graph, map[string]*pipeline.Graph, pipeline.BundleInfo, error) {
+	graph, subgraphs, bundleInfo, err := loadAndValidatePipeline(pipelineFile, format)
+	if err != nil {
+		return nil, nil, pipeline.BundleInfo{}, err
+	}
+	if err := applyRunParamOverrides(graph); err != nil {
+		return nil, nil, pipeline.BundleInfo{}, err
+	}
+	if err := applyGitPreflight(ctx, graph, workdir); err != nil {
+		return nil, nil, pipeline.BundleInfo{}, err
+	}
+	return graph, subgraphs, bundleInfo, nil
+}
+
+// resolveArtifactDir returns the configured artifact dir, defaulting to
+// <workdir>/.tracker/runs when none was set. Extracted from run/runTUI for the
+// complexity gate.
+func resolveArtifactDir(workdir string) string {
+	if activeArtifactDir != "" {
+		return activeArtifactDir
+	}
+	return filepath.Join(workdir, ".tracker", "runs")
+}
+
+// setupActivityLog constructs the JSONL activity-log handler, configures raw-LLM
+// capture and bundle identity, and records any forced bundle-mismatch resume.
+// Extracted from run/runTUI for the complexity gate. Caller owns Close().
+func setupActivityLog(artifactDir string, verbose bool, bundleIdentity string) *pipeline.JSONLEventHandler {
+	activityLog := pipeline.NewJSONLEventHandler(artifactDir)
+	// Raw provider streaming chunks are debugging payload — only capture
+	// them in the activity log under --verbose (#354).
+	activityLog.SetCaptureRawLLM(verbose)
+	// Stamp the .dipx bundle identity on agent/llm JSONL writes too —
+	// these bypass HandlePipelineEvent (and therefore Engine.emit and the
+	// registry's BundleIdentityStamper). Empty identity is a no-op for
+	// plain .dip runs.
+	activityLog.SetBundleIdentity(bundleIdentity)
+	// If this resume only proceeded because --force-bundle-mismatch was
+	// passed, record the override in activity.jsonl now — the engine
+	// hasn't fired yet, so without this the audit trail would lack the
+	// signal that the run executed against a different bundle than its
+	// checkpoint claimed. No-op when no resume / no forced mismatch.
+	emitForcedBundleMismatch(activityLog, activeResumeInfo)
+	return activityLog
 }
 
 // prepareNativeLLMClient creates the LLM client, returning nil without error
@@ -473,26 +514,9 @@ func loadAndValidatePipeline(pipelineFile, format string) (*pipeline.Graph, map[
 		return nil, nil, pipeline.BundleInfo{}, err
 	}
 
-	var (
-		graph     *pipeline.Graph
-		subgraphs map[string]*pipeline.Graph
-		bundle    pipeline.BundleInfo
-	)
-	if isEmbedded {
-		// Embedded workflows have no subgraphs (none of the 3 core pipelines use them).
-		graph, err = loadEmbeddedPipeline(info)
-		if err != nil {
-			return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load pipeline: %w", err)
-		}
-		subgraphs, err = loadSubgraphs(graph, info.File)
-		if err != nil {
-			return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load subgraphs: %w", err)
-		}
-	} else {
-		graph, subgraphs, bundle, err = loadPipelineAndBundle(resolved, format)
-		if err != nil {
-			return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load pipeline: %w", err)
-		}
+	graph, subgraphs, bundle, err := loadGraphAndSubgraphs(resolved, format, info, isEmbedded)
+	if err != nil {
+		return nil, nil, pipeline.BundleInfo{}, err
 	}
 
 	if err := pipeline.Validate(graph); err != nil {
@@ -504,6 +528,29 @@ func loadAndValidatePipeline(pipelineFile, format string) (*pipeline.Graph, map[
 	return graph, subgraphs, bundle, nil
 }
 
+// loadGraphAndSubgraphs loads the graph + subgraphs from either an embedded
+// workflow or a filesystem path / .dipx bundle. Extracted from
+// loadAndValidatePipeline for the complexity gate.
+func loadGraphAndSubgraphs(resolved, format string, info WorkflowInfo, isEmbedded bool) (*pipeline.Graph, map[string]*pipeline.Graph, pipeline.BundleInfo, error) {
+	if !isEmbedded {
+		graph, subgraphs, bundle, err := loadPipelineAndBundle(resolved, format)
+		if err != nil {
+			return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load pipeline: %w", err)
+		}
+		return graph, subgraphs, bundle, nil
+	}
+	// Embedded workflows have no subgraphs (none of the 3 core pipelines use them).
+	graph, err := loadEmbeddedPipeline(info)
+	if err != nil {
+		return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load pipeline: %w", err)
+	}
+	subgraphs, err := loadSubgraphs(graph, info.File)
+	if err != nil {
+		return nil, nil, pipeline.BundleInfo{}, fmt.Errorf("load subgraphs: %w", err)
+	}
+	return graph, subgraphs, pipeline.BundleInfo{}, nil
+}
+
 func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose bool) error {
 	// Signal context covers preflight + engine for consistent Ctrl+C
 	// handling. The TUI's tea.Program owns the terminal once running,
@@ -512,14 +559,8 @@ func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose b
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	graph, subgraphs, bundleInfo, err := loadAndValidatePipeline(pipelineFile, format)
+	graph, subgraphs, bundleInfo, err := loadAndPreflightPipeline(ctx, pipelineFile, format, workdir)
 	if err != nil {
-		return err
-	}
-	if err := applyRunParamOverrides(graph); err != nil {
-		return err
-	}
-	if err := applyGitPreflight(ctx, graph, workdir); err != nil {
 		return err
 	}
 
@@ -534,10 +575,7 @@ func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose b
 
 	execEnv := exec.NewLocalEnvironment(workdir)
 	pipelineName := resolvePipelineName(graph, pipelineFile)
-	artifactDir := activeArtifactDir
-	if artifactDir == "" {
-		artifactDir = filepath.Join(workdir, ".tracker", "runs")
-	}
+	artifactDir := resolveArtifactDir(workdir)
 
 	prog, store, activityLog, err := setupTUIProgram(graph, subgraphs, pipelineName, checkpoint, tokenTracker, llmClient, verbose, backend, artifactDir)
 	if err != nil {
@@ -547,14 +585,8 @@ func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose b
 	// Stamp the .dipx bundle identity on agent/llm JSONL writes too —
 	// these bypass HandlePipelineEvent (and therefore Engine.emit and the
 	// registry's BundleIdentityStamper). Empty identity is a no-op for
-	// plain .dip runs.
+	// plain .dip runs. Then record any forced bundle-mismatch resume.
 	activityLog.SetBundleIdentity(bundleInfo.Identity)
-
-	// If this resume only proceeded because --force-bundle-mismatch was
-	// passed, record the override in activity.jsonl now — the engine
-	// hasn't fired yet, so without this the audit trail would lack the
-	// signal that the run executed against a different bundle than its
-	// checkpoint claimed. No-op when no resume / no forced mismatch.
 	emitForcedBundleMismatch(activityLog, activeResumeInfo)
 
 	sendFn := tui.SendFunc(func(msg tea.Msg) { prog.Send(msg) })
@@ -575,6 +607,13 @@ func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose b
 		return err
 	}
 
+	return finishTUIRun(outcome, pipelineName, pipelineFile, artifactDir)
+}
+
+// finishTUIRun prints the summary, fires the completion notification, and
+// exports the bundle when a run ID is present. Extracted from runTUI for the
+// complexity gate.
+func finishTUIRun(outcome pipelineOutcome, pipelineName, pipelineFile, artifactDir string) error {
 	printRunSummary(outcome.result, outcome.err, pipelineFile)
 	notifyPipelineComplete(pipelineName, outcome.err)
 	if outcome.result != nil && outcome.result.RunID != "" {
@@ -984,22 +1023,33 @@ func chooseTUIInterviewer(send tui.SendFunc, cfg autopilotCfg, llmClient *llm.Cl
 		return newWebhookInterviewerFromCfg(activeWebhookGate)
 	}
 	if cfg.persona != "" {
-		persona, _ := handlers.ParsePersona(cfg.persona)
-		// Use claude-code autopilot when backend is claude-code.
-		if backend == "claude-code" {
-			ccAutopilot, ccErr := handlers.NewClaudeCodeAutopilotInterviewer(persona)
-			if ccErr == nil {
-				return tui.NewAutopilotTUIInterviewer(ccAutopilot, send)
-			}
-			fmt.Fprintf(os.Stderr, "warning: claude-code autopilot init failed (%v), falling back to native\n", ccErr)
+		if iv := chooseTUIAutopilotInterviewer(send, cfg.persona, llmClient, backend); iv != nil {
+			return iv
 		}
-		if llmClient != nil {
-			autopilot := handlers.NewAutopilotInterviewer(llmClient, persona)
-			return tui.NewAutopilotTUIInterviewer(autopilot, send)
-		}
-		fmt.Fprintf(os.Stderr, "warning: no LLM client for autopilot, falling back to interactive\n")
 	}
 	return tui.NewBubbleteaInterviewer(send)
+}
+
+// chooseTUIAutopilotInterviewer builds the persona-backed TUI autopilot
+// interviewer (claude-code subprocess when the backend is claude-code, else the
+// native LLM client). Returns nil to signal a fall-back to the interactive
+// Bubbletea interviewer. Extracted from chooseTUIInterviewer for the
+// complexity gate.
+func chooseTUIAutopilotInterviewer(send tui.SendFunc, persona string, llmClient *llm.Client, backend string) handlers.LabeledFreeformInterviewer {
+	parsed, _ := handlers.ParsePersona(persona)
+	if backend == "claude-code" {
+		ccAutopilot, ccErr := handlers.NewClaudeCodeAutopilotInterviewer(parsed)
+		if ccErr == nil {
+			return tui.NewAutopilotTUIInterviewer(ccAutopilot, send)
+		}
+		fmt.Fprintf(os.Stderr, "warning: claude-code autopilot init failed (%v), falling back to native\n", ccErr)
+	}
+	if llmClient != nil {
+		autopilot := handlers.NewAutopilotInterviewer(llmClient, parsed)
+		return tui.NewAutopilotTUIInterviewer(autopilot, send)
+	}
+	fmt.Fprintf(os.Stderr, "warning: no LLM client for autopilot, falling back to interactive\n")
+	return nil
 }
 
 // maybeExportBundle exports a git bundle of the run artifact repository when

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -654,7 +654,7 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 	// unhandled failure (incl. turn-exhaustion) escalates to a safety node
 	// instead of skipping every downstream node (#295). One-shot per node.
 	if node := e.graph.Nodes[nodeID]; node != nil {
-		if lr := e.strictFailureFallback(s, node, traceEntry); lr != nil {
+		if lr := e.strictFailureFallback(s, node, traceEntry, preserveErr); lr != nil {
 			return lr
 		}
 	}
@@ -693,13 +693,27 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 // checkpoint) to prevent loop-backs from re-escalating forever. Returns an
 // advancing loopResult when a fallback resolves, or nil to let the caller
 // perform today's terminal halt.
-func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *TraceEntry) *loopResult {
+func (e *Engine) strictFailureFallback(s *runState, node *Node, traceEntry *TraceEntry, preserveErr error) *loopResult {
 	if s.cp.FallbackTaken[node.ID] {
 		return nil
 	}
 	fb := e.findFallbackTarget(node)
 	if fb == "" {
 		return nil
+	}
+	// MID-ROUTING: the preserve error is discarded so it cannot override this
+	// routing decision (the terminal branch in checkStrictFailure hard-escalates
+	// instead), but surface it once as a WARNING — never silently swallow a
+	// never-lose-work degradation (CLAUDE.md). Mirrors handleRetryExhausted's
+	// fallback branch (#428 review).
+	if preserveErr != nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    node.ID,
+			Message:   fmt.Sprintf("could not preserve uncommitted work for node %q before routing to fallback %q: %v", node.ID, fb, preserveErr),
+		})
 	}
 	traceEntry.EdgeTo = fb
 	s.trace.AddEntry(*traceEntry)

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -30,6 +30,13 @@ type EngineResult struct {
 	// len(ValidationOverrides) > 0 AND the run reached the success exit;
 	// failure paths return fail/budget regardless of override presence.
 	ValidationOverrides []OverrideDetail
+	// WorkPreserveFailed is true when a TERMINAL halt path could not preserve a
+	// failed node's uncommitted work because the artifact git repo went
+	// unavailable and reattach failed (#423). The never-lose-work guarantee
+	// degraded; Status remains the original OutcomeFail (the original node
+	// failure is never masked). Zero value (false) on every healthy run, so the
+	// success-path serialization is unchanged.
+	WorkPreserveFailed bool
 }
 
 // OutcomeBudgetExceeded signals that a BudgetGuard halted the run.
@@ -253,6 +260,12 @@ func (e *Engine) Run(ctx context.Context) (*EngineResult, error) {
 	}
 
 done:
+	return e.successResult(s), nil
+}
+
+// successResult finalizes the trace, emits EventPipelineCompleted, and builds
+// the terminal success EngineResult. Extracted from Run for the complexity gate.
+func (e *Engine) successResult(s *runState) *EngineResult {
 	s.trace.EndTime = time.Now()
 
 	e.emit(PipelineEvent{
@@ -277,7 +290,7 @@ done:
 		Trace:               s.trace,
 		Usage:               s.trace.AggregateUsage(),
 		ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
-	}, nil
+	}
 }
 
 // processNode handles a single iteration of the main engine loop.
@@ -327,7 +340,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 		// died, or a cancellation mid-write. No-op on a clean tree. executeNode
 		// already appended this node's trace entry, so mirror the recorded ref
 		// onto it after the helper sets it on our local copy.
-		e.commitWIPBeforeRouting(s, currentNodeID, &traceEntry)
+		preserveErr := e.commitWIPBeforeRouting(s, currentNodeID, &traceEntry)
 		if traceEntry.WIPRef != "" && len(s.trace.Entries) > 0 {
 			s.trace.Entries[len(s.trace.Entries)-1].WIPRef = traceEntry.WIPRef
 		}
@@ -336,6 +349,11 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 		s.pctx.ScopeToNode(currentNodeID)
 		e.saveCheckpoint(s.cp, s.pctx, s.runID)
 		s.trace.EndTime = time.Now()
+		// TERMINAL never-lose-work path (#423): if the artifact repo went
+		// unavailable and reattach failed, surface a HARD signal — Status stays
+		// the original OutcomeFail (original failure not masked) but the
+		// degradation is loud (EventStageFailed) and machine-detectable.
+		workPreserveFailed := e.escalateWorkPreserve(s, currentNodeID, preserveErr)
 		return loopResult{
 			action: loopReturn,
 			result: &EngineResult{
@@ -346,6 +364,7 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 				Trace:               s.trace,
 				Usage:               s.trace.AggregateUsage(),
 				ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
+				WorkPreserveFailed:  workPreserveFailed,
 			},
 			err: fmt.Errorf("handler error at node %q: %w", currentNodeID, err),
 		}
@@ -615,7 +634,13 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 	// BEFORE deciding to halt or route to a fallback, so green-but-uncommitted
 	// work is never discarded by the routing decision (#302). No-op on a clean
 	// tree; warns and skips when no git adapter is configured.
-	e.commitWIPBeforeRouting(s, nodeID, traceEntry)
+	//
+	// MID-ROUTING (#423): the routing decision (halt vs strictFailureFallback)
+	// is not yet known here, so an unavailable-repo error stays a WARNING and is
+	// discarded — escalating would change the routing outcome, violating the
+	// commitWIPBeforeRouting contract. The hard escalation lives only on the
+	// unambiguous terminal-halt sites.
+	_ = e.commitWIPBeforeRouting(s, nodeID, traceEntry)
 	// Before dead-stopping, consult the node/graph-level fallback_target so an
 	// unhandled failure (incl. turn-exhaustion) escalates to a safety node
 	// instead of skipping every downstream node (#295). One-shot per node.

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -352,7 +352,8 @@ func (e *Engine) processActiveNode(ctx context.Context, s *runState, currentNode
 		// TERMINAL never-lose-work path (#423): if the artifact repo went
 		// unavailable and reattach failed, surface a HARD signal — Status stays
 		// the original OutcomeFail (original failure not masked) but the
-		// degradation is loud (EventStageFailed) and machine-detectable.
+		// degradation is loud (escalateWorkPreserve emits EventWorkPreserveFailed
+		// and sets EngineResult.WorkPreserveFailed) and machine-detectable.
 		workPreserveFailed := e.escalateWorkPreserve(s, currentNodeID, preserveErr)
 		return loopResult{
 			action: loopReturn,

--- a/pipeline/engine.go
+++ b/pipeline/engine.go
@@ -635,12 +635,13 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 	// work is never discarded by the routing decision (#302). No-op on a clean
 	// tree; warns and skips when no git adapter is configured.
 	//
-	// MID-ROUTING (#423): the routing decision (halt vs strictFailureFallback)
-	// is not yet known here, so an unavailable-repo error stays a WARNING and is
-	// discarded — escalating would change the routing outcome, violating the
-	// commitWIPBeforeRouting contract. The hard escalation lives only on the
-	// unambiguous terminal-halt sites.
-	_ = e.commitWIPBeforeRouting(s, nodeID, traceEntry)
+	// (#423) Two outcomes follow: strictFailureFallback may route this node
+	// onward to a safety node (MID-ROUTING — a preserve error stays a discarded
+	// WARNING so escalating cannot override the routing decision), or the run
+	// dead-stops with no onward edge (TERMINAL — the preserve error must
+	// hard-escalate). Capture the error here and branch on it at the terminal
+	// site below.
+	preserveErr := e.commitWIPBeforeRouting(s, nodeID, traceEntry)
 	// Before dead-stopping, consult the node/graph-level fallback_target so an
 	// unhandled failure (incl. turn-exhaustion) escalates to a safety node
 	// instead of skipping every downstream node (#295). One-shot per node.
@@ -649,6 +650,9 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 			return lr
 		}
 	}
+	// TERMINAL halt with no onward edge — hard-escalate an unrecoverable preserve
+	// failure (#423) so silently-lost work is surfaced.
+	workPreserveFailed := e.escalateWorkPreserve(s, nodeID, preserveErr)
 	e.emit(PipelineEvent{
 		Type:      EventStageFailed,
 		Timestamp: time.Now(),
@@ -667,6 +671,7 @@ func (e *Engine) checkStrictFailure(s *runState, nodeID string, traceEntry *Trac
 			Trace:               s.trace,
 			Usage:               s.trace.AggregateUsage(),
 			ValidationOverrides: append([]OverrideDetail(nil), s.validationOverrides...),
+			WorkPreserveFailed:  workPreserveFailed,
 		},
 		err: fmt.Errorf("node %q failed with no conditional edges to handle failure", nodeID),
 	}

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -99,16 +99,20 @@ func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *
 
 // escalateWorkPreserve handles the TERMINAL never-lose-work degradation (#423).
 // When commitWIPBeforeRouting reported the artifact repo unavailable (and
-// reattach failed), it emits a HARD EventStageFailed and returns true so the
-// caller can set EngineResult.WorkPreserveFailed. Returns false (no event) when
-// preserveErr is nil, so the healthy path is byte-identical. This NEVER changes
-// Status — the original node failure remains the primary cause.
+// reattach failed), it emits a HARD EventWorkPreserveFailed and returns true so
+// the caller can set EngineResult.WorkPreserveFailed. Returns false (no event)
+// when preserveErr is nil, so the healthy path is byte-identical. This NEVER
+// changes Status — the original node failure remains the primary cause.
+//
+// The event is intentionally EventWorkPreserveFailed, NOT EventStageFailed:
+// this is not another execution attempt for the node, so `tracker diagnose`
+// must not fold it into that node's RetryCount / IdenticalRetries (#428 review).
 func (e *Engine) escalateWorkPreserve(s *runState, nodeID string, preserveErr error) bool {
 	if preserveErr == nil {
 		return false
 	}
 	e.emit(PipelineEvent{
-		Type:      EventStageFailed,
+		Type:      EventWorkPreserveFailed,
 		Timestamp: time.Now(),
 		RunID:     s.runID,
 		NodeID:    nodeID,

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -907,11 +907,13 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 	// Preserve any dirty (possibly green) tree to a recoverable ref before
 	// routing away from the exhausted node (#302). No-op on a clean tree.
 	//
-	// MID-ROUTING (#423): this node may route to fallback_retry_target, so an
-	// unavailable-repo error stays a WARNING (discarded) rather than escalating
-	// — escalating would override the fallback routing decision. Terminal
-	// hard-escalation is reserved for the no-onward-edge halt sites.
-	_ = e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
+	// (#423) This node has two outcomes below: it either routes onward to
+	// fallback_retry_target (MID-ROUTING — an unavailable-repo error stays a
+	// discarded WARNING so escalating cannot override the routing decision) or
+	// it dead-stops the run with no onward edge (TERMINAL — the preserve error
+	// must hard-escalate so unrecoverable work loss is surfaced). Capture the
+	// error here and branch on it at the terminal site below.
+	preserveErr := e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 	if fallback, ok := execNode.Attrs["fallback_retry_target"]; ok {
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
@@ -927,7 +929,10 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 		return fallback, true, nil, nil
 	}
 
-	// No fallback — fail.
+	// No fallback — TERMINAL halt. Hard-escalate an unrecoverable preserve
+	// failure (#423): this is a no-onward-edge dead stop with no later commit,
+	// so a discarded preserve error would silently lose work.
+	workPreserveFailed := e.escalateWorkPreserve(s, currentNodeID, preserveErr)
 	s.trace.AddEntry(*traceEntry)
 	e.emit(PipelineEvent{
 		Type:      EventStageFailed,
@@ -939,6 +944,7 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 	e.emitGitCommit(s, currentNodeID, traceEntry)
 	s.trace.EndTime = time.Now()
 	result := e.failResult(s)
+	result.WorkPreserveFailed = workPreserveFailed
 	return "", false, result, nil
 }
 

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -67,16 +67,12 @@ func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *
 		return nil
 	}
 	// Probe artifact-repo availability and reattach if it went unreachable
-	// post-suspend (#423). Only an unrecoverable repo returns non-nil; the
-	// caller hard-escalates on terminal paths and discards on routing paths.
+	// post-suspend (#423). Only an unrecoverable repo returns non-nil. We emit
+	// NO diagnostic here: the caller owns severity, so emitting one here too
+	// would double-log the same cause on terminal halts (#428 review). Terminal
+	// paths hard-escalate via escalateWorkPreserve (EventWorkPreserveFailed);
+	// the mid-routing path emits a single discarded EventWarning at its site.
 	if err := s.gitRepo.ensureHealthy(); err != nil {
-		e.emit(PipelineEvent{
-			Type:      EventWarning,
-			Timestamp: time.Now(),
-			RunID:     s.runID,
-			NodeID:    nodeID,
-			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: %v", nodeID, err),
-		})
 		return err
 	}
 	ref, err := s.gitRepo.CommitWIP(nodeID)
@@ -919,6 +915,18 @@ func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNod
 	// error here and branch on it at the terminal site below.
 	preserveErr := e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 	if fallback, ok := execNode.Attrs["fallback_retry_target"]; ok {
+		// MID-ROUTING: the preserve error is discarded so it cannot override the
+		// routing decision, but surface it once as a WARNING (never silently
+		// swallow — CLAUDE.md). The terminal branch below hard-escalates instead.
+		if preserveErr != nil {
+			e.emit(PipelineEvent{
+				Type:      EventWarning,
+				Timestamp: time.Now(),
+				RunID:     s.runID,
+				NodeID:    currentNodeID,
+				Message:   fmt.Sprintf("could not preserve uncommitted work for node %q before routing to %q: %v", currentNodeID, fallback, preserveErr),
+			})
+		}
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -46,7 +46,13 @@ func (e *Engine) emitGitCommit(s *runState, nodeID string, traceEntry *TraceEntr
 // it never reaches into the user's real working repo. A WIP-commit failure is
 // surfaced as a warning and never masks the original node failure or changes
 // the routing outcome (CLAUDE.md: never silently swallow errors).
-func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *TraceEntry) {
+// Returns nil on every path EXCEPT when the artifact repo has gone unavailable
+// post-suspend and reattach failed (#423) — that returns a wrapped
+// ErrArtifactRepoUnavailable so the caller can decide terminal-vs-routing. A
+// WIP-commit failure on a HEALTHY repo, or the no-repo-configured case, keeps
+// today's warning-and-skip (returns nil) — those are not the never-lose-work
+// degradation incident and must not start hard-failing.
+func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *TraceEntry) error {
 	if s.gitRepo == nil {
 		// gitRepo is nil when git artifacts are disabled, when enabled but no
 		// artifact dir was configured, or when repo init failed (initRunState
@@ -58,7 +64,20 @@ func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *
 			NodeID:    nodeID,
 			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: git artifact repository unavailable (enable with --git-artifacts and an artifact dir, or see the earlier init-failure warning)", nodeID),
 		})
-		return
+		return nil
+	}
+	// Probe artifact-repo availability and reattach if it went unreachable
+	// post-suspend (#423). Only an unrecoverable repo returns non-nil; the
+	// caller hard-escalates on terminal paths and discards on routing paths.
+	if err := s.gitRepo.ensureHealthy(); err != nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    nodeID,
+			Message:   fmt.Sprintf("cannot preserve uncommitted work for failed node %q: %v", nodeID, err),
+		})
+		return err
 	}
 	ref, err := s.gitRepo.CommitWIP(nodeID)
 	if err != nil {
@@ -69,11 +88,39 @@ func (e *Engine) commitWIPBeforeRouting(s *runState, nodeID string, traceEntry *
 			NodeID:    nodeID,
 			Message:   fmt.Sprintf("WIP commit failed for node %q (work may be unpreserved): %v", nodeID, err),
 		})
-		return
+		return nil
 	}
 	if ref == "" {
-		return // clean tree — nothing to preserve
+		return nil // clean tree — nothing to preserve
 	}
+	e.recordWIPRef(s, nodeID, ref, traceEntry)
+	return nil
+}
+
+// escalateWorkPreserve handles the TERMINAL never-lose-work degradation (#423).
+// When commitWIPBeforeRouting reported the artifact repo unavailable (and
+// reattach failed), it emits a HARD EventStageFailed and returns true so the
+// caller can set EngineResult.WorkPreserveFailed. Returns false (no event) when
+// preserveErr is nil, so the healthy path is byte-identical. This NEVER changes
+// Status — the original node failure remains the primary cause.
+func (e *Engine) escalateWorkPreserve(s *runState, nodeID string, preserveErr error) bool {
+	if preserveErr == nil {
+		return false
+	}
+	e.emit(PipelineEvent{
+		Type:      EventStageFailed,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    nodeID,
+		Message:   fmt.Sprintf("FATAL: could not preserve uncommitted work for failed node %q — artifact git repository unavailable and recovery failed: %v", nodeID, preserveErr),
+	})
+	return true
+}
+
+// recordWIPRef persists a freshly-created WIP ref on the trace entry and the
+// checkpoint, and surfaces a discoverability warning. Extracted from
+// commitWIPBeforeRouting to keep that function under the complexity gate (#423).
+func (e *Engine) recordWIPRef(s *runState, nodeID, ref string, traceEntry *TraceEntry) {
 	s.cp.RecordWIPRef(nodeID, ref)
 	if traceEntry != nil {
 		traceEntry.WIPRef = ref
@@ -311,22 +358,7 @@ func (e *Engine) initRunState(ctx context.Context) (*runState, error) {
 	// copied into the first node's scoped namespace when ScopeToNode is called.
 	pctx.ClearDirty()
 
-	// Initialize git artifact repo if requested and an artifact dir is set.
-	var gitRepo *gitArtifactRepo
-	if e.gitArtifacts && e.artifactDir != "" {
-		repoDir := filepath.Join(e.artifactDir, runID)
-		gitRepo = newGitArtifactRepo(repoDir, runID)
-		if err := gitRepo.Init(); err != nil {
-			// Best-effort: emit a warning and continue without git tracking.
-			e.emit(PipelineEvent{
-				Type:      EventWarning,
-				Timestamp: time.Now(),
-				RunID:     runID,
-				Message:   fmt.Sprintf("git artifact init failed (continuing without git tracking): %v", err),
-			})
-			gitRepo = nil
-		}
-	}
+	gitRepo := e.initGitRepo(runID)
 
 	// Seed the in-memory sticky list from any prior checkpoint so a resumed
 	// run preserves overrides that fired before the kill / SIGINT. The cp
@@ -346,6 +378,28 @@ func (e *Engine) initRunState(ctx context.Context) (*runState, error) {
 		gitRepo:             gitRepo,
 		validationOverrides: stickyOverrides,
 	}, nil
+}
+
+// initGitRepo initializes the git artifact repo when requested and an artifact
+// dir is set. Best-effort: on init failure it warns and returns nil so the run
+// continues without git tracking. Extracted from initRunState for the
+// complexity gate.
+func (e *Engine) initGitRepo(runID string) *gitArtifactRepo {
+	if !e.gitArtifacts || e.artifactDir == "" {
+		return nil
+	}
+	repoDir := filepath.Join(e.artifactDir, runID)
+	gitRepo := newGitArtifactRepo(repoDir, runID)
+	if err := gitRepo.Init(); err != nil {
+		e.emit(PipelineEvent{
+			Type:      EventWarning,
+			Timestamp: time.Now(),
+			RunID:     runID,
+			Message:   fmt.Sprintf("git artifact init failed (continuing without git tracking): %v", err),
+		})
+		return nil
+	}
+	return gitRepo
 }
 
 // buildInitialContext creates a PipelineContext seeded with graph and initial context values.
@@ -595,10 +649,17 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 	traceEntry.Stats = outcome.Stats
 	traceEntry.ChildUsage = outcome.ChildUsage
 
-	// Surface tool-output truncation as structured events so `tracker
-	// diagnose`, the TUI activity log, and NDJSON consumers can correlate
-	// routing misses with dropped output (issue #208). One event per
-	// truncated stream — stdout and stderr can both fire if both
+	e.emitNodeDiagnostics(s, currentNodeID, &outcome)
+
+	return &outcome, traceEntry, nil
+}
+
+// emitNodeDiagnostics surfaces post-execution audit events (tool-output
+// truncation #208, marker_grep no-match #210, missing route sentinel #212, and
+// missing auto_status #346) as typed PipelineEvents. Extracted from executeNode
+// for the complexity gate; behavior is unchanged.
+func (e *Engine) emitNodeDiagnostics(s *runState, currentNodeID string, outcome *Outcome) {
+	// One event per truncated stream — stdout and stderr can both fire if both
 	// overflowed the per-stream cap.
 	for i := range outcome.Truncations {
 		td := &outcome.Truncations[i]
@@ -612,36 +673,20 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 		})
 	}
 
-	// Surface marker_grep no-match as a typed audit event so `tracker
-	// diagnose` can call out exactly why a node failed (issue #210).
-	// The tool handler already set Status = OutcomeFail; this is the
-	// audit-trail companion. Emit before returning so the event ordering
-	// matches the rest of the per-node emissions. The message branches
-	// on MissingMarker.Error: a populated Error means the regex itself
-	// was invalid (author error), an empty Error means the regex was
-	// fine but matched nothing in the captured stdout.
+	// marker_grep no-match: a populated Error means the regex failed to compile
+	// (author error); an empty Error means it matched nothing in stdout.
 	if outcome.MissingMarker != nil {
-		var msg string
-		if outcome.MissingMarker.Error != "" {
-			msg = fmt.Sprintf("tool node %q: marker_grep regex %q failed to compile: %s — failing node to avoid silent fallback",
-				currentNodeID, outcome.MissingMarker.Pattern, outcome.MissingMarker.Error)
-		} else {
-			msg = fmt.Sprintf("tool node %q: marker_grep %q matched nothing in captured stdout — failing node to avoid silent fallback",
-				currentNodeID, outcome.MissingMarker.Pattern)
-		}
 		e.emit(PipelineEvent{
 			Type:      EventToolMarkerMissing,
 			Timestamp: time.Now(),
 			RunID:     s.runID,
 			NodeID:    currentNodeID,
-			Message:   msg,
+			Message:   missingMarkerMessage(currentNodeID, outcome.MissingMarker),
 			Marker:    outcome.MissingMarker,
 		})
 	}
 
-	// Same shape as the MissingMarker emission above, different
-	// mechanism: route_required: true was set on the node but no
-	// _TRACKER_ROUTE= sentinel was present in captured stdout (#212).
+	// route_required: true but no _TRACKER_ROUTE= sentinel in captured stdout.
 	if outcome.MissingRoute != nil {
 		e.emit(PipelineEvent{
 			Type:      EventToolRouteMissing,
@@ -654,31 +699,40 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 		})
 	}
 
-	// Same shape again for auto_status (#346): the agent completed normally
-	// but emitted no parseable STATUS line. The handler already chose the
-	// status (fail-closed on goal gates, legacy success default otherwise);
-	// this is the audit-trail companion so the TUI and `tracker diagnose`
-	// can surface the anomaly instead of it registering as a silent verdict.
+	// auto_status set but no parseable STATUS line; the handler already chose
+	// the status (fail-closed on goal gates, legacy success default otherwise).
 	if outcome.MissingStatus != nil {
-		var msg string
-		if outcome.MissingStatus.FailClosed {
-			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
-				currentNodeID)
-		} else {
-			msg = fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — the STATUS verdict defaulted to success (legacy behavior; the node's final status may still differ, e.g. on a declared-writes failure; mark the node goal_gate: true to fail closed)",
-				currentNodeID)
-		}
 		e.emit(PipelineEvent{
 			Type:       EventAutoStatusMissing,
 			Timestamp:  time.Now(),
 			RunID:      s.runID,
 			NodeID:     currentNodeID,
-			Message:    msg,
+			Message:    missingStatusMessage(currentNodeID, outcome.MissingStatus),
 			AutoStatus: outcome.MissingStatus,
 		})
 	}
+}
 
-	return &outcome, traceEntry, nil
+// missingMarkerMessage builds the marker_grep no-match diagnostic. A populated
+// Error means the regex failed to compile; empty means it matched nothing.
+func missingMarkerMessage(nodeID string, m *MarkerDetail) string {
+	if m.Error != "" {
+		return fmt.Sprintf("tool node %q: marker_grep regex %q failed to compile: %s — failing node to avoid silent fallback",
+			nodeID, m.Pattern, m.Error)
+	}
+	return fmt.Sprintf("tool node %q: marker_grep %q matched nothing in captured stdout — failing node to avoid silent fallback",
+		nodeID, m.Pattern)
+}
+
+// missingStatusMessage builds the auto_status no-verdict diagnostic, branching
+// on whether the gate fails closed or defaults to legacy success.
+func missingStatusMessage(nodeID string, ms *AutoStatusDetail) string {
+	if ms.FailClosed {
+		return fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — failing goal gate closed (an unparseable verdict on a gate is an anomaly, not a pass)",
+			nodeID)
+	}
+	return fmt.Sprintf("node %q: auto_status is set but no parseable STATUS line was found — the STATUS verdict defaulted to success (legacy behavior; the node's final status may still differ, e.g. on a declared-writes failure; mark the node goal_gate: true to fail closed)",
+		nodeID)
 }
 
 // applyOutcome merges handler outcome into pipeline context and emits the decision_outcome event.
@@ -852,7 +906,12 @@ func (e *Engine) handleRetryWithinBudget(ctx context.Context, s *runState, curre
 func (e *Engine) handleRetryExhausted(s *runState, currentNodeID string, execNode *Node, traceEntry *TraceEntry) (string, bool, *EngineResult, error) {
 	// Preserve any dirty (possibly green) tree to a recoverable ref before
 	// routing away from the exhausted node (#302). No-op on a clean tree.
-	e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
+	//
+	// MID-ROUTING (#423): this node may route to fallback_retry_target, so an
+	// unavailable-repo error stays a WARNING (discarded) rather than escalating
+	// — escalating would override the fallback routing decision. Terminal
+	// hard-escalation is reserved for the no-onward-edge halt sites.
+	_ = e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 	if fallback, ok := execNode.Attrs["fallback_retry_target"]; ok {
 		traceEntry.EdgeTo = fallback
 		s.trace.AddEntry(*traceEntry)
@@ -918,6 +977,47 @@ func (e *Engine) handleOutcomeStatus(s *runState, currentNodeID string, status s
 	}
 }
 
+// handleGoalGateRetry processes the goal-gate retry redirect extracted from
+// handleExitNode to keep that function under the complexity gate. It emits the
+// retry/recheck event, records the trace, and redirects the run to target.
+// Returns (false, target, nil) so the caller re-enters at target.
+func (e *Engine) handleGoalGateRetry(s *runState, currentNodeID, target, gateNodeID string, traceEntry *TraceEntry) (bool, string, *EngineResult) {
+	// A pending re-entry (target == the gate itself, flagged by a prior
+	// redirect) completes that redirect's retry cycle — the budget was
+	// charged when the redirect fired, so it is not charged again here.
+	// It cannot loop: the gate executes next, clearing the pending flag.
+	reentry := s.cp.IsGateRecheckPending(gateNodeID) && target == gateNodeID
+	gateNode := e.nodeOrDefault(gateNodeID)
+	msg := fmt.Sprintf("goal-gate recheck: re-entering %q so the gate re-judges the current tree (attempt %d/%d)",
+		gateNodeID, s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+	if !reentry {
+		s.cp.IncrementRetry(gateNodeID)
+		msg = fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
+			gateNodeID, target,
+			s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
+	}
+	e.emit(PipelineEvent{
+		Type:      EventStageRetrying,
+		Timestamp: time.Now(),
+		RunID:     s.runID,
+		NodeID:    gateNodeID,
+		Message:   msg,
+	})
+	traceEntry.EdgeTo = target
+	s.trace.AddEntry(*traceEntry)
+	e.emitGitCommit(s, currentNodeID, traceEntry)
+	// #348 defect 1: the redirect's clearDownstream below may remove the
+	// gate from CompletedNodes while the executed path routes around it
+	// to the exit. Mark the gate recheck-pending so it stays visible to
+	// this check and the next retry re-enters at the gate itself; the
+	// flag clears when the gate actually re-executes (applyOutcome).
+	s.cp.SetGateRecheckPending(gateNodeID)
+	e.clearDownstream(target, s.cp)
+	s.cp.CurrentNode = target
+	e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
+	return false, target, nil
+}
+
 // handleExitNode processes the exit node. Returns (shouldBreak, result, error).
 // If shouldBreak is true, the main loop should break (success).
 // If result is non-nil, return early with that result.
@@ -925,40 +1025,7 @@ func (e *Engine) handleOutcomeStatus(s *runState, currentNodeID string, status s
 func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus string, traceEntry *TraceEntry) (bool, string, *EngineResult) {
 	target, gateNodeID, retry, unsatisfied := e.goalGateRetryTarget(s.cp, s.nodeOutcomes)
 	if retry {
-		// A pending re-entry (target == the gate itself, flagged by a prior
-		// redirect) completes that redirect's retry cycle — the budget was
-		// charged when the redirect fired, so it is not charged again here.
-		// It cannot loop: the gate executes next, clearing the pending flag.
-		reentry := s.cp.IsGateRecheckPending(gateNodeID) && target == gateNodeID
-		gateNode := e.nodeOrDefault(gateNodeID)
-		msg := fmt.Sprintf("goal-gate recheck: re-entering %q so the gate re-judges the current tree (attempt %d/%d)",
-			gateNodeID, s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
-		if !reentry {
-			s.cp.IncrementRetry(gateNodeID)
-			msg = fmt.Sprintf("goal-gate retry for %q → %q (attempt %d/%d)",
-				gateNodeID, target,
-				s.cp.RetryCount(gateNodeID), e.maxRetries(gateNode))
-		}
-		e.emit(PipelineEvent{
-			Type:      EventStageRetrying,
-			Timestamp: time.Now(),
-			RunID:     s.runID,
-			NodeID:    gateNodeID,
-			Message:   msg,
-		})
-		traceEntry.EdgeTo = target
-		s.trace.AddEntry(*traceEntry)
-		e.emitGitCommit(s, currentNodeID, traceEntry)
-		// #348 defect 1: the redirect's clearDownstream below may remove the
-		// gate from CompletedNodes while the executed path routes around it
-		// to the exit. Mark the gate recheck-pending so it stays visible to
-		// this check and the next retry re-enters at the gate itself; the
-		// flag clears when the gate actually re-executes (applyOutcome).
-		s.cp.SetGateRecheckPending(gateNodeID)
-		e.clearDownstream(target, s.cp)
-		s.cp.CurrentNode = target
-		e.saveCheckpointWithTag(s.cp, s.pctx, s.runID, s, currentNodeID)
-		return false, target, nil
+		return e.handleGoalGateRetry(s, currentNodeID, target, gateNodeID, traceEntry)
 	}
 	// Fallback/escalation: target is set but not a retry (one-time redirect).
 	if unsatisfied && target != "" {
@@ -1000,11 +1067,14 @@ func (e *Engine) handleExitNode(s *runState, currentNodeID string, outcomeStatus
 	if outcomeStatus == string(OutcomeFail) {
 		// Preserve any dirty (possibly green) tree to a recoverable ref before
 		// the failing exit node halts the run (#302). No-op on a clean tree.
-		e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
+		// TERMINAL never-lose-work path (#423): hard-escalate if the artifact
+		// repo went unavailable and reattach failed.
+		preserveErr := e.commitWIPBeforeRouting(s, currentNodeID, traceEntry)
 		s.trace.AddEntry(*traceEntry)
 		e.emitGitCommit(s, currentNodeID, traceEntry)
 		s.trace.EndTime = time.Now()
 		result := e.failResult(s)
+		result.WorkPreserveFailed = e.escalateWorkPreserve(s, currentNodeID, preserveErr)
 		return false, "", result
 	}
 	s.trace.AddEntry(*traceEntry)

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -63,6 +63,16 @@ const (
 	// NodeID and Message. (#304)
 	EventNodeNoProgressDetected PipelineEventType = "node_no_progress_detected"
 
+	// EventWorkPreserveFailed fires on a TERMINAL never-lose-work halt (#423)
+	// when uncommitted work for the failed node could NOT be preserved because
+	// the artifact git repo went unavailable and reattach failed. It is a HARD
+	// signal (paired with EngineResult.WorkPreserveFailed), but it is
+	// deliberately NOT a stage_failed event: it is not another execution attempt
+	// for the node, so `tracker diagnose` must not count it toward that node's
+	// RetryCount / IdenticalRetries (#428 review). The TUI still surfaces it as a
+	// failure line. Carries NodeID and a diagnostic Message.
+	EventWorkPreserveFailed PipelineEventType = "work_preserve_failed"
+
 	// EventBundleMismatchForced is emitted to activity.jsonl when resume
 	// proceeds despite a bundle-identity mismatch because --force-bundle-mismatch
 	// was set. Records both the original (checkpoint) and current identities

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -139,6 +139,34 @@ func TestEnsureHealthy_ReattachFails(t *testing.T) {
 	}
 }
 
+// breakArtifactRepo dirties the artifact tree then destroys the repo (RemoveAll
+// .git + chmod 0500) so the next commitWIPBeforeRouting hits an unrecoverable
+// repo. It REFUSES to act on a missing/empty/relative artifact dir: otherwise
+// filepath.Join("", ".git") resolves to a relative ".git" and os.RemoveAll could
+// delete the .git of the repo checkout the test runs in. Every step's error is
+// surfaced via t.Errorf (safe from a handler goroutine — it calls Fail, not
+// FailNow) rather than swallowed, so a broken precondition fails the test loudly
+// instead of silently invalidating the signal.
+func breakArtifactRepo(t *testing.T, pctx *PipelineContext, breakNode string) {
+	t.Helper()
+	dir, ok := pctx.GetInternal(InternalKeyArtifactDir)
+	if !ok || dir == "" || !filepath.IsAbs(dir) {
+		t.Errorf("breakArtifactRepo: artifact dir not set to an absolute path (ok=%v dir=%q); refusing destructive ops", ok, dir)
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, breakNode+".go"), []byte("package x\n"), 0o644); err != nil {
+		t.Errorf("breakArtifactRepo: dirty-tree write failed: %v", err)
+		return
+	}
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Errorf("breakArtifactRepo: removing .git failed: %v", err)
+		return
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Errorf("breakArtifactRepo: chmod 0500 failed: %v", err)
+	}
+}
+
 // breakRepoHandler returns a registry whose target node dirties the tree, then
 // destroys the artifact repo (RemoveAll .git + chmod 0500), then returns a
 // handler ERROR — driving the terminal halt path (engine.go:330) into
@@ -149,10 +177,7 @@ func breakRepoHandler(t *testing.T, breakNode string) *HandlerRegistry {
 	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
 		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
 			if node.ID == breakNode {
-				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
-				_ = os.WriteFile(filepath.Join(dir, node.ID+".go"), []byte("package x\n"), 0o644)
-				_ = os.RemoveAll(filepath.Join(dir, ".git"))
-				_ = os.Chmod(dir, 0o500)
+				breakArtifactRepo(t, pctx, node.ID)
 				return Outcome{}, errors.New("simulated handler crash after sandbox suspend")
 			}
 			return Outcome{Status: string(OutcomeSuccess)}, nil
@@ -309,10 +334,7 @@ func breakRepoOnStatusHandler(t *testing.T, breakNode, status string) *HandlerRe
 	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
 		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
 			if node.ID == breakNode {
-				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
-				_ = os.WriteFile(filepath.Join(dir, node.ID+".go"), []byte("package x\n"), 0o644)
-				_ = os.RemoveAll(filepath.Join(dir, ".git"))
-				_ = os.Chmod(dir, 0o500)
+				breakArtifactRepo(t, pctx, node.ID)
 				return Outcome{Status: status}, nil
 			}
 			return Outcome{Status: string(OutcomeSuccess)}, nil

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -1,5 +1,7 @@
 // ABOUTME: Tests for artifact-repo health probe + reattach and terminal-path hard escalation (#423).
 // ABOUTME: Injects an unavailable artifact repo to assert a HARD failure (not silent degradation) on the terminal commit path.
+//go:build unix
+
 package pipeline
 
 import (
@@ -58,6 +60,51 @@ func TestEnsureHealthy_ReattachSucceeds(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
 		t.Errorf(".git not re-created after reattach: %v", err)
+	}
+}
+
+// TestEnsureHealthy_RejectsParentRepoDiscovery verifies the #428-review P1: when
+// the artifact dir is NESTED under the user's git repo and its own .git is lost,
+// `git rev-parse` walks up and resolves against the PARENT worktree. ensureHealthy
+// must reject that (not declare healthy) and reattach a fresh repo rooted at the
+// nested dir — so subsequent commits never mutate the user's repository.
+func TestEnsureHealthy_RejectsParentRepoDiscovery(t *testing.T) {
+	requireGit(t)
+	parent := t.TempDir()
+	// Make the parent a git repo (the user's enclosing repository).
+	parentRepo := newGitArtifactRepo(parent, "parent")
+	if err := parentRepo.Init(); err != nil {
+		t.Fatalf("parent Init: %v", err)
+	}
+
+	// Nested artifact run dir under the parent, with its own repo.
+	nested := filepath.Join(parent, "runs", "nested")
+	r := newGitArtifactRepo(nested, "nested")
+	if err := r.Init(); err != nil {
+		t.Fatalf("nested Init: %v", err)
+	}
+	// Lose the nested .git — now rev-parse from `nested` discovers the parent.
+	if err := os.RemoveAll(filepath.Join(nested, ".git")); err != nil {
+		t.Fatalf("RemoveAll nested .git: %v", err)
+	}
+
+	// Sanity: parent discovery really happens (guards against the test passing
+	// for the wrong reason if git ever stopped walking up).
+	top := gitOutput(t, nested, "rev-parse", "--show-toplevel")
+	if samePathForLatch(resolveSymlinksOrFallback(top), resolveSymlinksOrFallback(nested)) {
+		t.Fatalf("precondition: expected parent discovery, but --show-toplevel already == nested (%s)", top)
+	}
+
+	if err := r.ensureHealthy(); err != nil {
+		t.Fatalf("ensureHealthy should reattach a nested repo, got %v", err)
+	}
+	// .git must be re-created at the nested dir, and rev-parse must now root there.
+	if _, err := os.Stat(filepath.Join(nested, ".git")); err != nil {
+		t.Errorf("nested .git not re-created after reattach: %v", err)
+	}
+	gotTop := gitOutput(t, nested, "rev-parse", "--show-toplevel")
+	if !samePathForLatch(resolveSymlinksOrFallback(gotTop), resolveSymlinksOrFallback(nested)) {
+		t.Errorf("after reattach, work-tree root = %q, want nested dir %q (still resolving to parent)", gotTop, nested)
 	}
 }
 

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -1,0 +1,274 @@
+// ABOUTME: Tests for artifact-repo health probe + reattach and terminal-path hard escalation (#423).
+// ABOUTME: Injects an unavailable artifact repo to assert a HARD failure (not silent degradation) on the terminal commit path.
+package pipeline
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestEnsureHealthy_Reachable verifies a healthy repo passes the probe with NO
+// state mutation and NO new commit (AC3 byte-identical happy path).
+func TestEnsureHealthy_Reachable(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	r := newGitArtifactRepo(dir, "healthy")
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	before := gitOutput(t, dir, "rev-list", "--count", "HEAD")
+
+	if err := r.ensureHealthy(); err != nil {
+		t.Fatalf("ensureHealthy on healthy repo: %v", err)
+	}
+	if r.failed {
+		t.Error("ensureHealthy must not mutate r.failed on a healthy repo")
+	}
+	after := gitOutput(t, dir, "rev-list", "--count", "HEAD")
+	if before != after {
+		t.Errorf("ensureHealthy added a commit on a healthy repo: before=%s after=%s", before, after)
+	}
+}
+
+// TestEnsureHealthy_ReattachSucceeds verifies that a repo whose .git was lost
+// (sandbox suspend) is reattached: failed-latch cleared, .git re-created.
+func TestEnsureHealthy_ReattachSucceeds(t *testing.T) {
+	requireGit(t)
+	dir := t.TempDir()
+	r := newGitArtifactRepo(dir, "reattach")
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	// Simulate suspend loss of the git dir and a latched failure.
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf("RemoveAll .git: %v", err)
+	}
+	r.failed = true
+
+	if err := r.ensureHealthy(); err != nil {
+		t.Fatalf("ensureHealthy should reattach, got %v", err)
+	}
+	if r.failed {
+		t.Error("ensureHealthy should clear the failed latch after a successful reattach")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git")); err != nil {
+		t.Errorf(".git not re-created after reattach: %v", err)
+	}
+}
+
+// TestEnsureHealthy_ReattachFails verifies that when recovery cannot complete
+// (dir non-writable so re-Init fails), ensureHealthy returns a wrapped
+// ErrArtifactRepoUnavailable rather than silently un-failing a dead repo.
+func TestEnsureHealthy_ReattachFails(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	dir := t.TempDir()
+	r := newGitArtifactRepo(dir, "deadrepo")
+	if err := r.Init(); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if err := os.RemoveAll(filepath.Join(dir, ".git")); err != nil {
+		t.Fatalf("RemoveAll .git: %v", err)
+	}
+	// Make the dir non-writable so `git init` (re-Init) fails.
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := r.ensureHealthy()
+	if err == nil {
+		t.Fatal("expected ErrArtifactRepoUnavailable when reattach fails, got nil")
+	}
+	if !errors.Is(err, ErrArtifactRepoUnavailable) {
+		t.Fatalf("expected ErrArtifactRepoUnavailable, got %v", err)
+	}
+}
+
+// breakRepoHandler returns a registry whose target node dirties the tree, then
+// destroys the artifact repo (RemoveAll .git + chmod 0500), then returns a
+// handler ERROR — driving the terminal halt path (engine.go:330) into
+// commitWIPBeforeRouting against an unrecoverable repo.
+func breakRepoHandler(t *testing.T, breakNode string) *HandlerRegistry {
+	t.Helper()
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == breakNode {
+				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
+				_ = os.WriteFile(filepath.Join(dir, node.ID+".go"), []byte("package x\n"), 0o644)
+				_ = os.RemoveAll(filepath.Join(dir, ".git"))
+				_ = os.Chmod(dir, 0o500)
+				return Outcome{}, errors.New("simulated handler crash after sandbox suspend")
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		}})
+	}
+	return reg
+}
+
+// TestCommitWIPBeforeRouting_TerminalHardFail drives the handler-error terminal
+// path with an unrecoverable artifact repo and asserts AC2: WorkPreserveFailed
+// is set, an EventStageFailed carrying the repo-unavailable diagnostic fires,
+// and Status stays the original OutcomeFail (original failure not masked).
+func TestCommitWIPBeforeRouting_TerminalHardFail(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_terminal_hardfail_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := breakRepoHandler(t, "Implement")
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
+	result, _ := engine.Run(context.Background())
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Status != OutcomeFail {
+		t.Fatalf("Status must stay original OutcomeFail (not masked), got %q", result.Status)
+	}
+	if !result.WorkPreserveFailed {
+		t.Error("expected WorkPreserveFailed=true on terminal path when artifact repo is unrecoverable")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	foundHardSignal := false
+	for _, e := range events {
+		if e.Type == EventStageFailed && strings.Contains(e.Message, "artifact") &&
+			strings.Contains(e.Message, "preserve") {
+			foundHardSignal = true
+		}
+	}
+	if !foundHardSignal {
+		t.Errorf("expected EventStageFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
+	}
+}
+
+// TestCommitWIPBeforeRouting_MidRoutingStaysWarning verifies that on a
+// MID-ROUTING path (retry exhausted with a fallback_retry_target) an
+// unavailable artifact repo stays a WARNING and does NOT change routing:
+// WorkPreserveFailed is false and the run still routes to the fallback.
+func TestCommitWIPBeforeRouting_MidRoutingStaysWarning(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_midrouting_test")
+	g.Attrs["default_max_retry"] = "1"
+	g.Attrs["default_retry_policy"] = "none"
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "flaky", Shape: "box", Label: "Flaky", Attrs: map[string]string{"fallback_retry_target": "Escalate"}})
+	g.AddNode(&Node{ID: "Escalate", Shape: "box", Label: "Escalate"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "flaky"})
+	g.AddEdge(&Edge{From: "flaky", To: "end"})
+	g.AddEdge(&Edge{From: "Escalate", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := NewHandlerRegistry()
+	escalateRan := false
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "flaky":
+				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
+				_ = os.WriteFile(filepath.Join(dir, "flaky.go"), []byte("package x\n"), 0o644)
+				_ = os.RemoveAll(filepath.Join(dir, ".git"))
+				_ = os.Chmod(dir, 0o500)
+				return Outcome{Status: string(OutcomeRetry)}, nil
+			case "Escalate":
+				escalateRan = true
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		}})
+	}
+
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
+	result, _ := engine.Run(context.Background())
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.WorkPreserveFailed {
+		t.Error("mid-routing path must NOT set WorkPreserveFailed (preserves routing contract)")
+	}
+	if !escalateRan {
+		t.Error("mid-routing path must still route to the fallback target")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, e := range events {
+		if e.Type == EventStageFailed && strings.Contains(e.Message, "preserve") && strings.Contains(e.Message, "artifact") {
+			t.Errorf("mid-routing path must not emit a hard EventStageFailed for the repo; got %q", e.Message)
+		}
+	}
+}
+
+// TestEngine_HealthyRepo_NoWorkPreserveFailed is the AC3 regression: a healthy
+// device + healthy repo run produces WorkPreserveFailed=false and no new
+// repo-unavailable EventStageFailed.
+func TestEngine_HealthyRepo_NoWorkPreserveFailed(t *testing.T) {
+	requireGit(t)
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_healthy_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	g.AddNode(&Node{ID: "Implement", Shape: "box", Label: "Implement"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Implement"})
+	g.AddEdge(&Edge{From: "Implement", To: "end"})
+
+	reg := makeWIPRegistry(map[string]bool{"Implement": true}, map[string]bool{"Implement": true})
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true))
+	result, _ := engine.Run(context.Background())
+	if result == nil || result.Status != OutcomeFail {
+		t.Fatalf("expected fail result, got %+v", result)
+	}
+	if result.WorkPreserveFailed {
+		t.Error("healthy repo must not set WorkPreserveFailed")
+	}
+	// WIP ref still preserved as before (behavior unchanged).
+	repoDir := filepath.Join(artifactBase, result.RunID)
+	wantRef := "tracker/wip/" + result.RunID + "/Implement"
+	if tags := gitOutput(t, repoDir, "tag", "-l", "tracker/wip/*"); !strings.Contains(tags, wantRef) {
+		t.Errorf("expected WIP tag %q on healthy repo, got:\n%s", wantRef, tags)
+	}
+}

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -242,6 +242,127 @@ func TestCommitWIPBeforeRouting_MidRoutingStaysWarning(t *testing.T) {
 	}
 }
 
+// breakRepoOnStatusHandler returns a registry whose breakNode dirties the tree,
+// destroys the artifact repo, then returns the given outcome status (no Go
+// error) — driving the retry-exhausted and strict-failure terminal halt paths
+// (rather than the handler-error path that breakRepoHandler exercises).
+func breakRepoOnStatusHandler(t *testing.T, breakNode, status string) *HandlerRegistry {
+	t.Helper()
+	reg := NewHandlerRegistry()
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			if node.ID == breakNode {
+				dir, _ := pctx.GetInternal(InternalKeyArtifactDir)
+				_ = os.WriteFile(filepath.Join(dir, node.ID+".go"), []byte("package x\n"), 0o644)
+				_ = os.RemoveAll(filepath.Join(dir, ".git"))
+				_ = os.Chmod(dir, 0o500)
+				return Outcome{Status: status}, nil
+			}
+			return Outcome{Status: string(OutcomeSuccess)}, nil
+		}})
+	}
+	return reg
+}
+
+// assertTerminalPreserveHardFail asserts the AC2 contract on a terminal halt:
+// Status stays OutcomeFail, WorkPreserveFailed is set, and a hard
+// EventStageFailed carries the repo-unavailable preserve diagnostic.
+func assertTerminalPreserveHardFail(t *testing.T, result *EngineResult, events []PipelineEvent) {
+	t.Helper()
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Status != OutcomeFail {
+		t.Fatalf("Status must stay original OutcomeFail (not masked), got %q", result.Status)
+	}
+	if !result.WorkPreserveFailed {
+		t.Error("expected WorkPreserveFailed=true on terminal path when artifact repo is unrecoverable")
+	}
+	for _, e := range events {
+		if e.Type == EventStageFailed && strings.Contains(e.Message, "artifact") && strings.Contains(e.Message, "preserve") {
+			return
+		}
+	}
+	t.Errorf("expected EventStageFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
+}
+
+// TestRetryExhaustedNoFallback_TerminalHardFail drives the retry-exhausted
+// no-fallback terminal halt (handleRetryExhausted) with an unrecoverable
+// artifact repo and asserts AC2: the preserve error hard-escalates rather than
+// being silently discarded (the bug the review caught).
+func TestRetryExhaustedNoFallback_TerminalHardFail(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_retry_exhausted_terminal_test")
+	g.Attrs["default_max_retry"] = "1"
+	g.Attrs["default_retry_policy"] = "none"
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	// No fallback_retry_target — exhaustion must dead-stop, not route.
+	g.AddNode(&Node{ID: "flaky", Shape: "box", Label: "Flaky"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "flaky"})
+	g.AddEdge(&Edge{From: "flaky", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := breakRepoOnStatusHandler(t, "flaky", string(OutcomeRetry))
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
+	result, _ := engine.Run(context.Background())
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertTerminalPreserveHardFail(t, result, events)
+}
+
+// TestStrictFailureNoFallback_TerminalHardFail drives the strict-failure
+// no-fallback terminal halt (checkStrictFailure) with an unrecoverable artifact
+// repo and asserts AC2: the preserve error hard-escalates rather than being
+// silently discarded.
+func TestStrictFailureNoFallback_TerminalHardFail(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_strict_failure_terminal_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	// Only an unconditional edge and no fallback_target — a fail here is a
+	// strict-failure dead stop.
+	g.AddNode(&Node{ID: "Build", Shape: "box", Label: "Build"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Build"})
+	g.AddEdge(&Edge{From: "Build", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := breakRepoOnStatusHandler(t, "Build", string(OutcomeFail))
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
+	result, _ := engine.Run(context.Background())
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+
+	mu.Lock()
+	defer mu.Unlock()
+	assertTerminalPreserveHardFail(t, result, events)
+}
+
 // TestEngine_HealthyRepo_NoWorkPreserveFailed is the AC3 regression: a healthy
 // device + healthy repo run produces WorkPreserveFailed=false and no new
 // repo-unavailable EventStageFailed.

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -452,6 +452,89 @@ func TestStrictFailureNoFallback_TerminalHardFail(t *testing.T) {
 	assertTerminalPreserveHardFail(t, result, events)
 }
 
+// TestStrictFailureFallback_MidRoutingStaysWarning drives the strict-failure
+// MID-ROUTING fallback path (strictFailureFallback resolves a fallback_target)
+// with an unrecoverable artifact repo and asserts the preserve error surfaces as
+// a single EventWarning rather than being silently discarded — while routing is
+// unchanged: the fallback node still runs and WorkPreserveFailed stays false.
+func TestStrictFailureFallback_MidRoutingStaysWarning(t *testing.T) {
+	requireGit(t)
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not prevent writes")
+	}
+	artifactBase := t.TempDir()
+
+	g := NewGraph("wip_strict_failure_midrouting_test")
+	g.AddNode(&Node{ID: "start", Shape: "Mdiamond", Label: "Start"})
+	// Only an unconditional edge, but a node-level fallback_target — a fail here
+	// routes to Escalate instead of dead-stopping.
+	g.AddNode(&Node{ID: "Build", Shape: "box", Label: "Build", Attrs: map[string]string{"fallback_target": "Escalate"}})
+	g.AddNode(&Node{ID: "Escalate", Shape: "box", Label: "Escalate"})
+	g.AddNode(&Node{ID: "end", Shape: "Msquare", Label: "End"})
+	g.AddEdge(&Edge{From: "start", To: "Build"})
+	g.AddEdge(&Edge{From: "Build", To: "end"})
+	g.AddEdge(&Edge{From: "Escalate", To: "end"})
+
+	var mu sync.Mutex
+	var events []PipelineEvent
+	handler := PipelineEventHandlerFunc(func(evt PipelineEvent) {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+	})
+
+	reg := NewHandlerRegistry()
+	escalateRan := false
+	for _, name := range []string{"start", "exit", "codergen", "wait.human", "conditional", "parallel", "parallel.fan_in", "tool"} {
+		reg.Register(&testHandler{name: name, executeFn: func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+			switch node.ID {
+			case "Build":
+				breakArtifactRepo(t, pctx, node.ID)
+				return Outcome{Status: string(OutcomeFail)}, nil
+			case "Escalate":
+				escalateRan = true
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			default:
+				return Outcome{Status: string(OutcomeSuccess)}, nil
+			}
+		}})
+	}
+
+	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
+	result, _ := engine.Run(context.Background())
+	t.Cleanup(func() {
+		if result != nil {
+			_ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700)
+		}
+	})
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.WorkPreserveFailed {
+		t.Error("mid-routing fallback path must NOT set WorkPreserveFailed (preserves routing contract)")
+	}
+	if !escalateRan {
+		t.Error("mid-routing fallback path must still route to the fallback target")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	found := false
+	for _, e := range events {
+		if e.Type == EventWarning && e.NodeID == "Build" &&
+			strings.Contains(e.Message, "preserve uncommitted work") && strings.Contains(e.Message, "fallback") {
+			found = true
+		}
+		if e.Type == EventWorkPreserveFailed {
+			t.Errorf("mid-routing path must not emit a hard EventWorkPreserveFailed; got %q", e.Message)
+		}
+	}
+	if !found {
+		t.Errorf("expected an EventWarning surfacing the discarded mid-routing preserve error; events=%v", events)
+	}
+}
+
 // TestEngine_HealthyRepo_NoWorkPreserveFailed is the AC3 regression: a healthy
 // device + healthy repo run produces WorkPreserveFailed=false and no new
 // repo-unavailable EventWorkPreserveFailed.

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -192,7 +192,11 @@ func TestCommitWIPBeforeRouting_TerminalHardFail(t *testing.T) {
 	reg := breakRepoHandler(t, "Implement")
 	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
 	result, _ := engine.Run(context.Background())
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+	t.Cleanup(func() {
+		if result != nil {
+			_ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700)
+		}
+	})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
@@ -270,7 +274,11 @@ func TestCommitWIPBeforeRouting_MidRoutingStaysWarning(t *testing.T) {
 
 	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
 	result, _ := engine.Run(context.Background())
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+	t.Cleanup(func() {
+		if result != nil {
+			_ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700)
+		}
+	})
 
 	if result == nil {
 		t.Fatal("expected non-nil result")
@@ -369,7 +377,11 @@ func TestRetryExhaustedNoFallback_TerminalHardFail(t *testing.T) {
 	reg := breakRepoOnStatusHandler(t, "flaky", string(OutcomeRetry))
 	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
 	result, _ := engine.Run(context.Background())
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+	t.Cleanup(func() {
+		if result != nil {
+			_ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700)
+		}
+	})
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -407,7 +419,11 @@ func TestStrictFailureNoFallback_TerminalHardFail(t *testing.T) {
 	reg := breakRepoOnStatusHandler(t, "Build", string(OutcomeFail))
 	engine := NewEngine(g, reg, WithArtifactDir(artifactBase), WithGitArtifacts(true), WithPipelineEventHandler(handler))
 	result, _ := engine.Run(context.Background())
-	t.Cleanup(func() { _ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700) })
+	t.Cleanup(func() {
+		if result != nil {
+			_ = os.Chmod(filepath.Join(artifactBase, result.RunID), 0o700)
+		}
+	})
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/pipeline/git_artifact_health_test.go
+++ b/pipeline/git_artifact_health_test.go
@@ -163,7 +163,9 @@ func breakRepoHandler(t *testing.T, breakNode string) *HandlerRegistry {
 
 // TestCommitWIPBeforeRouting_TerminalHardFail drives the handler-error terminal
 // path with an unrecoverable artifact repo and asserts AC2: WorkPreserveFailed
-// is set, an EventStageFailed carrying the repo-unavailable diagnostic fires,
+// is set, an EventWorkPreserveFailed carrying the repo-unavailable diagnostic
+// fires (a hard signal that, unlike EventStageFailed, is NOT counted by
+// `tracker diagnose` as another per-node execution attempt — #428 review),
 // and Status stays the original OutcomeFail (original failure not masked).
 func TestCommitWIPBeforeRouting_TerminalHardFail(t *testing.T) {
 	requireGit(t)
@@ -206,13 +208,13 @@ func TestCommitWIPBeforeRouting_TerminalHardFail(t *testing.T) {
 	defer mu.Unlock()
 	foundHardSignal := false
 	for _, e := range events {
-		if e.Type == EventStageFailed && strings.Contains(e.Message, "artifact") &&
+		if e.Type == EventWorkPreserveFailed && strings.Contains(e.Message, "artifact") &&
 			strings.Contains(e.Message, "preserve") {
 			foundHardSignal = true
 		}
 	}
 	if !foundHardSignal {
-		t.Errorf("expected EventStageFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
+		t.Errorf("expected EventWorkPreserveFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
 	}
 }
 
@@ -283,8 +285,8 @@ func TestCommitWIPBeforeRouting_MidRoutingStaysWarning(t *testing.T) {
 	mu.Lock()
 	defer mu.Unlock()
 	for _, e := range events {
-		if e.Type == EventStageFailed && strings.Contains(e.Message, "preserve") && strings.Contains(e.Message, "artifact") {
-			t.Errorf("mid-routing path must not emit a hard EventStageFailed for the repo; got %q", e.Message)
+		if e.Type == EventWorkPreserveFailed && strings.Contains(e.Message, "preserve") && strings.Contains(e.Message, "artifact") {
+			t.Errorf("mid-routing path must not emit a hard EventWorkPreserveFailed for the repo; got %q", e.Message)
 		}
 	}
 }
@@ -313,7 +315,9 @@ func breakRepoOnStatusHandler(t *testing.T, breakNode, status string) *HandlerRe
 
 // assertTerminalPreserveHardFail asserts the AC2 contract on a terminal halt:
 // Status stays OutcomeFail, WorkPreserveFailed is set, and a hard
-// EventStageFailed carries the repo-unavailable preserve diagnostic.
+// EventWorkPreserveFailed carries the repo-unavailable preserve diagnostic. The
+// event is intentionally NOT EventStageFailed so `tracker diagnose` does not
+// count it as another per-node execution attempt (#428 review).
 func assertTerminalPreserveHardFail(t *testing.T, result *EngineResult, events []PipelineEvent) {
 	t.Helper()
 	if result == nil {
@@ -326,11 +330,11 @@ func assertTerminalPreserveHardFail(t *testing.T, result *EngineResult, events [
 		t.Error("expected WorkPreserveFailed=true on terminal path when artifact repo is unrecoverable")
 	}
 	for _, e := range events {
-		if e.Type == EventStageFailed && strings.Contains(e.Message, "artifact") && strings.Contains(e.Message, "preserve") {
+		if e.Type == EventWorkPreserveFailed && strings.Contains(e.Message, "artifact") && strings.Contains(e.Message, "preserve") {
 			return
 		}
 	}
-	t.Errorf("expected EventStageFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
+	t.Errorf("expected EventWorkPreserveFailed carrying the repo-unavailable preserve diagnostic; events=%v", events)
 }
 
 // TestRetryExhaustedNoFallback_TerminalHardFail drives the retry-exhausted
@@ -412,7 +416,7 @@ func TestStrictFailureNoFallback_TerminalHardFail(t *testing.T) {
 
 // TestEngine_HealthyRepo_NoWorkPreserveFailed is the AC3 regression: a healthy
 // device + healthy repo run produces WorkPreserveFailed=false and no new
-// repo-unavailable EventStageFailed.
+// repo-unavailable EventWorkPreserveFailed.
 func TestEngine_HealthyRepo_NoWorkPreserveFailed(t *testing.T) {
 	requireGit(t)
 	artifactBase := t.TempDir()

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -285,7 +285,11 @@ func (r *gitArtifactRepo) ensureHealthy() error {
 func (r *gitArtifactRepo) checkRootedHere() error {
 	out, err := r.git("rev-parse", "--show-toplevel")
 	if err != nil {
-		return fmt.Errorf("rev-parse --show-toplevel: %w", err)
+		// Include git's combined output (the 'not a git repository', 'cannot
+		// change to ...', etc. text) like every other error in this file, so the
+		// resulting ErrArtifactRepoUnavailable diagnostic stays actionable (#428
+		// review).
+		return fmt.Errorf("rev-parse --show-toplevel: %w\n%s", err, strings.TrimSpace(out))
 	}
 	top := strings.TrimSpace(out)
 	if top == "" {

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -12,6 +12,12 @@ import (
 	"strings"
 )
 
+// ErrArtifactRepoUnavailable — the artifact git repo went unreachable mid-run
+// (e.g. its gitdir was lost across a sandbox suspend, #423) and the reattach /
+// reinit recovery attempt failed. On the terminal never-lose-work commit path
+// this is surfaced as a HARD signal, not a best-effort warning.
+var ErrArtifactRepoUnavailable = errors.New("git artifact repository unavailable")
+
 // gitArtifactRepo manages a git repo backing the artifact dir for a run.
 // All operations are best-effort — if git fails, the engine logs a warning
 // via the event handler and continues without git tracking (not a fatal error).
@@ -237,6 +243,34 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 		return "", fmt.Errorf("git tag %q for WIP: %w\n%s", ref, err, out)
 	}
 	return ref, nil
+}
+
+// ensureHealthy probes the artifact repo's git dir and, if it has gone
+// unreachable (e.g. lost across a sandbox suspend, #423), attempts a single
+// reattach: clear the latched failure and re-run the idempotent Init.
+//
+// Returns nil when the repo is reachable — and in that healthy case makes NO
+// state change and NO commit, so the happy path is byte-identical to before.
+// Returns a wrapped ErrArtifactRepoUnavailable when the repo is unreachable and
+// recovery fails (or does not restore reachability). NOTE: a reattach against a
+// wiped .git reinitializes a fresh repo capturing the CURRENT tree — prior WIP
+// refs / history are gone; this preserves the working tree so the terminal
+// commit can still land, not full history.
+func (r *gitArtifactRepo) ensureHealthy() error {
+	if out, err := r.git("rev-parse", "--git-dir"); err == nil && strings.TrimSpace(out) != "" {
+		return nil // reachable — no recovery, no mutation
+	}
+	// Unreachable. Clear the latch (otherwise Init/CommitWIP no-op after a prior
+	// failure) and re-run the idempotent Init to reattach.
+	r.failed = false
+	if err := r.Init(); err != nil {
+		return fmt.Errorf("%w: reattach failed: %v", ErrArtifactRepoUnavailable, err)
+	}
+	// Re-probe so we never silently "un-fail" a still-dead repo.
+	if out, err := r.git("rev-parse", "--git-dir"); err != nil || strings.TrimSpace(out) == "" {
+		return fmt.Errorf("%w: still unreachable after reattach: %v", ErrArtifactRepoUnavailable, err)
+	}
+	return nil
 }
 
 // git runs a git command in r.dir with a sanitized environment.

--- a/pipeline/git_artifacts.go
+++ b/pipeline/git_artifacts.go
@@ -257,18 +257,46 @@ func (r *gitArtifactRepo) CommitWIP(nodeID string) (string, error) {
 // refs / history are gone; this preserves the working tree so the terminal
 // commit can still land, not full history.
 func (r *gitArtifactRepo) ensureHealthy() error {
-	if out, err := r.git("rev-parse", "--git-dir"); err == nil && strings.TrimSpace(out) != "" {
-		return nil // reachable — no recovery, no mutation
+	if err := r.checkRootedHere(); err == nil {
+		return nil // reachable AND rooted at r.dir — no recovery, no mutation
 	}
-	// Unreachable. Clear the latch (otherwise Init/CommitWIP no-op after a prior
-	// failure) and re-run the idempotent Init to reattach.
+	// Unreachable, or rev-parse discovered a PARENT repo (a nested artifact dir
+	// whose own .git was lost would otherwise resolve against the user's
+	// enclosing repo — #428 review). Clear the latch (otherwise Init/CommitWIP
+	// no-op after a prior failure) and re-run the idempotent Init to reattach a
+	// fresh repo rooted at r.dir.
 	r.failed = false
 	if err := r.Init(); err != nil {
-		return fmt.Errorf("%w: reattach failed: %v", ErrArtifactRepoUnavailable, err)
+		return fmt.Errorf("%w: reattach failed: %w", ErrArtifactRepoUnavailable, err)
 	}
-	// Re-probe so we never silently "un-fail" a still-dead repo.
-	if out, err := r.git("rev-parse", "--git-dir"); err != nil || strings.TrimSpace(out) == "" {
-		return fmt.Errorf("%w: still unreachable after reattach: %v", ErrArtifactRepoUnavailable, err)
+	// Re-probe so we never silently "un-fail" a still-dead repo or one that
+	// still resolves to a parent.
+	if err := r.checkRootedHere(); err != nil {
+		return fmt.Errorf("%w: still unreachable after reattach: %w", ErrArtifactRepoUnavailable, err)
+	}
+	return nil
+}
+
+// checkRootedHere reports nil only when r.dir is itself the root of a git work
+// tree. git rev-parse walks UP the directory tree, so a nested artifact dir
+// whose own .git was lost resolves against the enclosing user repo; comparing
+// --show-toplevel to r.dir rejects that parent-repo discovery (#428 review).
+// Returns a descriptive (never nil-interpolated) error on any non-rooted state.
+func (r *gitArtifactRepo) checkRootedHere() error {
+	out, err := r.git("rev-parse", "--show-toplevel")
+	if err != nil {
+		return fmt.Errorf("rev-parse --show-toplevel: %w", err)
+	}
+	top := strings.TrimSpace(out)
+	if top == "" {
+		return errors.New("git reported no work-tree root")
+	}
+	want := r.dir
+	if abs, err := filepath.Abs(want); err == nil {
+		want = abs
+	}
+	if !samePathForLatch(resolveSymlinksOrFallback(top), resolveSymlinksOrFallback(want)) {
+		return fmt.Errorf("git resolved to %q, not artifact dir %q (parent-repo discovery)", top, r.dir)
 	}
 	return nil
 }

--- a/tui/adapter.go
+++ b/tui/adapter.go
@@ -26,7 +26,12 @@ func AdaptPipelineEvent(evt pipeline.PipelineEvent) tea.Msg {
 		return MsgNodeStarted{NodeID: evt.NodeID}
 	case pipeline.EventStageCompleted:
 		return MsgNodeCompleted{NodeID: evt.NodeID, Outcome: "success"}
-	case pipeline.EventStageFailed:
+	case pipeline.EventStageFailed, pipeline.EventWorkPreserveFailed:
+		// EventWorkPreserveFailed (#423) is the terminal never-lose-work HARD
+		// signal. It surfaces in the TUI identically to a stage failure — a hard
+		// failure line — but is a distinct event type upstream only so that
+		// `tracker diagnose` does NOT count it as another per-node execution
+		// attempt toward RetryCount / IdenticalRetries (#428 review).
 		return MsgNodeFailed{NodeID: evt.NodeID, Error: pipelineEventMsg(evt)}
 	case pipeline.EventStageRetrying:
 		return MsgNodeRetrying{NodeID: evt.NodeID, Message: evt.Message}
@@ -122,6 +127,15 @@ func AdaptAgentEvent(evt agent.Event, nodeID string) tea.Msg {
 		return MsgThinkingStopped{NodeID: nodeID}
 	case agent.EventTextDelta:
 		return MsgTextChunk{NodeID: nodeID, Text: evt.Text}
+	default:
+		return adaptAgentToolEvent(evt, nodeID)
+	}
+}
+
+// adaptAgentToolEvent handles the tool-call and status agent events. Split out
+// of AdaptAgentEvent so each switch stays under the complexity gate.
+func adaptAgentToolEvent(evt agent.Event, nodeID string) tea.Msg {
+	switch evt.Type {
 	case agent.EventToolCallStart:
 		return MsgToolCallStart{NodeID: nodeID, ToolName: evt.ToolName, ToolInput: evt.ToolInput}
 	case agent.EventToolCallEnd:


### PR DESCRIPTION
## Summary

Closes **#423** (PR-D of the b65fb64 review-fidelity & engine-resilience workstream). Hardens two resilience gaps surfaced by the `build_product` dogfood run `b65fb64ac099`, both opt-in/no-op when the relevant conditions are healthy.

### 1. Sandbox device-node hygiene preflight
Before any git or subprocess work, `applyGitPreflight` runs `checkDeviceNodes` to verify standard device nodes are usable (`/dev/null` must be a readable+writable character device). A suspended/restored sandbox can silently corrupt `/dev/null` (becomes unreadable, or a regular file masquerading as the device), which otherwise produces baffling downstream failures. POSIX probe is build-tagged (`device_probe_posix.go`); Windows is a no-op (`device_probe_windows.go`). No new behavior when devices are healthy.

### 2. Artifact-repo health probe + reattach, and never-lose-work hardening
`commitWIPBeforeRouting` now probes artifact-repo availability via `ensureHealthy()` (re-Inits + re-verifies a `.git` lost to a sandbox suspend). When the repo is genuinely unrecoverable, **terminal halt paths** emit an `EventStageFailed` diagnostic and set `EngineResult.WorkPreserveFailed` — surfacing silently-lost work instead of swallowing it. `Status` is never masked (the original node failure stays the primary cause).

## Review remediation (this PR's second commit)

Adversarial review caught that the initial implementation hardened only 2 of the 4 terminal never-lose-work sites. `handleRetryExhausted` and `checkStrictFailure` each have a **no-onward-edge terminal dead-stop branch** that was mis-classified as mid-routing — both discarded the preserve error and never set `WorkPreserveFailed`. Fixed: the preserve error is captured once, still discarded on the genuine mid-routing branch (`fallback_retry_target` / `strictFailureFallback`), and hard-escalated on the terminal sub-branch via `escalateWorkPreserve`. Added `TestRetryExhaustedNoFallback_TerminalHardFail` and `TestStrictFailureNoFallback_TerminalHardFail`.

## Verification
- `go build ./...` ✓
- `go test ./... -short` ✓
- race on `pipeline` + `cmd/tracker` ✓
- `dippin doctor` on the three core pipelines: **Grade A (95/100)** ✓
- pre-commit gates (coverage 85.2%, complexity ≤8, lint, format) ✓

## Residual (unchanged)
Device probe covers `/dev/null` only; network egress and read-side exfil remain out of scope per the #272 jail threat model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785013365&installation_id=131176874&pr_number=428&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F428&signature=865f103b75761af7b6894d9578089962d1cf7ed394d42203e934efc4d1ccf5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sandbox device-node hygiene preflight (e.g., `/dev/null`) with actionable remediation, run before any git checks.
  * Added a dedicated terminal “work preserve failed” signal when artifact-repo recovery can’t complete.

* **Bug Fixes**
  * Improved artifact repository health checking with a single reattach/recovery attempt before attempting WIP preservation; detects nested git scenarios to avoid committing to the wrong repo.
  * Preserves the original failure status while escalating only on terminal never-lose-work paths; mid-routing remains warning-only.
  * Kept UI diagnostics consistent for the new terminal escalation case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->