### PR TITLE
refactor: decompose over-threshold config parsers to satisfy complexity gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Behavior-preserving decomposition of the config parsers to satisfy the
+  complexity gate (#393 follow-up).** `(*Node).AgentConfig`, `(*Node).RetryConfig`,
+  `(*Node).ParallelConfig` (`pipeline/node_config.go`) and
+  `(*CodergenHandler).buildConfig` (`pipeline/handlers/codergen.go`) were split
+  into small focused helpers so both gocyclo and gocognit report <=8 for every
+  function. Pure mechanical extraction: the graph-default-then-node-override
+  order, all conditions, and evaluation semantics are unchanged — no new attrs,
+  no API changes, no behavior change.
 - **`build_product` review panel reads a bounded diff and tiers its models
   (#418).** A new `ComputeReviewDiff` tool node (inserted
   `ClearStaleReviews -> ComputeReviewDiff -> ReviewParallel`) computes the

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -920,6 +920,38 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 
 	cfg := node.AgentConfig(h.graphAttrs)
 
+	applyBackendAndPaths(&config, cfg)
+	applyModelIdentity(&config, cfg)
+	// #318 warm continue+N: a node-scoped, disk-driven override bumps MaxTurns
+	// on warm re-entry of this agent node (the operator-decision "continue"
+	// path writes it via a capped tool node). Consulted here because MaxTurns
+	// is otherwise read statically and nothing reads context for it. A missing
+	// or malformed override is a no-op, so normal runs are unaffected. (The
+	// conditional lives in resolveMaxTurns to keep buildConfig's branch count flat.)
+	config.MaxTurns = resolveMaxTurns(config.WorkingDir, node.ID, config.MaxTurns)
+	applyGenerationParams(&config, cfg)
+	applyTypedCompaction(&config, cfg)
+	applyReflectAndVerify(&config, cfg)
+
+	// #349: commit_only scope guard — outermost prepend so the restriction acts
+	// as the strongest constraint, overriding any node-supplied system_prompt.
+	// Enforced for all three backends: native (SessionConfig.SystemPrompt → Extra),
+	// claude-code (AgentRunConfig.SystemPrompt → --system-prompt flag), and ACP
+	// (buildACPPromptBlocks prepends AgentRunConfig.SystemPrompt as a text block).
+	if cfg.CommitOnly {
+		if config.SystemPrompt != "" {
+			config.SystemPrompt = commitOnlyScopeGuard + "\n\n" + config.SystemPrompt
+		} else {
+			config.SystemPrompt = commitOnlyScopeGuard
+		}
+	}
+
+	return config
+}
+
+// applyBackendAndPaths copies the backend selection and writable-paths jail
+// config from the typed AgentNodeConfig onto the session config.
+func applyBackendAndPaths(config *agent.SessionConfig, cfg pipeline.AgentNodeConfig) {
 	if cfg.Backend != "" {
 		// Normalize the documented "codergen" alias to "native" before the
 		// jail check. selectBackend already treats both as native; carrying
@@ -936,7 +968,11 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 		config.WritablePathsSet = true
 		config.WritablePaths = append([]string(nil), cfg.WritablePaths...) // defensive copy
 	}
+}
 
