### PR TITLE
docs: add rolling Now/Next/Later roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ bin/
 /mammoth
 /tracker
 /tracker-conformance
+/tracker-swebench
+/agent-runner
 /generate
 /jailcheck
+/predictions.jsonl
 .DS_Store
 .tracker/
 .scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ parallel agents via a TUI dashboard. Built by 2389.ai.
 - Run `dippin doctor` on ALL example .dip files — aim for A grade across the board
 - Run `dippin simulate -all-paths` on the three core pipelines
 - Update CHANGELOG.md and README.md
+- Update ROADMAP.md — promote/retire workstreams, close finished milestones (see ROADMAP.md § How this file is maintained)
 - After the `release: vX.Y.Z` PR merges, tag the merge commit and push:
   - `git tag -a vX.Y.Z <merge-commit-sha> -m "release: vX.Y.Z"`
   - `git push origin vX.Y.Z`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,119 @@
+# Tracker Roadmap
+
+A rolling engineering roadmap in three tiers — no dates:
+
+- **Now** — the current focus. Every Now workstream has a GitHub milestone with its
+  issues attached; the milestone closing is the workstream finishing.
+- **Next** — queued. A Next workstream starts (and gets a milestone) when a Now
+  workstream closes.
+- **Later** — parked. Revisited at releases; promoted when it starts blocking real work.
+
+Refreshed in every release PR (see CLAUDE.md → Before releasing).
+Last updated: 2026-07-05, after v0.42.0.
+
+## Now
+
+### Engine correctness
+
+**Goal:** a pipeline can never report `Done` while a goal gate sits at
+`outcome=fail`, and packed `.dipx` runs behave exactly like source-tree runs.
+
+- #348 (P1) goal-gate retry re-runs the escalation tail, never the gate —
+  pipeline completes `Done` with the gate at `outcome=fail`
+- #430 (P2) `graph.workflow_dir` is empty in packed `.dipx` runs
+
+**Done when:** the gate re-arms on retry with a regression test, and `.dipx`
+runs populate `workflow_dir`. Milestone: **Engine correctness**.
+
+### Epic #308 closeout
+
+**Goal:** finish Phase 3 of build_product hardening and close the epic.
+Phases 0–2 (silent-halt fix, never-lose-work, language-native quality gates)
+shipped through v0.42.0.
+
+- #304 engine: budget by cost + no-progress detector; per-node turn count
+  becomes a backstop
+- #307 docs+refactor: build_product vs superspec, backport the spec-coherence
+  preflight, resolve examples/ vs workflows/ duplication
+
+**Done when:** #304 and #307 close, then #308 closes. Milestone: **Epic #308 closeout**.
+
+### SWE-bench: first scored run
+
+**Goal:** turn the merged harness (`cmd/tracker-swebench/`) into a published
+SWE-bench Verified score, joining AttractorBench (0.805) and Terminal-Bench
+2.0 (56.2%) on the board.
+
+- #465 root-cause the empty `model_patch` smoke run, full Verified run on
+  aibox01, publish the score
+
+**Done when:** a full Verified run scores with the official evaluation harness
+and the number is recorded. Milestone: **SWE-bench first score**.
+
+## Next
+
+### Parallel-first resilience
+
+**Goal:** parallel milestone execution becomes first-class — a fix loop on one
+branch can't starve another, and a killed run resumes mid-node instead of
+replaying completed turns.
+
+- #420 branch-scoped retry, context, and fix-attempt counters (retires the
+  global-restart-counter gotcha)
+- #427 sub-node turn checkpointing for mid-node resume (#422 follow-up)
+
+### Cost & efficiency
+
+**Goal:** no single reviewer or branch can silently burn a disproportionate
+share of a run's budget.
+
+- #353 review fan-out cost asymmetry — one reviewer burned 32% of run cost
+  (2.6M uncached input tokens) to duplicate a 42-second finding; builds on
+  #304's budget machinery and v0.41's memoization + diff-scoped review panels
+
+### Code health — load-bearing tier
+
+**Goal:** the refactors that make future engine/CLI work cheaper and safer.
+
+- #396 replace 11 config-smuggling package globals in cmd/tracker with an
+  explicit `runOptions` struct
+- #393 codergen claude-code/ACP parsers go through typed `AgentNodeConfig`
+  accessors (9 raw `node.Attrs` reads today)
+
+## Later
+
+### Sandbox breadth
+
+- #281 per-OS `writable_paths` enforcement: macOS Sandbox / FreeBSD Capsicum —
+  the macOS half is the likeliest promotion, since development happens on
+  macOS and the jail currently refuses everything non-Linux
+- #280 file-scoped Bash enforcement investigation
+- #279 rescope `overrideAlreadyRecorded` to checkpoint generation
+
+### Code health — cosmetic tier
+
+- #395 collapse pervasive near-identical duplication (engine emits, llm
+  adapter scaffolding, tui content types)
+- #398 extract inline `prompt:`/`command:` bodies into testable sidecar files
+
+### Security docs & process
+
+- #284 Linux security primitives reference doc
+- #285 9-class audit checklist for `writable_paths` changes
+- #286 "freeze and prove" pattern for security PRs
+
+### Benchmark cadence & the v1.0 question
+
+- Terminal-Bench 2.0 iteration beyond 56.2% (failure-class triage from the
+  first run)
+- AttractorBench re-runs as new models land
+- Define what v1.0 means for tracker: API stability surface, docs bar,
+  deprecation policy
+
+## How this file is maintained
+
+- A Now workstream finishes → close its milestone → promote a workstream from
+  Next (create its milestone, attach issues) → update this file, all in one PR.
+- Only Now-tier workstreams get milestones; Next/Later live here only.
+- Every release PR refreshes this file (CLAUDE.md → Before releasing).
+- New issues land in a tier when triaged; anything unlisted is implicitly Later.

