### PR TITLE
fix(examples): grade human_gate_test_suite.dip A/100 under dippin v0.43 (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   progress mark with the (later) anchor time and undercounting stall (#426
   review).
 
+### Fixed
+
+- **`examples/human_gate_test_suite.dip` now grades A/100 under `dippin` v0.43
+  doctor (#335).** Removed the unused `weight:` edge attributes (DIP151) and
+  marked the routing key on each labeled human-gate edge with `choice:` (DIP150),
+  leaving `label:` for display — no change to the suite's semantic purpose of
+  exercising every human-gate mode.
+
 ### Notes
 
 - `sleep_aware_budget` is read from `graph.Attrs` by `ResolveBudgetLimits` for

--- a/examples/human_gate_test_suite.dip
+++ b/examples/human_gate_test_suite.dip
@@ -298,9 +298,9 @@ workflow HumanGateTestSuite
 
     # Section 5: Hybrid Freeform
     FreeformConfirm -> HybridGate
-    HybridGate -> ApproveRoute  label: "Approve"
-    HybridGate -> RejectRoute  label: "Reject"
-    HybridGate -> EscalateRoute  label: "Escalate"
+    HybridGate -> ApproveRoute  choice: "Approve"  label: "Approve"
+    HybridGate -> RejectRoute  choice: "Reject"  label: "Reject"
+    HybridGate -> EscalateRoute  choice: "Escalate"  label: "Escalate"
     ApproveRoute -> HybridConfirm
     RejectRoute -> HybridConfirm
     EscalateRoute -> HybridConfirm

--- a/examples/human_gate_test_suite.dip
+++ b/examples/human_gate_test_suite.dip
@@ -270,24 +270,24 @@ workflow HumanGateTestSuite
   edges
     # Section 1: Yes/No
     Start -> YesNoGate
-    YesNoGate -> YesPath  when ctx.outcome = success  label: "[Y] Yes"  weight: 2
-    YesNoGate -> NoPath  when ctx.outcome = fail  label: "[N] No"
+    YesNoGate -> YesPath  when ctx.outcome = success  choice: "[Y] Yes"  label: "[Y] Yes"
+    YesNoGate -> NoPath  when ctx.outcome = fail  choice: "[N] No"  label: "[N] No"
     YesPath -> YesNoConfirm
     NoPath -> YesNoConfirm
 
     # Section 2: Choice
     YesNoConfirm -> ChoiceGate
-    ChoiceGate -> NorthPath  label: "North"  weight: 2
-    ChoiceGate -> SouthPath  label: "South"
-    ChoiceGate -> EastPath  label: "East"
+    ChoiceGate -> NorthPath  choice: "North"  label: "North"
+    ChoiceGate -> SouthPath  choice: "South"  label: "South"
+    ChoiceGate -> EastPath  choice: "East"  label: "East"
     NorthPath -> ChoiceConfirm
     SouthPath -> ChoiceConfirm
     EastPath -> ChoiceConfirm
 
     # Section 3: Binary Choice
     ChoiceConfirm -> BinaryChoiceGate
-    BinaryChoiceGate -> ContinuePath  label: "[Y] Yes"  weight: 2
-    BinaryChoiceGate -> SkipPath  label: "[N] No"
+    BinaryChoiceGate -> ContinuePath  choice: "[Y] Yes"  label: "[Y] Yes"
+    BinaryChoiceGate -> SkipPath  choice: "[N] No"  label: "[N] No"
     ContinuePath -> BinaryConfirm
     SkipPath -> BinaryConfirm
 
@@ -298,7 +298,7 @@ workflow HumanGateTestSuite
 
     # Section 5: Hybrid Freeform
     FreeformConfirm -> HybridGate
-    HybridGate -> ApproveRoute  label: "Approve"  weight: 2
+    HybridGate -> ApproveRoute  label: "Approve"
     HybridGate -> RejectRoute  label: "Reject"
     HybridGate -> EscalateRoute  label: "Escalate"
     ApproveRoute -> HybridConfirm
@@ -314,22 +314,22 @@ workflow HumanGateTestSuite
     # Section 7: Interview Cancel
     InterviewConfirm -> QuestionWriter2
     QuestionWriter2 -> CancelableInterview
-    CancelableInterview -> CompletedPath  when ctx.outcome = success  weight: 2
+    CancelableInterview -> CompletedPath  when ctx.outcome = success
     CancelableInterview -> CanceledPath  when ctx.outcome = fail
     CompletedPath -> CancelConfirm
     CanceledPath -> CancelConfirm
 
     # Section 8: Timed Yes/No
     CancelConfirm -> TimedGate
-    TimedGate -> TimedYesPath  when ctx.outcome = success  label: "[Y] Yes"  weight: 2
-    TimedGate -> TimedFailPath  when ctx.outcome = fail  label: "[N] No / Timeout"
+    TimedGate -> TimedYesPath  when ctx.outcome = success  choice: "[Y] Yes"  label: "[Y] Yes"
+    TimedGate -> TimedFailPath  when ctx.outcome = fail  choice: "[N] No / Timeout"  label: "[N] No / Timeout"
     TimedYesPath -> TimeoutConfirm
     TimedFailPath -> TimeoutConfirm
 
     # Section 9: Timed Choice with Default
     TimeoutConfirm -> DefaultTimedGate
-    DefaultTimedGate -> SafePath  label: "Safe"  weight: 2
-    DefaultTimedGate -> RiskyPath  label: "Risky"
+    DefaultTimedGate -> SafePath  choice: "Safe"  label: "Safe"
+    DefaultTimedGate -> RiskyPath  choice: "Risky"  label: "Risky"
     SafePath -> DefaultConfirm
     RiskyPath -> DefaultConfirm
 


### PR DESCRIPTION
## Summary

`examples/human_gate_test_suite.dip` was scoring below A under the `dippin` v0.43 doctor due to two lint classes on its labeled human-gate edges:

- **DIP151** — unused `weight:` edge attributes had no effect on routing.
- **DIP150** — the routing key on labeled edges should be marked with `choice:`, leaving `label:` for display.

This change removes the `weight:` attributes and adds `choice:` to each labeled human-gate edge (mirroring the display `label:`). The suite's purpose — exercising every human-gate mode (yes/no, choice, binary, freeform, hybrid, interview, timed) — is unchanged.

Closes #335

## Verified

- `go build ./...` — clean
- `go test ./... -short` — all packages pass
- Pre-commit gates (gofmt, vet, build, tests, race, pipeline coverage 85.4%, complexity, dippin lint) — all passed without `--no-verify`
- `dippin doctor examples/human_gate_test_suite.dip` — **Grade A, 100/100**, 0 lint errors/warnings/hints, 41/41 nodes reachable, all paths terminate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzCQexSnLpdasxcYKRhFVZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785513138&installation_id=131176874&pr_number=429&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F429&signature=545e33822c04a55199832665f79ffc73e6b1152c49275decf59c7d6859e741f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved human-gate routing behavior in the example suite so labeled paths now use clearer choice metadata and no longer rely on unused edge attributes.
  * Updated cancel, timeout, and default flow labels for better readability and more accurate routing display.
  * The example suite now reports a higher grading result under the latest `dippin` check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->