### PR TITLE
refactor(swebench): decompose main(), cap container CPU, co-locate prompt temp file

### DIFF
--- a/cmd/tracker-swebench/main.go
+++ b/cmd/tracker-swebench/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -19,33 +20,60 @@ import (
 	"time"
 )
 
-func main() {
-	// helpRequested is set when the user passes the bare `help` verb; it's
-	// handled after flag registration so flag.Usage sees the flag set.
-	var helpRequested bool
+// runConfig holds the resolved benchmark run flags.
+type runConfig struct {
+	dataset     string
+	model       string
+	provider    string
+	gatewayURL  string
+	output      string
+	resultsDir  string
+	instance    string
+	dockerImage string
+	maxTurns    int
+	timeout     time.Duration
+	force       bool
+}
 
-	// Subcommand dispatch: if the first argument is a known verb, route to
-	// its handler. Otherwise fall through to the default "run" flow so that
-	// existing invocations like `tracker-swebench --dataset ...` keep working.
-	if len(os.Args) > 1 {
-		switch os.Args[1] {
-		case "analyze":
-			if err := runAnalyze(os.Args[2:], os.Stdout); err != nil {
-				fmt.Fprintln(os.Stderr, err)
-				os.Exit(1)
-			}
-			return
-		case "help":
-			// Explicitly handle the bare "help" verb: flag.Parse() only
-			// recognizes -h / --help as *flags*, not a positional verb, so
-			// without this branch `tracker-swebench help` would fall through
-			// to flag.Parse() and then to the required-dataset check,
-			// exiting with "--dataset is required" instead of printing
-			// usage. Defer the actual usage print until after flag
-			// registration (flag.Usage captures the registered flags).
-			helpRequested = true
+// runDeps bundles the shared state a single instance run needs.
+type runDeps struct {
+	rw            *ResultsWriter
+	docker        *DockerRunner
+	agentEnv      map[string]string
+	absResultsDir string
+	logsDir       string
+	cacheDir      string
+	force         bool
+}
+
+func main() {
+	// Subcommand dispatch: the "analyze" verb routes to its handler and exits.
+	// Everything else falls through to the default run flow so that existing
+	// invocations like `tracker-swebench --dataset ...` keep working.
+	if len(os.Args) > 1 && os.Args[1] == "analyze" {
+		if err := runAnalyze(os.Args[2:], os.Stdout); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
 		}
+		return
 	}
+
+	cfg, run := parseRunFlags()
+	if !run {
+		return // the bare "help" verb was given; usage already printed
+	}
+	if err := runBenchmark(cfg); err != nil {
+		os.Exit(1)
+	}
+}
+
+// parseRunFlags registers and parses the benchmark run flags. It returns the
+// resolved config and true when the caller should proceed, or (nil, false)
+// when the bare "help" verb was given and usage was printed.
+func parseRunFlags() (*runConfig, bool) {
+	// The bare `help` verb is handled here (not by flag.Parse, which only
+	// recognizes -h/--help as flags) so that flag.Usage sees the full flag set.
+	helpRequested := len(os.Args) > 1 && os.Args[1] == "help"
 
 	dataset := flag.String("dataset", "", "path to JSONL file (required)")
 	model := flag.String("model", "claude-sonnet-4-6", "model name")
@@ -86,7 +114,7 @@ Flags:
 
 	if helpRequested {
 		flag.Usage()
-		return
+		return nil, false
 	}
 
 	flag.Parse()
@@ -95,62 +123,31 @@ Flags:
 		log.Fatal("--dataset is required")
 	}
 
-	instances, err := LoadDataset(*dataset)
-	if err != nil {
-		log.Fatalf("load dataset: %v", err)
-	}
+	return &runConfig{
+		dataset:     *dataset,
+		model:       *model,
+		provider:    *provider,
+		gatewayURL:  *gatewayURL,
+		output:      *output,
+		resultsDir:  *resultsDir,
+		instance:    *instance,
+		dockerImage: *dockerImage,
+		maxTurns:    *maxTurns,
+		timeout:     *timeout,
+		force:       *force,
+	}, true
+}
 
-	// Filter to single instance if requested.
-	if *instance != "" {
-		found := false
-		for _, inst := range instances {
-			if inst.InstanceID == *instance {
-				instances = []Instance{inst}
-				found = true
-				break
-			}
-		}
-		if !found {
-			log.Fatalf("instance %q not found in dataset", *instance)
-		}
-	}
+// runBenchmark runs the agent over every instance in the dataset, writing
+// predictions and per-instance logs. It returns a non-nil error when any
+// instance errored, so the caller can exit non-zero.
+func runBenchmark(cfg *runConfig) error {
+	instances := loadInstances(cfg)
 
-	// Create results directories. Docker -v requires absolute paths.
-	absResultsDir, err := filepath.Abs(*resultsDir)
-	if err != nil {
-		log.Fatalf("resolve results dir: %v", err)
-	}
-	logsDir := filepath.Join(absResultsDir, "logs")
-	cacheDir := filepath.Join(absResultsDir, "repo-cache")
-	for _, dir := range []string{absResultsDir, logsDir, cacheDir} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
-			log.Fatalf("create dir %q: %v", dir, err)
-		}
-	}
+	absResultsDir, logsDir, cacheDir := setupResultsDirs(cfg.resultsDir)
+	writeRunMetadata(cfg, absResultsDir)
 