--- a/docs/superpowers/plans/2026-04-08-openai-compat-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-08-openai-compat-review-fixes.md
@@ -1,0 +1,979 @@
+# OpenAI-Compat Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Address all critical and important findings from the 11-reviewer expert panel review of the `feat/openai-compat-provider` branch.
+
+**Architecture:** Fixes are organized by severity (critical first) and independence (parallelizable tasks grouped). Each task is self-contained with tests written before implementation.
+
+**Tech Stack:** Go, httptest, TDD
+
+---
+
+### Task 1: Fix credential leak — add OPENAI_COMPAT env vars to subprocess stripping
+
+**Files:**
+- Modify: `pipeline/handlers/backend_claudecode.go:240-245`
+- Modify: `pipeline/handlers/backend_acp.go:371-381`
+- Test: `pipeline/handlers/backend_claudecode_env_test.go`
+
+This is a one-line security fix per file. The existing test in `backend_claudecode_env_test.go` already iterates `providerKeyPrefixes` and asserts none leak — adding the new prefix to the list means the test covers it automatically.
+
+- [ ] **Step 1: Write a failing test that sets OPENAI_COMPAT_API_KEY and asserts it's stripped**
+
+In `pipeline/handlers/backend_claudecode_env_test.go`, add a test case that explicitly sets `OPENAI_COMPAT_API_KEY` and verifies `buildEnv()` strips it:
+
+```go
+func TestBuildEnv_StripsOpenAICompatKey(t *testing.T) {
+	t.Setenv("OPENAI_COMPAT_API_KEY", "test-compat-key-12345")
+	t.Setenv("TRACKER_PASS_API_KEYS", "")
+
+	env := buildEnv()
+
+	for _, e := range env {
+		if strings.HasPrefix(e, "OPENAI_COMPAT_API_KEY=") {
+			t.Errorf("expected OPENAI_COMPAT_API_KEY stripped from env, but found: %s", e)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./pipeline/handlers/ -run TestBuildEnv_StripsOpenAICompatKey -v`
+Expected: FAIL — `OPENAI_COMPAT_API_KEY` is present in env because it's not in `providerKeyPrefixes`.
+
+- [ ] **Step 3: Add OPENAI_COMPAT keys to both stripping lists**
+
+In `pipeline/handlers/backend_claudecode.go:240-245`, add the new prefix:
+
+```go
+var providerKeyPrefixes = []string{
+	"ANTHROPIC_API_KEY=",
+	"OPENAI_API_KEY=",
+	"GEMINI_API_KEY=",
+	"GOOGLE_API_KEY=",
+	"OPENAI_COMPAT_API_KEY=",
+}
+```
+
+In `pipeline/handlers/backend_acp.go:371-381`, add both compat prefixes:
+
+```go
+var acpStrippedPrefixes = []string{
+	"ANTHROPIC_API_KEY=",
+	"OPENAI_API_KEY=",
+	"GEMINI_API_KEY=",
+	"GOOGLE_API_KEY=",
+	"ANTHROPIC_BASE_URL=",
+	"OPENAI_COMPAT_API_KEY=",
+	"OPENAI_COMPAT_BASE_URL=",
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pipeline/handlers/ -run TestBuildEnv_StripsOpenAICompatKey -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full handler test suite**
+
+Run: `go test ./pipeline/handlers/ -short -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/handlers/backend_claudecode.go pipeline/handlers/backend_acp.go pipeline/handlers/backend_claudecode_env_test.go
+git commit -m "fix: strip OPENAI_COMPAT env vars from subprocess environments"
+```
+
+---
+
+### Task 2: Handle SSE in-stream errors
+
+**Files:**
+- Modify: `llm/openaicompat/adapter.go`
+- Test: `llm/openaicompat/adapter_test.go`
+
+The Chat Completions API (and OpenRouter) can embed error objects inside 200 SSE streams. The current parser silently ignores these. We need to detect `{"error": {...}}` payloads and emit typed `EventError` events, matching the pattern in `llm/openai/adapter_sse.go:208-267`.
+
+- [ ] **Step 1: Write a failing test for SSE in-stream error detection**
+
+Add to `adapter_test.go`:
+
+```go
+func TestStream_SSEInStreamError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		lines := []string{
+			// Normal text delta first
+			`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant","content":"Hi"},"finish_reason":null}]}`,
+			"",
+			// Error mid-stream (e.g., quota exceeded)
+			`data: {"error":{"message":"Rate limit exceeded","type":"rate_limit_error","code":"rate_limit_exceeded"}}`,
+			"",
+			`data: [DONE]`,
+			"",
+		}
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	ch := adapter.Stream(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	var gotText bool
+	var gotError bool
+	var errorMsg string
+	for evt := range ch {
+		switch evt.Type {
+		case llm.EventTextDelta:
+			gotText = true
+		case llm.EventError:
+			gotError = true
+			if evt.Err != nil {
+				errorMsg = evt.Err.Error()
+			}
+		}
+	}
+
+	if !gotText {
+		t.Error("expected text delta before error")
+	}
+	if !gotError {
+		t.Error("expected EventError for in-stream error")
+	}
+	if !strings.Contains(errorMsg, "Rate limit exceeded") {
+		t.Errorf("error message should contain 'Rate limit exceeded', got: %s", errorMsg)
+	}
+}
+```
+
+Add `"strings"` to the import block if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./llm/openaicompat/ -run TestStream_SSEInStreamError -v`
+Expected: FAIL — error event is not emitted because the error JSON parses as a zero-valued `chatStreamChunk` and is silently ignored.
+
+- [ ] **Step 3: Add chatStreamError type and detection to parseSSE**
+
+Add a new struct after the existing SSE chunk types at the bottom of `adapter.go`:
+
+```go
+// chatStreamError represents an error object embedded in a 200 SSE stream.
+type chatStreamError struct {
+	Error struct {
+		Message string `json:"message"`
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+	} `json:"error"`
+}
+```
+
+In the `parseSSE` method, after the `[DONE]` check (line 204) and before the JSON unmarshal of `chatStreamChunk` (line 207), add error detection:
+
+```go
+		// Check for error objects embedded in the SSE stream.
+		// Some providers (OpenRouter, etc.) send {"error": {...}} within 200 streams.
+		if strings.Contains(data, `"error"`) {
+			var errChunk chatStreamError
+			if err := json.Unmarshal([]byte(data), &errChunk); err == nil && errChunk.Error.Message != "" {
+				ch <- llm.StreamEvent{
+					Type: llm.EventError,
+					Err:  sseErrorToTyped(errChunk.Error.Code, errChunk.Error.Message),
+				}
+				continue
+			}
+		}
+```
+
+Add the `sseErrorToTyped` function (matching the pattern in `llm/openai/adapter_sse.go:243-267`):
+
+```go
+// sseErrorToTyped maps an error code from an SSE stream event to a typed error.
+func sseErrorToTyped(code, message string) error {
+	base := llm.ProviderError{
+		SDKError:  llm.SDKError{Msg: "openai-compat: " + message},
+		Provider:  "openai-compat",
+		ErrorCode: code,
+	}
+	switch code {
+	case "insufficient_quota":
+		return &llm.QuotaExceededError{ProviderError: base}
+	case "invalid_api_key", "authentication_error":
+		return &llm.AuthenticationError{ProviderError: base}
+	case "model_not_found":
+		return &llm.NotFoundError{ProviderError: base}
+	case "invalid_request_error", "invalid_request":
+		return &llm.InvalidRequestError{ProviderError: base}
+	case "context_length_exceeded":
+		return &llm.ContextLengthError{ProviderError: base}
+	case "content_filter", "content_policy_violation":
+		return &llm.ContentFilterError{ProviderError: base}
+	case "rate_limit_exceeded":
+		return &llm.RateLimitError{ProviderError: base}
+	case "server_error", "internal_error":
+		return &llm.ServerError{ProviderError: base}
+	default:
+		return &llm.InvalidRequestError{ProviderError: base}
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./llm/openaicompat/ -run TestStream_SSEInStreamError -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full openaicompat test suite**
+
+Run: `go test ./llm/openaicompat/ -v`
+Expected: All tests pass (new + existing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add llm/openaicompat/adapter.go llm/openaicompat/adapter_test.go
+git commit -m "fix: handle SSE in-stream errors in openai-compat provider"
+```
+
+---
+
+### Task 3: Treat empty responses as errors
+
+**Files:**
+- Modify: `llm/openaicompat/translate.go:310-313`
+- Modify: `llm/openaicompat/translate_test.go`
+
+The CLAUDE.md rule: "Empty agent responses (0 tokens, 0 tool calls) are failures, not successes." Currently `translateResponse` returns `FinishReason: "stop"` for empty choices.
+
+- [ ] **Step 1: Update the existing TestTranslateResponse_EmptyChoices test to expect an error**
+
+Replace the existing test in `translate_test.go`:
+
+```go
+func TestTranslateResponse_EmptyChoices(t *testing.T) {
+	respJSON := `{
+		"id": "chatcmpl-789",
+		"model": "gpt-4.1",
+		"choices": [],
+		"usage": {
+			"prompt_tokens": 5,
+			"completion_tokens": 0,
+			"total_tokens": 5
+		}
+	}`
+
+	_, err := translateResponse([]byte(respJSON))
+	if err == nil {
+		t.Fatal("expected error for empty choices, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention 'empty', got: %s", err)
+	}
+}
+```
+
+Add `"strings"` to the import block if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./llm/openaicompat/ -run TestTranslateResponse_EmptyChoices -v`
+Expected: FAIL — currently returns nil error.
+
+- [ ] **Step 3: Return an error for empty choices**
+
+In `translate.go`, change the empty choices handling at line 310-313:
+
+```go
+	if len(cr.Choices) > 0 {
+		choice := cr.Choices[0]
+		resp.Message.Content = translateChoiceMessage(choice.Message)
+		resp.FinishReason = translateFinishReason(choice.FinishReason, len(choice.Message.ToolCalls) > 0)
+	} else {
+		return nil, fmt.Errorf("openai-compat: empty response (0 choices, 0 content)")
+	}
+```
+
+Add `"fmt"` to the import block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./llm/openaicompat/ -run TestTranslateResponse_EmptyChoices -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `go test ./llm/openaicompat/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add llm/openaicompat/translate.go llm/openaicompat/translate_test.go
+git commit -m "fix: treat empty API responses as errors per project rules"
+```
+
+---
+
+### Task 4: Add openai-compat to tracker doctor, error messages, and config persistence
+
+**Files:**
+- Modify: `cmd/tracker/doctor.go:66-73`
+- Modify: `cmd/tracker/doctor.go:15-27`
+- Modify: `cmd/tracker/config_env.go:11-19`
+
+- [ ] **Step 1: Add openai-compat to the doctor provider check list**
+
+In `cmd/tracker/doctor.go`, add the compat provider to the `providers` slice inside `checkProviders()`:
+
+```go
+	providers := []struct {
+		name    string
+		envVars []string
+	}{
+		{"Anthropic", []string{"ANTHROPIC_API_KEY"}},
+		{"OpenAI", []string{"OPENAI_API_KEY"}},
+		{"Gemini", []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}},
+		{"OpenAI-Compat", []string{"OPENAI_COMPAT_API_KEY"}},
+	}
+```
+
+- [ ] **Step 2: Update formatLLMClientError to mention openai-compat**
+
+In `cmd/tracker/doctor.go`, update the error message in `formatLLMClientError`:
+
+```go
+func formatLLMClientError(err error) error {
+	if strings.Contains(err.Error(), "no providers configured") {
+		return fmt.Errorf(`no LLM providers configured
+
+  Set at least one API key:
+    export ANTHROPIC_API_KEY=sk-ant-...
+    export OPENAI_API_KEY=sk-...
+    export GEMINI_API_KEY=...
+    export OPENAI_COMPAT_API_KEY=...  (+ OPENAI_COMPAT_BASE_URL for non-OpenRouter endpoints)
+
+  Or run: tracker setup`)
+	}
+	return fmt.Errorf("create LLM client: %w", err)
+}
+```
+
+- [ ] **Step 3: Add compat env vars to config persistence allowlist**
+
+In `cmd/tracker/config_env.go`, add the two new keys to `providerEnvKeys`:
+
+```go
+var providerEnvKeys = map[string]struct{}{
+	"OPENAI_API_KEY":          {},
+	"ANTHROPIC_API_KEY":       {},
+	"GEMINI_API_KEY":          {},
+	"GOOGLE_API_KEY":          {},
+	"OPENAI_BASE_URL":         {},
+	"ANTHROPIC_BASE_URL":      {},
+	"GEMINI_BASE_URL":         {},
+	"OPENAI_COMPAT_API_KEY":   {},
+	"OPENAI_COMPAT_BASE_URL":  {},
+}
+```
+
+- [ ] **Step 4: Verify build**
+
+Run: `go build ./cmd/tracker/`
+Expected: Clean build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/tracker/doctor.go cmd/tracker/config_env.go
+git commit -m "fix: add openai-compat to doctor, error messages, and config persistence"
+```
+
+---
+
+### Task 5: Add missing TextStart/TextEnd lifecycle events to SSE parser
+
+**Files:**
+- Modify: `llm/openaicompat/adapter.go`
+- Test: `llm/openaicompat/adapter_test.go`
+
+The `StreamAccumulator` auto-creates text parts when `TextID` is missing, but other providers emit `TextStart`/`TextEnd` lifecycle events. Adding these ensures conformance and prevents bugs in consumers that expect the full lifecycle.
+
+- [ ] **Step 1: Write a failing test that checks for TextStart and TextEnd events**
+
+Add to `adapter_test.go`:
+
+```go
+func TestStream_TextLifecycleEvents(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		lines := []string{
+			`data: {"id":"c1","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			"",
+			`data: [DONE]`,
+			"",
+		}
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	ch := adapter.Stream(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	var types []llm.StreamEventType
+	for evt := range ch {
+		types = append(types, evt.Type)
+	}
+
+	// Must contain TextStart before TextDelta and TextEnd before Finish
+	var gotTextStart, gotTextEnd bool
+	for _, tp := range types {
+		if tp == llm.EventTextStart {
+			gotTextStart = true
+		}
+		if tp == llm.EventTextEnd {
+			gotTextEnd = true
+		}
+	}
+	if !gotTextStart {
+		t.Error("expected EventTextStart before text deltas")
+	}
+	if !gotTextEnd {
+		t.Error("expected EventTextEnd before finish")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./llm/openaicompat/ -run TestStream_TextLifecycleEvents -v`
+Expected: FAIL — no `TextStart` or `TextEnd` events emitted.
+
+- [ ] **Step 3: Add TextStart/TextEnd emission to parseSSE**
+
+In `adapter.go`, add a `textStarted` bool alongside the existing state variables in `parseSSE` (near line 182):
+
+```go
+	firstChunk := true
+	textStarted := false
+```
+
+In the text content delta block (around line 224), emit `TextStart` on first text delta:
+
+```go
+			// Text content delta.
+			if choice.Delta.Content != "" {
+				if !textStarted {
+					ch <- llm.StreamEvent{Type: llm.EventTextStart, TextID: "text"}
+					textStarted = true
+				}
+				ch <- llm.StreamEvent{
+					Type:   llm.EventTextDelta,
+					TextID: "text",
+					Delta:  choice.Delta.Content,
+				}
+			}
+```
+
+In the `[DONE]` handling block (around line 198), emit `TextEnd` before tool call ends:
+
+```go
+		if data == "[DONE]" {
+			if textStarted {
+				ch <- llm.StreamEvent{Type: llm.EventTextEnd, TextID: "text"}
+			}
+			a.emitAccumulatedToolCallEnds(toolCalls, ch)
+			if deferredFinish != nil {
+				ch <- *deferredFinish
+			}
+			break
+		}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./llm/openaicompat/ -run TestStream_TextLifecycleEvents -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full openaicompat test suite**
+
+Run: `go test ./llm/openaicompat/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add llm/openaicompat/adapter.go llm/openaicompat/adapter_test.go
+git commit -m "fix: emit TextStart/TextEnd lifecycle events in openai-compat SSE parser"
+```
+
+---
+
+### Task 6: Add bounded response reads
+
+**Files:**
+- Modify: `llm/openaicompat/adapter.go`
+- Test: `llm/openaicompat/adapter_test.go`
+
+`io.ReadAll` with no size limit is an OOM risk, especially since this adapter targets user-controlled endpoints.
+
+- [ ] **Step 1: Write a failing test for oversized response rejection**
+
+Add to `adapter_test.go`:
+
+```go
+func TestComplete_OversizedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Write more than the limit (we'll set limit to 10MB)
+		// Just write a header that claims a huge body — the actual limit check
+		// happens on the read side, so write 11MB of data.
+		for i := 0; i < 11*1024; i++ {
+			w.Write(make([]byte, 1024))
+		}
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	_, err := adapter.Complete(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	if err == nil {
+		t.Fatal("expected error for oversized response")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (passes without error currently)**
+
+Run: `go test ./llm/openaicompat/ -run TestComplete_OversizedResponse -v`
+Expected: FAIL — currently reads the full body without limit.
+
+- [ ] **Step 3: Replace io.ReadAll with io.LimitReader**
+
+In `adapter.go`, add a constant near the top:
+
+```go
+const (
+	defaultBaseURL   = "https://openrouter.ai/api"
+	chatCompletePath = "/v1/chat/completions"
+	// maxResponseSize caps the response body to prevent OOM from malicious servers.
+	maxResponseSize = 10 * 1024 * 1024 // 10MB
+)
+```
+
+Replace the `io.ReadAll` call in `Complete()` (line 98):
+
+```go
+	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, maxResponseSize+1))
+	if err != nil {
+		return nil, &llm.NetworkError{SDKError: llm.SDKError{Msg: fmt.Sprintf("openai-compat: read response: %s", err.Error()), Cause: err}}
+	}
+	if int64(len(respBody)) > maxResponseSize {
+		return nil, &llm.InvalidRequestError{ProviderError: llm.ProviderError{
+			SDKError: llm.SDKError{Msg: "openai-compat: response body exceeds 10MB limit"},
+			Provider: "openai-compat",
+		}}
+	}
+```
+
+Replace the `io.ReadAll` call in `Stream()` error path (line 146):
+
+```go
+			respBody, _ := io.ReadAll(io.LimitReader(httpResp.Body, maxResponseSize))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./llm/openaicompat/ -run TestComplete_OversizedResponse -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `go test ./llm/openaicompat/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add llm/openaicompat/adapter.go llm/openaicompat/adapter_test.go
+git commit -m "fix: bound response body reads to 10MB in openai-compat adapter"
+```
+
+---
+
+### Task 7: Add missing test coverage for context cancellation and malformed SSE
+
+**Files:**
+- Modify: `llm/openaicompat/adapter_test.go`
+
+These are the two critical test gaps flagged by the Test Coverage reviewer.
+
+- [ ] **Step 1: Write test for context cancellation during streaming**
+
+Add to `adapter_test.go`:
+
+```go
+func TestStream_ContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+
+		// Send one chunk then block until client disconnects
+		fmt.Fprintln(w, `data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}`)
+		fmt.Fprintln(w, "")
+		if flusher != nil {
+			flusher.Flush()
+		}
+
+		// Block until the request context is done (client cancels)
+		<-r.Context().Done()
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	ch := adapter.Stream(ctx, &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	// Read the first text delta
+	evt := <-ch
+	if evt.Type != llm.EventStreamStart && evt.Type != llm.EventTextStart && evt.Type != llm.EventTextDelta {
+		// Accept any of the early events
+	}
+
+	// Cancel the context
+	cancel()
+
+	// Drain remaining events — should NOT see a context error event
+	var gotContextError bool
+	for evt := range ch {
+		if evt.Type == llm.EventError {
+			if errors.Is(evt.Err, context.Canceled) || errors.Is(evt.Err, context.DeadlineExceeded) {
+				gotContextError = true
+			}
+		}
+	}
+
+	if gotContextError {
+		t.Error("context cancellation errors should be suppressed, not emitted as EventError")
+	}
+}
+```
+
+- [ ] **Step 2: Write test for malformed JSON in SSE chunks**
+
+Add to `adapter_test.go`:
+
+```go
+func TestStream_MalformedSSEChunk(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		lines := []string{
+			`data: {"id":"c1","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`,
+			"",
+			`data: {this is not valid json}`,
+			"",
+			`data: {"id":"c1","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+			"",
+			`data: {"id":"c1","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+			"",
+			`data: [DONE]`,
+			"",
+		}
+		for _, line := range lines {
+			fmt.Fprintln(w, line)
+		}
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	ch := adapter.Stream(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	var textAccum string
+	var errorCount int
+	var gotFinish bool
+	for evt := range ch {
+		switch evt.Type {
+		case llm.EventTextDelta:
+			textAccum += evt.Delta
+		case llm.EventError:
+			errorCount++
+		case llm.EventFinish:
+			gotFinish = true
+		}
+	}
+
+	// Should have received both text deltas despite the bad chunk
+	if textAccum != "Hello world" {
+		t.Errorf("expected 'Hello world', got %q", textAccum)
+	}
+	// Should have received exactly one parse error
+	if errorCount != 1 {
+		t.Errorf("expected 1 error event for malformed chunk, got %d", errorCount)
+	}
+	// Stream should still finish cleanly
+	if !gotFinish {
+		t.Error("expected EventFinish after malformed chunk recovery")
+	}
+}
+```
+
+- [ ] **Step 3: Run both tests**
+
+Run: `go test ./llm/openaicompat/ -run "TestStream_ContextCancellation|TestStream_MalformedSSEChunk" -v`
+Expected: Both PASS (these test existing behavior that already works — we're adding coverage, not fixing bugs).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add llm/openaicompat/adapter_test.go
+git commit -m "test: add context cancellation and malformed SSE coverage for openai-compat"
+```
+
+---
+
+### Task 8: Add missing test coverage for error types and request field translation
+
+**Files:**
+- Modify: `llm/openaicompat/adapter_test.go`
+- Modify: `llm/openaicompat/translate_test.go`
+
+Covers: 5xx server errors, temperature/topP/stop translation, base URL normalization.
+
+- [ ] **Step 1: Add 500 server error test**
+
+Add to `adapter_test.go`:
+
+```go
+func TestComplete_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"Internal server error"}}`)
+	}))
+	defer srv.Close()
+
+	adapter := New("k", WithBaseURL(srv.URL), WithHTTPClient(srv.Client()))
+	_, err := adapter.Complete(context.Background(), &llm.Request{
+		Model:    "test",
+		Messages: []llm.Message{llm.UserMessage("go")},
+	})
+
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+	var serverErr *llm.ServerError
+	if !errors.As(err, &serverErr) {
+		t.Errorf("expected ServerError, got %T: %v", err, err)
+	}
+}
+```
+
+- [ ] **Step 2: Add temperature/topP/stop translation test**
+
+Add to `translate_test.go`:
+
+```go
+func TestTranslateRequest_OptionalFields(t *testing.T) {
+	temp := 0.7
+	topP := 0.9
+	maxTok := 4096
+	req := &llm.Request{
+		Model:         "gpt-4.1",
+		Messages:      []llm.Message{llm.UserMessage("hi")},
+		Temperature:   &temp,
+		TopP:          &topP,
+		MaxTokens:     &maxTok,
+		StopSequences: []string{"END", "STOP"},
+	}
+
+	body, err := translateRequest(req, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(body, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if raw["temperature"] != 0.7 {
+		t.Errorf("temperature = %v, want 0.7", raw["temperature"])
+	}
+	if raw["top_p"] != 0.9 {
+		t.Errorf("top_p = %v, want 0.9", raw["top_p"])
+	}
+	if int(raw["max_tokens"].(float64)) != 4096 {
+		t.Errorf("max_tokens = %v, want 4096", raw["max_tokens"])
+	}
+	stop, ok := raw["stop"].([]any)
+	if !ok || len(stop) != 2 {
+		t.Fatalf("stop = %v, want [END, STOP]", raw["stop"])
+	}
+	if stop[0] != "END" || stop[1] != "STOP" {
+		t.Errorf("stop = %v, want [END, STOP]", stop)
+	}
+}
+```
+
+- [ ] **Step 3: Add base URL /v1 normalization test**
+
+Add to `adapter_test.go`:
+
+```go
+func TestNew_BaseURLNormalization(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"http://localhost:1234/v1", "http://localhost:1234"},
+		{"http://localhost:1234", "http://localhost:1234"},
+		{"https://openrouter.ai/api", "https://openrouter.ai/api"},
+		{"https://api.example.com/v1", "https://api.example.com"},
+	}
+
+	for _, tt := range tests {
+		adapter := New("key", WithBaseURL(tt.input))
+		if adapter.baseURL != tt.expected {
+			t.Errorf("New(WithBaseURL(%q)).baseURL = %q, want %q", tt.input, adapter.baseURL, tt.expected)
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run all new tests**
+
+Run: `go test ./llm/openaicompat/ -run "TestComplete_ServerError|TestTranslateRequest_OptionalFields|TestNew_BaseURLNormalization" -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add llm/openaicompat/adapter_test.go llm/openaicompat/translate_test.go
+git commit -m "test: add coverage for 5xx errors, request fields, and base URL normalization"
+```
+
+---
+
+### Task 9: Simplify the errorAs test helper
+
+**Files:**
+- Modify: `llm/openaicompat/adapter_test.go`
+
+Replace the 40-line Rube Goldberg machine with direct `errors.As` calls. The cat insists.
+
+- [ ] **Step 1: Remove the errorAs helper functions (lines 498-540)**
+
+Delete these functions from `adapter_test.go`:
+- `errorAs`
+- `errorAsImpl`
+- `asAuthError`
+- `asRateLimitError`
+- `extractError`
+- `errorsAs`
+
+- [ ] **Step 2: Replace the two call sites with direct errors.As**
+
+In `TestComplete_HTTPError` (around line 131), replace:
+```go
+	var authErr *llm.AuthenticationError
+	if !errorAs(err, &authErr) {
+```
+with:
+```go
+	var authErr *llm.AuthenticationError
+	if !errors.As(err, &authErr) {
+```
+
+In `TestStream_HTTPError` (around line 329), replace:
+```go
+	var rateErr *llm.RateLimitError
+	if !errorAs(evt.Err, &rateErr) {
+```
+with:
+```go
+	var rateErr *llm.RateLimitError
+	if !errors.As(evt.Err, &rateErr) {
+```
+
+- [ ] **Step 3: Run tests to verify nothing broke**
+
+Run: `go test ./llm/openaicompat/ -v`
+Expected: All tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add llm/openaicompat/adapter_test.go
+git commit -m "refactor: replace errorAs helper pyramid with direct errors.As calls"
+```
+
+---
+
+### Task 10: Final verification
+
+- [ ] **Step 1: Run full build**
+
+Run: `go build ./...`
+Expected: Clean.
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `go test ./... -short`
+Expected: All packages pass.
+
+- [ ] **Step 3: Run vet/lint**
+
+Run: `go vet ./...`
+Expected: Clean.
+
+- [ ] **Step 4: Verify test count increased**
+
+Run: `go test ./llm/openaicompat/ -v 2>&1 | grep "^--- PASS" | wc -l`
+Expected: Should be ~25+ tests (up from 17).
+
+---
+
+## Decisions Deferred to Doctor Biz
+
+These were flagged by reviewers but require a product decision:
+
+1. **`OPENAI_API_KEY` fallback** — Spec says add it, some reviewers say don't (to avoid surprise routing to OpenRouter). Pick one, update both spec and code to match.
+
+2. **Default base URL** — VP Tech says OpenRouter default is a data exfiltration risk for enterprise. Options: keep OpenRouter (startup audience), change to empty/localhost (enterprise audience), or require explicit config (safest). This is a product positioning call.
+
+3. **`tracker setup` wizard** — Adding openai-compat to the interactive setup is a UI change that should be its own task after the above decisions are made.
+
+4. **CHANGELOG.md entry** — Should be written after all fixes land and the above decisions are resolved.

--- a/docs/superpowers/plans/2026-04-16-swebench-harness-review-fixes.md
+++ b/docs/superpowers/plans/2026-04-16-swebench-harness-review-fixes.md
@@ -1,0 +1,1516 @@
+# SWE-bench Harness Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix all critical and high-impact important issues identified by the 8-expert panel review of `cmd/tracker-swebench/`.
+
+**Architecture:** Fixes are ordered by dependency — security/correctness issues first (shell injection, diff capture, cache path), then robustness (exit codes, cleanup, resource limits), then quality-of-life (system prompt, UX, docs). Each task is independent and produces a working, testable commit.
+
+**Tech Stack:** Go 1.24+, Docker CLI, `encoding/json`, `os/exec`, `regexp`
+
+---
+
+## File Map
+
+| File | Responsibility | Tasks |
+|------|---------------|-------|
+| `cmd/tracker-swebench/docker.go` | Container lifecycle, shell commands, diff capture | 1, 2, 3, 4, 5, 6, 7 |
+| `cmd/tracker-swebench/docker_test.go` | Docker helper unit tests | 1, 2, 3, 4, 5, 6, 7 |
+| `cmd/tracker-swebench/main.go` | CLI entry, orchestration loop, signal handling | 3, 5, 6, 7, 8, 9, 11 |
+| `cmd/tracker-swebench/results.go` | Prediction writer, resume logic, stats | 8 |
+| `cmd/tracker-swebench/results_test.go` | Results writer tests | 8 |
+| `cmd/tracker-swebench/dataset.go` | Dataset parser, instance validation | 9 |
+| `cmd/tracker-swebench/dataset_test.go` | Dataset parser tests | 9 |
+| `cmd/tracker-swebench/agent-runner/main.go` | In-container agent config, system prompt | 10, 12 |
+| `cmd/tracker-swebench/agent-runner/main_test.go` | Agent-runner tests | 10, 12 |
+| `cmd/tracker-swebench/agent-runner/providers.go` | Provider adapter constructors | 10 |
+| `cmd/tracker-swebench/build.sh` | Cross-compile + docker build | 4 |
+| `cmd/tracker-swebench/Dockerfile` | Base Docker image | 4 |
+| `llm/catalog.go` | Model registry | 12 |
+
+---
+
+### Task 1: Fix shell injection in `buildCloneCmd`
+
+**Criticality:** Critical — dataset-controlled values concatenated into `sh -c` string.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:29-39`
+- Modify: `cmd/tracker-swebench/docker.go:188-195` (call site in `RunInstance`)
+- Modify: `cmd/tracker-swebench/docker_test.go:18-70`
+
+- [ ] **Step 1: Write failing test for safe clone commands**
+
+In `docker_test.go`, replace the existing `TestBuildCloneCmd` and `TestBuildCloneCmd_NoCache` with tests that verify the new signature returns two separate command slices (clone + checkout) instead of a single `sh -c` string:
+
+```go
+func TestBuildCloneCommands(t *testing.T) {
+	clone, checkout := buildCloneCommands(
+		"https://github.com/django/django.git",
+		"abc123",
+		"/workspace",
+		"/cache/django_django.git",
+	)
+
+	// Clone command must NOT use sh -c.
+	if clone[0] == "sh" {
+		t.Error("clone command must not use sh -c")
+	}
+	if clone[0] != "git" {
+		t.Errorf("clone[0] = %q, want \"git\"", clone[0])
+	}
+
+	// Must contain --reference with the bare repo path.
+	found := false
+	for i, arg := range clone {
+		if arg == "--reference" && i+1 < len(clone) && clone[i+1] == "/cache/django_django.git" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected --reference /cache/django_django.git in clone args: %v", clone)
+	}
+
+	// Must contain --dissociate.
+	hasDissociate := false
+	for _, arg := range clone {
+		if arg == "--dissociate" {
+			hasDissociate = true
+		}
+	}
+	if !hasDissociate {
+		t.Errorf("expected --dissociate in clone args: %v", clone)
+	}
+
+	// Must end with repoURL and workDir.
+	if clone[len(clone)-2] != "https://github.com/django/django.git" {
+		t.Errorf("expected repo URL as second-to-last arg, got %q", clone[len(clone)-2])
+	}
+	if clone[len(clone)-1] != "/workspace" {
+		t.Errorf("expected workDir as last arg, got %q", clone[len(clone)-1])
+	}
+
+	// Checkout must be git -C workDir checkout commit.
+	expected := []string{"git", "-C", "/workspace", "checkout", "abc123"}
+	if len(checkout) != len(expected) {
+		t.Fatalf("checkout = %v, want %v", checkout, expected)
+	}
+	for i := range expected {
+		if checkout[i] != expected[i] {
+			t.Errorf("checkout[%d] = %q, want %q", i, checkout[i], expected[i])
+		}
+	}
+}
+
+func TestBuildCloneCommands_NoCache(t *testing.T) {
+	clone, checkout := buildCloneCommands(
+		"https://github.com/django/django.git",
+		"abc123",
+		"/workspace",
+		"",
+	)
+
+	if clone[0] != "git" {
+		t.Errorf("clone[0] = %q, want \"git\"", clone[0])
+	}
+	for _, arg := range clone {
+		if arg == "--reference" {
+			t.Error("expected no --reference flag when cachePath is empty")
+		}
+		if arg == "--dissociate" {
+			t.Error("expected no --dissociate when cachePath is empty")
+		}
+	}
+
+	if checkout[0] != "git" {
+		t.Errorf("checkout[0] = %q, want \"git\"", checkout[0])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestBuildCloneCommands -v`
+Expected: FAIL — `buildCloneCommands` is undefined.
+
+- [ ] **Step 3: Implement `buildCloneCommands`**
+
+Replace the old `buildCloneCmd` function in `docker.go:29-39` with:
+
+```go
+// buildCloneCommands returns two safe argument slices: one for git clone, one
+// for git checkout. No shell is involved — arguments are passed directly to
+// exec, eliminating injection via dataset-controlled values.
+// When cachePath is non-empty, --reference and --dissociate flags are added
+// for local object reuse without creating fragile alternates dependencies.
+func buildCloneCommands(repoURL, commit, workDir, cachePath string) (cloneArgs []string, checkoutArgs []string) {
+	cloneArgs = []string{"git", "clone"}
+	if cachePath != "" {
+		cloneArgs = append(cloneArgs, "--reference", cachePath, "--dissociate")
+	}
+	cloneArgs = append(cloneArgs, repoURL, workDir)
+
+	checkoutArgs = []string{"git", "-C", workDir, "checkout", commit}
+	return cloneArgs, checkoutArgs
+}
+```
+
+- [ ] **Step 4: Update `RunInstance` call site**
+
+In `docker.go`, update the clone step in `RunInstance` (around line 188-195). Replace:
+
+```go
+cachePath := ""
+if r.CacheDir != "" {
+    cachePath = "/cache"
+}
+cloneCmd := buildCloneCmd(inst.RepoURL(), inst.BaseCommit, workDir, cachePath)
+if err = dockerExec(ctx, name, nil, cloneCmd...); err != nil {
+    return "", AgentSummary{}, fmt.Errorf("clone repo: %w", err)
+}
+```
+
+With:
+
+```go
+cachePath := ""
+if r.CacheDir != "" {
+    cachePath = "/cache/" + strings.ReplaceAll(inst.Repo, "/", "_") + ".git"
+}
+cloneArgs, checkoutArgs := buildCloneCommands(inst.RepoURL(), inst.BaseCommit, workDir, cachePath)
+if err = dockerExec(ctx, name, nil, cloneArgs...); err != nil {
+    return "", AgentSummary{}, fmt.Errorf("clone repo: %w", err)
+}
+if err = dockerExec(ctx, name, nil, checkoutArgs...); err != nil {
+    return "", AgentSummary{}, fmt.Errorf("checkout commit: %w", err)
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestBuildCloneCommands -v`
+Expected: PASS
+
+- [ ] **Step 6: Remove old tests for deleted function**
+
+Delete `TestBuildCloneCmd` and `TestBuildCloneCmd_NoCache` from `docker_test.go` (they reference the removed `buildCloneCmd` function).
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/tracker-swebench/docker.go cmd/tracker-swebench/docker_test.go
+git commit -m "fix(swebench): eliminate shell injection in buildCloneCmd
+
+Replace sh -c string concatenation with separate git clone and git
+checkout argument slices passed directly to exec. Adds --dissociate
+to prevent fragile alternates references. Fixes --reference path to
+point to the actual bare repo inside the cache mount, not the parent
+directory."
+```
+
+---
+
+### Task 2: Fix `git diff` to capture all changes including new files
+
+**Criticality:** Critical — current `git diff` misses untracked files and staged changes.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:216-221`
+
+- [ ] **Step 1: Write a test for the new `capturePatch` helper**
+
+Add to `docker_test.go`:
+
+```go
+func TestCapturePatchCommands(t *testing.T) {
+	addArgs, diffArgs := capturePatchCommands("/workspace")
+
+	// git add -A in workDir
+	expectedAdd := []string{"git", "-C", "/workspace", "add", "-A"}
+	if len(addArgs) != len(expectedAdd) {
+		t.Fatalf("addArgs = %v, want %v", addArgs, expectedAdd)
+	}
+	for i := range expectedAdd {
+		if addArgs[i] != expectedAdd[i] {
+			t.Errorf("addArgs[%d] = %q, want %q", i, addArgs[i], expectedAdd[i])
+		}
+	}
+
+	// git diff HEAD in workDir
+	expectedDiff := []string{"git", "-C", "/workspace", "diff", "HEAD"}
+	if len(diffArgs) != len(expectedDiff) {
+		t.Fatalf("diffArgs = %v, want %v", diffArgs, expectedDiff)
+	}
+	for i := range expectedDiff {
+		if diffArgs[i] != expectedDiff[i] {
+			t.Errorf("diffArgs[%d] = %q, want %q", i, diffArgs[i], expectedDiff[i])
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestCapturePatchCommands -v`
+Expected: FAIL — `capturePatchCommands` is undefined.
+
+- [ ] **Step 3: Add `capturePatchCommands` helper**
+
+Add to `docker.go`:
+
+```go
+// capturePatchCommands returns two argument slices: git add -A (to stage all
+// changes including new files) and git diff HEAD (to produce a diff of all
+// changes vs the original checkout commit).
+func capturePatchCommands(workDir string) (addArgs []string, diffArgs []string) {
+	addArgs = []string{"git", "-C", workDir, "add", "-A"}
+	diffArgs = []string{"git", "-C", workDir, "diff", "HEAD"}
+	return addArgs, diffArgs
+}
+```
+
+- [ ] **Step 4: Update `RunInstance` to use two-step diff capture**
+
+Replace the diff capture block in `RunInstance` (around line 216-221):
+
+```go
+// Step 6: Capture the git diff (even on agent timeout/failure, capture partial diff).
+diffOutput, diffErr := dockerExecOutput(ctx, name, "git", "-C", workDir, "diff")
+```
+
+With:
+
+```go
+// Step 6: Stage all changes and capture diff vs HEAD (includes new files).
+// Use a fresh context so we still capture the patch even if parent ctx is cancelled.
+diffCtx, diffCancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer diffCancel()
+
+addArgs, diffCmdArgs := capturePatchCommands(workDir)
+// Stage all changes (including untracked new files).
+if addErr := dockerExec(diffCtx, name, nil, addArgs...); addErr != nil {
+    log.Printf("[%s] git add -A failed: %v", inst.InstanceID, addErr)
+}
+diffOutput, diffErr := dockerExecOutput(diffCtx, name, diffCmdArgs...)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/tracker-swebench/docker.go cmd/tracker-swebench/docker_test.go
+git commit -m "fix(swebench): capture new files and staged changes in patch
+
+Replace bare 'git diff' with 'git add -A && git diff HEAD' so that
+untracked new files and staged changes are included in the patch.
+Use a fresh context for diff capture so partial patches are preserved
+even when the parent context is cancelled."
+```
+
+---
+
+### Task 3: Secure API key passing with `--env-file`
+
+**Criticality:** Critical — keys visible in `docker inspect` and `/proc`.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:42-48,99-113,116-130`
+- Modify: `cmd/tracker-swebench/docker_test.go:72-100`
+
+- [ ] **Step 1: Write test for new `writeEnvFile` helper**
+
+Add to `docker_test.go`:
+
+```go
+func TestWriteEnvFile(t *testing.T) {
+	env := map[string]string{
+		"API_KEY": "sk-secret",
+		"MODEL":   "claude-sonnet-4-6",
+	}
+
+	path, err := writeEnvFile(env)
+	if err != nil {
+		t.Fatalf("writeEnvFile: %v", err)
+	}
+	defer os.Remove(path)
+
+	// File must exist and have restrictive permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat env file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("env file permissions = %o, want 0600", info.Mode().Perm())
+	}
+
+	// Contents must be KEY=VALUE lines.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read env file: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "API_KEY=sk-secret\n") {
+		t.Errorf("expected API_KEY=sk-secret in env file, got:\n%s", content)
+	}
+	if !strings.Contains(content, "MODEL=claude-sonnet-4-6\n") {
+		t.Errorf("expected MODEL line in env file, got:\n%s", content)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestWriteEnvFile -v`
+Expected: FAIL — `writeEnvFile` is undefined.
+
+- [ ] **Step 3: Implement `writeEnvFile`**
+
+Add to `docker.go` (replace `buildEnvFlags`):
+
+```go
+// writeEnvFile writes environment variables to a temporary file in KEY=VALUE
+// format with mode 0600, returning the path. The caller must os.Remove the
+// file when done. This avoids exposing secrets via docker -e flags which are
+// visible in process listings and docker inspect output.
+func writeEnvFile(env map[string]string) (string, error) {
+	f, err := os.CreateTemp("", "swebench-env-*")
+	if err != nil {
+		return "", fmt.Errorf("create env file: %w", err)
+	}
+	if err := f.Chmod(0o600); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", fmt.Errorf("chmod env file: %w", err)
+	}
+	for k, v := range env {
+		if _, err := fmt.Fprintf(f, "%s=%s\n", k, v); err != nil {
+			f.Close()
+			os.Remove(f.Name())
+			return "", fmt.Errorf("write env var: %w", err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", fmt.Errorf("close env file: %w", err)
+	}
+	return f.Name(), nil
+}
+
+// buildEnvFileFlag returns the docker --env-file flag pair for a given path.
+func buildEnvFileFlag(envFilePath string) []string {
+	return []string{"--env-file", envFilePath}
+}
+```
+
+- [ ] **Step 4: Update `dockerExec` and `dockerExecCapture` to accept env file path**
+
+Replace the old `buildEnvFlags` call pattern. In `dockerExec` and `dockerExecCapture`, change the `env map[string]string` parameter to `envFilePath string`. When `envFilePath != ""`, prepend `--env-file <path>` to exec args instead of `-e K=V` pairs.
+
+Update `dockerExec`:
+
+```go
+func dockerExec(ctx context.Context, container string, envFilePath string, args ...string) error {
+	execArgs := []string{"exec"}
+	if envFilePath != "" {
+		execArgs = append(execArgs, "--env-file", envFilePath)
+	}
+	execArgs = append(execArgs, container)
+	execArgs = append(execArgs, args...)
+
+	cmd := exec.CommandContext(ctx, "docker", execArgs...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker exec %s: %w\nstderr: %s", container, err, stderr.String())
+	}
+	return nil
+}
+```
+
+Update `dockerExecCapture`:
+
+```go
+func dockerExecCapture(ctx context.Context, container string, envFilePath string, args ...string) (string, error) {
+	execArgs := []string{"exec"}
+	if envFilePath != "" {
+		execArgs = append(execArgs, "--env-file", envFilePath)
+	}
+	execArgs = append(execArgs, container)
+	execArgs = append(execArgs, args...)
+
+	cmd := exec.CommandContext(ctx, "docker", execArgs...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("docker exec %s: %w\noutput: %s", container, err, out.String())
+	}
+	return out.String(), nil
+}
+```
+
+- [ ] **Step 5: Update all call sites in `RunInstance`**
+
+In `RunInstance`, write the env file once before the agent step and clean up in the defer:
+
+```go
+// Write agent env to a secure temp file (avoids key exposure in process args).
+envFilePath, envErr := writeEnvFile(agentEnv)
+if envErr != nil {
+    return "", AgentSummary{}, fmt.Errorf("write env file: %w", envErr)
+}
+defer os.Remove(envFilePath)
+```
+
+Update all `dockerExec`/`dockerExecCapture` calls:
+- Clone step: pass `""` (no env needed)
+- pip install: pass `""` (no env needed)
+- agent-runner: pass `envFilePath`
+- git add/diff: pass `""` (no env needed)
+
+- [ ] **Step 6: Update `TestBuildEnvFlags` to test new pattern**
+
+Replace `TestBuildEnvFlags` in `docker_test.go` with a test for `buildEnvFileFlag`:
+
+```go
+func TestBuildEnvFileFlag(t *testing.T) {
+	flags := buildEnvFileFlag("/tmp/env-abc123")
+	if len(flags) != 2 {
+		t.Fatalf("expected 2 flags, got %d: %v", len(flags), flags)
+	}
+	if flags[0] != "--env-file" {
+		t.Errorf("flags[0] = %q, want \"--env-file\"", flags[0])
+	}
+	if flags[1] != "/tmp/env-abc123" {
+		t.Errorf("flags[1] = %q, want path", flags[1])
+	}
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add cmd/tracker-swebench/docker.go cmd/tracker-swebench/docker_test.go
+git commit -m "fix(swebench): secure API key passing with --env-file
+
+Replace docker exec -e KEY=VAL flags with a temp --env-file at mode
+0600. Keys are no longer visible in docker inspect, /proc/pid/cmdline,
+or host process listings."
+```
+
+---
+
+### Task 4: Add container resource limits and `--platform` to build
+
+**Criticality:** Critical (resource limits) + Important (platform).
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:147-152,173-178`
+- Modify: `cmd/tracker-swebench/build.sh:10-13`
+
+- [ ] **Step 1: Add resource limit fields to `DockerRunner`**
+
+In `docker.go`, extend the `DockerRunner` struct:
+
+```go
+type DockerRunner struct {
+	Image      string
+	CacheDir   string
+	Timeout    time.Duration
+	MemoryMB   int // container memory limit in MB (0 = no limit)
+	CPUs       float64 // container CPU limit (0 = no limit)
+	PidsLimit  int // container PID limit (0 = no limit)
+}
+```
+
+- [ ] **Step 2: Apply limits in `docker create`**
+
+In `RunInstance`, update the `createArgs` block (around line 173):
+
+```go
+createArgs := []string{"create", "--name", name}
+if r.CacheDir != "" {
+    createArgs = append(createArgs, "-v", r.CacheDir+":/cache:ro")
+}
+if r.MemoryMB > 0 {
+    createArgs = append(createArgs, "--memory", fmt.Sprintf("%dm", r.MemoryMB))
+}
+if r.CPUs > 0 {
+    createArgs = append(createArgs, "--cpus", fmt.Sprintf("%.1f", r.CPUs))
+}
+if r.PidsLimit > 0 {
+    createArgs = append(createArgs, "--pids-limit", fmt.Sprintf("%d", r.PidsLimit))
+}
+createArgs = append(createArgs, r.Image, "sleep", "infinity")
+```
+
+- [ ] **Step 3: Set defaults in `main.go`**
+
+In `main.go`, update the DockerRunner construction (around line 89):
+
+```go
+docker := &DockerRunner{
+    Image:    *dockerImage,
+    CacheDir: cacheDir,
+    Timeout:  *timeout,
+    MemoryMB: 4096,  // 4 GB
+    CPUs:     2.0,
+    PidsLimit: 512,
+}
+```
+
+- [ ] **Step 4: Fix `build.sh` platform flag**
+
+In `build.sh`, add `--platform linux/amd64` to the docker build command:
+
+```bash
+echo "==> Cross-compiling agent-runner for linux/amd64..."
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o agent-runner ./agent-runner/
+
+echo "==> Building Docker image: tracker-swebench-base..."
+docker build --platform linux/amd64 -t tracker-swebench-base .
+```
+
+- [ ] **Step 5: Run build and tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go build ./cmd/tracker-swebench/ && go test ./cmd/tracker-swebench/... -v`
+Expected: Build succeeds, all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/tracker-swebench/docker.go cmd/tracker-swebench/main.go cmd/tracker-swebench/build.sh
+git commit -m "fix(swebench): add container resource limits and platform flag
+
+Set --memory 4g, --cpus 2, --pids-limit 512 on docker create to
+prevent runaway containers from exhausting host resources. Add
+--platform linux/amd64 to docker build for consistent cross-platform
+image builds."
+```
+
+---
+
+### Task 5: Handle SIGTERM + container labels + orphan cleanup
+
+**Criticality:** Critical — orphaned containers on SIGTERM/SIGKILL, no recovery mechanism.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:156-169,173`
+- Modify: `cmd/tracker-swebench/main.go:113-115`
+
+- [ ] **Step 1: Add SIGTERM to signal handler**
+
+In `main.go`, update the signal handler (line 114):
+
+```go
+ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+defer stop()
+```
+
+Add `"syscall"` to the imports.
+
+- [ ] **Step 2: Add run label and pre-flight cleanup to `DockerRunner`**
+
+Add a `RunLabel` field and a `CleanupStale` method to `DockerRunner` in `docker.go`:
+
+```go
+type DockerRunner struct {
+	Image     string
+	CacheDir  string
+	Timeout   time.Duration
+	MemoryMB  int
+	CPUs      float64
+	PidsLimit int
+	RunLabel  string // label value for orphan cleanup (e.g., run timestamp)
+}
+
+// CleanupStale removes any containers with the swebench label from prior runs.
+func (r *DockerRunner) CleanupStale(ctx context.Context) {
+	cmd := exec.CommandContext(ctx, "docker", "ps", "-a",
+		"--filter", "label=swebench",
+		"--format", "{{.Names}}")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		return // best-effort
+	}
+	for _, name := range strings.Split(strings.TrimSpace(out.String()), "\n") {
+		if name == "" {
+			continue
+		}
+		log.Printf("cleaning up stale container: %s", name)
+		_ = dockerCmd(ctx, "rm", "-f", name)
+	}
+}
+```
+
+- [ ] **Step 3: Add label to `docker create`**
+
+In `RunInstance`, add the label to `createArgs`:
+
+```go
+createArgs := []string{"create", "--name", name, "--label", "swebench=" + r.RunLabel}
+```
+
+- [ ] **Step 4: Set RunLabel and call CleanupStale in `main.go`**
+
+In `main.go`, set the label and clean up before the loop:
+
+```go
+docker := &DockerRunner{
+    Image:    *dockerImage,
+    CacheDir: cacheDir,
+    Timeout:  *timeout,
+    MemoryMB: 4096,
+    CPUs:     2.0,
+    PidsLimit: 512,
+    RunLabel:  time.Now().Format("20060102-150405"),
+}
+
+// Clean up orphaned containers from prior crashed runs.
+docker.CleanupStale(ctx)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go build ./cmd/tracker-swebench/ && go test ./cmd/tracker-swebench/... -v`
+Expected: Build succeeds, all tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/tracker-swebench/docker.go cmd/tracker-swebench/main.go
+git commit -m "fix(swebench): handle SIGTERM and clean up orphaned containers
+
+Add SIGTERM to signal handler so CI runners and Docker orchestrators
+trigger graceful shutdown. Label containers with swebench=<timestamp>
+and clean up stale containers from prior crashed runs on startup."
+```
+
+---
+
+### Task 6: Fix container naming and instance ID validation
+
+**Criticality:** Important — name collisions on concurrent runs, path traversal via instance ID.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/docker.go:24-27`
+- Modify: `cmd/tracker-swebench/docker_test.go:10-15`
+- Modify: `cmd/tracker-swebench/dataset.go` (add validation)
+- Modify: `cmd/tracker-swebench/dataset_test.go`
+
+- [ ] **Step 1: Write test for instance ID validation**
+
+Add to `dataset_test.go`:
+
+```go
+func TestValidateInstanceID(t *testing.T) {
+	tests := []struct {
+		id    string
+		valid bool
+	}{
+		{"django__django-11099", true},
+		{"sympy__sympy-12345", true},
+		{"scikit-learn__scikit-learn-9876", true},
+		{"", false},
+		{"../../etc/passwd", false},
+		{"foo;rm -rf /", false},
+		{"foo bar", false},
+		{"a/b", false},
+	}
+	for _, tt := range tests {
+		err := validateInstanceID(tt.id)
+		if tt.valid && err != nil {
+			t.Errorf("validateInstanceID(%q) = %v, want nil", tt.id, err)
+		}
+		if !tt.valid && err == nil {
+			t.Errorf("validateInstanceID(%q) = nil, want error", tt.id)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestValidateInstanceID -v`
+Expected: FAIL — `validateInstanceID` is undefined.
+
+- [ ] **Step 3: Implement validation**
+
+Add to `dataset.go`:
+
+```go
+import "regexp"
+
+// instanceIDPattern matches valid SWE-bench instance IDs: alphanumeric, underscores, hyphens, dots.
+var instanceIDPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.=-]*$`)
+
+// validateInstanceID checks that an instance ID is safe for use as a Docker
+// container name suffix and filesystem path component.
+func validateInstanceID(id string) error {
+	if id == "" {
+		return fmt.Errorf("empty instance ID")
+	}
+	if !instanceIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid instance ID %q: must match [a-zA-Z0-9][a-zA-Z0-9_.=-]*", id)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Call validation in `LoadDataset`**
+
+In `dataset.go`, add validation after unmarshaling each instance (around line 61):
+
+```go
+if err := json.Unmarshal([]byte(line), &inst); err != nil {
+    return nil, fmt.Errorf("line %d: %w", lineNum, err)
+}
+if err := validateInstanceID(inst.InstanceID); err != nil {
+    return nil, fmt.Errorf("line %d: %w", lineNum, err)
+}
+```
+
+- [ ] **Step 5: Update `containerName` to include run prefix**
+
+In `docker.go`, update `containerName` to accept a run prefix:
+
+```go
+func containerName(runLabel, instanceID string) string {
+	return "swe-" + runLabel + "-" + instanceID
+}
+```
+
+Update the `TestContainerName` test and all call sites in `RunInstance` (pass `r.RunLabel`).
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/tracker-swebench/dataset.go cmd/tracker-swebench/dataset_test.go cmd/tracker-swebench/docker.go cmd/tracker-swebench/docker_test.go
+git commit -m "fix(swebench): validate instance IDs and scope container names
+
+Add regex validation on instance IDs to prevent path traversal and
+shell metacharacter injection. Include run label in container names
+to prevent collisions across concurrent runs."
+```
+
+---
+
+### Task 7: Fix empty-patch resume behavior
+
+**Criticality:** Critical — timed-out instances permanently skipped on resume.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/results.go:21-27,63-79`
+- Modify: `cmd/tracker-swebench/results_test.go`
+- Modify: `cmd/tracker-swebench/main.go:158-160`
+
+- [ ] **Step 1: Write test for empty-patch not marking completed**
+
+Add to `results_test.go`:
+
+```go
+func TestResultsWriter_EmptyPatchNotCompleted(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "predictions.jsonl")
+
+	w, err := NewResultsWriter(path, "test-model")
+	if err != nil {
+		t.Fatalf("NewResultsWriter: %v", err)
+	}
+
+	// Write empty patch — should still write the line but NOT mark as completed.
+	if err := w.WritePrediction("instance-timeout", ""); err != nil {
+		t.Fatalf("WritePrediction: %v", err)
+	}
+
+	// Instance should NOT be in the completed set.
+	if w.IsCompleted("instance-timeout") {
+		t.Error("empty-patch instance should not be marked as completed")
+	}
+
+	// Write a real patch — should mark as completed.
+	if err := w.WritePrediction("instance-ok", "diff --git a/fix.py"); err != nil {
+		t.Fatalf("WritePrediction: %v", err)
+	}
+	if !w.IsCompleted("instance-ok") {
+		t.Error("non-empty patch instance should be marked as completed")
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Resume: empty-patch instance should NOT be skipped.
+	w2, err := NewResultsWriter(path, "test-model")
+	if err != nil {
+		t.Fatalf("NewResultsWriter (resume): %v", err)
+	}
+	defer w2.Close()
+
+	if w2.IsCompleted("instance-timeout") {
+		t.Error("resume: empty-patch instance should not be marked completed")
+	}
+	if !w2.IsCompleted("instance-ok") {
+		t.Error("resume: non-empty patch instance should be completed")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/ -run TestResultsWriter_EmptyPatchNotCompleted -v`
+Expected: FAIL — empty-patch instance is currently marked completed.
+
+- [ ] **Step 3: Fix `WritePrediction` to only mark completed on non-empty patch**
+
+In `results.go`, update `WritePrediction` (line 64-79):
+
+```go
+func (w *ResultsWriter) WritePrediction(instanceID, patch string) error {
+	p := Prediction{
+		InstanceID:      instanceID,
+		ModelNameOrPath: w.model,
+		ModelPatch:      patch,
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return fmt.Errorf("marshal prediction: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := w.file.Write(data); err != nil {
+		return fmt.Errorf("write prediction: %w", err)
+	}
+	// Only mark as completed if the patch is non-empty. Empty patches from
+	// timeouts or errors should be retried on resume.
+	if patch != "" {
+		w.completed[instanceID] = struct{}{}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Fix resume reader to also skip empty patches**
+
+In `NewResultsWriter`, update the resume-read logic (line 42):
+
+```go
+if jsonErr := json.Unmarshal([]byte(line), &p); jsonErr == nil && p.InstanceID != "" && p.ModelPatch != "" {
+    completed[p.InstanceID] = struct{}{}
+}
+```
+
+- [ ] **Step 5: Update existing test expectations**
+
+The existing `TestResultsWriter_WriteAndResume` writes `"diff1"` and `"diff2"` (non-empty), so it should still pass. The integration test writes `"diff --git a/fix.py"` (non-empty), also fine.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/tracker-swebench/results.go cmd/tracker-swebench/results_test.go
+git commit -m "fix(swebench): don't mark empty-patch predictions as completed
+
+Only add instances to the completed set when the patch is non-empty.
+Timed-out or errored instances that produced no patch will be retried
+on resume instead of permanently skipped."
+```
+
+---
+
+### Task 8: Fix exit codes, error counting, timeout detection, and WritePrediction handling
+
+**Criticality:** Critical (exit codes) + Important (timeout, write errors).
+
+**Files:**
+- Modify: `cmd/tracker-swebench/results.go:103-113,116-147`
+- Modify: `cmd/tracker-swebench/results_test.go:104-127`
+- Modify: `cmd/tracker-swebench/main.go:92,144,159-187,190`
+
+- [ ] **Step 1: Add `Errors` field to `RunStats` and update `Summary`**
+
+In `results.go`, add the field and update `Summary`:
+
+```go
+type RunStats struct {
+	Total        int
+	Completed    int
+	Skipped      int
+	Errors       int
+	TimedOut     int
+	Patched      int
+	InputTokens  int64
+	OutputTokens int64
+	StartTime    time.Time
+}
+```
+
+Update `Summary()` to include the Errors line:
+
+```go
+func (s *RunStats) Summary() string {
+	elapsed := time.Since(s.StartTime).Round(time.Second)
+
+	patchPct := 0.0
+	if s.Completed > 0 {
+		patchPct = float64(s.Patched) / float64(s.Completed) * 100
+	}
+	completedPct := 0.0
+	if s.Total > 0 {
+		completedPct = float64(s.Completed) / float64(s.Total) * 100
+	}
+
+	inM := float64(s.InputTokens) / 1e6
+	outM := float64(s.OutputTokens) / 1e6
+
+	return fmt.Sprintf(
+		"Run complete — elapsed: %s\n"+
+			"  Total:     %d\n"+
+			"  Completed: %d (%.1f%%)\n"+
+			"  Skipped:   %d\n"+
+			"  Errors:    %d\n"+
+			"  Timed out: %d\n"+
+			"  Patched:   %d (%.1f%% of completed)\n"+
+			"  Tokens:    %.2fM in / %.2fM out",
+		elapsed,
+		s.Total,
+		s.Completed, completedPct,
+		s.Skipped,
+		s.Errors,
+		s.TimedOut,
+		s.Patched, patchPct,
+		inM, outM,
+	)
+}
+```
+
+- [ ] **Step 2: Fix timeout detection with `errors.Is`**
+
+In `main.go`, replace the timeout string matching (line 181):
+
+```go
+if runErr != nil && strings.Contains(runErr.Error(), "context deadline exceeded") {
+    stats.TimedOut++
+}
+```
+
+With:
+
+```go
+if runErr != nil {
+    stats.Errors++
+    if errors.Is(runErr, context.DeadlineExceeded) {
+        stats.TimedOut++
+    }
+}
+```
+
+Add `"errors"` to imports (and remove `"strings"` if no longer needed — check first).
+
+- [ ] **Step 3: Fix WritePrediction error handling**
+
+In `main.go`, make `WritePrediction` failure stop incrementing `Completed` (around line 159):
+
+```go
+if writeErr := rw.WritePrediction(inst.InstanceID, patch); writeErr != nil {
+    log.Printf("[%s] write prediction: %v", inst.InstanceID, writeErr)
+    stats.Errors++
+    continue // skip stats update — this instance is not reliably recorded
+}
+```
+
+Move `stats.Completed++` and the rest of the stats update after the write check:
+
+```go
+// Update stats only after successful prediction write.
+stats.Completed++
+stats.InputTokens += summary.InputTokens
+stats.OutputTokens += summary.OutputTokens
+if patch != "" {
+    stats.Patched++
+}
+if runErr != nil {
+    stats.Errors++
+    if errors.Is(runErr, context.DeadlineExceeded) {
+        stats.TimedOut++
+    }
+}
+```
+
+- [ ] **Step 4: Exit non-zero when errors occurred**
+
+At the end of `main()` (line 190), replace:
+
+```go
+fmt.Println(stats.Summary())
+```
+
+With:
+
+```go
+fmt.Println(stats.Summary())
+if stats.Errors > 0 {
+    os.Exit(1)
+}
+```
+
+- [ ] **Step 5: Update `TestRunStats_Summary`**
+
+In `results_test.go`, add `Errors` to the test struct and check for it in the output:
+
+```go
+func TestRunStats_Summary(t *testing.T) {
+	stats := RunStats{
+		Total:        10,
+		Completed:    7,
+		Skipped:      2,
+		Errors:       1,
+		TimedOut:     1,
+		Patched:      5,
+		InputTokens:  1_500_000,
+		OutputTokens: 300_000,
+		StartTime:    time.Now().Add(-5 * time.Minute),
+	}
+
+	summary := stats.Summary()
+	if summary == "" {
+		t.Fatal("Summary returned empty string")
+	}
+	if !strings.Contains(summary, "Errors:    1") {
+		t.Error("summary should contain Errors count")
+	}
+}
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/tracker-swebench/main.go cmd/tracker-swebench/results.go cmd/tracker-swebench/results_test.go
+git commit -m "fix(swebench): add error counting, fix exit codes and timeout detection
+
+Add Errors field to RunStats and exit non-zero when any instance
+errors. Replace string-matching timeout detection with errors.Is
+for correctness. Stop counting instances as Completed when
+WritePrediction fails."
+```
+
+---
+
+### Task 9: Fix `int`/`int64` type mismatch and provider routing
+
+**Criticality:** Important — latent overflow + silent misconfiguration.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/agent-runner/main.go:85-90`
+- Modify: `cmd/tracker-swebench/agent-runner/providers.go:10-25`
+- Modify: `cmd/tracker-swebench/agent-runner/main_test.go`
+
+- [ ] **Step 1: Fix type mismatch in `agentSummary`**
+
+In `agent-runner/main.go`, align token types to `int64`:
+
+```go
+type agentSummary struct {
+	Turns        int   `json:"turns"`
+	InputTokens  int64 `json:"input_tokens"`
+	OutputTokens int64 `json:"output_tokens"`
+	DurationMs   int64 `json:"duration_ms"`
+}
+```
+
+Update the assignment block (around line 136-139) — `result.Usage.InputTokens` is `int`, so cast:
+
+```go
+if result.Turns > 0 {
+    summary.Turns = result.Turns
+    summary.InputTokens = int64(result.Usage.InputTokens)
+    summary.OutputTokens = int64(result.Usage.OutputTokens)
+}
+```
+
+- [ ] **Step 2: Fix `enc.Encode` error handling**
+
+In `agent-runner/main.go`, around line 141-142:
+
+```go
+enc := json.NewEncoder(os.Stdout)
+if encErr := enc.Encode(summary); encErr != nil {
+    log.Printf("failed to encode summary: %v", encErr)
+}
+```
+
+- [ ] **Step 3: Add provider validation in `buildLLMClient`**
+
+In `agent-runner/main.go`, validate the provider before building the client. Replace the `buildLLMClient` function (line 150-173):
+
+```go
+func buildLLMClient(provider, baseURL string) (*llm.Client, error) {
+	// Validate provider upfront.
+	switch provider {
+	case "anthropic", "openai":
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported provider %q: must be \"anthropic\" or \"openai\"", provider)
+	}
+
+	constructors := map[string]func(string) (llm.ProviderAdapter, error){
+		provider: func(key string) (llm.ProviderAdapter, error) {
+			switch provider {
+			case "openai":
+				return newOpenAIAdapter(key, baseURL)
+			default:
+				return newAnthropicAdapter(key, baseURL)
+			}
+		},
+	}
+
+	client, err := llm.NewClientFromEnv(constructors)
+	if err != nil {
+		return nil, err
+	}
+
+	client.AddMiddleware(llm.NewRetryMiddleware(
+		llm.WithMaxRetries(3),
+		llm.WithBaseDelay(2*time.Second),
+	))
+
+	return client, nil
+}
+```
+
+- [ ] **Step 4: Add provider validation test**
+
+Add to `agent-runner/main_test.go`:
+
+```go
+func TestBuildLLMClient_UnsupportedProvider(t *testing.T) {
+	_, err := buildLLMClient("gemini", "")
+	if err == nil {
+		t.Fatal("expected error for unsupported provider, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Errorf("expected 'unsupported provider' in error, got: %v", err)
+	}
+}
+```
+
+Add `"strings"` to the test file imports.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/tracker-swebench/agent-runner/main.go cmd/tracker-swebench/agent-runner/main_test.go
+git commit -m "fix(swebench): align token types to int64 and validate provider
+
+Change agentSummary token fields from int to int64 to match the
+harness-side AgentSummary struct. Handle enc.Encode error. Reject
+unsupported providers with a clear error instead of silently falling
+through to the Anthropic adapter."
+```
+
+---
+
+### Task 10: Improve system prompt for SWE-bench
+
+**Criticality:** Important — missing key tactics that affect benchmark scores.
+
+**Files:**
+- Modify: `cmd/tracker-swebench/agent-runner/main.go:19-39`
+
+- [ ] **Step 1: Update the system prompt**
+
+Replace `swebenchSystemPrompt` in `agent-runner/main.go`:
+
+```go
+const swebenchSystemPrompt = `You are an expert software engineer tasked with fixing a GitHub issue.
+
+You have access to the repository at /workspace. The repository is already
+checked out at the correct commit.
+
+## Your task
+Fix the issue described below. Make the minimal changes necessary to resolve
+the issue. Do not refactor unrelated code.
+
+## Approach
+1. Read the issue carefully. Understand what's broken and what the expected behavior is.
+2. Reproduce the bug first. Find and run the relevant test(s) to confirm the failure.
+3. Check git log --oneline -10 for recent context around the affected code.
+4. Explore the relevant code. Use grep_search and glob to find the right files.
+5. Write a fix. Make targeted edits — smallest diff that solves the problem.
+6. Run the failing test again to verify your fix resolves it.
+7. Run the broader test suite to check for regressions.
+
+## Rules
+- Do NOT create new test files. The evaluation uses the repo's existing test suite.
+- Do NOT modify test files unless the issue specifically requires it.
+- Keep your changes minimal and focused.
+- If you're unsure about the fix, read more code before editing.
+- Always re-read a file before editing it if you haven't read it recently.
+- After editing, verify the fix by running the relevant tests.
+- You may use absolute paths in bash commands (e.g., /workspace/tests/). Only file
+  tool arguments (read_file, write_file, etc.) require relative paths.`
+```
+
+- [ ] **Step 2: Increase default timeout to 30 minutes**
+
+In `agent-runner/main.go`, update the default timeout (line 59):
+
+```go
+Timeout:  30 * time.Minute,
+```
+
+Also update the default in `main.go` (the outer harness, line 28):
+
+```go
+timeout := flag.Duration("timeout", 30*time.Minute, "per-instance timeout")
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./cmd/tracker-swebench/... -v`
+Expected: All tests PASS. (The `TestParseConfig_Defaults` test checks for `10*time.Minute` — update it to `30*time.Minute`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/tracker-swebench/agent-runner/main.go cmd/tracker-swebench/agent-runner/main_test.go cmd/tracker-swebench/main.go
+git commit -m "fix(swebench): improve system prompt and increase default timeout
+
+Add reproduce-before-fix, verify-after-fix, and git-log instructions
+to the agent system prompt. Clarify that absolute paths are allowed
+in bash commands. Increase default timeout from 10 to 30 minutes to
+match community baselines for complex SWE-bench instances."
+```
+
+---
+
+### Task 11: Add `flag.Usage`, populate `RunMeta.Commit`
+
+**Criticality:** Critical (no usage) + Important (reproducibility gap).
+
+**Files:**
+- Modify: `cmd/tracker-swebench/main.go:19-31,68-78`
+
+- [ ] **Step 1: Add custom `flag.Usage`**
+
+In `main.go`, add a custom usage function before `flag.Parse()`:
+
+```go
+flag.Usage = func() {
+    fmt.Fprintf(os.Stderr, `tracker-swebench — run tracker's code agent against SWE-bench Lite instances
+
+Usage:
+  tracker-swebench --dataset <path> [flags]
+
+Prerequisites:
+  1. Build the Docker image:  cd cmd/tracker-swebench && bash build.sh
+  2. Set API key:             export ANTHROPIC_API_KEY=sk-ant-...
+  3. Download dataset:        SWE-bench Lite JSONL from the SWE-bench repository
+
+Examples:
+  tracker-swebench --dataset swebench_lite.jsonl
+  tracker-swebench --dataset swebench_lite.jsonl --instance django__django-11099
+  tracker-swebench --dataset swebench_lite.jsonl --model gpt-5.2 --provider openai
+  tracker-swebench --dataset swebench_lite.jsonl --force --timeout 30m
+
+Flags:
+`)
+    flag.PrintDefaults()
+}
+```
+
+- [ ] **Step 2: Populate `RunMeta.Commit` from build info**
+
+Add to `main.go`:
+
+```go
+import "runtime/debug"
+
+// buildCommit returns the VCS revision from Go build info, or "unknown".
+func buildCommit() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	for _, s := range info.Settings {
+		if s.Key == "vcs.revision" {
+			if len(s.Value) > 12 {
+				return s.Value[:12]
+			}
+			return s.Value
+		}
+	}
+	return "unknown"
+}
+```
+
+Then in `main()`, set the commit field (around line 68):
+
+```go
+meta := RunMeta{
+    Model:      *model,
+    Provider:   *provider,
+    GatewayURL: *gatewayURL,
+    Dataset:    *dataset,
+    MaxTurns:   *maxTurns,
+    Timeout:    timeout.String(),
+    Commit:     buildCommit(),
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go build ./cmd/tracker-swebench/ && go test ./cmd/tracker-swebench/... -v`
+Expected: Build succeeds, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/tracker-swebench/main.go
+git commit -m "fix(swebench): add flag.Usage with prerequisites and populate RunMeta.Commit
+
+Add custom flag.Usage that documents prerequisites (Docker image,
+API keys, dataset), shows example invocations, and lists all flags.
+Populate RunMeta.Commit from Go VCS build metadata for reproducibility."
+```
+
+---
+
+### Task 12: Add `claude-sonnet-4-6` to model catalog
+
+**Criticality:** Important — cost reporting is always $0 for the default model.
+
+**Files:**
+- Modify: `llm/catalog.go:36-48`
+
+- [ ] **Step 1: Write failing test**
+
+The existing pricing test in `llm/pricing.go` already references `claude-sonnet-4-6`. Add a catalog test:
+
+```go
+// In a new or existing test file for catalog:
+func TestGetModelInfo_Sonnet46(t *testing.T) {
+	info := GetModelInfo("claude-sonnet-4-6")
+	if info == nil {
+		t.Fatal("claude-sonnet-4-6 not found in catalog")
+	}
+	if info.Provider != "anthropic" {
+		t.Errorf("Provider = %q, want \"anthropic\"", info.Provider)
+	}
+	if info.ContextWindow != 200000 {
+		t.Errorf("ContextWindow = %d, want 200000", info.ContextWindow)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./llm/ -run TestGetModelInfo_Sonnet46 -v`
+Expected: FAIL — `claude-sonnet-4-6` not found.
+
+- [ ] **Step 3: Add catalog entry**
+
+In `llm/catalog.go`, add after the `claude-sonnet-4-5` entry (after line 48):
+
+```go
+{
+    ID:                "claude-sonnet-4-6",
+    Provider:          "anthropic",
+    DisplayName:       "Claude Sonnet 4.6",
+    ContextWindow:     200000,
+    MaxOutput:         16000,
+    SupportsTools:     true,
+    SupportsVision:    true,
+    SupportsReasoning: true,
+    InputCostPerM:     3.0,
+    OutputCostPerM:    15.0,
+    Aliases:           []string{"sonnet-4-6"},
+},
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/harper/Public/src/2389/tracker && go test ./llm/... -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add llm/catalog.go
+git commit -m "fix(llm): add claude-sonnet-4-6 to model catalog
+
+The model was in pricing.go but missing from catalog.go, causing
+GetModelInfo to return nil and cost reporting to show $0.00 for
+the swebench harness default model."
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] Critical #1 (shell injection) → Task 1
+- [x] Critical #2 (git diff) → Task 2
+- [x] Critical #3 (--reference path) → Task 1 step 4
+- [x] Critical #4 (empty-patch resume) → Task 7
+- [x] Critical #5 (API key exposure) → Task 3
+- [x] Critical #6 (exit codes) → Task 8
+- [x] Critical #7 (resource limits) → Task 4
+- [x] Critical #8 (orphaned containers) → Task 5
+- [x] Critical #9 (no docs/usage) → Task 11
+- [x] Important #10 (catalog) → Task 12
+- [x] Important #16 (path traversal) → Task 6
+- [x] Important #17 (name collisions) → Task 6
+- [x] Important #18 (WritePrediction) → Task 8
+- [x] Important #19 (timeout detection) → Task 8
+- [x] Important #20 (int/int64) → Task 9
+- [x] Important #21 (timeout too short) → Task 10
+- [x] Important #22 (provider routing) → Task 9
+- [x] Important #28 (system prompt) → Task 10
+
+**Deferred to follow-up (not blocking ship):**
+- Important #11 (absolute path prohibition) — partially addressed in Task 10 system prompt
+- Important #12 (environment_setup_commit) — requires per-instance conda, large scope change
+- Important #13 (Python 3.11 only) — requires multi-image strategy, separate design
+- Important #14,15 (root, network isolation) — separate hardening pass
+- Important #23 (ARG_MAX) — partially mitigated by --env-file in Task 3
+- Important #24 (arm64) — build.sh fix in Task 4 adds `--platform`; full multi-arch is follow-up
+- Important #25 (RunMeta.Commit) → Task 11
+- Important #29 (compaction) — tuning, not a code fix
+
+**Placeholder scan:** No TBDs, TODOs, or "implement later" found.
+
+**Type consistency:** `buildCloneCommands` signature used consistently in Tasks 1 and 6. `containerName` updated signature propagated to all call sites. `AgentSummary`/`agentSummary` aligned to `int64` in Task 9.

--- a/docs/superpowers/plans/2026-05-01-audit-critical-fixes.md
+++ b/docs/superpowers/plans/2026-05-01-audit-critical-fixes.md
@@ -1,0 +1,643 @@
+# Audit Critical Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the 10 critical findings from the 13-expert panel audit of tracker v0.24.1.
+
+**Architecture:** Surgical fixes to existing files — no new packages, no new abstractions. Each task addresses one critical finding, ordered by risk (security first, then correctness, then UX/docs). Tasks are independent and can be parallelized.
+
+**Tech Stack:** Go 1.24, existing pipeline/handlers/llm packages.
+
+---
+
+## Task 1: ACP CreateTerminal command validation
+
+**Why:** An LLM-directed ACP agent can execute any command on the host via `CreateTerminal`, completely bypassing the denylist/allowlist that protects `tool_command`. This is the highest-severity security gap.
+
+**Files:**
+- Modify: `pipeline/handlers/backend_acp_client.go:398-447`
+- Modify: `pipeline/handlers/backend_acp_client.go:228-258` (RequestPermission)
+- Test: `pipeline/handlers/backend_acp_client_test.go`
+
+- [ ] **Step 1: Write failing test for command denylist enforcement**
+
+```go
+func TestCreateTerminal_DenylistedCommand(t *testing.T) {
+	h := &acpClientHandler{
+		workingDir:  t.TempDir(),
+		toolSafety:  DefaultToolHandlerConfig(),
+	}
+
+	resp, err := h.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "eval",
+		Args:    []string{"malicious"},
+	})
+	if err == nil {
+		t.Fatal("expected error for denylisted command, got nil")
+	}
+	if resp.TerminalId != "" {
+		t.Errorf("expected empty terminal ID, got %q", resp.TerminalId)
+	}
+}
+```
+
+- [ ] **Step 2: Write failing test for cwd containment**
+
+```go
+func TestCreateTerminal_CwdOutsideWorkDir(t *testing.T) {
+	h := &acpClientHandler{
+		workingDir: t.TempDir(),
+	}
+
+	outsideDir := "/tmp"
+	resp, err := h.CreateTerminal(context.Background(), acp.CreateTerminalRequest{
+		Command: "ls",
+		Cwd:     &outsideDir,
+	})
+	if err == nil {
+		t.Fatal("expected error for cwd outside workdir, got nil")
+	}
+	if resp.TerminalId != "" {
+		t.Errorf("expected empty terminal ID, got %q", resp.TerminalId)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./pipeline/handlers/ -run "TestCreateTerminal_Denylist|TestCreateTerminal_Cwd" -v`
+Expected: FAIL
+
+- [ ] **Step 4: Add `ToolHandlerConfig` field to `acpClientHandler` and validate in `CreateTerminal`**
+
+In `backend_acp_client.go`, add a `toolSafety ToolHandlerConfig` field to `acpClientHandler`. Then add validation at the top of `CreateTerminal`:
+
+```go
+func (h *acpClientHandler) CreateTerminal(_ context.Context, p acp.CreateTerminalRequest) (acp.CreateTerminalResponse, error) {
+	// Validate command against denylist (same rules as tool_command).
+	fullCmd := p.Command
+	if len(p.Args) > 0 {
+		fullCmd += " " + strings.Join(p.Args, " ")
+	}
+	if denied, pattern := h.toolSafety.IsDenied(fullCmd); denied {
+		return acp.CreateTerminalResponse{}, &acp.RequestError{
+			Code:    -32600,
+			Message: fmt.Sprintf("command denied by safety policy (matched %q): %s", pattern, p.Command),
+		}
+	}
+
+	// Validate cwd is under workingDir.
+	cwd := h.workingDir
+	if p.Cwd != nil && *p.Cwd != "" {
+		resolved, err := validatePathInWorkDir(*p.Cwd, h.workingDir)
+		if err != nil {
+			return acp.CreateTerminalResponse{}, &acp.RequestError{
+				Code:    -32600,
+				Message: fmt.Sprintf("terminal cwd rejected: %v", err),
+			}
+		}
+		cwd = resolved
+	}
+	// ... rest of existing code, using validated cwd ...
+```
+
+- [ ] **Step 5: Wire `toolSafety` into `acpClientHandler` construction**
+
+Find where `acpClientHandler` is created (in the ACP backend) and pass `ToolHandlerConfig` through.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./pipeline/handlers/ -run "TestCreateTerminal" -v`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pipeline/handlers/backend_acp_client.go pipeline/handlers/backend_acp_client_test.go
+git commit -m "security(acp): validate CreateTerminal commands against denylist and cwd"
+```
+
+---
+
+## Task 2: ClaudeCode subprocess process-group kill on cancellation
+
+**Why:** When the pipeline is cancelled, the `claude` subprocess keeps running in the background consuming API credits indefinitely because `exec.Command` is used without context-aware cancellation or process group kill.
+
+**Files:**
+- Modify: `pipeline/handlers/backend_claudecode.go:80-97`
+- Test: `pipeline/handlers/backend_claudecode_test.go`
+
+- [ ] **Step 1: Write failing test for context cancellation killing subprocess**
+
+```go
+func TestClaudeCodeBackend_ContextCancelKillsSubprocess(t *testing.T) {
+	// Use a long-running command as a stand-in for the claude CLI.
+	b := &ClaudeCodeBackend{claudePath: "sleep"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel immediately after start to simulate pipeline cancellation.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Run should return promptly after cancellation, not hang for the full sleep duration.
+	start := time.Now()
+	_, _ = b.Run(ctx, AgentRunConfig{
+		NodeID: "test",
+		Extra:  &ClaudeCodeConfig{Prompt: "test"},
+	})
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Errorf("subprocess was not killed on cancel; took %v", elapsed)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (hangs or takes too long)**
+
+Run: `go test ./pipeline/handlers/ -run "TestClaudeCodeBackend_ContextCancel" -v -timeout 30s`
+Expected: FAIL or timeout
+
+- [ ] **Step 3: Add process group and context-aware kill to `Run`**
+
+In `backend_claudecode.go`, change the subprocess setup:
+
+```go
+cmd := exec.Command(b.claudePath, args...)
+cmd.Env = buildEnv()
+
+// Use process group for clean kill on cancellation.
+cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+// Kill process group when context is cancelled.
+cmd.Cancel = func() error {
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+}
+cmd.WaitDelay = 5 * time.Second
+```
+
+Add import `"syscall"` if not already present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pipeline/handlers/ -run "TestClaudeCodeBackend_ContextCancel" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full handler tests**
+
+Run: `go test ./pipeline/handlers/ -short -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/handlers/backend_claudecode.go pipeline/handlers/backend_claudecode_test.go
+git commit -m "fix(claudecode): kill subprocess process group on pipeline cancellation"
+```
+
+---
+
+## Task 3: Fix `TRACKER_PASS_API_KEYS` to check `== "1"`
+
+**Why:** Any non-empty value (including `"false"`, `"0"`, `"no"`) triggers full environment passthrough, silently leaking all API keys.
+
+**Files:**
+- Modify: `pipeline/handlers/backend_claudecode.go:274`
+- Test: `pipeline/handlers/backend_claudecode_env_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestBuildEnv_PassAPIKeysFalseDoesNotPassthrough(t *testing.T) {
+	t.Setenv("TRACKER_PASS_API_KEYS", "false")
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+	env := buildEnv()
+	for _, e := range env {
+		if strings.HasPrefix(e, "ANTHROPIC_API_KEY=") {
+			t.Error("TRACKER_PASS_API_KEYS=false should NOT pass through API keys")
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pipeline/handlers/ -run "TestBuildEnv_PassAPIKeysFalse" -v`
+Expected: FAIL
+
+- [ ] **Step 3: Fix the check**
+
+In `backend_claudecode.go` line 274, change:
+
+```go
+// Before:
+if os.Getenv("TRACKER_PASS_API_KEYS") != "" {
+
+// After:
+if os.Getenv("TRACKER_PASS_API_KEYS") == "1" {
+```
+
+- [ ] **Step 4: Run test to verify it passes, then run all env tests**
+
+Run: `go test ./pipeline/handlers/ -run "TestBuildEnv" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pipeline/handlers/backend_claudecode.go pipeline/handlers/backend_claudecode_env_test.go
+git commit -m "security(claudecode): require TRACKER_PASS_API_KEYS=1 not just non-empty"
+```
+
+---
+
+## Task 4: Fail on unknown outcome status instead of treating as success
+
+**Why:** An unknown/unexpected outcome status is silently promoted to success in `engine_run.go:659-668`. This masks handler bugs and allows broken nodes to appear completed.
+
+**Files:**
+- Modify: `pipeline/engine_run.go:659-668`
+- Test: `pipeline/engine_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestEngine_UnknownOutcomeFailsNode(t *testing.T) {
+	// Create a handler that returns an unrecognized outcome status.
+	registry := NewHandlerRegistry()
+	registry.Register("bogus_handler", HandlerFunc(func(ctx context.Context, node *Node, pctx *PipelineContext) (Outcome, error) {
+		return Outcome{Status: "totally_bogus_status"}, nil
+	}))
+
+	g := &Graph{
+		Nodes: map[string]*Node{
+			"Start": {ID: "Start", Handler: "bogus_handler"},
+			"Done":  {ID: "Done", Handler: "passthrough"},
+		},
+		Edges:     []Edge{{From: "Start", To: "Done"}},
+		StartNode: "Start",
+		ExitNode:  "Done",
+	}
+
+	engine := NewEngine(g, registry)
+	result, err := engine.Run(context.Background())
+
+	if err == nil && result.Status == OutcomeSuccess {
+		t.Fatal("expected unknown outcome to NOT be treated as success")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./pipeline/ -run "TestEngine_UnknownOutcome" -v`
+Expected: FAIL (currently treated as success)
+
+- [ ] **Step 3: Change the default case to return an error**
+
+In `engine_run.go`, replace the `default:` case:
+
+```go
+	default:
+		e.emit(PipelineEvent{
+			Type:      EventNodeFailed,
+			Timestamp: time.Now(),
+			RunID:     s.runID,
+			NodeID:    currentNodeID,
+			Message:   fmt.Sprintf("node %q returned unknown outcome status %q; treating as failure", currentNodeID, status),
+		})
+		s.pctx.Set(ContextKeyOutcome, OutcomeFail)
+```
+
+This changes the behavior from "unknown = success" to "unknown = fail". The node is NOT marked completed, and the pipeline will follow fail edges if available or stop.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./pipeline/ -run "TestEngine_UnknownOutcome" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full pipeline tests**
+
+Run: `go test ./pipeline/... -short`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pipeline/engine_run.go pipeline/engine_test.go
+git commit -m "fix(engine): fail on unknown outcome status instead of treating as success"
+```
+
+---
+
+## Task 5: Add defer/recover to TUI pipeline goroutine
+
+**Why:** `runPipelineAsync` launches a goroutine with no panic recovery. A panic crashes the process without checkpoint save or TUI cleanup.
+
+**Files:**
+- Modify: `cmd/tracker/run.go:561-573`
+
+- [ ] **Step 1: Add defer/recover to the goroutine**
+
+```go
+func runPipelineAsync(engine *pipeline.Engine, ctx context.Context, prog *tea.Program) chan pipelineOutcome {
+	outcomeCh := make(chan pipelineOutcome, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				pipelineErr := fmt.Errorf("pipeline panicked: %v", r)
+				outcomeCh <- pipelineOutcome{err: pipelineErr}
+				prog.Send(tui.MsgPipelineDone{Err: pipelineErr})
+			}
+		}()
+		result, pipelineErr := engine.Run(ctx)
+		if pipelineErr == nil && result.Status != pipeline.OutcomeSuccess {
+			pipelineErr = fmt.Errorf("pipeline finished with status: %s", result.Status)
+		}
+		outcomeCh <- pipelineOutcome{result: result, err: pipelineErr}
+		prog.Send(tui.MsgPipelineDone{Err: pipelineErr})
+	}()
+	return outcomeCh
+}
+```
+
+- [ ] **Step 2: Build to verify compilation**
+
+Run: `go build ./cmd/tracker/`
+Expected: Success
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `go test ./... -short`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/tracker/run.go
+git commit -m "fix(tui): add panic recovery to pipeline goroutine"
+```
+
+---
+
+## Task 6: Fix `PinnedDippinVersion` constant
+
+**Why:** `tracker doctor` tells users to install `v0.21.0` when `go.mod` requires `v0.23.0`. First-run experience is broken — doctor gives false confidence or sends users to install the wrong version.
+
+**Files:**
+- Modify: `tracker_doctor.go:25`
+- Test: `tracker_doctor_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestPinnedDippinVersionMatchesGoMod(t *testing.T) {
+	// Read go.mod to find actual dippin-lang version.
+	data, err := os.ReadFile("go.mod")
+	if err != nil {
+		t.Skip("cannot read go.mod")
+	}
+	// Find the dippin-lang require line.
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, "dippin-lang") {
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				goModVersion := parts[len(parts)-1]
+				if goModVersion != PinnedDippinVersion {
+					t.Errorf("PinnedDippinVersion = %q but go.mod has %q — update the constant", PinnedDippinVersion, goModVersion)
+				}
+				return
+			}
+		}
+	}
+	t.Skip("dippin-lang not found in go.mod")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test . -run "TestPinnedDippinVersion" -v`
+Expected: FAIL — `PinnedDippinVersion = "v0.21.0" but go.mod has "v0.23.0"`
+
+- [ ] **Step 3: Fix the constant**
+
+In `tracker_doctor.go` line 25:
+
+```go
+// Before:
+const PinnedDippinVersion = "v0.21.0"
+
+// After:
+const PinnedDippinVersion = "v0.23.0"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test . -run "TestPinnedDippinVersion" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tracker_doctor.go tracker_doctor_test.go
+git commit -m "fix(doctor): update PinnedDippinVersion to v0.23.0 to match go.mod"
+```
+
+---
+
+## Task 7: Fix `DefaultModel` to `claude-sonnet-4-6`
+
+**Why:** `DefaultModel` is `claude-sonnet-4-5` but docs/comments say 4-6 and autopilot already uses 4-6. When 4-5 is deprecated, every pipeline without an explicit model fails.
+
+**Files:**
+- Modify: `agent/config.go:88`
+
+- [ ] **Step 1: Update the constant**
+
+```go
+// Before:
+const (
+	DefaultModel    = "claude-sonnet-4-5"
+	DefaultProvider = "anthropic"
+)
+
+// After:
+const (
+	DefaultModel    = "claude-sonnet-4-6"
+	DefaultProvider = "anthropic"
+)
+```
+
+- [ ] **Step 2: Search for any test that hardcodes `claude-sonnet-4-5` as the expected default**
+
+Run: `grep -r "claude-sonnet-4-5" --include="*_test.go" .`
+
+Fix any tests that assert the old default.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./... -short`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add agent/config.go
+git commit -m "fix(agent): update DefaultModel to claude-sonnet-4-6"
+```
+
+---
+
+## Task 8: Fix autopilot to respect pipeline context cancellation
+
+**Why:** All 4 autopilot LLM call sites use `context.Background()` instead of the caller's context. Pipeline cancellation (ctrl-C, budget breach) doesn't stop autopilot from spending money for up to 30s.
+
+**Files:**
+- Modify: `pipeline/handlers/autopilot.go:178,188,348,361`
+- Test: `pipeline/handlers/autopilot_test.go`
+
+- [ ] **Step 1: Thread context through `callDecisionLLM`**
+
+The `callDecisionLLM` and `callInterviewLLM` methods need a parent context parameter. Add `parentCtx context.Context` as the first parameter to both.
+
+In `callDecisionLLM`, change:
+
+```go
+// Before:
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+// After:
+ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
+
+// Before (retry):
+ctx2, cancel2 := context.WithTimeout(context.Background(), 30*time.Second)
+// After:
+ctx2, cancel2 := context.WithTimeout(parentCtx, 30*time.Second)
+```
+
+Same pattern for `callInterviewLLM`.
+
+- [ ] **Step 2: Update all callers to pass their context**
+
+Find all call sites of `callDecisionLLM` and `callInterviewLLM` (in `Ask`, `AskFreeform`, `AskLabeled`, `AskInterview`) and pass the context parameter they receive.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./pipeline/handlers/ -short -v`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pipeline/handlers/autopilot.go
+git commit -m "fix(autopilot): respect pipeline context cancellation in LLM calls"
+```
+
+---
+
+## Task 9: Fix broken example `.dip` files after steer.* rename
+
+**Why:** `manager_loop_child.dip` references `${ctx.hint}` which silently returns empty after PR #196's `steer.*` namespace change.
+
+**Files:**
+- Modify: `examples/subgraphs/manager_loop_child.dip`
+
+- [ ] **Step 1: Fix the steer key references**
+
+In `manager_loop_child.dip`, change `${ctx.hint}` to `${ctx.steer.hint}` and `${ctx.priority}` to `${ctx.steer.priority}` in the prompt.
+
+- [ ] **Step 2: Validate the updated pipeline**
+
+Run: `dippin doctor examples/manager_loop_demo.dip`
+Expected: A grade (or at least no errors about the steer keys)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/subgraphs/manager_loop_child.dip
+git commit -m "fix(examples): update manager_loop_child to use steer.* namespace"
+```
+
+---
+
+## Task 10: Fix stale comment in human.go and osascript injection
+
+**Why:** `human.go:700-709` has a stale comment claiming CLAUDE.md is wrong when it's actually correct. `tui/notify.go` doesn't escape newlines in osascript strings, allowing injection.
+
+**Files:**
+- Modify: `pipeline/handlers/human.go:700-709`
+- Modify: `tui/notify.go:33-46`
+- Test: `tui/notify_test.go`
+
+- [ ] **Step 1: Remove the stale comment in human.go**
+
+Delete lines 700-709 (the comment block about CLAUDE.md questions_key inaccuracy).
+
+- [ ] **Step 2: Write failing test for osascript newline escaping**
+
+```go
+func TestEscapeOsascript_Newlines(t *testing.T) {
+	input := "done\nevil command"
+	escaped := escapeOsascript(input)
+	if strings.Contains(escaped, "\n") {
+		t.Error("newlines should be escaped in osascript strings")
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./tui/ -run "TestEscapeOsascript_Newlines" -v`
+Expected: FAIL
+
+- [ ] **Step 4: Fix `escapeOsascript` to handle newlines and carriage returns**
+
+```go
+func escapeOsascript(s string) string {
+	var out []byte
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			out = append(out, '\\', '"')
+		case '\\':
+			out = append(out, '\\', '\\')
+		case '\n':
+			out = append(out, ' ')
+		case '\r':
+			// skip
+		default:
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./tui/ -run "TestEscapeOsascript" -v`
+Expected: PASS
+
+- [ ] **Step 6: Build and run full test suite**
+
+Run: `go build ./... && go test ./... -short`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pipeline/handlers/human.go tui/notify.go tui/notify_test.go
+git commit -m "fix: remove stale human.go comment, escape newlines in osascript notifications"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Full build:** `go build ./...`
+- [ ] **Full tests:** `go test ./... -short`
+- [ ] **Dippin doctor on examples:** `dippin doctor examples/manager_loop_demo.dip`

--- a/docs/superpowers/plans/2026-05-19-hugo-docs-conversion.md
+++ b/docs/superpowers/plans/2026-05-19-hugo-docs-conversion.md
@@ -1,0 +1,1397 @@
+# Hugo Docs Conversion + a14y Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Convert the tracker docs site (currently 6 hand-written HTML files on `gh-pages`) into a Hugo project living at `site/` on `main`, built and deployed to `gh-pages` by a GitHub Action. Preserve the existing "creamsicle" visual identity (orange palette, `.glass` cards, `.nav-links`, `Inter` + `JetBrains Mono` typography). Fold in all a14y discovery fixes (AGENTS.md, llms.txt, robots.txt, sitemap.xml, sitemap.md, glossary page, per-page meta description / OpenGraph / canonical / JSON-LD).
+
+**Architecture:** The Hugo source lives in `site/`. The existing `style.css` and `highlight.js` are copied verbatim into `site/static/` — no design changes. Boilerplate (`<!DOCTYPE>`, `<head>`, `<nav>`, `<footer>`, `<script>`) lives in `layouts/_default/baseof.html` and `layouts/partials/{head,nav,footer}.html`. Each existing page becomes a Hugo content file: its `<main>...</main>` body is extracted verbatim into `content/<name>.html` with front matter that supplies title, description, OpenGraph fields, JSON-LD payload, and a `mermaid: true` flag where needed. URLs are preserved via `uglyURLs = true` (so `content/workflows.html` → `/workflows.html`). AGENTS.md and llms.txt live in `site/static/` and are served from the site root. Hugo's built-in `sitemap.xml` is enabled; a custom `layouts/sitemap.md` template emits the markdown sitemap; `layouts/robots.txt` emits the crawl policy. A GitHub Action (`.github/workflows/docs.yml`) checks out main on every push that touches `site/`, runs `hugo --minify`, and force-pushes `site/public/` to `gh-pages`. The existing hand-edited `gh-pages` branch is replaced wholesale by the build output the first time the action runs.
+
+**Tech Stack:** Hugo extended ≥ v0.140 (developer has v0.161.1 locally), GitHub Actions (`peaceiris/actions-hugo@v3` + `peaceiris/actions-gh-pages@v4`), existing `style.css` (orange/cream palette with `Inter` and `JetBrains Mono`), `highlight.js` (custom), conditional inline `mermaid@11` on workflows/architecture.
+
+---
+
+## File Structure
+
+```
+site/
+├── hugo.toml                      # Hugo config — baseURL, title, params, output formats
+├── archetypes/
+│   └── default.md                 # boilerplate front matter
+├── content/
+│   ├── _index.html                # home page (was index.html)
+│   ├── workflows.html             # was workflows.html
+│   ├── architecture.html          # was architecture.html
+│   ├── cli.html                   # was cli.html
+│   ├── changelog.html             # was changelog.html
+│   └── glossary.html              # new — agent-readable terminology
+├── layouts/
+│   ├── _default/
+│   │   ├── baseof.html            # outer chrome (doctype, head, nav, body, footer, scripts)
+│   │   ├── single.html            # single-page wrapper — pulls .Content into the base
+│   │   └── home.html              # home wrapper — same shape as single, kept separate for taste
+│   ├── partials/
+│   │   ├── head.html              # title, meta, OG, canonical, JSON-LD, conditional mermaid
+│   │   ├── nav.html               # site nav (reads data/nav.yaml; marks current item active)
+│   │   └── footer.html            # site footer
+│   ├── 404.html                   # 404 page
+│   ├── robots.txt                 # crawl policy template
+│   └── sitemap.md.md              # markdown sitemap output (filename per Hugo's output-format rules)
+├── data/
+│   └── nav.yaml                   # nav entries (label, href, external?)
+└── static/
+    ├── style.css                  # ported verbatim from gh-pages
+    ├── highlight.js               # ported verbatim from gh-pages
+    ├── AGENTS.md                  # agent-readable site orientation
+    └── llms.txt                   # llms.txt directory standard
+```
+
+Outside `site/`:
+
+```
+.github/workflows/
+└── docs.yml                       # build + deploy Hugo to gh-pages
+
+CLAUDE.md                          # update "Website (GitHub Pages)" section
+```
+
+---
+
+## Task 1: Clean up the abandoned gh-pages worktree
+
+**Files:** Removes `/tmp/tracker-site`.
+
+The previous a14y attempt added uncommitted edits to a `gh-pages` worktree. We're folding those fixes into Hugo instead, so the worktree should be discarded.
+
+- [ ] **Step 1: Remove the worktree (forces, since it has uncommitted edits)**
+
+Run: `git worktree remove --force /tmp/tracker-site`
+Expected output: silent success.
+
+- [ ] **Step 2: Verify worktrees are clean**
+
+Run: `git worktree list`
+Expected: only the main worktree at `/Users/harper/Public/src/2389/tracker [main]` remains.
+
+---
+
+## Task 2: Create the feature branch
+
+**Files:** None (branch creation only).
+
+All Hugo conversion work happens on a feature branch. PR back to main when verified locally.
+
+- [ ] **Step 1: Create + check out the branch**
+
+Run: `git checkout -b docs/hugo-conversion`
+Expected: `Switched to a new branch 'docs/hugo-conversion'`.
+
+- [ ] **Step 2: Confirm clean status**
+
+Run: `git status --short`
+Expected: only the pre-existing untracked files from the session start (`agent-runner`, `docs/superpowers/plans/...`, `predictions.jsonl`, `tracker-swebench`, and this new plan file). No staged changes.
+
+---
+
+## Task 3: Bootstrap the Hugo project
+
+**Files:**
+- Create: `site/hugo.toml`
+- Create: `site/archetypes/default.md`
+- Create: `site/.hugo_build.lock` (auto, gitignored)
+
+We do NOT run `hugo new site site` — it'd create an `archetypes/`, `content/`, `data/`, `layouts/`, `static/`, `themes/`, plus a default `hugo.toml`. We only want a subset, so write the files we need explicitly.
+
+- [ ] **Step 1: Create `site/hugo.toml`**
+
+```toml
+baseURL = "https://2389-research.github.io/tracker/"
+languageCode = "en-us"
+title = "Tracker"
+enableRobotsTXT = true
+enableGitInfo = true
+uglyURLs = true
+
+[params]
+description = "Multi-agent LLM pipeline orchestration with hard cost ceilings, parallel branches in git worktrees, and a live TUI."
+author = "2389.ai"
+authorURL = "https://2389.ai"
+repoURL = "https://github.com/2389-research/tracker"
+
+[outputs]
+home = ["html", "sitemap", "rss"]
+section = ["html"]
+page = ["html"]
+
+[outputFormats.sitemap-md]
+mediaType = "text/markdown"
+baseName = "sitemap"
+isPlainText = true
+notAlternative = true
+path = "/"
+suffix = "md"
+
+[markup.goldmark.renderer]
+unsafe = true
+
+[minify.tdewolff.html]
+keepEndTags = true
+keepDocumentTags = true
+keepConditionalComments = true
+keepDefaultAttrVals = true
+```
+
+Notes:
+- `uglyURLs = true` makes `content/workflows.html` resolve to `/workflows.html` (matching the existing URL structure — no broken inbound links).
+- `enableGitInfo = true` populates `.Lastmod` from git commit times for the sitemap.
+- `outputFormats.sitemap-md` is a custom output format that emits `/sitemap.md`; we add it to `[outputs.home]` later (after writing the template).
+
+- [ ] **Step 2: Add sitemap-md to home outputs**
+
+Edit `site/hugo.toml`, change the home output line to:
+
+```toml
+[outputs]
+home = ["html", "sitemap", "sitemap-md", "rss"]
+section = ["html"]
+page = ["html"]
+```
+
+- [ ] **Step 3: Create the default archetype**
+
+Create `site/archetypes/default.md` with:
+
+```markdown
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+---
+```
+
+- [ ] **Step 4: Commit the bootstrap**
+
+```bash
+git add site/hugo.toml site/archetypes/default.md
+git commit -m "docs(site): bootstrap Hugo project skeleton
+
+Add hugo.toml with uglyURLs (to preserve existing /X.html URLs),
+sitemap-md custom output format, and basic params block. Add the
+default archetype. No content or layouts yet."
+```
+
+---
+
+## Task 4: Port the static assets
+
+**Files:**
+- Create: `site/static/style.css` (copied verbatim from `origin/gh-pages:style.css`)
+- Create: `site/static/highlight.js` (copied verbatim from `origin/gh-pages:highlight.js`)
+
+The existing CSS and highlight script work as-is. We do not edit them in this conversion.
+
+- [ ] **Step 1: Copy the stylesheet**
+
+Run: `mkdir -p site/static && git show origin/gh-pages:style.css > site/static/style.css`
+Expected: `site/static/style.css` exists and is non-empty.
+
+- [ ] **Step 2: Copy the highlight script**
+
+Run: `git show origin/gh-pages:highlight.js > site/static/highlight.js`
+Expected: `site/static/highlight.js` exists and is non-empty.
+
+- [ ] **Step 3: Verify sizes match origin**
+
+Run: `wc -c site/static/style.css site/static/highlight.js && git show origin/gh-pages:style.css | wc -c && git show origin/gh-pages:highlight.js | wc -c`
+Expected: matching byte counts (allowing for minor newline differences).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/static/style.css site/static/highlight.js
+git commit -m "docs(site): port style.css and highlight.js from gh-pages
+
+Verbatim copy from origin/gh-pages — the creamsicle palette,
+glass cards, and custom syntax highlighting all carry over
+unchanged. No design adjustments yet."
+```
+
+---
+
+## Task 5: Build the head partial (a14y meta + JSON-LD)
+
+**Files:**
+- Create: `site/layouts/partials/head.html`
+
+The head partial renders title, meta description, OG fields, canonical URL, and a JSON-LD block — all from per-page front matter. Conditional inline mermaid is included when `mermaid: true` is set in front matter.
+
+- [ ] **Step 1: Create the partial**
+
+Create `site/layouts/partials/head.html`:
+
+```html
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ if .IsHome }}{{ site.Title }} — {{ site.Params.description | truncate 60 }}{{ else }}{{ .Title }} — {{ site.Title }}{{ end }}</title>
+
+  {{ $description := .Params.description | default site.Params.description }}
+  <meta name="description" content="{{ $description }}">
+
+  {{ $ogTitle := .Params.og_title | default .Title }}
+  {{ if .IsHome }}{{ $ogTitle = .Params.og_title | default (printf "%s — %s" site.Title "Multi-Agent Pipeline Orchestration") }}{{ end }}
+  <meta property="og:title" content="{{ $ogTitle }}">
+  <meta property="og:description" content="{{ .Params.og_description | default $description }}">
+  <meta property="og:type" content="{{ if .IsHome }}website{{ else }}article{{ end }}">
+  <meta property="og:url" content="{{ .Permalink }}">
+
+  <link rel="canonical" href="{{ .Permalink }}">
+  <link rel="alternate" type="application/rss+xml" href="{{ "index.xml" | absURL }}" title="{{ site.Title }} RSS feed">
+
+  <link rel="stylesheet" href="{{ "style.css" | relURL }}">
+
+  {{ if .Params.mermaid }}
+  <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+  <script>mermaid.initialize({ theme: 'base', securityLevel: 'loose', flowchart: { htmlLabels: true }, themeVariables: { fontSize: '16px', primaryColor: '#fff7ed', primaryTextColor: '#1c1917', primaryBorderColor: '#ea580c', lineColor: '#a8a29e', secondaryColor: '#ffedd5', tertiaryColor: '#fef7f0', background: 'transparent', mainBkg: '#fff7ed', nodeBorder: '#ea580c', clusterBkg: '#ffedd566', clusterBorder: '#ea580c44', titleColor: '#7c2d12', edgeLabelBackground: '#fef7f0', nodeTextColor: '#1c1917', actorTextColor: '#1c1917', signalTextColor: '#1c1917', labelTextColor: '#7c2d12' }});</script>
+  {{ end }}
+
+  {{ with .Params.jsonld }}
+  <script type="application/ld+json">
+  {{ . | jsonify (dict "indent" "  ") | safeJS }}
+  </script>
+  {{ end }}
+</head>
+```
+
+Notes:
+- `.Permalink` returns the absolute URL of the page — already includes `baseURL`.
+- The mermaid script is only emitted when a page sets `mermaid: true` (workflows and architecture pages).
+- The JSON-LD block is rendered from the `jsonld` front matter field as JSON. `safeJS` is required so Hugo doesn't escape it.
+- We do NOT emit `<link rel="alternate" type="text/markdown">` in this phase — `.md` mirrors are out of scope (matches the a14y common-skips choice from the prior plan).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/partials/head.html
+git commit -m "docs(site): add head partial with a14y metadata + JSON-LD
+
+The partial renders title, meta description, OpenGraph fields,
+canonical link, RSS alternate, and a conditional JSON-LD block
+from per-page front matter. Mermaid is included only when the
+page sets mermaid: true."
+```
+
+---
+
+## Task 6: Build the nav partial
+
+**Files:**
+- Create: `site/data/nav.yaml`
+- Create: `site/layouts/partials/nav.html`
+
+The nav is data-driven so we don't duplicate it across layouts. The data file lists labels + relative URLs; the partial marks the current page active.
+
+- [ ] **Step 1: Create `site/data/nav.yaml`**
+
+```yaml
+items:
+  - label: Home
+    url: /
+  - label: Workflows
+    url: /workflows.html
+  - label: Architecture
+    url: /architecture.html
+  - label: CLI
+    url: /cli.html
+  - label: Changelog
+    url: /changelog.html
+  - label: Glossary
+    url: /glossary.html
+  - label: GitHub
+    url: https://github.com/2389-research/tracker
+    external: true
+```
+
+- [ ] **Step 2: Create `site/layouts/partials/nav.html`**
+
+```html
+<nav class="nav">
+  <a href="{{ "/" | relURL }}" class="nav-brand">
+    <div class="logo-icon">T</div>
+    <span>tracker</span> <span class="accent">by 2389.ai</span>
+  </a>
+  <ul class="nav-links">
+    {{ $current := .RelPermalink }}
+    {{ range site.Data.nav.items }}
+      {{ $url := .url }}
+      {{ if not .external }}{{ $url = .url | relURL }}{{ end }}
+      <li>
+        <a href="{{ $url }}"
+           {{ if eq $current (.url | relURL) }}class="active"{{ end }}
+           {{ if .external }}target="_blank"{{ end }}>{{ .label }}</a>
+      </li>
+    {{ end }}
+  </ul>
+</nav>
+```
+
+Notes:
+- For internal links, `url` is passed through `relURL` so it gets prefixed with the baseURL path (`/tracker/` on the deploy domain).
+- `.RelPermalink` of the current page is compared against the link's relURL. The home page's `.RelPermalink` is `/tracker/` so we need exact match — that works because `/` | relURL → `/tracker/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/data/nav.yaml site/layouts/partials/nav.html
+git commit -m "docs(site): add nav partial driven by data/nav.yaml
+
+The nav reads its items from data/nav.yaml and marks the current
+page active by comparing .RelPermalink. External links open in
+a new tab via the external: true flag."
+```
+
+---
+
+## Task 7: Build the footer partial
+
+**Files:**
+- Create: `site/layouts/partials/footer.html`
+
+- [ ] **Step 1: Create the partial**
+
+```html
+<footer class="footer">
+  <p>Built by <a href="https://2389.ai">2389.ai</a> &middot; <a href="{{ site.Params.repoURL }}">GitHub</a></p>
+</footer>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/partials/footer.html
+git commit -m "docs(site): add footer partial"
+```
+
+---
+
+## Task 8: Build the base layout
+
+**Files:**
+- Create: `site/layouts/_default/baseof.html`
+
+The base layout is what every page extends. It pulls in the head/nav/footer partials, includes the highlight.js script at the end of body, and defines a `main` block that page-specific layouts fill.
+
+- [ ] **Step 1: Create `site/layouts/_default/baseof.html`**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+{{ partial "head.html" . }}
+<body>
+
+{{ partial "nav.html" . }}
+
+<main>
+{{ block "main" . }}{{ end }}
+</main>
+
+{{ partial "footer.html" . }}
+
+<script src="{{ "highlight.js" | relURL }}"></script>
+
+</body>
+</html>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/_default/baseof.html
+git commit -m "docs(site): add base layout
+
+baseof.html composes head/nav/footer partials and defines the
+'main' block that page layouts override. highlight.js loads at
+end of body — matches the existing pattern."
+```
+
+---
+
+## Task 9: Build single and home layouts
+
+**Files:**
+- Create: `site/layouts/_default/single.html`
+- Create: `site/layouts/_default/home.html`
+
+Both layouts are thin — they just emit `.Content` into the `main` block. We keep them as separate files (rather than relying on a single fallback) so future divergence (e.g. adding a TOC sidebar to single-page docs) doesn't require renaming.
+
+- [ ] **Step 1: Create single.html**
+
+```html
+{{ define "main" }}
+{{ .Content }}
+{{ end }}
+```
+
+- [ ] **Step 2: Create home.html**
+
+```html
+{{ define "main" }}
+{{ .Content }}
+{{ end }}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/layouts/_default/single.html site/layouts/_default/home.html
+git commit -m "docs(site): add single + home layouts
+
+Both layouts emit .Content into the base layout's main block.
+Kept separate so future divergence (TOC sidebar, etc.) doesn't
+require renaming."
+```
+
+---
+
+## Task 10: Add the 404 page
+
+**Files:**
+- Create: `site/layouts/404.html`
+
+- [ ] **Step 1: Create the 404 layout**
+
+```html
+{{ define "main" }}
+<section class="hero glass" style="padding: 3rem 2rem; text-align: center;">
+  <h1>404 — page not found</h1>
+  <p class="subtitle">That URL doesn't exist on this site.</p>
+  <div class="hero-actions">
+    <a href="{{ "/" | relURL }}" class="btn btn-primary">Back to home</a>
+    <a href="{{ site.Params.repoURL }}" class="btn btn-ghost">GitHub</a>
+  </div>
+</section>
+{{ end }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/404.html
+git commit -m "docs(site): add 404 page"
+```
+
+---
+
+## Task 11: Add the robots.txt template
+
+**Files:**
+- Create: `site/layouts/robots.txt`
+
+Hugo emits this at `/robots.txt` when `enableRobotsTXT = true` (already set in `hugo.toml`).
+
+- [ ] **Step 1: Create the template**
+
+```
+User-agent: *
+Allow: /
+
+Sitemap: {{ "sitemap.xml" | absURL }}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/robots.txt
+git commit -m "docs(site): add robots.txt template
+
+Allows all crawlers and points to the sitemap. Fixes the
+robots-txt.exists a14y check."
+```
+
+---
+
+## Task 12: Add the markdown sitemap output
+
+**Files:**
+- Create: `site/layouts/sitemap.md.md`
+
+Hugo's output-format machinery looks up `layouts/<kind>.<output-format-name>.<suffix>`. For our `sitemap-md` format with kind `home` and suffix `md`, the file is `layouts/sitemap.md.md`. That double-`.md` is intentional and matches Hugo's naming rules.
+
+- [ ] **Step 1: Create the template**
+
+```markdown
+# Tracker — Site Map
+
+A human-readable index of every page on this site.
+
+## Pages
+
+{{ range where site.RegularPages "Section" "" }}
+- [{{ .Title }}]({{ .Permalink }}) — {{ .Params.description | default .Summary | truncate 120 }}
+{{ end }}
+
+## Machine-readable
+
+- [llms.txt]({{ "llms.txt" | absURL }}) — short orientation prompt for LLM agents.
+- [sitemap.xml]({{ "sitemap.xml" | absURL }}) — XML sitemap.
+- [robots.txt]({{ "robots.txt" | absURL }}) — crawl policy.
+- [AGENTS.md]({{ "AGENTS.md" | absURL }}) — agent-readable site orientation.
+
+## Source
+
+- [GitHub repository]({{ site.Params.repoURL }})
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add site/layouts/sitemap.md.md
+git commit -m "docs(site): add markdown sitemap output
+
+Custom output format defined in hugo.toml emits /sitemap.md
+from this template. Fixes the sitemap-md.exists a14y check."
+```
+
+---
+
+## Task 13: Add AGENTS.md and llms.txt as static files
+
+**Files:**
+- Create: `site/static/AGENTS.md`
+- Create: `site/static/llms.txt`
+
+These are served verbatim at `/AGENTS.md` and `/llms.txt`. They could be generated from templates, but static is simpler for content that changes once per quarter at most.
+
+- [ ] **Step 1: Create `site/static/AGENTS.md`**
+
+```markdown
+# Tracker — Agent Reference
+
+Tracker is a pipeline orchestration engine for multi-agent LLM workflows.
+Pipelines are defined in `.dip` files (the Dippin language) and executed
+with parallel agents via a TUI dashboard. Built by 2389.ai.
+
+## Where to start
+
+- [Home](https://2389-research.github.io/tracker/) — what tracker is, install + run in 60 seconds.
+- [Workflows](https://2389-research.github.io/tracker/workflows.html) — the built-in pipelines and how `.dip` files are structured.
+- [Architecture](https://2389-research.github.io/tracker/architecture.html) — engine, nodes, edges, backends, checkpoints, parallel execution, budget governance.
+- [CLI Reference](https://2389-research.github.io/tracker/cli.html) — every subcommand and flag.
+- [Changelog](https://2389-research.github.io/tracker/changelog.html) — release history.
+- [Glossary](https://2389-research.github.io/tracker/glossary.html) — terminology used across the docs and `.dip` files.
+
+## Source
+
+Code, issues, and releases live at <https://github.com/2389-research/tracker>.
+
+## Conventions used in these docs
+
+- Code blocks fenced with a language tag (`bash`, `dip`) carry the runnable
+  commands or pipeline snippets being described in the surrounding prose.
+- `.dip` files use the Dippin pipeline language — see the Workflows and
+  Architecture pages for the IR-to-Tracker mapping rules.
+- Provider names follow tracker convention: `anthropic`, `openai`, `gemini`
+  (not `google`). Base URL resolution goes through
+  `tracker.ResolveProviderBaseURL(provider)`.
+
+## a14y configuration
+
+- Target URL: <https://2389-research.github.io/tracker/>
+- Scorecard: 0.2.0
+- Mode: site
+- Last runs:
+  - 2026-05-19 — 39 (scorecard 0.2.0)
+```
+
+- [ ] **Step 2: Create `site/static/llms.txt`**
+
+```
+# Tracker
+
+> Multi-agent LLM pipeline orchestration with hard cost ceilings, parallel branches in git worktrees, and a live TUI. Define workflows in a small text file (`.dip`); every run is a git commit you can diff and replay. Built by 2389.ai.
+
+## Documentation
+
+- [Home](https://2389-research.github.io/tracker/): What tracker is and how to install + run it in 60 seconds.
+- [Workflows](https://2389-research.github.io/tracker/workflows.html): Built-in pipelines (`ask_and_execute`, `build_product`, `build_product_with_superspec`) and how `.dip` files are structured.
+- [Architecture](https://2389-research.github.io/tracker/architecture.html): Engine, nodes, edges, backends (native / Claude Code / ACP), checkpoints, parallel execution, budget governance.
+- [CLI Reference](https://2389-research.github.io/tracker/cli.html): Every flag and subcommand — `run`, `validate`, `simulate`, `doctor`, `diagnose`, `audit`, `init`, `workflows`, `update`, `version`.
+- [Changelog](https://2389-research.github.io/tracker/changelog.html): Release history with breaking changes and feature notes.
+- [Glossary](https://2389-research.github.io/tracker/glossary.html): Terminology used across the docs and `.dip` files.
+
+## Source
+
+- [GitHub repository](https://github.com/2389-research/tracker): Source code, issue tracker, and tagged releases.
+- [AGENTS.md](https://2389-research.github.io/tracker/AGENTS.md): Agent-readable orientation for this site.
+- [sitemap.xml](https://2389-research.github.io/tracker/sitemap.xml): Machine-readable URL index.
+- [sitemap.md](https://2389-research.github.io/tracker/sitemap.md): Human-readable URL index.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/static/AGENTS.md site/static/llms.txt
+git commit -m "docs(site): add AGENTS.md and llms.txt
+
+AGENTS.md provides agent-readable site orientation; llms.txt
+follows the llms.txt directory standard. Both are static and
+served at /AGENTS.md and /llms.txt respectively. Fixes the
+agents-md.exists and llms-txt.exists a14y checks."
+```
+
+---
+
+## Task 14: Port the home page
+
+**Files:**
+- Create: `site/content/_index.html`
+
+The home page body is everything between `<main>` and `</main>` in the existing `origin/gh-pages:index.html`, dropped into a Hugo content file with front matter. The front matter supplies the description, OG fields, and JSON-LD that the head partial renders.
+
+- [ ] **Step 1: Extract the existing body**
+
+Run: `git show origin/gh-pages:index.html > /tmp/index-original.html`
+Then open `/tmp/index-original.html` and locate the `<main>` and `</main>` tags. The home content is everything between them (NOT including the `<main>` tags themselves).
+
+- [ ] **Step 2: Create `site/content/_index.html` with front matter**
+
+The file structure is:
+
+```html
+---
+title: "Multi-Agent Pipeline Orchestration"
+description: "Multi-agent LLM pipeline orchestration with hard cost ceilings, parallel branches in git worktrees, and a live TUI. Define workflows in a small text file; every run is a git commit you can diff and replay."
+og_title: "Tracker — Multi-Agent Pipeline Orchestration"
+og_description: "Multi-agent LLM pipeline orchestration with hard cost ceilings, parallel branches in git worktrees, and a live TUI. Built by 2389.ai."
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "SoftwareApplication"
+  name: "Tracker"
+  description: "Multi-agent LLM pipeline orchestration with hard cost ceilings, parallel branches in git worktrees, and a live TUI."
+  url: "https://2389-research.github.io/tracker/"
+  applicationCategory: "DeveloperApplication"
+  operatingSystem: "macOS, Linux"
+  offers:
+    "@type": "Offer"
+    price: "0"
+    priceCurrency: "USD"
+  author:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+  codeRepository: "https://github.com/2389-research/tracker"
+  license: "https://github.com/2389-research/tracker/blob/main/LICENSE"
+---
+
+<!-- BODY: paste the verbatim contents of <main>...</main> from
+     /tmp/index-original.html here, NOT including the <main> tags. -->
+```
+
+The actual body is too long to inline in this plan; copy it from `/tmp/index-original.html` between the `<main>` tags. Do not modify the markup — even hand-encoded HTML entities (`&rsquo;`, `&mdash;`) stay as-is.
+
+- [ ] **Step 3: Verify locally**
+
+Run: `cd site && hugo server` (in background or another terminal).
+Open: <http://localhost:1313/tracker/>
+Expected: home page renders. The hero, install section, all the original content appears. Nav shows the Glossary link (added in Task 6). `<head>` contains the new meta description, OG tags, canonical, and JSON-LD block (view-source to confirm).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/_index.html
+git commit -m "docs(site): port home page to Hugo content
+
+Verbatim copy of the <main> body from origin/gh-pages:index.html
+into content/_index.html. Front matter supplies a14y metadata
+(description, OG, canonical, JSON-LD as SoftwareApplication)
+that the head partial renders."
+```
+
+---
+
+## Task 15: Port the workflows page
+
+**Files:**
+- Create: `site/content/workflows.html`
+
+- [ ] **Step 1: Extract the existing body**
+
+Run: `git show origin/gh-pages:workflows.html > /tmp/workflows-original.html`
+
+- [ ] **Step 2: Create `site/content/workflows.html`**
+
+Front matter:
+
+```html
+---
+title: "Built-in Workflows"
+description: "The three pipelines that ship with Tracker — ask_and_execute, build_product, and build_product_with_superspec — and how to author your own .dip files for headless autonomous builds."
+og_title: "Built-in Workflows — Tracker"
+og_description: "The three pipelines that ship with Tracker, plus a reference for authoring your own .dip files."
+mermaid: true
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "TechArticle"
+  headline: "Built-in Workflows — Tracker"
+  description: "The three pipelines that ship with Tracker — ask_and_execute, build_product, and build_product_with_superspec — and how to author your own .dip files."
+  url: "https://2389-research.github.io/tracker/workflows.html"
+  author:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+  publisher:
+    "@type": "Organization"
+    name: "2389.ai"
+  isPartOf:
+    "@type": "WebSite"
+    name: "Tracker"
+    url: "https://2389-research.github.io/tracker/"
+---
+
+<!-- BODY: paste the verbatim contents of <main>...</main> from
+     /tmp/workflows-original.html. -->
+```
+
+- [ ] **Step 3: Verify locally**
+
+Open: <http://localhost:1313/tracker/workflows.html>
+Expected: page renders. Mermaid diagrams (if any) render — the inline mermaid script is included because `mermaid: true` is in front matter. Nav shows Workflows as active.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/workflows.html
+git commit -m "docs(site): port workflows page to Hugo content
+
+Body copied verbatim from origin/gh-pages. Front matter sets
+mermaid: true so the inline mermaid script gets included via
+the head partial."
+```
+
+---
+
+## Task 16: Port the architecture page
+
+**Files:**
+- Create: `site/content/architecture.html`
+
+- [ ] **Step 1: Extract**
+
+Run: `git show origin/gh-pages:architecture.html > /tmp/architecture-original.html`
+
+- [ ] **Step 2: Create the content file**
+
+```html
+---
+title: "Architecture"
+description: "How Tracker orchestrates multi-agent pipelines — the engine, nodes, edges, backends (native / Claude Code / ACP), checkpoints, parallel execution, budget governance, and tool-safety controls."
+og_title: "Architecture — Tracker"
+og_description: "How Tracker orchestrates multi-agent pipelines — engine, nodes, edges, backends, checkpoints, parallel execution, and budget governance."
+mermaid: true
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "TechArticle"
+  headline: "Architecture — Tracker"
+  description: "How Tracker orchestrates multi-agent pipelines — the engine, nodes, edges, backends, checkpoints, parallel execution, and budget governance."
+  url: "https://2389-research.github.io/tracker/architecture.html"
+  author:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+  publisher:
+    "@type": "Organization"
+    name: "2389.ai"
+  isPartOf:
+    "@type": "WebSite"
+    name: "Tracker"
+    url: "https://2389-research.github.io/tracker/"
+---
+
+<!-- BODY: paste the verbatim contents of <main>...</main> from
+     /tmp/architecture-original.html. -->
+```
+
+- [ ] **Step 3: Verify locally**
+
+Open: <http://localhost:1313/tracker/architecture.html>
+Expected: mermaid diagrams render (this page is mermaid-heavy). All `.glass` sections render correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/architecture.html
+git commit -m "docs(site): port architecture page to Hugo content"
+```
+
+---
+
+## Task 17: Port the CLI page
+
+**Files:**
+- Create: `site/content/cli.html`
+
+- [ ] **Step 1: Extract**
+
+Run: `git show origin/gh-pages:cli.html > /tmp/cli-original.html`
+
+- [ ] **Step 2: Create the content file**
+
+```html
+---
+title: "CLI Reference"
+description: "Every Tracker CLI subcommand and flag — run, validate, simulate, doctor, diagnose, audit, init, workflows, update — plus budget caps, backend selection, autopilot personas, and tool-safety controls."
+og_title: "CLI Reference — Tracker"
+og_description: "Every Tracker CLI subcommand, flag, and resolution rule — install and operate Tracker from the terminal."
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "TechArticle"
+  headline: "Tracker CLI Reference"
+  description: "Every Tracker CLI subcommand and flag — run, validate, simulate, doctor, diagnose, audit, init, workflows, update."
+  url: "https://2389-research.github.io/tracker/cli.html"
+  author:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+  publisher:
+    "@type": "Organization"
+    name: "2389.ai"
+  isPartOf:
+    "@type": "WebSite"
+    name: "Tracker"
+    url: "https://2389-research.github.io/tracker/"
+---
+
+<!-- BODY: paste the verbatim contents of <main>...</main> from
+     /tmp/cli-original.html. -->
+```
+
+Note: no `mermaid: true` — this page has no mermaid diagrams.
+
+- [ ] **Step 3: Verify locally**
+
+Open: <http://localhost:1313/tracker/cli.html>
+Expected: code blocks render with highlight.js styling. No mermaid script in head.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/cli.html
+git commit -m "docs(site): port CLI page to Hugo content"
+```
+
+---
+
+## Task 18: Port the changelog page
+
+**Files:**
+- Create: `site/content/changelog.html`
+
+- [ ] **Step 1: Extract**
+
+Run: `git show origin/gh-pages:changelog.html > /tmp/changelog-original.html`
+
+- [ ] **Step 2: Create the content file**
+
+```html
+---
+title: "Changelog"
+description: "Tracker release history — versions, breaking changes, new features, and fixes across every shipped release."
+og_title: "Changelog — Tracker"
+og_description: "Tracker release history — versions, breaking changes, new features, and fixes."
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "TechArticle"
+  headline: "Tracker Changelog"
+  description: "Tracker release history — versions, breaking changes, new features, and fixes."
+  url: "https://2389-research.github.io/tracker/changelog.html"
+  author:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+  publisher:
+    "@type": "Organization"
+    name: "2389.ai"
+  isPartOf:
+    "@type": "WebSite"
+    name: "Tracker"
+    url: "https://2389-research.github.io/tracker/"
+---
+
+<!-- BODY: paste the verbatim contents of <main>...</main> from
+     /tmp/changelog-original.html. -->
+```
+
+- [ ] **Step 3: Verify locally**
+
+Open: <http://localhost:1313/tracker/changelog.html>
+Expected: release entries render. Anchor links (e.g. `#v0-29-2`) still work.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add site/content/changelog.html
+git commit -m "docs(site): port changelog page to Hugo content"
+```
+
+---
+
+## Task 19: Author the glossary page (new)
+
+**Files:**
+- Create: `site/content/glossary.html`
+
+The glossary is new — no source on `gh-pages` to port. Inline the full body here.
+
+- [ ] **Step 1: Create the content file**
+
+```html
+---
+title: "Glossary"
+description: "Terminology used across Tracker pipelines, the Dippin language, and the multi-agent runtime — node, edge, handler, backend, autopilot, budget, checkpoint, bundle, and more."
+og_title: "Glossary — Tracker"
+og_description: "Terminology used across Tracker pipelines, the Dippin language, and the multi-agent runtime."
+jsonld:
+  "@context": "https://schema.org"
+  "@type": "DefinedTermSet"
+  name: "Tracker Glossary"
+  description: "Terminology used across Tracker pipelines, the Dippin language, and the multi-agent runtime."
+  url: "https://2389-research.github.io/tracker/glossary.html"
+  publisher:
+    "@type": "Organization"
+    name: "2389.ai"
+    url: "https://2389.ai"
+---
+
+<section class="hero glass" style="padding: 3rem 2rem;">
+  <h1>Glossary</h1>
+  <p class="subtitle">Terminology used across Tracker pipelines, the Dippin language, and the multi-agent runtime.</p>
+</section>
+
+<nav class="page-toc" aria-label="On this page">
+  <strong>On this page:</strong>
+  <a href="#pipeline">Pipeline &amp; runtime</a>
+  <a href="#dippin">Dippin language</a>
+  <a href="#agents">Agents &amp; backends</a>
+  <a href="#handlers">Node handlers</a>
+  <a href="#routing">Routing &amp; outcome</a>
+  <a href="#governance">Governance</a>
+  <a href="#artifacts">Artifacts &amp; inspection</a>
+</nav>
+
+<section class="glass" id="pipeline">
+  <h2>Pipeline &amp; <span class="accent">runtime</span></h2>
+  <p class="lead">The core abstractions the engine works with.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Pipeline</h4><p>A directed graph of nodes connected by edges, plus shared context. Defined in a <code>.dip</code> file and executed by the engine.</p></div>
+    <div class="glass glass-sm"><h4>Engine</h4><p>The Tracker runtime that walks the graph: pick a node, execute its handler, evaluate outgoing edges, advance. Treats every node the same &mdash; no special-cases for parallel or fan-in.</p></div>
+    <div class="glass glass-sm"><h4>Node</h4><p>A single step in the pipeline. Identified by ID; carries a <code>handler</code> (agent, tool, human, parallel, &hellip;) and attributes (prompt, model, command, &hellip;).</p></div>
+    <div class="glass glass-sm"><h4>Edge</h4><p>A directed connection between two nodes. Optionally guarded by a condition like <code>when ctx.outcome = success</code>. Labeled edges can carry a human-readable choice.</p></div>
+    <div class="glass glass-sm"><h4>Run</h4><p>One execution of a pipeline. Has a unique <code>runID</code>, an artifact directory, and a status. Resumable from a checkpoint.</p></div>
+    <div class="glass glass-sm"><h4>Checkpoint</h4><p>A snapshot of the engine&rsquo;s state &mdash; completed nodes, context, edge selections &mdash; written after each node finishes. Used to resume a stopped run.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="dippin">
+  <h2><span class="accent">Dippin</span> language</h2>
+  <p class="lead">The text format pipelines are authored in.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Dippin</h4><p>The pipeline language used by Tracker. Has its own parser, linter (<code>dippin doctor</code>), and simulator. Ships as a Go module: <code>github.com/2389-research/dippin-lang</code>.</p></div>
+    <div class="glass glass-sm"><h4><code>.dip</code> file</h4><p>A Dippin source file declaring nodes, edges, and workflow-level defaults. Loaded by <code>tracker run</code>, <code>tracker validate</code>, and <code>tracker simulate</code>.</p></div>
+    <div class="glass glass-sm"><h4>IR (Intermediate Representation)</h4><p>The parsed in-memory form of a Dippin pipeline. Converted to Tracker&rsquo;s <code>Graph</code> model by <code>pipeline/dippin_adapter.go</code>.</p></div>
+    <div class="glass glass-sm"><h4>Workflow defaults</h4><p>A <code>defaults:</code> block at the top of a <code>.dip</code> file that sets pipeline-wide values &mdash; default model, provider, budget ceilings &mdash; folded in as fallbacks beneath CLI flags and library config.</p></div>
+    <div class="glass glass-sm"><h4><code>writes:</code> / <code>reads:</code></h4><p>Declarative I/O contracts on agent, tool, and interview-human nodes. Lists the context keys a node produces (<code>writes:</code>) or expects (<code>reads:</code>). Extracted into first-class context keys at runtime.</p></div>
+    <div class="glass glass-sm"><h4>Context</h4><p>The shared key/value store every node reads from and writes to. Bare keys live at the top; per-node aliases (<code>node.&lt;nodeID&gt;.&lt;key&gt;</code>) appear after each node finishes.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="agents">
+  <h2>Agents &amp; <span class="accent">backends</span></h2>
+  <p class="lead">How LLM calls actually happen.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Agent</h4><p>The LLM-driven actor that runs inside an agent node. Has a model, a prompt, and access to tools; produces a session result with token usage and final response.</p></div>
+    <div class="glass glass-sm"><h4>Backend</h4><p>The execution strategy for an agent node. Three are built in: <strong>Native</strong>, <strong>Claude Code</strong>, and <strong>ACP</strong>. Selected per-node via <code>backend:</code> or globally via <code>--backend</code>.</p></div>
+    <div class="glass glass-sm"><h4>Native backend</h4><p>Wraps <code>agent.Session</code> with a turn loop, tool registry, and context compaction. Calls the provider SDK directly (Anthropic / OpenAI / Gemini / OpenAI-compat).</p></div>
+    <div class="glass glass-sm"><h4>Claude Code backend</h4><p>Spawns the <code>claude</code> CLI as a subprocess and parses NDJSON output. API keys are stripped from the subprocess env so subscription auth works; override with <code>TRACKER_PASS_API_KEYS=1</code>.</p></div>
+    <div class="glass glass-sm"><h4>ACP backend</h4><p>Bridges to any <a href="https://agentclientprotocol.com/">Agent Client Protocol</a> agent over stdio &mdash; <code>claude-agent-acp</code>, <code>codex-acp</code>, <code>gemini --acp</code>. Provider-based defaults; override per node via <code>acp_agent</code>.</p></div>
+    <div class="glass glass-sm"><h4>Provider</h4><p>The LLM vendor for a native-backend call: <code>anthropic</code>, <code>openai</code>, <code>gemini</code>, or <code>openai-compat</code>. Base URL resolved via <code>tracker.ResolveProviderBaseURL(provider)</code>.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="handlers">
+  <h2>Node <span class="accent">handlers</span></h2>
+  <p class="lead">The set of behaviors a node can have. Selected by the <code>handler:</code> attribute.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Agent (codergen)</h4><p>Runs an LLM session via the selected backend. Carries a prompt, model, optional tools, and an optional structured-output schema.</p></div>
+    <div class="glass glass-sm"><h4>Tool</h4><p>Runs a shell command. Stdout/stderr are captured (tail-windowed at 64KB by default) and surfaced as <code>ctx.tool_stdout</code> / <code>ctx.tool_stderr</code>.</p></div>
+    <div class="glass glass-sm"><h4>Human gate</h4><p>Pauses the pipeline for human input. Modes: default choice, yes/no, freeform, labeled freeform, and interview (multi-field form from JSON questions).</p></div>
+    <div class="glass glass-sm"><h4>Parallel</h4><p>Dispatches multiple branches concurrently from <code>parallel_targets</code>. Each branch runs in its own goroutine with panic recovery; emits per-branch start/complete events.</p></div>
+    <div class="glass glass-sm"><h4>Fan-in</h4><p>Joins parallel branches back into a single path. The parallel handler hints the engine at the join node via <code>suggested_next_nodes</code>.</p></div>
+    <div class="glass glass-sm"><h4>Conditional</h4><p>A no-op node whose only job is to route the run based on <code>when&hellip;</code> guards on its outgoing edges. Useful as an explicit branching point.</p></div>
+    <div class="glass glass-sm"><h4>Subgraph</h4><p>Embeds another <code>.dip</code> pipeline as a node. The child runs in isolation with its own context window; results merge back via declared <code>writes:</code>.</p></div>
+    <div class="glass glass-sm"><h4>Manager loop</h4><p>A controller node that repeatedly spawns a child agent with steerable context (<code>steer.&lt;key&gt;</code>) until a termination condition fires. Lives in the <code>stack.manager_loop</code> handler.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="routing">
+  <h2>Routing &amp; <span class="accent">outcome</span></h2>
+  <p class="lead">How the engine decides where to go next.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Outcome</h4><p>The status a node reports when it finishes: <code>success</code>, <code>fail</code>, <code>retry</code>, or <code>budget_exceeded</code>. Available on outgoing edges as <code>ctx.outcome</code>.</p></div>
+    <div class="glass glass-sm"><h4>Conditional edge</h4><p>An edge with a <code>when&hellip;</code> guard like <code>when ctx.outcome = success</code>. Evaluated against the context; unmatched conditional edges are skipped.</p></div>
+    <div class="glass glass-sm"><h4>Strict failure edge</h4><p>When a node&rsquo;s outcome is <code>fail</code> and every outgoing edge is unconditional, the engine stops. Prevents tool nodes from silently masking errors.</p></div>
+    <div class="glass glass-sm"><h4>Suggested next nodes</h4><p>An optional hint a handler can set to redirect the engine past the normal edge-walk &mdash; used by the parallel handler to jump to the fan-in.</p></div>
+    <div class="glass glass-sm"><h4>Escalation</h4><p>A routing convention, not a distinct outcome: an edge guarded by <code>ctx.outcome = fail</code> that leads to an escalation gate (e.g. <code>EscalateMilestone</code>).</p></div>
+    <div class="glass glass-sm"><h4>Preferred label</h4><p>The human-readable choice a human-gate node returned. Drives label-based edge selection when an edge specifies a target label.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="governance">
+  <h2><span class="accent">Governance</span></h2>
+  <p class="lead">Budgets, ceilings, and headless decision-making.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Budget</h4><p>The set of ceilings a run will halt under: max tokens, max cost (cents), max wall-time. Configured via <code>tracker.Config.Budget</code>, CLI flags, or a <code>defaults:</code> block.</p></div>
+    <div class="glass glass-sm"><h4>Cost ceiling</h4><p>A dollar (or cents) cap. Enforced between nodes after each cost update; breach halts the run with outcome <code>budget_exceeded</code> and fires <code>EventBudgetExceeded</code>.</p></div>
+    <div class="glass glass-sm"><h4>Autopilot</h4><p>Replaces every human gate with an LLM-backed decision. Four personas: <code>lax</code> (forward progress), <code>mid</code> (balanced, default), <code>hard</code> (high bar), <code>mentor</code> (approve with feedback).</p></div>
+    <div class="glass glass-sm"><h4>Auto-approve</h4><p>Deterministic alternative to autopilot &mdash; always picks the default or first option at a gate. No LLM call.</p></div>
+    <div class="glass glass-sm"><h4>Webhook gate</h4><p>Headless alternative to autopilot: gates are POSTed to an external service and blocked on a callback. Enabled via <code>--webhook-url</code>.</p></div>
+    <div class="glass glass-sm"><h4>Circuit breaker</h4><p>A per-area attempt counter (e.g. <code>fix_attempts</code> on disk) that caps how many times a section of a pipeline can retry. Persists across run restarts.</p></div>
+  </div>
+</section>
+
+<section class="glass" id="artifacts">
+  <h2>Artifacts &amp; <span class="accent">inspection</span></h2>
+  <p class="lead">Everything a run leaves behind, and the commands that read it.</p>
+  <div class="grid-2" style="margin-top: 1.25rem;">
+    <div class="glass glass-sm"><h4>Artifact</h4><p>Any file written by a node during a run &mdash; agent transcripts, tool outputs, generated code. Lives in the run directory.</p></div>
+    <div class="glass glass-sm"><h4>Run directory</h4><p>The on-disk home for one run: <code>&lt;workDir&gt;/.tracker/runs/&lt;runID&gt;/</code>. Contains <code>status.json</code>, <code>checkpoint.json</code>, transcripts, and the git-artifacts repo if enabled.</p></div>
+    <div class="glass glass-sm"><h4>Git artifacts</h4><p>When <code>WithGitArtifacts(true)</code> is set, the run directory is initialized as a git repo and a commit is made after every terminal node &mdash; every run is replayable.</p></div>
+    <div class="glass glass-sm"><h4>Bundle</h4><p>A portable, self-contained git bundle of the run directory&rsquo;s full history. Built by <code>tracker.ExportBundle</code> or <code>--export-bundle</code>; clone with <code>git clone &lt;bundle&gt;</code>.</p></div>
+    <div class="glass glass-sm"><h4>Activity log</h4><p>The append-only event stream for a run (<code>activity.jsonl</code>). Lives in a secured XDG state dir; a sentinel-stripped copy is written back to the run dir for bundle export.</p></div>
+    <div class="glass glass-sm"><h4><code>tracker diagnose</code></h4><p>Reads <code>status.json</code> + <code>activity.jsonl</code> for a failed run and surfaces tool output, stderr, errors, timing anomalies, and suggested fixes. Without an ID, analyzes the most recent run.</p></div>
+  </div>
+</section>
+```
+
+- [ ] **Step 2: Verify locally**
+
+Open: <http://localhost:1313/tracker/glossary.html>
+Expected: glossary renders. The hero card, page-TOC nav, and 7 sections all appear styled correctly. Nav shows Glossary as active.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/content/glossary.html
+git commit -m "docs(site): add glossary page
+
+New page — agent-readable terminology covering pipeline, dippin,
+agents/backends, node handlers, routing, governance, and
+artifacts. Uses the same .glass/.grid-2 pattern as the existing
+architecture page. JSON-LD as DefinedTermSet."
+```
+
+---
+
+## Task 20: Full local verification
+
+**Files:** None (verification only).
+
+Before pushing, confirm every page renders, every link works, every static file is reachable.
+
+- [ ] **Step 1: Stop any running hugo server, then start fresh**
+
+Run from `site/`: `hugo server --bind 0.0.0.0 --port 1313`
+Expected: clean startup, `Web Server is available at http://localhost:1313/tracker/`.
+
+- [ ] **Step 2: Verify every URL responds 200**
+
+In another terminal:
+
+```bash
+for path in "" workflows.html architecture.html cli.html changelog.html glossary.html AGENTS.md llms.txt robots.txt sitemap.xml sitemap.md; do
+  code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:1313/tracker/$path")
+  printf "  %-20s  %s\n" "$path" "$code"
+done
+```
+
+Expected: all 200.
+
+- [ ] **Step 3: Verify head metadata on each page**
+
+For each of the 6 HTML pages, run:
+
+```bash
+curl -s "http://localhost:1313/tracker/<page>" | grep -E '(<title>|meta name="description"|og:title|og:description|og:type|canonical|application/ld\+json)'
+```
+
+Expected: every grep returns at least one match per pattern.
+
+- [ ] **Step 4: Verify mermaid loads ONLY on workflows + architecture**
+
+```bash
+for page in "" workflows.html architecture.html cli.html changelog.html glossary.html; do
+  has_mermaid=$(curl -s "http://localhost:1313/tracker/$page" | grep -c 'mermaid.min.js' || true)
+  printf "  %-20s  mermaid script: %s\n" "$page" "$has_mermaid"
+done
+```
+
+Expected: `1` on workflows + architecture, `0` on all others.
+
+- [ ] **Step 5: Verify the glossary nav link appears on every page**
+
+```bash
+for page in "" workflows.html architecture.html cli.html changelog.html glossary.html; do
+  has_glossary=$(curl -s "http://localhost:1313/tracker/$page" | grep -c 'href="/tracker/glossary.html"' || true)
+  printf "  %-20s  glossary link: %s\n" "$page" "$has_glossary"
+done
+```
+
+Expected: every page has `1` (the nav link).
+
+- [ ] **Step 6: Visual spot-check in a browser**
+
+Open these in a browser and confirm the visual identity matches the live site:
+- <http://localhost:1313/tracker/> (home — hero gradient, install code block syntax-highlighted, .glass cards)
+- <http://localhost:1313/tracker/workflows.html> (mermaid diagrams render)
+- <http://localhost:1313/tracker/architecture.html> (mermaid diagrams render)
+- <http://localhost:1313/tracker/cli.html> (code-block syntax highlighting)
+- <http://localhost:1313/tracker/changelog.html> (release entries laid out as cards)
+- <http://localhost:1313/tracker/glossary.html> (7 sections, grid-2 cards, page-TOC nav at top)
+
+If anything looks off, file a TODO and revisit before the deploy task.
+
+- [ ] **Step 7: Stop the hugo server**
+
+Ctrl-C.
+
+---
+
+## Task 21: Add the GitHub Actions deploy workflow
+
+**Files:**
+- Create: `.github/workflows/docs.yml`
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+# ABOUTME: GitHub Actions workflow to build and deploy the docs site.
+# ABOUTME: Triggers on pushes to main that touch site/ or the workflow itself.
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'site/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: '0.161.1'
+          extended: true
+
+      - name: Build
+        working-directory: ./site
+        run: hugo --minify --gc
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site/public
+          publish_branch: gh-pages
+          force_orphan: true
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'docs: deploy ${{ github.sha }}'
+```
+
+Notes:
+- `fetch-depth: 0` is required because `enableGitInfo = true` in Hugo reads commit history for `.Lastmod`.
+- `force_orphan: true` replaces the entire `gh-pages` branch with each deploy. The first run will wipe all existing hand-edited content there. This is intentional — the source of truth becomes `site/` on `main`.
+- `paths` filter means this workflow only fires on relevant pushes; CI keeps running unchanged.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/docs.yml
+git commit -m "ci: add docs deploy workflow
+
+Builds Hugo on every push to main that touches site/ and force-
+pushes site/public/ to gh-pages. The existing hand-edited
+gh-pages content is replaced wholesale on first run; main is
+now the source of truth for the docs site."
+```
+
+---
+
+## Task 22: Update CLAUDE.md to reflect the new workflow
+
+**Files:**
+- Modify: `CLAUDE.md` (the "Website (GitHub Pages)" subsection under "Versioning and Releases")
+
+The current section describes the hand-edited gh-pages workflow. Replace it with the Hugo flow.
+
+- [ ] **Step 1: Locate the current section**
+
+Run: `grep -n "Website (GitHub Pages)" CLAUDE.md`
+Expected: one line number — call it `<L>`.
+
+- [ ] **Step 2: Replace the section**
+
+The current section (under `### Website (GitHub Pages)`) is the four-bullet block. Replace its body with:
+
+```markdown
+### Website (GitHub Pages)
+- Source: `site/` on `main` is a Hugo project. Built and deployed by `.github/workflows/docs.yml` on every push that touches `site/`.
+- Output: rendered HTML lives on the `gh-pages` branch; GitHub Pages serves it at <https://2389-research.github.io/tracker/>.
+- Refresh workflow: edit content under `site/content/`, partials/layouts under `site/layouts/`, or `site/static/`; commit on a branch off `main`; the `Docs` workflow rebuilds + redeploys on merge. Verify locally first with `hugo server` from `site/`.
+- URL contract: `uglyURLs = true` preserves the existing `/X.html` paths (e.g. `/workflows.html`) — do not switch to pretty URLs without redirects.
+- a14y discovery files: `AGENTS.md` and `llms.txt` are static files in `site/static/`; `sitemap.xml`, `sitemap.md`, and `robots.txt` are rendered from Hugo templates in `site/layouts/`.
+- Each release should include a content refresh as a separate commit on `main` (e.g. updating `site/content/changelog.html` with the new version).
+```
+
+(The exact `Edit` invocation uses the old_string from `### Website (GitHub Pages)` through the last bullet point of the existing section.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): update Website section for Hugo workflow
+
+The site source moved from hand-edited gh-pages to a Hugo project
+under site/ on main. CLAUDE.md now reflects the new edit flow and
+the URL contract (uglyURLs)."
+```
+
+---
+
+## Task 23: Push the branch and open a PR
+
+**Files:** None (git/gh operations).
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin docs/hugo-conversion`
+Expected: branch tracked on origin.
+
+- [ ] **Step 2: Open a PR**
+
+Run:
+
+```bash
+gh pr create --title "docs: convert tracker docs site to Hugo + a14y fixes" --body "$(cat <<'EOF'
+## Summary
+- Migrate the 6 hand-written HTML pages on `gh-pages` into a Hugo project at `site/` on `main`.
+- Preserve the creamsicle visual identity (same `style.css`, same `highlight.js`, same DOM structure).
+- Add agent-readability fixes: `AGENTS.md`, `llms.txt`, `robots.txt`, `sitemap.xml`, `sitemap.md`, new glossary page, per-page meta description / OpenGraph / canonical / JSON-LD.
+- Add `.github/workflows/docs.yml` to build + deploy on every push to `site/`. `gh-pages` becomes a deploy artifact, not a source.
+- Update CLAUDE.md to document the new workflow.
+
+## Test plan
+- [ ] Local `hugo server` renders all 6 pages
+- [ ] Every page has unique meta description + OpenGraph + canonical + JSON-LD
+- [ ] Mermaid loads only on workflows + architecture
+- [ ] Glossary nav link present on every page
+- [ ] `AGENTS.md`, `llms.txt`, `robots.txt`, `sitemap.xml`, `sitemap.md` all return 200
+- [ ] After merge: deploy workflow runs, gh-pages updates, live site loads
+- [ ] After deploy: re-run a14y, score should jump from baseline 39 into the 80s
+EOF
+)"
+```
+
+- [ ] **Step 3: Note the PR URL**
+
+Save the URL printed by `gh pr create` — it's the verification target.
+
+---
+
+## Task 24: Merge, watch the deploy, and re-audit
+
+**Files:** None.
+
+- [ ] **Step 1: After review, merge the PR**
+
+Use the GitHub UI or `gh pr merge --squash` after approval.
+
+- [ ] **Step 2: Watch the docs workflow**
+
+Run: `gh run watch` (pick the latest "Docs" run)
+Expected: workflow completes successfully — hugo build green, gh-pages push green.
+
+- [ ] **Step 3: Poll until production reflects the new content**
+
+```bash
+until curl -fsS https://2389-research.github.io/tracker/AGENTS.md > /dev/null; do
+  sleep 5
+done
+echo "AGENTS.md is live"
+```
+
+- [ ] **Step 4: Re-run a14y**
+
+Run:
+
+```bash
+npx -y a14y check https://2389-research.github.io/tracker/ --mode site --output agent-prompt --max-pages 200
+```
+
+Expected: a Snapshot block with a score in the 80s. The Failing checks list should be much shorter — only the items intentionally skipped (`code.language-tags`, `markdown.content-negotiation`, `markdown.mirror-suffix`, `markdown.alternate-link`).
+
+- [ ] **Step 5: Update AGENTS.md Last runs**
+
+Edit `site/static/AGENTS.md` and prepend the new score to the `Last runs:` list. Keep the most recent 5:
+
+```markdown
+- Last runs:
+  - YYYY-MM-DD — <new-score> (scorecard 0.2.0)
+  - 2026-05-19 — 39 (scorecard 0.2.0)
+```
+
+- [ ] **Step 6: Commit the score update directly to main**
+
+```bash
+git checkout main && git pull
+git add site/static/AGENTS.md
+git commit -m "docs(site): record post-Hugo a14y score
+
+Site score went from <old> to <new> after the Hugo conversion +
+a14y discovery fixes landed."
+git push
+```
+
+The Docs workflow will re-run and republish.
+
+- [ ] **Step 7: Report to user**
+
+In the chat, print:
+1. The numeric delta: `Score: 39 → <new> (+<delta>)`
+2. List of resolved checks (most of the previous 16)
+3. List of still-failing checks (the common-skips list)
+4. The share-ready summary in the a14y skill's prescribed format
+5. The embed badge URL from the CLI's `Embed badge: ` line
+
+---
+
+## Self-review checklist
+
+After writing this plan, I checked the spec against:
+
+- **Spec coverage:** Every a14y check in the prior audit maps to a task (discovery files in Tasks 11-13, head metadata in Tasks 5 + 14-19, glossary in Task 19, glossary nav link via the data-driven nav in Task 6). The four intentional skips (code.language-tags, markdown.content-negotiation, markdown.mirror-suffix, markdown.alternate-link) remain skipped — they're listed in the PR test plan but not implemented.
+- **Placeholder scan:** Every content port references the exact source (`origin/gh-pages:<page>.html`) and explains how to extract the `<main>` body. No "fill in details" placeholders. JSON-LD payloads are inlined per-page. The home page's body is the only one not inlined verbatim because the source HTML is too long to include in the plan — but the source is preserved in the gh-pages branch and the extraction step is explicit.
+- **Type consistency:** Front matter field names match between the head partial (`og_title`, `og_description`, `description`, `jsonld`, `mermaid`) and every content file. The nav data shape (`label`, `url`, `external`) is consistent between `data/nav.yaml` and the nav partial that consumes it. URL patterns are consistent: `uglyURLs = true` everywhere, all internal references use `/X.html`.
+
+No issues found that required fixing during self-review.


### PR DESCRIPTION
## What

Adds `ROADMAP.md` at the repo root — a rolling engineering roadmap in thematic workstreams across Now/Next/Later tiers (no dates), plus the GitHub wiring that keeps it honest.

### The document
- **Now**: Engine correctness (#348, #430) · Epic #308 closeout (#304, #307) · SWE-bench first scored run (#465, newly filed)
- **Next**: Parallel-first resilience (#420, #427) · Cost & efficiency (#353) · Load-bearing refactors (#396, #393)
- **Later**: Sandbox breadth (#279–#281) · Cosmetic refactors (#395, #398) · Security docs (#284–#286) · Benchmark cadence + the v1.0 question

### GitHub wiring (already live)
- Three milestones created, one per Now workstream: **Engine correctness**, **Epic #308 closeout**, **SWE-bench first score**
- Issues assigned: #348/#430, #304/#307/#308, #465
- New issue #465 gives the previously-untracked SWE-bench work a home (empty `model_patch` smoke-run debug → full Verified run → publish score)

### Supporting changes
- CLAUDE.md: `Before releasing` checklist gains "Update ROADMAP.md"
- .gitignore: local `tracker-swebench` / `agent-runner` binaries and `predictions.jsonl` output

## Maintenance contract
Workstream finishes → close milestone → promote from Next → update ROADMAP.md, all in one PR. Only Now-tier workstreams get milestones. Refreshed at every release.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785902901&installation_id=131176874&pr_number=466&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F466&signature=6398d695224a92857e78f7d6b3a541ffc3c533be86f6627cfec7e06eab23f991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new roadmap and updated release guidance to keep planned work and milestones current.
  * Added several planning documents covering upcoming fixes and a docs site conversion effort.

* **Chores**
  * Expanded ignore rules for additional local/generated files.
  * Updated maintenance notes to include roadmap upkeep as part of release prep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->