+// applyModelIdentity copies model/provider/system-prompt and the turn/cost
+// ceilings from the typed AgentNodeConfig onto the session config.
+func applyModelIdentity(config *agent.SessionConfig, cfg pipeline.AgentNodeConfig) {
 	if cfg.Model != "" {
 		config.Model = cfg.Model
 	}
@@ -956,13 +992,11 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	if cfg.NoProgressTurns > 0 {
 		config.NoProgressTurns = cfg.NoProgressTurns
 	}
-	// #318 warm continue+N: a node-scoped, disk-driven override bumps MaxTurns
-	// on warm re-entry of this agent node (the operator-decision "continue"
-	// path writes it via a capped tool node). Consulted here because MaxTurns
-	// is otherwise read statically and nothing reads context for it. A missing
-	// or malformed override is a no-op, so normal runs are unaffected. (The
-	// conditional lives in resolveMaxTurns to keep buildConfig's branch count flat.)
-	config.MaxTurns = resolveMaxTurns(config.WorkingDir, node.ID, config.MaxTurns)
+}
+
+// applyGenerationParams copies the timeout/reasoning/response-format/cache
+// generation parameters from the typed AgentNodeConfig onto the session config.
+func applyGenerationParams(config *agent.SessionConfig, cfg pipeline.AgentNodeConfig) {
 	if cfg.CommandTimeout > 0 {
 		config.CommandTimeout = cfg.CommandTimeout
 	}
@@ -978,7 +1012,12 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	if cfg.CacheToolResultsSet {
 		config.CacheToolResults = cfg.CacheToolResults
 	}
-	applyTypedCompaction(&config, cfg)
+}
+
+// applyReflectAndVerify copies the reflect-on-error, verify, turn-breach,
+// plan, and tool-access settings from the typed AgentNodeConfig onto the
+// session config.
+func applyReflectAndVerify(config *agent.SessionConfig, cfg pipeline.AgentNodeConfig) {
 	if cfg.ReflectOnErrorSet && !cfg.ReflectOnError {
 		config.ReflectOnError = false
 	}
@@ -1004,21 +1043,6 @@ func (h *CodergenHandler) buildConfig(node *pipeline.Node) agent.SessionConfig {
 	if cfg.ToolAccess != "" {
 		config.ToolAccess = cfg.ToolAccess
 	}
-
-	// #349: commit_only scope guard — outermost prepend so the restriction acts
-	// as the strongest constraint, overriding any node-supplied system_prompt.
-	// Enforced for all three backends: native (SessionConfig.SystemPrompt → Extra),
-	// claude-code (AgentRunConfig.SystemPrompt → --system-prompt flag), and ACP
-	// (buildACPPromptBlocks prepends AgentRunConfig.SystemPrompt as a text block).
-	if cfg.CommitOnly {
-		if config.SystemPrompt != "" {
-			config.SystemPrompt = commitOnlyScopeGuard + "\n\n" + config.SystemPrompt
-		} else {
-			config.SystemPrompt = commitOnlyScopeGuard
-		}
-	}
-
-	return config
 }
 
 // applyTypedCompaction applies the context-compaction mode + threshold from

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -137,11 +137,41 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	cfg.ResponseFormat = n.Attrs["response_format"]
 	cfg.ResponseSchema = n.Attrs["response_schema"]
 
+	// Numeric/duration/tri-state cascades are extracted into focused helpers so
+	// each stays under the complexity gate; every helper preserves the exact
+	// graph-default-then-node-override order and conditions of the original.
+	n.applyMaxBudget(&cfg)
+	n.applyMaxCostGraph(&cfg, graphAttrs)
+	n.applyMaxCostNode(&cfg)
+	n.applyNoProgressGraph(&cfg, graphAttrs)
+	n.applyNoProgressNode(&cfg)
+	n.applyMaxTurns(&cfg)
+	n.applyTurnBreach(&cfg, graphAttrs)
+	n.applyCommandTimeout(&cfg)
+	n.applyAutoStatusAndReflect(&cfg)
+	n.applyVerifyDefaults(&cfg, graphAttrs)
+	n.applyVerifyOverrides(&cfg)
+	n.applyPlanBeforeExecute(&cfg, graphAttrs)
+	n.applyModelProvider(&cfg, graphAttrs)
+	n.applyReasoningEffort(&cfg, graphAttrs)
+	n.applyCache(&cfg, graphAttrs)
+	n.applyCompaction(&cfg, graphAttrs)
+	n.applyWritablePathsAndCommitOnly(&cfg)
+
+	return cfg
+}
+
+// applyMaxBudget resolves the node-only max_budget_usd attr.
+func (n *Node) applyMaxBudget(cfg *AgentNodeConfig) {
 	if v := n.Attrs["max_budget_usd"]; v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			cfg.MaxBudgetUSD = f
 		}
 	}
+}
+
+// applyMaxCostGraph applies the graph-level max_cost_usd default (positive only).
+func (n *Node) applyMaxCostGraph(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// #304: max_cost_usd — per-node cost ceiling. Graph default (positive only)
 	// then node override. Node-level "0" explicitly disables a graph default.
 	if v, ok := graphAttrs["max_cost_usd"]; ok && v != "" {
@@ -149,11 +179,19 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.MaxCostUSD = f
 		}
 	}
+}
+
+// applyMaxCostNode applies the node-level max_cost_usd override ("0" disables).
+func (n *Node) applyMaxCostNode(cfg *AgentNodeConfig) {
 	if v, ok := n.Attrs["max_cost_usd"]; ok && v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil && f >= 0 {
 			cfg.MaxCostUSD = f // 0 disables the inherited graph default
 		}
 	}
