### PR TITLE
refactor: route claude-code/ACP config through typed AgentNodeConfig accessors (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Codergen claude-code/ACP config now reads through the typed
+  `AgentNodeConfig` accessor (#393).** The claude-code/ACP backend parsers
+  (`selectBackend`, `applyMCPServers`, `applyToolLists`,
+  `isNodeToolAccessRestricted`, `applyMaxBudget`, `applyPermissionMode`,
+  `buildACPConfig`, and the `auto_status` check) no longer read `node.Attrs`
+  directly; the `max_budget_usd` accessor now surfaces its `ParseFloat` error via
+  `AgentNodeConfig.MaxBudgetUSDErr` so an unparseable value still hard-fails
+  instead of being silently dropped.
 - **Behavior-preserving decomposition of the config parsers to satisfy the
   complexity gate (#393 follow-up).** `(*Node).AgentConfig`, `(*Node).RetryConfig`,
   `(*Node).ParallelConfig` (`pipeline/node_config.go`) and

--- a/pipeline/handlers/codergen.go
+++ b/pipeline/handlers/codergen.go
@@ -164,7 +164,7 @@ func (h *CodergenHandler) trackExternalBackendUsage(backend pipeline.AgentBacken
 // global --backend flag is "claude-code", enabling mixed-backend pipelines.
 func (h *CodergenHandler) selectBackend(node *pipeline.Node) (pipeline.AgentBackend, error) {
 	// Check node-level backend attr (explicit override always wins).
-	if backend := node.Attrs["backend"]; backend != "" {
+	if backend := node.AgentConfig(h.graphAttrs).Backend; backend != "" {
 		switch backend {
 		case "claude-code":
 			return h.ensureClaudeCodeBackend()
@@ -316,8 +316,8 @@ func parseClaudeCodeToolAttrs(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeCon
 
 // applyMCPServers parses and sets MCPServers from node attrs if present.
 func applyMCPServers(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) error {
-	raw, ok := node.Attrs["mcp_servers"]
-	if !ok || raw == "" {
+	raw := node.AgentConfig(nil).McpServers
+	if raw == "" {
 		return nil
 	}
 	servers, err := pipeline.ParseMCPServers(raw)
@@ -340,10 +340,11 @@ func applyToolLists(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) {
 	if isNodeToolAccessRestricted(node) {
 		return
 	}
-	if raw := node.Attrs["allowed_tools"]; raw != "" {
+	cfg := node.AgentConfig(nil)
+	if raw := cfg.AllowedTools; raw != "" {
 		ccCfg.AllowedTools = pipeline.ParseToolList(raw)
 	}
-	if raw := node.Attrs["disallowed_tools"]; raw != "" {
+	if raw := cfg.DisallowedTools; raw != "" {
 		ccCfg.DisallowedTools = pipeline.ParseToolList(raw)
 	}
 }
@@ -353,7 +354,7 @@ func applyToolLists(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) {
 // agent.SessionConfig.IsToolAccessRestricted; defined here to avoid an
 // import cycle. Issue: github.com/2389-research/tracker#258.
 func isNodeToolAccessRestricted(node *pipeline.Node) bool {
-	return strings.TrimSpace(node.Attrs["tool_access"]) != ""
+	return strings.TrimSpace(node.AgentConfig(nil).ToolAccess) != ""
 }
 
 // canonicalClaudeCodeToolDenyList is the best-effort enumeration of
@@ -404,16 +405,12 @@ func parseClaudeCodeBudgetAttrs(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeC
 
 // applyMaxBudget parses and applies the max_budget_usd attribute if present.
 func applyMaxBudget(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) error {
-	raw, ok := node.Attrs["max_budget_usd"]
-	if !ok || raw == "" {
-		return nil
+	cfg := node.AgentConfig(nil)
+	if cfg.MaxBudgetUSDErr != nil {
+		return fmt.Errorf("node %q: %w", node.ID, cfg.MaxBudgetUSDErr)
 	}
-	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil {
-		return fmt.Errorf("node %q: invalid max_budget_usd %q: %w", node.ID, raw, err)
-	}
-	if v > 0 {
-		ccCfg.MaxBudgetUSD = v
+	if cfg.MaxBudgetUSD > 0 {
+		ccCfg.MaxBudgetUSD = cfg.MaxBudgetUSD
 	}
 	return nil
 }
@@ -428,8 +425,8 @@ func applyPermissionMode(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) 
 	if isNodeToolAccessRestricted(node) {
 		return nil
 	}
-	raw, ok := node.Attrs["permission_mode"]
-	if !ok || raw == "" {
+	raw := node.AgentConfig(nil).PermissionMode
+	if raw == "" {
 		return nil
 	}
 	mode := pipeline.PermissionMode(raw)
@@ -443,7 +440,7 @@ func applyPermissionMode(node *pipeline.Node, ccCfg *pipeline.ClaudeCodeConfig) 
 // buildACPConfig constructs an ACPConfig from node attributes.
 func buildACPConfig(node *pipeline.Node) *pipeline.ACPConfig {
 	cfg := &pipeline.ACPConfig{}
-	if agent, ok := node.Attrs["acp_agent"]; ok && agent != "" {
+	if agent := node.AgentConfig(nil).ACPAgent; agent != "" {
 		cfg.Agent = agent
 	}
 	return cfg
@@ -854,7 +851,7 @@ func (h *CodergenHandler) resolveTerminalStatus(node *pipeline.Node, responseTex
 		policy := node.AgentConfig(h.graphAttrs).TurnBreachPolicy
 		status, breachClass = classifyBreach(policy, sessResult, native)
 	}
-	if node.Attrs["auto_status"] == "true" && turnLimitMsg == "" {
+	if node.AgentConfig(h.graphAttrs).AutoStatus && turnLimitMsg == "" {
 		parsed, found := parseAutoStatus(responseText)
 		switch {
 		case found:

--- a/pipeline/node_config.go
+++ b/pipeline/node_config.go
@@ -3,6 +3,7 @@
 package pipeline
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +32,12 @@ type AgentNodeConfig struct {
 	AllowedTools    string
 	DisallowedTools string
 	MaxBudgetUSD    float64
+	// MaxBudgetUSDErr carries a non-nil error when max_budget_usd was present
+	// but failed to parse as a float. Unlike the other numeric attrs (which
+	// fall back to the zero value silently), the claude-code applyMaxBudget
+	// path surfaces this error to hard-fail node config — so the accessor must
+	// preserve it rather than swallow it (#393).
+	MaxBudgetUSDErr error
 	MaxCostUSD      float64 // #304: per-node cost ceiling in USD; 0 = unlimited
 	NoProgressTurns int     // #304: halt after K consecutive tool-call-free turns; 0 = disabled
 	PermissionMode  string
@@ -162,10 +169,16 @@ func (n *Node) AgentConfig(graphAttrs map[string]string) AgentNodeConfig {
 }
 
 // applyMaxBudget resolves the node-only max_budget_usd attr.
+//
+// max_budget_usd is the one numeric attr whose parse failure is not silently
+// dropped: MaxBudgetUSDErr carries the error so the claude-code path can
+// hard-fail (#393). All other unparseable numerics fall back to the zero value.
 func (n *Node) applyMaxBudget(cfg *AgentNodeConfig) {
 	if v := n.Attrs["max_budget_usd"]; v != "" {
 		if f, err := strconv.ParseFloat(v, 64); err == nil {
 			cfg.MaxBudgetUSD = f
+		} else {
+			cfg.MaxBudgetUSDErr = fmt.Errorf("invalid max_budget_usd %q: %w", v, err)
 		}
 	}
 }

--- a/pipeline/node_config_test.go
+++ b/pipeline/node_config_test.go
@@ -4,6 +4,7 @@ package pipeline
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -177,6 +178,35 @@ func TestAgentConfig_NumericParseSuccesses(t *testing.T) {
 	}
 	if cfg.CompactionThreshold != 0.8 {
 		t.Errorf("CompactionThreshold = %v, want 0.8", cfg.CompactionThreshold)
+	}
+}
+
+// TestAgentConfig_MaxBudgetUSDParseErrorSurfaced verifies that an unparseable
+// max_budget_usd does not silently drop to zero: MaxBudgetUSDErr must carry the
+// parse error so the claude-code applyMaxBudget path can hard-fail (#393).
+func TestAgentConfig_MaxBudgetUSDParseErrorSurfaced(t *testing.T) {
+	n := &Node{Attrs: map[string]string{"max_budget_usd": "$$"}}
+	cfg := n.AgentConfig(nil)
+	if cfg.MaxBudgetUSDErr == nil {
+		t.Fatal("MaxBudgetUSDErr = nil, want a parse error for unparseable max_budget_usd")
+	}
+	if !strings.Contains(cfg.MaxBudgetUSDErr.Error(), "invalid max_budget_usd") {
+		t.Errorf("MaxBudgetUSDErr = %q, want it to name the offending attr", cfg.MaxBudgetUSDErr)
+	}
+	if cfg.MaxBudgetUSD != 0 {
+		t.Errorf("MaxBudgetUSD = %v, want 0 on parse failure", cfg.MaxBudgetUSD)
+	}
+
+	// A valid value leaves MaxBudgetUSDErr nil.
+	ok := (&Node{Attrs: map[string]string{"max_budget_usd": "5.25"}}).AgentConfig(nil)
+	if ok.MaxBudgetUSDErr != nil {
+		t.Errorf("MaxBudgetUSDErr = %v, want nil for a valid value", ok.MaxBudgetUSDErr)
+	}
+
+	// Absent attr leaves both zero-valued.
+	absent := (&Node{Attrs: map[string]string{}}).AgentConfig(nil)
+	if absent.MaxBudgetUSDErr != nil {
+		t.Errorf("MaxBudgetUSDErr = %v, want nil when attr absent", absent.MaxBudgetUSDErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Migrates the claude-code and ACP config parsing in `pipeline/handlers/codergen.go` off raw `node.Attrs[...]` map reads and onto the typed `AgentNodeConfig` accessor (`node.AgentConfig(...)`). This aligns codergen with the typed-config convention documented in CLAUDE.md ("don't add fresh `node.Attrs[...]` reads").

Attributes migrated:
- `backend` (in `selectBackend`)
- `mcp_servers` (`applyMCPServers`)
- `allowed_tools` / `disallowed_tools` (`applyToolLists`)
- `tool_access` (`isNodeToolAccessRestricted`)
- `max_budget_usd` (`applyMaxBudget`)
- `permission_mode` (`applyPermissionMode`)
- `acp_agent` (`buildACPConfig`)
- `auto_status` (`resolveTerminalStatus`)

### MaxBudgetUSDErr surfacing

`max_budget_usd` is the one numeric attr whose parse failure must not be silently dropped — the claude-code `applyMaxBudget` path hard-fails node config on a malformed value. The accessor previously would have swallowed the parse error (like the other numeric attrs, which fall back to the zero value). To preserve the hard-fail behavior, `AgentNodeConfig` now carries a `MaxBudgetUSDErr error` field: `Node.applyMaxBudget` records the parse error there, and `codergen.applyMaxBudget` returns it as `node %q: %w` rather than swallowing it. Per-node test coverage added in `node_config_test.go`.

Closes #393

## Stacking

This PR is **STACKED** on the decomposition PR (base `refactor/decompose-config-parsers`) and should merge **after** it. The typed-accessor migration builds on the decomposed config parsers.

## Verification

- `gocyclo -over 8` / `gocognit -over 8` on `node_config.go` + `codergen.go`: empty (clean)
- `go build ./...`: pass
- `go test ./pipeline/... -short`: pass
- Full pre-commit gates passed: gofmt, go vet, build, tests (19 packages), race detector, coverage (pipeline 85.5%), complexity (cyclomatic ≤ 8, cognitive ≤ 8), dippin lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CzCQexSnLpdasxcYKRhFVZ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785517793&installation_id=131176874&pr_number=434&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F434&signature=2d36979a35c2fdf793f669227354db6ab4862f978051a4340abd7c01af4f02b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->