### PR TITLE
fix(#496,#497,#498): unblock idea→artifact from chat front-ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Chat intent classifier no longer 404s on a stale model id (#496).** The
+  default `TRACKERBOT_MODEL` / `TRACKERCHAT_MODEL` was a nonexistent dated snapshot
+  (`claude-haiku-4-5-20251001`) that the provider rejected with `model_not_found`,
+  hard-blocking natural-language routing. The default is now the catalog id
+  `claude-haiku-4-5`; the resolver additionally maps a configured model through
+  the model catalog (resolving aliases, falling back to `claude-haiku-4-5` for an
+  unknown id) so a mistyped env var can never reach the provider as a 404, and a
+  classifier outage now degrades to the deterministic `run <workflow>` grammar
+  instead of leaking a raw provider error into the thread.
+
+- **trackerbot auto-inits git in its per-run workdirs (#497).** Each Slack thread
+  gets a fresh, empty per-thread workdir, but git was never initialized there, so
+  `requires: git` workflows (`ask_and_execute`, `build_product`) dead-stopped at
+  preflight with "not a git repository". trackerbot now runs the runs with
+  `Git: {Preflight: init, AllowInit: true}` — safe because the dirs are always
+  fresh and empty — so those workflows start cleanly from Slack with no manual
+  `git init`.
+
 - **Checkpoint no longer bloats with per-node episode-summary copies (#491).**
   Per-node context scoping aliased the running `episode_summaries` / `episode_summary`
   aggregate under `node.<id>.…` for *every* node, so a long build accumulated one
@@ -81,6 +99,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   count; the live summary the model sees is unchanged.
 
 ### Changed
+
+- **Spec-less "build me X" requests route to `ask_and_execute` (#498).** The chat
+  intent classifier is now biased so that when a user only describes an idea (no
+  written spec) and asks to build/make/create it, it prefers a workflow that
+  discovers and writes the spec itself (`ask_and_execute`) over one that hard-
+  requires a pre-existing `SPEC.md` (`build_product*`, which would dead-stop at its
+  spec-preflight). A user with only an idea now reaches a shipped artifact without
+  pre-writing a spec. (The durable path — an embedded `idea_to_spec` interview
+  workflow chained to `build_product` — remains blocked on embed-FS subgraph
+  resolution and is deferred.)
 
 - **Per-node cost in the run summary (#490 visibility).** The `tracker run`
   node-execution table now shows a **Cost** column per node, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,13 +81,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   classifier outage now degrades to the deterministic `run <workflow>` grammar
   instead of leaking a raw provider error into the thread.
 
-- **trackerbot auto-inits git in its per-run workdirs (#497).** Each Slack thread
-  gets a fresh, empty per-thread workdir, but git was never initialized there, so
-  `requires: git` workflows (`ask_and_execute`, `build_product`) dead-stopped at
-  preflight with "not a git repository". trackerbot now runs the runs with
-  `Git: {Preflight: init, AllowInit: true}` — safe because the dirs are always
-  fresh and empty — so those workflows start cleanly from Slack with no manual
-  `git init`.
+- **Chat front-ends auto-init git in their per-run workdirs (#497).** Each thread
+  gets a fresh, empty per-thread workdir (shared `chatops.Runner`), but git was
+  never initialized there, so `requires: git` workflows (`ask_and_execute`,
+  `build_product`) dead-stopped at preflight with "not a git repository".
+  trackerbot and trackerchat now run with `Git: {Preflight: init, AllowInit:
+  true}` — safe because the dirs are always fresh and empty — so those workflows
+  start cleanly with no manual `git init`.
 
 - **Checkpoint no longer bloats with per-node episode-summary copies (#491).**
   Per-node context scoping aliased the running `episode_summaries` / `episode_summary`

--- a/cmd/trackerbot/main.go
+++ b/cmd/trackerbot/main.go
@@ -48,6 +48,11 @@ func main() {
 	configBase := tracker.Config{
 		Backend: os.Getenv("TRACKERBOT_BACKEND"),
 		Budget:  pipeline.BudgetLimits{MaxCostCents: maxCostCents},
+		// Per-thread workdirs are created fresh and empty, so `requires: git`
+		// workflows (ask_and_execute, build_product) would dead-stop at preflight
+		// with "not a git repository". Auto-init git in the fresh dir — safe
+		// because it's always empty (see runner.launch's MkdirAll).
+		Git: &tracker.GitConfig{Preflight: tracker.GitPreflightInit, AllowInit: true},
 	}
 	st := chatops.OpenStore(filepath.Join(runsBase, "trackerbot-state.json"))
 	runner := chatops.NewRunner(rm, RunnerDeps{
@@ -108,7 +113,7 @@ func buildIntentResolver(cfg tracker.Config) IntentResolver {
 		log.Printf("trackerbot: LLM intent unavailable (%v) — using the 'run <workflow>' grammar", err)
 		return chatops.GrammarResolver{}
 	}
-	model := envOr("TRACKERBOT_MODEL", "claude-haiku-4-5-20251001")
+	model := envOr("TRACKERBOT_MODEL", "claude-haiku-4-5")
 	log.Printf("trackerbot: natural-language intent enabled (model %s)", model)
 	return chatops.NewLLMIntentResolver(client, model)
 }

--- a/cmd/trackerchat/main.go
+++ b/cmd/trackerchat/main.go
@@ -58,7 +58,7 @@ func buildIntentResolver(cfg tracker.Config) chatops.IntentResolver {
 		log.Printf("trackerchat: LLM intent unavailable (%v) — using the 'run <workflow>' grammar", err)
 		return chatops.GrammarResolver{}
 	}
-	model := envOr("TRACKERCHAT_MODEL", "claude-haiku-4-5-20251001")
+	model := envOr("TRACKERCHAT_MODEL", "claude-haiku-4-5")
 	return chatops.NewLLMIntentResolver(client, model)
 }
 

--- a/cmd/trackerchat/main.go
+++ b/cmd/trackerchat/main.go
@@ -33,6 +33,10 @@ func main() {
 	configBase := tracker.Config{
 		Backend: os.Getenv("TRACKERCHAT_BACKEND"),
 		Budget:  pipeline.BudgetLimits{MaxCostCents: maxCostCents},
+		// Per-thread workdirs are created fresh and empty (shared chatops.Runner),
+		// so `requires: git` workflows would dead-stop at preflight. Auto-init git
+		// in the fresh dir — same fix as trackerbot (#497).
+		Git: &tracker.GitConfig{Preflight: tracker.GitPreflightInit, AllowInit: true},
 	}
 	runner := chatops.NewRunner(rm, chatops.RunnerDeps{
 		NewThreadUI:  session.ThreadUI,

--- a/transport/chatops/intent.go
+++ b/transport/chatops/intent.go
@@ -6,12 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	tracker "github.com/2389-research/tracker"
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/llm"
 )
+
+// defaultIntentModel is the catalog id the classifier falls back to when the
+// configured model isn't a known model — so a stale or mistyped
+// TRACKERBOT_MODEL / TRACKERCHAT_MODEL can't 404 (model_not_found) the router.
+const defaultIntentModel = "claude-haiku-4-5"
 
 // Intent is a parsed request: which workflow to run and any param overrides.
 type Intent struct {
@@ -62,7 +68,19 @@ type llmIntentResolver struct {
 }
 
 func NewLLMIntentResolver(client agent.Completer, model string) *llmIntentResolver {
-	return &llmIntentResolver{client: client, model: model, catalog: tracker.Workflows()}
+	return &llmIntentResolver{client: client, model: resolveIntentModel(model), catalog: tracker.Workflows()}
+}
+
+// resolveIntentModel maps a configured model onto its canonical catalog id,
+// resolving aliases and falling back to defaultIntentModel when the id isn't a
+// known model. This keeps a bad model id from ever reaching the provider as a
+// 404 (the classifier never hard-blocks routing on a misconfigured env var).
+func resolveIntentModel(model string) string {
+	if info := llm.GetModelInfo(model); info != nil {
+		return info.ID
+	}
+	log.Printf("chatops: model %q is not in the catalog; routing with %q instead", model, defaultIntentModel)
+	return defaultIntentModel
 }
 
 func (r *llmIntentResolver) Resolve(ctx context.Context, text string) (Intent, error) {
@@ -91,7 +109,13 @@ const intentSystemPrompt = `You route a user's request to exactly ONE workflow a
 Respond ONLY with JSON of the form:
 {"workflow": "<name>", "params": {"key": "value"}, "reason": "<one line>"}
 Choose the single best workflow by its exact name from the provided list. If none
-fits, return an empty string for "workflow".`
+fits, return an empty string for "workflow".
+
+Routing bias: when the user only describes an idea of what to build (no written
+spec) and asks to build/make/create it, prefer a workflow that discovers and
+writes the spec itself (e.g. one whose goal is to "ask what to build … and spec
+it") over one that requires reading a pre-existing SPEC.md. The user has not
+written a spec, so a spec-requiring workflow would dead-stop.`
 
 func (r *llmIntentResolver) classify(ctx context.Context, text string) (Intent, error) {
 	var b strings.Builder
@@ -107,7 +131,12 @@ func (r *llmIntentResolver) classify(ctx context.Context, text string) (Intent, 
 		ResponseFormat: &llm.ResponseFormat{Type: "json_object"},
 	})
 	if err != nil {
-		return Intent{}, fmt.Errorf("intent classification failed: %w", err)
+		// Grammar fallback: a classifier outage (e.g. a provider 404) must never
+		// hard-block routing. Log the real error and point the user at the
+		// deterministic `run <workflow>` grammar instead of leaking a raw
+		// provider error into the thread.
+		log.Printf("chatops: intent classification failed (%v); falling back to the grammar", err)
+		return Intent{}, fmt.Errorf("natural-language routing is unavailable right now — try `run <workflow>` (options: %s)", r.catalogNames())
 	}
 
 	var out struct {

--- a/transport/chatops/intent_test.go
+++ b/transport/chatops/intent_test.go
@@ -4,6 +4,7 @@ package chatops
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	tracker "github.com/2389-research/tracker"
@@ -95,5 +96,43 @@ func TestLLMIntent_HallucinatedWorkflowRejected(t *testing.T) {
 	}
 	if _, err := r.Resolve(context.Background(), "do the thing"); err == nil {
 		t.Fatal("expected a workflow outside the catalog to be rejected")
+	}
+}
+
+func TestResolveIntentModel(t *testing.T) {
+	// A known catalog id passes through unchanged.
+	if got := resolveIntentModel("claude-haiku-4-5"); got != "claude-haiku-4-5" {
+		t.Fatalf("catalog id = %q, want claude-haiku-4-5", got)
+	}
+	// An alias resolves to its canonical id.
+	if got := resolveIntentModel("claude-haiku"); got != "claude-haiku-4-5" {
+		t.Fatalf("alias = %q, want claude-haiku-4-5", got)
+	}
+	// A stale/mistyped id (the old dated snapshot) falls back to the default
+	// instead of being handed to the provider as a 404.
+	if got := resolveIntentModel("claude-haiku-4-5-20251001"); got != defaultIntentModel {
+		t.Fatalf("unknown id = %q, want %s", got, defaultIntentModel)
+	}
+}
+
+// errCompleter always errors, standing in for a provider outage / 404.
+type errCompleter struct{}
+
+func (errCompleter) Complete(context.Context, *llm.Request) (*llm.Response, error) {
+	return nil, errors.New("model_not_found (404)")
+}
+
+func TestLLMIntent_ClassifierOutageDoesNotLeakProviderError(t *testing.T) {
+	r := &llmIntentResolver{client: errCompleter{}, model: "m", catalog: testCatalog()}
+	_, err := r.Resolve(context.Background(), "make me a cli that greets people")
+	if err == nil {
+		t.Fatal("expected an error when the classifier is unavailable")
+	}
+	// The user gets the grammar fallback guidance, not the raw provider error.
+	if strings.Contains(err.Error(), "404") {
+		t.Fatalf("provider error leaked to the user: %v", err)
+	}
+	if !strings.Contains(err.Error(), "run <workflow>") {
+		t.Fatalf("expected grammar guidance, got: %v", err)
 	}
 }


### PR DESCRIPTION
Three tightly-coupled pre-Phase-0 fixes to the chat front door (trackerbot /
trackerchat, sharing `transport/chatops`). They land as one stacked PR because
each touches the same two files (`transport/chatops/intent.go`,
`cmd/trackerbot/main.go`).

## #496 — intent-classifier model id 404
The default `TRACKERBOT_MODEL` / `TRACKERCHAT_MODEL` was a nonexistent dated
snapshot (`claude-haiku-4-5-20251001`) that the provider rejects with
`model_not_found`, hard-blocking natural-language routing.

- Default is now the catalog id `claude-haiku-4-5` (both mains).
- `NewLLMIntentResolver` resolves the configured model through the model catalog
  (`llm.GetModelInfo`) — aliases map to their canonical id; an unknown id falls
  back to `claude-haiku-4-5` — so a mistyped env var never reaches the provider.
- A classifier outage now degrades to the deterministic `run <workflow>` grammar
  guidance instead of leaking a raw provider error into the thread.

**AC:** an @mention in natural language routes to a workflow instead of a 404. ✅

## #497 — auto-init git in trackerbot per-run workdirs
Per-thread workdirs are created fresh and empty, but git was never initialized,
so `requires: git` workflows (`ask_and_execute`, `build_product`) dead-stopped at
preflight with "not a git repository". trackerbot now sets
`Git: {Preflight: init, AllowInit: true}` — safe because the dirs are always
fresh and empty.

**AC:** ask_and_execute / build_product start cleanly from Slack with no manual
`git init`. ✅

## #498 — route spec-less "build me X" to ask_and_execute
`build_product*` hard-require a pre-existing `SPEC.md` and dead-stop without one.
The intent prompt is now biased so that when a user only describes an idea (no
written spec) and asks to build/make/create it, the classifier prefers a
self-speccing workflow (`ask_and_execute`) over a spec-requiring one.

**AC:** a user with only an idea reaches a shipped artifact without pre-writing a
spec. ✅

### Deferred (durable path)
The issue's durable option — an embedded `idea_to_spec` interview workflow chained
to `build_product` — is **not** included. Embedding it requires the raw
`examples/subgraphs/*.dip` material to be reachable via `subgraph_ref` from an
embedded built-in, which is blocked by the known **subgraph-builtin delivery
gap** (embed-FS subgraph resolution + library subgraph loading are missing).
Shipping it today would produce a workflow that dead-stops on embedded/Slack
runs — the opposite of the AC. Left for the loader-infra work.

## Verification
- `go build ./...`, `go test ./... -short` green.
- Full pre-commit gate suite passed (fmt, vet, build, tests, race, coverage
  85.8%, complexity ≤8, dippin lint).
- New tests: `resolveIntentModel` (catalog id / alias / stale-id fallback) and
  classifier-outage grammar fallback (no raw provider error leaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787338919&installation_model_id=21126&pr_number=499&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F499&signature=ecb1ddf456a8d38b8d6bdbc80b3c32a038e1cc67b1ccad0a0a6f4e63af73538e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->