-	// Write run metadata.
-	// Record which base URL override is active (if any). Normalize hyphens
-	// to underscores before uppercasing so providers like "openai-compat"
-	// map to OPENAI_COMPAT_BASE_URL, matching how ResolveProviderBaseURL
-	// derives its env var keys.
-	baseURLOverride := os.Getenv(strings.ToUpper(strings.ReplaceAll(*provider, "-", "_")) + "_BASE_URL")
-	meta := RunMeta{
-		Model:           *model,
-		Provider:        *provider,
-		GatewayURL:      *gatewayURL,
-		BaseURLOverride: baseURLOverride,
-		Dataset:         *dataset,
-		MaxTurns:        *maxTurns,
-		Timeout:         timeout.String(),
-		Commit:          buildCommit(),
-	}
-	metaPath := filepath.Join(absResultsDir, "run_meta.json")
-	if err := WriteRunMeta(metaPath, meta); err != nil {
-		log.Fatalf("write run meta: %v", err)
-	}
-
-	// Open predictions writer.
-	rw, err := NewResultsWriter(*output, *model)
+	rw, err := NewResultsWriter(cfg.output, cfg.model)
 	if err != nil {
 		log.Fatalf("open results writer: %v", err)
 	}
@@ -160,178 +157,266 @@ Flags:
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	// Create Docker runner.
 	docker := &DockerRunner{
-		Image:     *dockerImage,
+		Image:     cfg.dockerImage,
 		CacheDir:  cacheDir,
-		Timeout:   *timeout,
+		Timeout:   cfg.timeout,
 		MemoryMB:  4096, // 4 GB
-		CPUs:      2.0,
+		CPUs:      1.0,
 		PidsLimit: 512,
 		RunLabel:  time.Now().Format("20060102-150405"),
 	}
-
 	// Clean up orphaned containers from prior crashed runs.
 	docker.CleanupStale(ctx)
 