+}
+
+// applyNoProgressGraph applies the graph-level no_progress_turns default (positive only).
+func (n *Node) applyNoProgressGraph(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// #304: no_progress_turns — no-progress detector K. Graph default (positive
 	// only) then node override. Node-level "0" explicitly disables a graph default.
 	if v, ok := graphAttrs["no_progress_turns"]; ok && v != "" {
@@ -161,16 +199,28 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.NoProgressTurns = i
 		}
 	}
+}
+
+// applyNoProgressNode applies the node-level no_progress_turns override ("0" disables).
+func (n *Node) applyNoProgressNode(cfg *AgentNodeConfig) {
 	if v, ok := n.Attrs["no_progress_turns"]; ok && v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i >= 0 {
 			cfg.NoProgressTurns = i // 0 disables the inherited graph default
 		}
 	}
+}
+
+// applyMaxTurns resolves the node-only max_turns attr (positive only).
+func (n *Node) applyMaxTurns(cfg *AgentNodeConfig) {
 	if v := n.Attrs["max_turns"]; v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {
 			cfg.MaxTurns = i
 		}
 	}
+}
+
+// applyTurnBreach resolves turn_breach_policy: graph default then node override.
+func (n *Node) applyTurnBreach(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// #303 turn_breach_policy: graph default then node override. Arrives via a
 	// dippin params: block, spilled into n.Attrs by the adapter.
 	if v, ok := graphAttrs["turn_breach_policy"]; ok && v != "" {
@@ -179,12 +229,19 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	if v, ok := n.Attrs["turn_breach_policy"]; ok && v != "" {
 		cfg.TurnBreachPolicy = v
 	}
+}
+
+// applyCommandTimeout resolves the node-only command_timeout attr (positive only).
+func (n *Node) applyCommandTimeout(cfg *AgentNodeConfig) {
 	if v := n.Attrs["command_timeout"]; v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			cfg.CommandTimeout = d
 		}
 	}
+}
 
+// applyAutoStatusAndReflect resolves the node-only auto_status and reflect_on_error attrs.
+func (n *Node) applyAutoStatusAndReflect(cfg *AgentNodeConfig) {
 	if v, ok := n.Attrs["auto_status"]; ok {
 		cfg.AutoStatus = v == "true"
 	}
@@ -195,7 +252,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 		cfg.ReflectOnError = v != "false"
 		cfg.ReflectOnErrorSet = true
 	}
+}
 
+// applyVerifyDefaults applies the graph-level verify_after_edit / verify_command
+// / max_verify_retries defaults.
+func (n *Node) applyVerifyDefaults(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// verify_after_edit + verify_command + max_verify_retries: graph-level
 	// defaults then node-level overrides.
 	if v, ok := graphAttrs["verify_after_edit"]; ok {
@@ -210,6 +271,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.MaxVerifyRetries = i
 		}
 	}
+}
+
+// applyVerifyOverrides applies the node-level verify_after_edit / verify_command
+// / max_verify_retries overrides.
+func (n *Node) applyVerifyOverrides(cfg *AgentNodeConfig) {
 	if v, ok := n.Attrs["verify_after_edit"]; ok {
 		cfg.VerifyAfterEdit = v == "true"
 		cfg.VerifyAfterEditSet = true
@@ -222,8 +288,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.MaxVerifyRetries = i
 		}
 	}
+}
 
-	// plan_before_execute (with "plan" shorthand alias): graph then node.
+// applyPlanBeforeExecute resolves plan_before_execute (with "plan" shorthand
+// alias): graph default then node override.
+func (n *Node) applyPlanBeforeExecute(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	if v, ok := graphAttrs["plan_before_execute"]; ok {
 		cfg.PlanBeforeExecute = v == "true"
 		cfg.PlanBeforeExecuteSet = true
@@ -235,7 +304,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 		cfg.PlanBeforeExecute = v == "true"
 		cfg.PlanBeforeExecuteSet = true
 	}
+}
 
