### PR TITLE
fix: surface swallowed errors in Gemini translator, TUI review, and CLI env loading (#397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   progress mark with the (later) anchor time and undercounting stall (#426
   review).
 
+### Fixed
+
+- **Silent error swallowing in the Gemini translator, TUI review, and CLI env
+  loading (#397).** The Google adapter now propagates tool-call argument
+  (un)marshal errors (`translateToolCallPart`, `extractCandidateContent`, and the
+  streaming `processGeminiPart` which emits an `EventError`) instead of dropping a
+  malformed blob; `writeTempPlan` returns write/close errors; and `tracker version`
+  / `tracker doctor` surface `loadEnvFiles` errors the same way `tracker run` does.
+
 ### Notes
 
 - `sleep_aware_budget` is read from `graph.Attrs` by `ResolveBudgetLimits` for

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -96,7 +96,9 @@ func dispatchPipelineCommands(cfg runConfig) (error, bool) {
 func executeVersion() error {
 	// Load env so provider status reflects .env files.
 	wd, _ := os.Getwd()
-	_ = loadEnvFiles(wd)
+	if err := loadEnvFiles(wd); err != nil {
+		return err
+	}
 
 	fmt.Printf("tracker %s\n", version)
 	fmt.Printf("  commit: %s\n", commit)
@@ -114,7 +116,9 @@ func executeDiagnose(cfg runConfig) error {
 }
 
 func executeDoctor(cfg runConfig) error {
-	_ = loadEnvFiles(cfg.workdir)
+	if err := loadEnvFiles(cfg.workdir); err != nil {
+		return err
+	}
 	doctorCfg := DoctorConfig{
 		probe:        cfg.probe,
 		pipelineFile: cfg.pipelineFile,

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -95,7 +95,10 @@ func dispatchPipelineCommands(cfg runConfig) (error, bool) {
 
 func executeVersion() error {
 	// Load env so provider status reflects .env files.
-	wd, _ := os.Getwd()
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("resolve working directory: %w", err)
+	}
 	if err := loadEnvFiles(wd); err != nil {
 		return err
 	}

--- a/cmd/tracker/loadenv_error_test.go
+++ b/cmd/tracker/loadenv_error_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeUnreadableEnv points config resolution at an empty dir and puts an
+// unreadable .env (a directory named ".env") in workdir so godotenv.Read
+// fails, forcing loadEnvFiles to return an error deterministically.
+func makeUnreadableEnv(t *testing.T) string {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	workdir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workdir, ".env"), 0o700); err != nil {
+		t.Fatalf("mkdir .env: %v", err)
+	}
+	return workdir
+}
+
+func TestLoadEnvFilesPropagatesReadError(t *testing.T) {
+	workdir := makeUnreadableEnv(t)
+	if err := loadEnvFiles(workdir); err == nil {
+		t.Fatal("loadEnvFiles = nil, want error for unreadable .env")
+	}
+}
+
+func TestExecuteDoctorPropagatesLoadEnvError(t *testing.T) {
+	workdir := makeUnreadableEnv(t)
+	if err := executeDoctor(runConfig{workdir: workdir}); err == nil {
+		t.Fatal("executeDoctor = nil, want error from loadEnvFiles")
+	}
+}
+
+func TestExecuteVersionPropagatesLoadEnvError(t *testing.T) {
+	workdir := makeUnreadableEnv(t)
+	t.Chdir(workdir)
+	if err := executeVersion(); err == nil {
+		t.Fatal("executeVersion = nil, want error from loadEnvFiles")
+	}
+}

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -239,18 +239,7 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 		return true
 	}
 
-	if chunk.Error != nil {
-		// The API reports errors inside HTTP-200 streams; surface them as
-		// typed errors instead of silently dropping the chunk.
-		state.flushPendingFinish(ch)
-		msg := chunk.Error.Message
-		if msg == "" {
-			msg = "unknown stream error"
-		}
-		if chunk.Error.Status != "" {
-			msg = fmt.Sprintf("%s (%s)", msg, chunk.Error.Status)
-		}
-		ch <- llm.StreamEvent{Type: llm.EventError, Err: llm.ErrorFromStatusCode(chunk.Error.Code, "google: "+msg, "gemini")}
+	if a.emitStreamError(&chunk, ch, state) {
 		return true
 	}
 
@@ -277,6 +266,25 @@ func (a *Adapter) processSSELine(data []byte, ch chan<- llm.StreamEvent, state *
 
 	a.processCandidate(chunk.Candidates[0], &chunk, ch, state)
 	return false
+}
+
+// emitStreamError surfaces an API error carried inside an HTTP-200 stream and
+// returns true so the caller stops scanning. Returns false when the chunk
+// carries no error.
+func (a *Adapter) emitStreamError(chunk *geminiResponse, ch chan<- llm.StreamEvent, state *geminiStreamState) bool {
+	if chunk.Error == nil {
+		return false
+	}
+	state.flushPendingFinish(ch)
+	msg := chunk.Error.Message
+	if msg == "" {
+		msg = "unknown stream error"
+	}
+	if chunk.Error.Status != "" {
+		msg = fmt.Sprintf("%s (%s)", msg, chunk.Error.Status)
+	}
+	ch <- llm.StreamEvent{Type: llm.EventError, Err: llm.ErrorFromStatusCode(chunk.Error.Code, "google: "+msg, "gemini")}
+	return true
 }
 
 // processCandidate handles a single candidate from a Gemini SSE chunk.
@@ -336,7 +344,11 @@ func (a *Adapter) processGeminiPart(part geminiPart, ch chan<- llm.StreamEvent, 
 			ch <- llm.StreamEvent{Type: llm.EventTextEnd, TextID: state.textID}
 			state.textActive = false
 		}
-		argsJSON, _ := json.Marshal(part.FunctionCall.Args)
+		argsJSON, err := json.Marshal(part.FunctionCall.Args)
+		if err != nil {
+			ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: marshal function call args for %q: %w", part.FunctionCall.Name, err)}
+			return
+		}
 		ch <- llm.StreamEvent{
 			Type: llm.EventToolCallStart,
 			ToolCall: &llm.ToolCallData{

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -346,6 +346,10 @@ func (a *Adapter) processGeminiPart(part geminiPart, ch chan<- llm.StreamEvent, 
 		}
 		argsJSON, err := json.Marshal(part.FunctionCall.Args)
 		if err != nil {
+			// Flush any buffered finish reason before the error so accumulators
+			// record work completed before the stream broke (flushPendingFinish
+			// invariant: flush before any EventError).
+			state.flushPendingFinish(ch)
 			ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: marshal function call args for %q: %w", part.FunctionCall.Name, err)}
 			return
 		}

--- a/llm/google/translate.go
+++ b/llm/google/translate.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -94,7 +95,11 @@ func translateRequest(req *llm.Request) ([]byte, error) {
 	gr := geminiRequest{}
 
 	// Extract system/developer messages into systemInstruction.
-	gr.SystemInstruction, gr.Contents = extractSystemAndContents(req.Messages)
+	var err error
+	gr.SystemInstruction, gr.Contents, err = extractSystemAndContents(req.Messages)
+	if err != nil {
+		return nil, err
+	}
 
 	// Tool definitions.
 	gr.Tools = translateGeminiTools(req.Tools)
@@ -117,22 +122,37 @@ func translateRequest(req *llm.Request) ([]byte, error) {
 
 // extractSystemAndContents separates system/developer messages into a
 // systemInstruction and converts remaining messages to Gemini contents.
-func extractSystemAndContents(messages []llm.Message) (*geminiContent, []geminiContent) {
+func extractSystemAndContents(messages []llm.Message) (*geminiContent, []geminiContent, error) {
 	var sysParts []geminiPart
 	var contents []geminiContent
 	for _, m := range messages {
 		if m.Role == llm.RoleSystem || m.Role == llm.RoleDeveloper {
 			sysParts = append(sysParts, extractSystemParts(m)...)
-		} else {
-			if content := translateMessageToContent(m); content != nil {
-				contents = append(contents, *content)
-			}
+			continue
+		}
+		var err error
+		contents, err = appendMessageContent(contents, m)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
 	if len(sysParts) == 0 {
-		return nil, contents
+		return nil, contents, nil
 	}
-	return &geminiContent{Parts: sysParts}, contents
+	return &geminiContent{Parts: sysParts}, contents, nil
+}
+
+// appendMessageContent translates a non-system message and appends it to
+// contents, skipping empty results. Returns an error if translation fails.
+func appendMessageContent(contents []geminiContent, m llm.Message) ([]geminiContent, error) {
+	content, err := translateMessageToContent(m)
+	if err != nil {
+		return nil, err
+	}
+	if content != nil {
+		contents = append(contents, *content)
+	}
+	return contents, nil
 }
 
 // extractSystemParts collects text parts from a system/developer message.
@@ -188,7 +208,7 @@ func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 	// (preserving prior behavior) instead of breaking shipped 2.5-pro reviewers.
 	useThinking := req.ReasoningEffort != "" && geminiSupportsThinkingLevel(req.Model)
 
-	if req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil && len(req.StopSequences) == 0 && !needsResponseFormat && !useThinking {
+	if genConfigUnset(req, needsResponseFormat, useThinking) {
 		return nil
 	}
 
@@ -209,6 +229,13 @@ func buildGenerationConfig(req *llm.Request) *geminiGenConfig {
 		gc.ThinkingConfig = &geminiThinkingConfig{ThinkingLevel: req.ReasoningEffort}
 	}
 	return gc
+}
+
+// genConfigUnset reports whether no generation-config field is set, so
+// buildGenerationConfig can return nil (no config block on the wire).
+func genConfigUnset(req *llm.Request, needsResponseFormat, useThinking bool) bool {
+	return req.Temperature == nil && req.MaxTokens == nil && req.TopP == nil &&
+		len(req.StopSequences) == 0 && !needsResponseFormat && !useThinking
 }
 
 // responseFormatRequired returns true when the request specifies a JSON response format.
@@ -246,50 +273,59 @@ func mergeProviderOptions(body []byte, providerOpts map[string]any, providerKey 
 }
 
 // translateMessageToContent converts a unified llm.Message to a Gemini content item.
-func translateMessageToContent(m llm.Message) *geminiContent {
+func translateMessageToContent(m llm.Message) (*geminiContent, error) {
 	role := geminiRole(m.Role)
-	parts := translateContentParts(m.Content)
-	if len(parts) == 0 {
-		return nil
+	parts, err := translateContentParts(m.Content)
+	if err != nil {
+		return nil, err
 	}
-	return &geminiContent{Role: role, Parts: parts}
+	if len(parts) == 0 {
+		return nil, nil
+	}
+	return &geminiContent{Role: role, Parts: parts}, nil
 }
 
 // translateContentParts converts a slice of unified content parts to Gemini parts.
-func translateContentParts(content []llm.ContentPart) []geminiPart {
+func translateContentParts(content []llm.ContentPart) ([]geminiPart, error) {
 	var parts []geminiPart
 	for _, part := range content {
-		if p := translateSingleContentPart(part); p != nil {
+		p, err := translateSingleContentPart(part)
+		if err != nil {
+			return nil, err
+		}
+		if p != nil {
 			parts = append(parts, *p)
 		}
 	}
-	return parts
+	return parts, nil
 }
 
 // translateSingleContentPart converts a single unified ContentPart to a Gemini part.
 // Returns nil for unsupported or empty parts.
-func translateSingleContentPart(part llm.ContentPart) *geminiPart {
+func translateSingleContentPart(part llm.ContentPart) (*geminiPart, error) {
 	switch part.Kind {
 	case llm.KindText:
 		p := geminiPart{Text: part.Text}
-		return &p
+		return &p, nil
 	case llm.KindToolCall:
 		return translateToolCallPart(part)
 	case llm.KindToolResult:
-		return translateToolResultPart(part)
+		return translateToolResultPart(part), nil
 	}
 	// Image content parts can be added when KindImage is defined in the core types.
-	return nil
+	return nil, nil
 }
 
 // translateToolCallPart converts a tool call content part to a Gemini function call part.
-func translateToolCallPart(part llm.ContentPart) *geminiPart {
+func translateToolCallPart(part llm.ContentPart) (*geminiPart, error) {
 	if part.ToolCall == nil {
-		return nil
+		return nil, nil
 	}
 	var args map[string]any
 	if len(part.ToolCall.Arguments) > 0 {
-		json.Unmarshal(part.ToolCall.Arguments, &args)
+		if err := json.Unmarshal(part.ToolCall.Arguments, &args); err != nil {
+			return nil, fmt.Errorf("google: unmarshal tool call arguments for %q: %w", part.ToolCall.Name, err)
+		}
 	}
 	return &geminiPart{
 		FunctionCall: &geminiFunctionCall{
@@ -297,7 +333,7 @@ func translateToolCallPart(part llm.ContentPart) *geminiPart {
 			Args: args,
 		},
 		ThoughtSignature: part.ToolCall.ThoughtSigData,
-	}
+	}, nil
 }
 
 // translateToolResultPart converts a tool result content part to a Gemini function response part.
@@ -388,7 +424,10 @@ func translateResponse(raw []byte) (*llm.Response, error) {
 		return nil, err
 	}
 
-	content, finishReason := extractCandidateContent(gr.Candidates)
+	content, finishReason, err := extractCandidateContent(gr.Candidates)
+	if err != nil {
+		return nil, err
+	}
 	usage := extractUsage(gr.UsageMetadata)
 	fr := translateFinishReason(finishReason, hasToolCalls(content))
 
@@ -406,30 +445,45 @@ func translateResponse(raw []byte) (*llm.Response, error) {
 }
 
 // extractCandidateContent pulls content parts and finish reason from the first candidate.
-func extractCandidateContent(candidates []geminiCandidate) ([]llm.ContentPart, string) {
+func extractCandidateContent(candidates []geminiCandidate) ([]llm.ContentPart, string, error) {
 	if len(candidates) == 0 {
-		return nil, ""
+		return nil, "", nil
 	}
 	candidate := candidates[0]
 	var content []llm.ContentPart
 	for _, part := range candidate.Content.Parts {
-		if part.Text != "" {
-			content = append(content, llm.ContentPart{Kind: llm.KindText, Text: part.Text})
+		parts, err := candidateContentParts(part)
+		if err != nil {
+			return nil, "", err
 		}
-		if part.FunctionCall != nil {
-			argsJSON, _ := json.Marshal(part.FunctionCall.Args)
-			content = append(content, llm.ContentPart{
-				Kind: llm.KindToolCall,
-				ToolCall: &llm.ToolCallData{
-					ID:             syntheticID(),
-					Name:           part.FunctionCall.Name,
-					Arguments:      argsJSON,
-					ThoughtSigData: part.ThoughtSignature,
-				},
-			})
-		}
+		content = append(content, parts...)
 	}
-	return content, candidate.FinishReason
+	return content, candidate.FinishReason, nil
+}
+
+// candidateContentParts converts one Gemini response part into unified content
+// parts, surfacing any function-call args-marshal error.
+func candidateContentParts(part geminiPart) ([]llm.ContentPart, error) {
+	var parts []llm.ContentPart
+	if part.Text != "" {
+		parts = append(parts, llm.ContentPart{Kind: llm.KindText, Text: part.Text})
+	}
+	if part.FunctionCall != nil {
+		argsJSON, err := json.Marshal(part.FunctionCall.Args)
+		if err != nil {
+			return nil, fmt.Errorf("google: marshal function call args for %q: %w", part.FunctionCall.Name, err)
+		}
+		parts = append(parts, llm.ContentPart{
+			Kind: llm.KindToolCall,
+			ToolCall: &llm.ToolCallData{
+				ID:             syntheticID(),
+				Name:           part.FunctionCall.Name,
+				Arguments:      argsJSON,
+				ThoughtSigData: part.ThoughtSignature,
+			},
+		})
+	}
+	return parts, nil
 }
 
 // extractUsage converts Gemini usage metadata to the unified Usage struct.

--- a/llm/google/translate_error_test.go
+++ b/llm/google/translate_error_test.go
@@ -1,0 +1,107 @@
+// ABOUTME: Tests that tool-call (un)marshal errors in the Gemini translator are surfaced, not swallowed (#397).
+package google
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// TestTranslateRequestToolCallArgumentsUnmarshal covers translateToolCallPart:
+// a malformed tool-call arguments blob must propagate an error out of
+// translateRequest instead of being silently dropped.
+func TestTranslateRequestToolCallArgumentsUnmarshal(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    json.RawMessage
+		wantErr bool
+	}{
+		{name: "valid object", args: json.RawMessage(`{"path":"a.go"}`), wantErr: false},
+		{name: "empty args", args: nil, wantErr: false},
+		{name: "malformed json", args: json.RawMessage(`{invalid`), wantErr: true},
+		{name: "wrong type", args: json.RawMessage(`["not","an","object"]`), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &llm.Request{
+				Model: "gemini-2.0-flash",
+				Messages: []llm.Message{{
+					Role: llm.RoleAssistant,
+					Content: []llm.ContentPart{{
+						Kind:     llm.KindToolCall,
+						ToolCall: &llm.ToolCallData{Name: "edit", Arguments: tt.args},
+					}},
+				}},
+			}
+
+			_, err := translateRequest(req)
+			if tt.wantErr && err == nil {
+				t.Fatal("translateRequest = nil error, want error for malformed tool-call arguments")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("translateRequest returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestExtractCandidateContentMarshalError covers extractCandidateContent:
+// a function-call args map that cannot be marshaled must surface an error.
+func TestExtractCandidateContentMarshalError(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]any
+		wantErr bool
+	}{
+		{name: "marshalable args", args: map[string]any{"path": "a.go"}, wantErr: false},
+		{name: "unmarshalable args", args: map[string]any{"ch": make(chan int)}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidates := []geminiCandidate{{
+				Content: geminiContent{Parts: []geminiPart{{
+					FunctionCall: &geminiFunctionCall{Name: "edit", Args: tt.args},
+				}}},
+			}}
+
+			_, _, err := extractCandidateContent(candidates)
+			if tt.wantErr && err == nil {
+				t.Fatal("extractCandidateContent = nil error, want error for unmarshalable args")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("extractCandidateContent returned unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestProcessGeminiPartMarshalError covers the streaming path: a function-call
+// args map that cannot be marshaled must emit an EventError on the channel.
+func TestProcessGeminiPartMarshalError(t *testing.T) {
+	a := &Adapter{}
+	ch := make(chan llm.StreamEvent, 4)
+	state := &geminiStreamState{}
+
+	part := geminiPart{FunctionCall: &geminiFunctionCall{Name: "edit", Args: map[string]any{"ch": make(chan int)}}}
+	a.processGeminiPart(part, ch, state)
+	close(ch)
+
+	var sawError bool
+	for ev := range ch {
+		if ev.Type == llm.EventError {
+			sawError = true
+			if ev.Err == nil {
+				t.Fatal("EventError with nil Err")
+			}
+		}
+		if ev.Type == llm.EventToolCallStart {
+			t.Fatal("emitted EventToolCallStart despite marshal failure")
+		}
+	}
+	if !sawError {
+		t.Fatal("processGeminiPart did not emit EventError for unmarshalable args")
+	}
+}

--- a/tui/review.go
+++ b/tui/review.go
@@ -26,13 +26,14 @@ const reviewChrome = 9
 // (e.g., execution plans). Top pane is a scrollable glamour-rendered
 // viewport, bottom pane is a textarea for the user's response.
 type ReviewContent struct {
-	viewport viewport.Model
-	textarea textarea.Model
-	replyCh  chan<- string
-	done     bool
-	width    int
-	height   int
-	tmpFile  string // path to temp file with the plan markdown
+	viewport   viewport.Model
+	textarea   textarea.Model
+	replyCh    chan<- string
+	done       bool
+	width      int
+	height     int
+	tmpFile    string // path to temp file with the plan markdown ("" if unavailable)
+	tmpFileErr error  // non-nil if writing the temp file failed; surfaced in the divider
 }
 
 // IsFullscreen signals the modal wrapper to skip centering and use the full terminal.
@@ -85,20 +86,19 @@ func NewReviewContent(prompt string, replyCh chan<- string, width, height int) *
 	ta.Focus()
 	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
 
-	// Write plan to temp file for external reading (best-effort — an empty
-	// path just disables the external-read affordance).
-	tmpFile, err := writeTempPlan(plan)
-	if err != nil {
-		tmpFile = ""
-	}
+	// Write plan to temp file for external reading (best-effort — a failure
+	// just disables the external-read affordance, surfaced in the divider so it
+	// isn't silently swallowed; the review modal still works without it).
+	tmpFile, tmpFileErr := writeTempPlan(plan)
 
 	return &ReviewContent{
-		viewport: vp,
-		textarea: ta,
-		replyCh:  replyCh,
-		width:    width,
-		height:   height,
-		tmpFile:  tmpFile,
+		viewport:   vp,
+		textarea:   ta,
+		replyCh:    replyCh,
+		width:      width,
+		height:     height,
+		tmpFile:    tmpFile,
+		tmpFileErr: tmpFileErr,
 	}
 }
 
@@ -192,6 +192,8 @@ func (r *ReviewContent) View() string {
 		int(r.viewport.ScrollPercent()*100)))
 	if r.tmpFile != "" {
 		divider += Styles.DimText.Render(fmt.Sprintf("[ %s ]", r.tmpFile))
+	} else if r.tmpFileErr != nil {
+		divider += Styles.DimText.Render(fmt.Sprintf("[ external read unavailable: %v ]", r.tmpFileErr))
 	}
 	sb.WriteString(divider)
 	sb.WriteString("\n")

--- a/tui/review.go
+++ b/tui/review.go
@@ -85,8 +85,12 @@ func NewReviewContent(prompt string, replyCh chan<- string, width, height int) *
 	ta.Focus()
 	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
 
-	// Write plan to temp file for external reading.
-	tmpFile := writeTempPlan(plan)
+	// Write plan to temp file for external reading (best-effort — an empty
+	// path just disables the external-read affordance).
+	tmpFile, err := writeTempPlan(plan)
+	if err != nil {
+		tmpFile = ""
+	}
 
 	return &ReviewContent{
 		viewport: vp,
@@ -228,13 +232,26 @@ func renderMarkdownForReview(md string, width int) string {
 	return strings.TrimSpace(rendered)
 }
 
+// createTempPlanFile creates the temp file backing writeTempPlan. It is a
+// package var so tests can inject write failures (#397).
+var createTempPlanFile = func() (*os.File, error) {
+	return os.CreateTemp("", "tracker-plan-*.md")
+}
+
 // writeTempPlan writes the plan markdown to a temp file and returns the path.
-func writeTempPlan(plan string) string {
-	f, err := os.CreateTemp("", "tracker-plan-*.md")
+func writeTempPlan(plan string) (string, error) {
+	f, err := createTempPlanFile()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	defer f.Close()
-	f.WriteString(plan)
-	return f.Name()
+	if _, err := f.WriteString(plan); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("write temp plan: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("close temp plan: %w", err)
+	}
+	return f.Name(), nil
 }

--- a/tui/review.go
+++ b/tui/review.go
@@ -242,7 +242,7 @@ var createTempPlanFile = func() (*os.File, error) {
 func writeTempPlan(plan string) (string, error) {
 	f, err := createTempPlanFile()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("create temp plan: %w", err)
 	}
 	if _, err := f.WriteString(plan); err != nil {
 		f.Close()

--- a/tui/review_temp_test.go
+++ b/tui/review_temp_test.go
@@ -1,0 +1,68 @@
+// ABOUTME: Tests that writeTempPlan surfaces file-write errors instead of swallowing them (#397).
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteTempPlanSuccess(t *testing.T) {
+	plan := "# Plan\n\nstep one\n"
+	path, err := writeTempPlan(plan)
+	if err != nil {
+		t.Fatalf("writeTempPlan returned error: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read temp plan: %v", err)
+	}
+	if string(got) != plan {
+		t.Fatalf("temp plan content = %q, want %q", string(got), plan)
+	}
+}
+
+func TestWriteTempPlanPropagatesCreateError(t *testing.T) {
+	// Point the temp dir at a non-existent path so os.CreateTemp fails,
+	// proving writeTempPlan surfaces the error rather than swallowing it.
+	t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	path, err := writeTempPlan("plan")
+	if err == nil {
+		os.Remove(path)
+		t.Fatal("writeTempPlan = nil error, want error for unwritable temp dir")
+	}
+	if path != "" {
+		t.Fatalf("writeTempPlan path = %q, want empty on error", path)
+	}
+}
+
+func TestWriteTempPlanPropagatesWriteError(t *testing.T) {
+	// Inject a read-only file so WriteString fails, proving writeTempPlan
+	// surfaces the write error rather than swallowing it (#397).
+	orig := createTempPlanFile
+	t.Cleanup(func() { createTempPlanFile = orig })
+
+	name := filepath.Join(t.TempDir(), "readonly.md")
+	createTempPlanFile = func() (*os.File, error) {
+		if err := os.WriteFile(name, nil, 0o400); err != nil {
+			return nil, err
+		}
+		return os.OpenFile(name, os.O_RDONLY, 0)
+	}
+
+	path, err := writeTempPlan("plan")
+	if err == nil {
+		os.Remove(path)
+		t.Fatal("writeTempPlan = nil error, want error when WriteString fails")
+	}
+	if path != "" {
+		t.Fatalf("writeTempPlan path = %q, want empty on error", path)
+	}
+	if !strings.Contains(err.Error(), "write temp plan") {
+		t.Fatalf("error = %v, want wrapped write temp plan error", err)
+	}
+}


### PR DESCRIPTION
## Summary

Stops three silent error swallows flagged in #397:

- **Gemini translator (`llm/google`).** Tool-call argument (un)marshal errors were discarded. Now propagated:
  - `translateToolCallPart` surfaces `json.Unmarshal` failures on a malformed arguments blob (out through `translateRequest`).
  - `extractCandidateContent` surfaces `json.Marshal` failures on function-call args.
  - The streaming `processGeminiPart` emits an `EventError` instead of dropping a malformed function-call blob.
- **TUI review (`tui/review.go`).** `writeTempPlan` now returns write/close errors; the caller keeps best-effort behavior by falling back to an empty path (external-read affordance simply disabled).
- **CLI (`cmd/tracker/commands.go`).** `tracker version` and `tracker doctor` no longer discard `loadEnvFiles` errors with the blank identifier — they surface them the same way `tracker run` does.

To keep the complexity gate green on the two touched Gemini files (pre-existing debt the whole-file gate scans once the files are staged), two mechanical helper extractions were made: `genConfigUnset` (out of `buildGenerationConfig`) and `emitStreamError` (out of `processSSELine`).

## Verified

- `go build ./...` — clean
- `go test ./... -short` — all packages pass
- Pre-commit gates passed WITHOUT `--no-verify`: gofmt, vet, build, tests, race detector, pipeline coverage 85.4%, complexity (cyclomatic/cognitive ≤ 8), dippin lint.
- New tests: `llm/google/translate_error_test.go`, `cmd/tracker/loadenv_error_test.go`, `tui/review_temp_test.go`.

Closes #397.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzCQexSnLpdasxcYKRhFVZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785515397&installation_id=131176874&pr_number=432&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F432&signature=ad9cb77d1d1408fec15ebd975033f93e40851eee1ea49e0197437fc3f3e3c247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Propagate `.env`/workdir loading errors consistently in version and doctor command flows.
  * Gemini handling now surfaces tool-call JSON marshal/unmarshal and streaming errors instead of silently ignoring malformed data.
  * Plan preview handling now fails gracefully: when temporary plan files can’t be created/written, the UI shows an “external read unavailable” message.

* **Tests**
  * Added deterministic coverage for `.env` error propagation, Gemini translator/tool-call error handling, and `writeTempPlan` success/failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->