-	// Build base agent environment map.
-	agentEnv := map[string]string{
-		"SWEBENCH_MODEL":     *model,
-		"SWEBENCH_PROVIDER":  *provider,
-		"SWEBENCH_MAX_TURNS": fmt.Sprintf("%d", *maxTurns),
-		"SWEBENCH_TIMEOUT":   timeout.String(),
-	}
-	if *gatewayURL != "" {
-		agentEnv["TRACKER_GATEWAY_URL"] = *gatewayURL
-	}
-	// Pass through API keys from host environment.
-	if v := os.Getenv("ANTHROPIC_API_KEY"); v != "" {
-		agentEnv["ANTHROPIC_API_KEY"] = v
-	}
-	if v := os.Getenv("OPENAI_API_KEY"); v != "" {
-		agentEnv["OPENAI_API_KEY"] = v
-	}
-	if v := os.Getenv("CF_AIG_TOKEN"); v != "" {
-		agentEnv["CF_AIG_TOKEN"] = v
-	}
-	// Pass through provider base URL overrides (e.g., Bedrock gateway).
-	for _, envKey := range []string{"ANTHROPIC_BASE_URL", "OPENAI_BASE_URL"} {
-		if v := os.Getenv(envKey); v != "" {
-			agentEnv[envKey] = v
-		}
+	deps := &runDeps{
+		rw:            rw,
+		docker:        docker,
+		agentEnv:      buildAgentEnv(cfg),
+		absResultsDir: absResultsDir,
+		logsDir:       logsDir,
+		cacheDir:      cacheDir,
+		force:         cfg.force,
 	}
 
-	stats := RunStats{
-		Total:     len(instances),
-		StartTime: time.Now(),
-	}
-
+	stats := RunStats{Total: len(instances), StartTime: time.Now()}
 	total := len(instances)
 	for i, inst := range instances {
-		// Check for cancellation.
 		select {
 		case <-ctx.Done():
 			log.Println("interrupted, stopping run")
 			fmt.Println(stats.Summary())
-			return
+			return nil
 		default:
 		}
-
-		// Skip already-completed instances unless --force.
-		if !*force && rw.IsCompleted(inst.InstanceID) {
-			stats.Skipped++
-			fmt.Printf("[%d/%d] %s ... skipped (already completed)\n", i+1, total, inst.InstanceID)
-			continue
-		}
-
-		// Ensure bare clone is cached for the repo.
-		repoCachePath := filepath.Join(cacheDir, strings.ReplaceAll(inst.Repo, "/", "_")+".git")
-		if err := ensureBareClone(ctx, inst.RepoURL(), repoCachePath); err != nil {
-			log.Printf("[%s] bare clone failed (continuing without cache): %v", inst.InstanceID, err)
-			repoCachePath = "" // fall back to no cache
-		}
-
-		// Set per-instance env (no multiline values — Docker --env-file
-		// does not support them).
-		instEnv := make(map[string]string, len(agentEnv))
-		for k, v := range agentEnv {
-			instEnv[k] = v
-		}
-
-		// Write the instance prompt to a temp file for mounting into the
-		// container. The prompt can be multiline and contain special chars
-		// that break Docker's --env-file format.
-		promptFile, promptErr := os.CreateTemp("", "swebench-prompt-*")
-		if promptErr != nil {
-			log.Printf("[%s] create prompt file: %v", inst.InstanceID, promptErr)
-			stats.addError(runErrorHarness)
-			continue
-		}
-		if _, promptErr = promptFile.WriteString(inst.AgentPrompt()); promptErr != nil {
-			promptFile.Close()
-			os.Remove(promptFile.Name())
-			log.Printf("[%s] write prompt file: %v", inst.InstanceID, promptErr)
-			stats.addError(runErrorHarness)
-			continue
-		}
-		promptFile.Close()
-
-		start := time.Now()
-		patch, summary, agentTranscript, runErr := docker.RunInstance(ctx, inst, instEnv, repoCachePath != "", promptFile.Name())
-		os.Remove(promptFile.Name())
-		elapsed := time.Since(start).Round(time.Second)
-
-		// Write prediction even on error (capture partial patch).
-		if writeErr := rw.WritePrediction(inst.InstanceID, patch); writeErr != nil {
-			log.Printf("[%s] write prediction: %v", inst.InstanceID, writeErr)
-			stats.addError(runErrorHarness)
-			// Write per-instance log even on prediction write failure.
-			logPath := filepath.Join(logsDir, inst.InstanceID+".log")
-			logContent := fmt.Sprintf("instance_id: %s\nelapsed: %s\nturns: %d\ninput_tokens: %d\noutput_tokens: %d\npatch_lines: %d\n",
-				inst.InstanceID, elapsed, summary.Turns, summary.InputTokens, summary.OutputTokens, patchLineCount(patch))
-			logContent += fmt.Sprintf("write_prediction_error: %v\n", writeErr)
-			if runErr != nil {
-				logContent += fmt.Sprintf("error: %v\n", runErr)
-			}
-			if logWriteErr := os.WriteFile(logPath, []byte(logContent), 0o644); logWriteErr != nil {
-				log.Printf("[%s] write log: %v", inst.InstanceID, logWriteErr)
-			}
-			continue
-		}
-
-		// Write per-instance log.
-		logPath := filepath.Join(logsDir, inst.InstanceID+".log")
-		logContent := fmt.Sprintf("instance_id: %s\nelapsed: %s\nturns: %d\ninput_tokens: %d\noutput_tokens: %d\npatch_lines: %d\n",
-			inst.InstanceID, elapsed, summary.Turns, summary.InputTokens, summary.OutputTokens, patchLineCount(patch))
-		if runErr != nil {
-			logContent += fmt.Sprintf("error: %v\n", runErr)
-		}
-		if writeErr := os.WriteFile(logPath, []byte(logContent), 0o644); writeErr != nil {
-			log.Printf("[%s] write log: %v", inst.InstanceID, writeErr)
-		}
-
-		// Write agent transcript for post-mortem analysis.
-		if agentTranscript != "" {
-			transcriptPath := filepath.Join(logsDir, inst.InstanceID+".transcript.log")
-			if writeErr := os.WriteFile(transcriptPath, []byte(agentTranscript), 0o644); writeErr != nil {
-				log.Printf("[%s] write transcript: %v", inst.InstanceID, writeErr)
-			}
-		}
-		if patch == "" {
-			diag := EmptyPatchDiagnostic{
-				InstanceID:        inst.InstanceID,
-				Turns:             summary.Turns,
-				TerminationReason: summary.TerminationReason,
-				FinalMessage:      summary.FinalMessage,
-				LastToolCalls:     summary.LastToolCalls,
-			}
-			if writeErr := WriteEmptyPatchDiagnostic(logsDir, diag); writeErr != nil {
-				log.Printf("[%s] write empty patch diagnostic: %v", inst.InstanceID, writeErr)
-			}
-		}
-
-		// Update stats only after successful prediction write.
-		stats.Completed++
-		stats.InputTokens += summary.InputTokens
-		stats.OutputTokens += summary.OutputTokens
-		if patch != "" {
-			stats.Patched++
-		}
-		if runErr != nil {
-			stats.addError(classifyRunError(runErr))
-			if errors.Is(runErr, context.DeadlineExceeded) {
-				stats.TimedOut++
-			}
-		}
-
-		// Print progress line.
-		fmt.Printf("[%d/%d] %s ... %d turns, %s, patch: %d lines\n",
-			i+1, total, inst.InstanceID, summary.Turns, elapsed, patchLineCount(patch))
+		processInstance(ctx, i, total, inst, deps, &stats)
 	}
 
 	fmt.Println(stats.Summary())
 	if stats.Errors > 0 {
-		os.Exit(1)
+		return fmt.Errorf("%d instance(s) errored", stats.Errors)
+	}
+	return nil
+}
+
+// loadInstances loads the dataset and applies the optional single-instance
+// filter.
+func loadInstances(cfg *runConfig) []Instance {
+	instances, err := LoadDataset(cfg.dataset)
+	if err != nil {
+		log.Fatalf("load dataset: %v", err)
+	}
+	if cfg.instance != "" {
+		instances = filterToInstance(instances, cfg.instance)
+	}
+	return instances
+}
+
+// filterToInstance narrows instances to the single one named, exiting if it is
+// not present.
+func filterToInstance(instances []Instance, name string) []Instance {
+	for _, inst := range instances {
+		if inst.InstanceID == name {
+			return []Instance{inst}
+		}
+	}
+	log.Fatalf("instance %q not found in dataset", name)
+	return nil
+}
+
+// setupResultsDirs resolves and creates the results, logs, and cache dirs.
+// Docker -v requires absolute paths.
+func setupResultsDirs(resultsDir string) (absResultsDir, logsDir, cacheDir string) {
+	absResultsDir, err := filepath.Abs(resultsDir)
+	if err != nil {
+		log.Fatalf("resolve results dir: %v", err)
+	}
+	logsDir = filepath.Join(absResultsDir, "logs")
+	cacheDir = filepath.Join(absResultsDir, "repo-cache")
+	for _, dir := range []string{absResultsDir, logsDir, cacheDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			log.Fatalf("create dir %q: %v", dir, err)
+		}
+	}
+	return absResultsDir, logsDir, cacheDir
+}
+
+// writeRunMetadata records run metadata to run_meta.json.
+func writeRunMetadata(cfg *runConfig, absResultsDir string) {
+	// Record which base URL override is active (if any). Normalize hyphens to
+	// underscores before uppercasing so providers like "openai-compat" map to
+	// OPENAI_COMPAT_BASE_URL, matching how ResolveProviderBaseURL derives keys.
+	baseURLOverride := os.Getenv(strings.ToUpper(strings.ReplaceAll(cfg.provider, "-", "_")) + "_BASE_URL")
+	meta := RunMeta{
+		Model:           cfg.model,
+		Provider:        cfg.provider,
+		GatewayURL:      cfg.gatewayURL,
+		BaseURLOverride: baseURLOverride,
+		Dataset:         cfg.dataset,
+		MaxTurns:        cfg.maxTurns,
+		Timeout:         cfg.timeout.String(),
+		Commit:          buildCommit(),
+	}
+	metaPath := filepath.Join(absResultsDir, "run_meta.json")
+	if err := WriteRunMeta(metaPath, meta); err != nil {
+		log.Fatalf("write run meta: %v", err)
+	}
+}
+
+// buildAgentEnv builds the base agent environment map: the SWEBENCH_* config
+// plus any API keys and base-URL overrides passed through from the host.
+func buildAgentEnv(cfg *runConfig) map[string]string {
+	agentEnv := map[string]string{
+		"SWEBENCH_MODEL":     cfg.model,
+		"SWEBENCH_PROVIDER":  cfg.provider,
+		"SWEBENCH_MAX_TURNS": fmt.Sprintf("%d", cfg.maxTurns),
+		"SWEBENCH_TIMEOUT":   cfg.timeout.String(),
+	}
+	if cfg.gatewayURL != "" {
+		agentEnv["TRACKER_GATEWAY_URL"] = cfg.gatewayURL
+	}
+	// Pass through API keys and provider base-URL overrides from the host env.
+	for _, key := range []string{
+		"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "CF_AIG_TOKEN",
+		"ANTHROPIC_BASE_URL", "OPENAI_BASE_URL",
+	} {
+		if v := os.Getenv(key); v != "" {
+			agentEnv[key] = v
+		}
+	}
+	return agentEnv
+}
+
+// processInstance runs a single instance end to end: skip check, repo cache,
+// prompt file, container run, and prediction/log/stats bookkeeping.
+func processInstance(ctx context.Context, idx, total int, inst Instance, d *runDeps, stats *RunStats) {
+	// Skip already-completed instances unless --force.
+	if !d.force && d.rw.IsCompleted(inst.InstanceID) {
+		stats.Skipped++
+		fmt.Printf("[%d/%d] %s ... skipped (already completed)\n", idx+1, total, inst.InstanceID)
+		return
+	}
+
+	repoCachePath := ensureRepoCache(ctx, d.cacheDir, inst)
+
+	promptPath, err := writePromptFile(d.absResultsDir, inst)
+	if err != nil {
+		log.Printf("[%s] create prompt file: %v", inst.InstanceID, err)
+		stats.addError(runErrorHarness)
+		return
+	}
+
+	start := time.Now()
+	patch, summary, transcript, runErr := d.docker.RunInstance(ctx, inst, cloneEnv(d.agentEnv), repoCachePath != "", promptPath)
+	os.Remove(promptPath)
+	elapsed := time.Since(start).Round(time.Second)
+
+	// Write prediction even on error (capture partial patch).
+	if writeErr := d.rw.WritePrediction(inst.InstanceID, patch); writeErr != nil {
+		log.Printf("[%s] write prediction: %v", inst.InstanceID, writeErr)
+		stats.addError(runErrorHarness)
+		writeInstanceRunLog(d.logsDir, inst, elapsed, summary, patch, runErr, writeErr)
+		return
+	}
+
+	writeInstanceRunLog(d.logsDir, inst, elapsed, summary, patch, runErr, nil)
+	writeArtifacts(d.logsDir, inst, transcript, patch, summary)
+	updateStats(stats, summary, patch, runErr)
+
+	fmt.Printf("[%d/%d] %s ... %d turns, %s, patch: %d lines\n",
+		idx+1, total, inst.InstanceID, summary.Turns, elapsed, patchLineCount(patch))
+}
+
+// ensureRepoCache ensures a bare clone of the instance repo exists, returning
+// its path or "" to fall back to no cache.
+func ensureRepoCache(ctx context.Context, cacheDir string, inst Instance) string {
+	repoCachePath := filepath.Join(cacheDir, strings.ReplaceAll(inst.Repo, "/", "_")+".git")
+	if err := ensureBareClone(ctx, inst.RepoURL(), repoCachePath); err != nil {
+		log.Printf("[%s] bare clone failed (continuing without cache): %v", inst.InstanceID, err)
+		return "" // fall back to no cache
+	}
+	return repoCachePath
+}
+
+// cloneEnv returns a shallow copy of src so per-instance runs cannot mutate the
+// shared base environment.
+func cloneEnv(src map[string]string) map[string]string {
+	dst := make(map[string]string, len(src))
+	maps.Copy(dst, src)
+	return dst
+}
+
+// writePromptFile writes the instance prompt to a temp file under dir for
+// mounting into the container. The prompt can be multiline and contain special
+// chars that break Docker's --env-file format, so it is passed as a file. The
+// file is created under the run's results dir to keep artifacts co-located.
+func writePromptFile(dir string, inst Instance) (string, error) {
+	promptFile, err := os.CreateTemp(dir, "swebench-prompt-*")
+	if err != nil {
+		return "", err
+	}
+	if _, err := promptFile.WriteString(inst.AgentPrompt()); err != nil {
+		promptFile.Close()
+		os.Remove(promptFile.Name())
+		return "", err
+	}
+	promptFile.Close()
+	return promptFile.Name(), nil
+}
+
+// writeInstanceLog writes the per-instance summary log. predErr, when non-nil,
+// records a prediction-write failure in the log body.
+func writeInstanceRunLog(logsDir string, inst Instance, elapsed time.Duration, summary AgentSummary, patch string, runErr, predErr error) {
+	logContent := fmt.Sprintf("instance_id: %s\nelapsed: %s\nturns: %d\ninput_tokens: %d\noutput_tokens: %d\npatch_lines: %d\n",
+		inst.InstanceID, elapsed, summary.Turns, summary.InputTokens, summary.OutputTokens, patchLineCount(patch))
+	if predErr != nil {
+		logContent += fmt.Sprintf("write_prediction_error: %v\n", predErr)
+	}
+	if runErr != nil {
+		logContent += fmt.Sprintf("error: %v\n", runErr)
+	}
+	logPath := filepath.Join(logsDir, inst.InstanceID+".log")
+	if err := os.WriteFile(logPath, []byte(logContent), 0o644); err != nil {
+		log.Printf("[%s] write log: %v", inst.InstanceID, err)
+	}
+}
+
+// writeArtifacts writes the agent transcript and, for empty patches, the
+// empty-patch diagnostic for post-mortem analysis.
+func writeArtifacts(logsDir string, inst Instance, transcript, patch string, summary AgentSummary) {
+	if transcript != "" {
+		transcriptPath := filepath.Join(logsDir, inst.InstanceID+".transcript.log")
+		if err := os.WriteFile(transcriptPath, []byte(transcript), 0o644); err != nil {
+			log.Printf("[%s] write transcript: %v", inst.InstanceID, err)
+		}
+	}
+	if patch == "" {
+		diag := EmptyPatchDiagnostic{
+			InstanceID:        inst.InstanceID,
+			Turns:             summary.Turns,
+			TerminationReason: summary.TerminationReason,
+			FinalMessage:      summary.FinalMessage,
+			LastToolCalls:     summary.LastToolCalls,
+		}
+		if err := WriteEmptyPatchDiagnostic(logsDir, diag); err != nil {
+			log.Printf("[%s] write empty patch diagnostic: %v", inst.InstanceID, err)
+		}
+	}
+}
+
+// updateStats folds one instance's result into the running totals.
+func updateStats(stats *RunStats, summary AgentSummary, patch string, runErr error) {
+	stats.Completed++
+	stats.InputTokens += summary.InputTokens
+	stats.OutputTokens += summary.OutputTokens
+	if patch != "" {
+		stats.Patched++
+	}
+	if runErr != nil {
+		stats.addError(classifyRunError(runErr))
+		if errors.Is(runErr, context.DeadlineExceeded) {
+			stats.TimedOut++
+		}
 	}
 }
 