+// applyModelProvider resolves llm_model and llm_provider with graph defaults
+// then node overrides.
+func (n *Node) applyModelProvider(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// Model/provider with graph defaults.
 	if v, ok := graphAttrs["llm_model"]; ok {
 		cfg.Model = v
@@ -249,16 +322,21 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	if v, ok := n.Attrs["llm_provider"]; ok {
 		cfg.Provider = v
 	}
+}
 
-	// reasoning_effort: graph then node; non-empty wins.
+// applyReasoningEffort resolves reasoning_effort: graph then node; non-empty wins.
+func (n *Node) applyReasoningEffort(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	if v, ok := graphAttrs["reasoning_effort"]; ok && v != "" {
 		cfg.ReasoningEffort = v
 	}
 	if v, ok := n.Attrs["reasoning_effort"]; ok && v != "" {
 		cfg.ReasoningEffort = v
 	}
+}
 
-	// cache_tool_results: graph default true-only; node-level tri-state override.
+// applyCache resolves cache_tool_results: graph default true-only; node-level
+// tri-state override.
+func (n *Node) applyCache(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	if v, ok := graphAttrs["cache_tool_results"]; ok && v == "true" {
 		cfg.CacheToolResults = true
 		cfg.CacheToolResultsSet = true
@@ -267,7 +345,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 		cfg.CacheToolResults = v == "true"
 		cfg.CacheToolResultsSet = true
 	}
+}
 
+// applyCompaction resolves context_compaction (graph "auto" default, node
+// override) and the compaction threshold.
+func (n *Node) applyCompaction(cfg *AgentNodeConfig, graphAttrs map[string]string) {
 	// context_compaction: graph "auto" default, node override.
 	if v, ok := graphAttrs["context_compaction"]; ok && v == "auto" {
 		cfg.ContextCompaction = "auto"
@@ -283,7 +365,11 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 			cfg.CompactionThreshold = f
 		}
 	}
+}
 
+// applyWritablePathsAndCommitOnly resolves the node-only writable_paths and
+// commit_only attrs.
+func (n *Node) applyWritablePathsAndCommitOnly(cfg *AgentNodeConfig) {
 	if raw, ok := n.Attrs["writable_paths"]; ok {
 		cfg.WritablePathsSet = true
 		cfg.WritablePaths = splitCommaNoEmpty(raw)
@@ -292,8 +378,6 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 	if v, ok := n.Attrs["commit_only"]; ok {
 		cfg.CommitOnly = parseBoolAttr(v)
 	}
-
-	return cfg
 }
 
 // splitCommaNoEmpty splits s on commas, trims whitespace from each entry, and
@@ -444,22 +528,37 @@ func (n *Node) ParallelConfig() ParallelNodeConfig {
 		JoinID:          n.Attrs["parallel_join"],
 		FanInPolicy:     n.Attrs["fan_in_policy"],
 	}
+	n.applyQuorum(&cfg)
+	n.applyMaxConcurrency(&cfg)
+	n.applyBranchTimeout(&cfg)
+	return cfg
+}
+
+// applyQuorum resolves the quorum attr (positive only).
+func (n *Node) applyQuorum(cfg *ParallelNodeConfig) {
 	if v := n.Attrs["quorum"]; v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {
 			cfg.Quorum = i
 		}
 	}
+}
+
+// applyMaxConcurrency resolves the max_concurrency attr (positive only).
+func (n *Node) applyMaxConcurrency(cfg *ParallelNodeConfig) {
 	if v := n.Attrs["max_concurrency"]; v != "" {
 		if i, err := strconv.Atoi(v); err == nil && i > 0 {
 			cfg.MaxConcurrency = i
 		}
 	}
+}
+
+// applyBranchTimeout resolves the branch_timeout attr (positive only).
+func (n *Node) applyBranchTimeout(cfg *ParallelNodeConfig) {
 	if v := n.Attrs["branch_timeout"]; v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			cfg.BranchTimeout = d
 		}
 	}
-	return cfg
 }
 
 // RetryConfig is a typed view over the retry-related attributes shared