--- a/scripts/complexity/baseline.txt
+++ b/scripts/complexity/baseline.txt
@@ -53,7 +53,6 @@ cognitive|./cmd/tracker-swebench/analyze.go|writePerRepo|9
 cognitive|./cmd/tracker-swebench/analyze.go|writeTopEmpty|9
 cognitive|./cmd/tracker-swebench/dataset.go|LoadDataset|9
 cognitive|./cmd/tracker-swebench/docker.go|(*DockerRunner).RunInstance|23
-cognitive|./cmd/tracker-swebench/main.go|main|74
 cognitive|./cmd/tracker-swebench/results.go|NewResultsWriter|11
 cognitive|./cmd/tracker/doctor.go|checkGitignore|11
 cognitive|./cmd/tracker/doctor.go|maybeFixGitignore|9
@@ -144,7 +143,6 @@ cyclo|./cmd/tracker-swebench/analyze.go|findEvaluatorReport|12
 cyclo|./cmd/tracker-swebench/analyze.go|parseInstanceLog|19
 cyclo|./cmd/tracker-swebench/analyze.go|scanLogsDir|13
 cyclo|./cmd/tracker-swebench/docker.go|(*DockerRunner).RunInstance|21
-cyclo|./cmd/tracker-swebench/main.go|main|44
 cyclo|./cmd/tracker-swebench/results.go|classifyRunError|13
 cyclo|./cmd/tracker/doctor.go|checkGitignore|10
 cyclo|./cmd/tracker/doctor.go|printCheckResult|15