@@ -485,12 +584,27 @@ type RetryConfig struct {
 func (n *Node) RetryConfig(graphAttrs map[string]string) RetryConfig {
 	cfg := RetryConfig{}
 
+	n.applyRetryPolicyName(&cfg, graphAttrs)
+	n.applyMaxRetriesNode(&cfg)
+	n.applyMaxRetriesGraphDefault(&cfg, graphAttrs)
+	n.applyBaseDelayNode(&cfg)
+	n.applyBaseDelayGraphDefault(&cfg, graphAttrs)
+
+	return cfg
+}
+
+// applyRetryPolicyName resolves retry_policy (node) with fallback to the graph
+// default_retry_policy.
+func (n *Node) applyRetryPolicyName(cfg *RetryConfig, graphAttrs map[string]string) {
 	if v, ok := n.Attrs["retry_policy"]; ok && v != "" {
 		cfg.PolicyName = v
 	} else if v, ok := graphAttrs["default_retry_policy"]; ok && v != "" {
 		cfg.PolicyName = v
 	}
+}
 
+// applyMaxRetriesNode resolves the node-level max_retries value.
+func (n *Node) applyMaxRetriesNode(cfg *RetryConfig) {
 	// max_retries: try node first; if present but unparseable, cascade to
 	// graph default rather than leaving MaxRetriesSet=false. Preserves the
 	// old engine_checkpoint.maxRetries fall-through semantics.
@@ -500,6 +614,11 @@ func (n *Node) RetryConfig(graphAttrs map[string]string) RetryConfig {
 			cfg.MaxRetriesSet = true
 		}
 	}
+}
+
+// applyMaxRetriesGraphDefault applies the graph default_max_retry when the node
+// did not set a parseable max_retries.
+func (n *Node) applyMaxRetriesGraphDefault(cfg *RetryConfig, graphAttrs map[string]string) {
 	if !cfg.MaxRetriesSet {
 		if v, ok := graphAttrs["default_max_retry"]; ok && v != "" {
 			if i, err := strconv.Atoi(v); err == nil {
@@ -508,7 +627,10 @@ func (n *Node) RetryConfig(graphAttrs map[string]string) RetryConfig {
 			}
 		}
 	}
+}
 
+// applyBaseDelayNode resolves the node-level base_delay value.
+func (n *Node) applyBaseDelayNode(cfg *RetryConfig) {
 	// base_delay: same cascade pattern as max_retries. The graph key
 	// `default_base_delay` is reserved for symmetry with the other retry
 	// attrs even though the current codebase doesn't set it from pipelines
@@ -519,6 +641,11 @@ func (n *Node) RetryConfig(graphAttrs map[string]string) RetryConfig {
 			cfg.BaseDelaySet = true
 		}
 	}
+}
+
+// applyBaseDelayGraphDefault applies the graph default_base_delay when the node
+// did not set a parseable base_delay.
+func (n *Node) applyBaseDelayGraphDefault(cfg *RetryConfig, graphAttrs map[string]string) {
 	if !cfg.BaseDelaySet {
 		if v, ok := graphAttrs["default_base_delay"]; ok && v != "" {
 			if d, err := time.ParseDuration(v); err == nil {
@@ -527,6 +654,4 @@ func (n *Node) RetryConfig(graphAttrs map[string]string) RetryConfig {
 			}
 		}
 	}
-
-	return cfg
 }


### PR DESCRIPTION
## What

Behavior-preserving decomposition of the over-threshold config parsers so both `gocyclo` and `gocognit` report `<=8` for every function.

- `(*Node).AgentConfig`, `(*Node).RetryConfig`, `(*Node).ParallelConfig` in `pipeline/node_config.go`
- `(*CodergenHandler).buildConfig` in `pipeline/handlers/codergen.go`

Each was split into small focused helpers.

## Why

This is a prerequisite for #393 (and future edits): those functions previously exceeded the `gocyclo`/`gocognit <= 8` complexity gate, so any touch to them would fail pre-commit hooks. Decomposing them now lets #393 and future work commit under the gate.

## Behavior

Zero behavior change. Pure mechanical extraction — the graph-default-then-node-override ordering, every condition, and all evaluation semantics are unchanged. No new attributes, no API changes.

## Verification

- `gocyclo -over 8` and `gocognit -over 8` both empty on `pipeline/node_config.go` and `pipeline/handlers/codergen.go`
- `go build ./...` green
- `go test ./pipeline/... -short` green
- Pre-commit quality gates (format, vet, build, tests, race, complexity) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzCQexSnLpdasxcYKRhFVZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785517065&installation_id=131176874&pr_number=433&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F433&signature=fa4d7217566ad02ec83a75234e92f74cc283b3acc56ca975ed885caf070998b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with an unreleased entry describing the latest internal cleanup.

* **Refactor**
  * Simplified several configuration-processing paths to make them easier to maintain.
  * Preserved existing behavior, precedence rules, and evaluation order with no API changes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->