### PR DESCRIPTION
## What

Decomposes the 200-line `tracker-swebench` `main()` (cyclo **44** / cognit **74**) into focused, behavior-preserving helpers, each under the complexity-8 gate:

- `parseRunFlags` — flag registration, `help` verb, dataset check
- `runBenchmark` — orchestration + the run loop
- `loadInstances` / `filterToInstance`, `setupResultsDirs`, `writeRunMetadata`, `buildAgentEnv`
- `processInstance` — per-instance body + `ensureRepoCache`, `cloneEnv`, `writePromptFile`, `writeInstanceRunLog`, `writeArtifacts`, `updateStats`

Burns the two grandfathered `main()` entries out of the ratchet baseline (218 → 216).

## Why

Touching `main.go` for even a one-line change was blocked by the pre-commit complexity hook (hard threshold 8, no baseline awareness). This unblocks future edits to the file and pays down real debt.

## Salvaged tweaks (from the closed #410)

- Bound each SWE-bench container to **1.0 CPU** (was 2.0) so concurrent instances don't oversubscribe the host.
- Create the per-instance prompt temp file under the run's **results dir** instead of the system temp dir, keeping artifacts co-located.

## Verification

- Pure extraction — no behavior change beyond the two tweaks above.
- `go build`, `go vet`, and the existing `cmd/tracker-swebench` package tests all pass.
- gocyclo/gocognit report **no functions over 8** in `main.go`; the pre-commit complexity gate passes with `main.go` staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786571362&installation_id=131176874&pr_number=469&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F469&signature=9be76bc159e3e708ca9ca6bbbe54ff9282dcc84c79c0365e210767ac0a83f0ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved benchmark command organization and execution flow.
  - Added clearer handling for configuration, run setup, instance processing, logging, predictions, and artifacts.
  - Preserved existing command behavior while making benchmark runs more consistent and maintainable.

- **Chores**
  - Updated complexity tracking baselines to reflect the reorganized command implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->