### PR TITLE
feat(runmanager): make paused_billing a first-class, resumable RunState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`paused_billing` is a first-class, resumable state for embedders.**
+  `RunManager` gained a `RunPaused` state, mapped from the engine's recoverable
+  `paused_billing` terminal (#487). Previously any non-success outcome was
+  reported as `RunFailed`, so a credit-exhausted run looked dead to an embedding
+  control plane — defeating the point of the resumable pause. `RunPaused` is
+  `Terminal()` (finished-but-resumable: the goroutine has exited, `Done()` is
+  closed, and the key is free for the resume attempt), and the new
+  `ManagedRun.ResumeRunID() string` returns the id to feed back as
+  `Config.ResumeRunID`. Docs for `Result.Status`,
+  `docs/architecture/embedding.md` §4, and
+  `docs/architecture/transport-boundary.md` now list `paused_billing` and state
+  explicitly that both the terminal-status set and `RunState` are **open enums** —
+  consumers must not switch exhaustively.
+
 - **Golden-trace conformance fixtures for downstream port verification.** New
   `tracker-conformance golden <fixture.dip>` subcommand emits a normalized,
   deterministic trace (event sequence + per-node `SessionStats` + aggregate

--- a/docs/architecture/embedding.md
+++ b/docs/architecture/embedding.md
@@ -63,9 +63,19 @@ seam), `Subgraphs`, `Git`, `GitArtifacts`, `SteeringChan`.
 ## 4. Terminal status & events
 
 - **Status is an open enum.** `Result.Status` is one of `success`, `fail`,
-  `budget_exceeded`, `validation_overridden` today; future minors may add more.
-  **Never switch on the raw string** — classify with
-  `pipeline.TerminalStatus(r.Status).IsSuccess()` (fail-closed).
+  `budget_exceeded`, `validation_overridden`, `paused_billing` today; future
+  minors may add more. **Never switch exhaustively on the raw string** — classify
+  with `pipeline.TerminalStatus(r.Status).IsSuccess()` (fail-closed) and treat an
+  unknown value as "not a success I understand", not as a failure to report.
+- **`paused_billing` is recoverable, not failed.** Provider credit/quota
+  exhaustion (#487) stops the run in a *resumable* terminal: the checkpoint is
+  written and in-flight work preserved, so re-running with
+  `Config.ResumeRunID = <run id>` (same `CheckpointDir`/`WorkingDir`) continues
+  from the paused node once credits are topped up. `Run` returns **both** the
+  `paused_billing` result and the billing error, so a control plane must classify
+  on `Result.Status` — `err != nil` alone is not "dead". Under `RunManager` this
+  surfaces as `RunPaused` with `ManagedRun.ResumeRunID()` (§ Concurrency in
+  [`transport-boundary.md`](transport-boundary.md)).
 - **Events:** `Config.EventHandler pipeline.PipelineEventHandler` receives the
   `pipeline.PipelineEvent` stream (types in `pipeline/events.go`);
   `Config.AgentEvents agent.EventHandler` receives per-session `agent.Event`s.

--- a/docs/architecture/transport-boundary.md
+++ b/docs/architecture/transport-boundary.md
@@ -99,7 +99,10 @@ Two Config-wired streams (a transport merges them):
   its model), `stage_*`, `cost_updated` (carries a `NodeID` for per-node
   attribution + a `CostSnapshot`), `budget_exceeded`, `validation_overridden`,
   and the terminal event (carries an authoritative `TerminalStatus` — `success` /
-  `validation_overridden` / `fail` / `budget_exceeded`). The **top-level** engine
+  `validation_overridden` / `fail` / `budget_exceeded` / `paused_billing`; the set
+  is an **open enum**, so classify with
+  `pipeline.TerminalStatus(s).IsSuccess()` rather than switching exhaustively, and
+  note `paused_billing` is a *resumable* stop, not a failure). The **top-level** engine
   emits exactly one terminal event carrying `TerminalStatus` for its own run —
   including panic and invariant-error exits, which the backstop covers — so "any
   event with a non-empty `TerminalStatus` **and an unscoped `NodeID`**" is the
@@ -152,8 +155,16 @@ once from one process:
   `key` (e.g. a Slack `thread_ts`); an atomic claim guards the active-key and an
   optional concurrency cap (`WithMaxConcurrent` → `ErrAtCapacity` /
   `ErrRunKeyActive` — mechanism, not policy).
-- `ManagedRun` exposes `State`/`Done`/`Result`/`RunID`; the manager exposes
-  `Get`/`List`/`Cancel`/`Forget`.
+- `ManagedRun` exposes `State`/`Done`/`Result`/`RunID`/`ResumeRunID`; the manager
+  exposes `Get`/`List`/`Cancel`/`Forget`.
+- `RunState` is an **open enum** (`starting`, `running`, `succeeded`, `failed`,
+  `canceled`, `paused`) — use `State().Terminal()` plus the states you care about
+  rather than an exhaustive switch. `RunPaused` maps from the engine's
+  `paused_billing` terminal: the run is *finished-but-resumable*, so `Terminal()`
+  is **true** (its goroutine exited, `Done()` is closed, the key is free for the
+  resume attempt) while `ResumeRunID()` returns the id to feed back as
+  `Config.ResumeRunID`. A control plane must distinguish `paused` from `failed` —
+  "add credit and resume" vs "this run is dead".
 - Per-run isolation makes concurrency safe: distinct `WorkingDir` per run
   (`WithWorkDirBase`), no shared mutable state, and the webhook interviewer's
   callback port defaults to `:0` so two webhook-gated runs never collide.

--- a/pipeline/terminal_status.go
+++ b/pipeline/terminal_status.go
@@ -11,6 +11,7 @@ package pipeline
 //   - OutcomeFail                 "fail"
 //   - OutcomeBudgetExceeded       "budget_exceeded"
 //   - OutcomeValidationOverridden "validation_overridden"
+//   - OutcomePausedBilling        "paused_billing" (recoverable + resumable)
 //
 // The enum is open — future minor releases may add new values. Consumers should
 // use IsSuccess() to classify rather than switching on the raw string.

--- a/tracker.go
+++ b/tracker.go
@@ -176,14 +176,18 @@ type CostReport struct {
 // Result contains the outcome of a pipeline execution.
 type Result struct {
 	RunID string
-	// Status carries the run's terminal status. One of:
+	// Status carries the run's terminal status. Known values today:
 	//   - "success"
 	//   - "fail"
 	//   - "budget_exceeded"
 	//   - "validation_overridden"
-	// The enum is open — future minor releases may add new values. Use
-	// pipeline.TerminalStatus(r.Status).IsSuccess() to classify rather than
-	// switching on the raw string.
+	//   - "paused_billing" — recoverable provider credit/quota exhaustion: the
+	//     checkpoint is saved and in-flight work preserved, so the run resumes
+	//     from the paused node (Config.ResumeRunID / `tracker -r`) once credits
+	//     are topped up. Not a failure; offer resume, not a from-scratch redo.
+	// The enum is OPEN — future minor releases may add new values, so never
+	// switch exhaustively on the raw string. Use
+	// pipeline.TerminalStatus(r.Status).IsSuccess() to classify (fail-closed).
 	Status           string
 	CompletedNodes   []string
 	Context          map[string]string

--- a/tracker_runmanager.go
+++ b/tracker_runmanager.go
@@ -19,17 +19,36 @@ import (
 // RunState is the lifecycle state of a managed run.
 type RunState string
 
+// The set of states is an OPEN enum — future minor releases may add more (e.g.
+// a blocked-on-human-gate state). Classify with Terminal() and compare against
+// the states you care about; do not switch exhaustively.
 const (
 	RunStarting  RunState = "starting"
 	RunRunning   RunState = "running"
 	RunSucceeded RunState = "succeeded"
 	RunFailed    RunState = "failed"
 	RunCanceled  RunState = "canceled"
+	// RunPaused is a run that stopped in a recoverable, resumable terminal —
+	// today only the engine's paused_billing halt (#487): the checkpoint is
+	// saved, in-flight work preserved, and the run continues from the paused
+	// node once credits are topped up. It is NOT a failure: an embedder should
+	// surface "add credit and resume", not "this run is dead". Feed
+	// ManagedRun.ResumeRunID() back as Config.ResumeRunID to resume.
+	RunPaused RunState = "paused"
 )
 
-// Terminal reports whether the state is a finished state.
+// Terminal reports whether the state is a finished state — the run's goroutine
+// has exited, Done() is closed, and Result() is populated.
+//
+// RunPaused counts as Terminal even though the *work* is unfinished. It is
+// "finished-but-resumable": this process's run really has ended, so a state
+// where Terminal() were false would contradict a closed Done() channel, keep the
+// key locked by the active-key guard in claim() (stranding the run — the caller
+// could never start the resume under the same key), and make Forget() refuse it
+// forever. Resumability is a separate axis from finishedness, surfaced by
+// State() == RunPaused and ResumeRunID(), not by Terminal().
 func (s RunState) Terminal() bool {
-	return s == RunSucceeded || s == RunFailed || s == RunCanceled
+	return s == RunSucceeded || s == RunFailed || s == RunCanceled || s == RunPaused
 }
 
 var (
@@ -68,7 +87,9 @@ func (m *ManagedRun) Done() <-chan struct{} { return m.done }
 // run is Done, it returns (nil, nil). After Done it mirrors tracker.Run: a run
 // that produced a terminal result has a non-nil *Result (with RunID and a
 // terminal Status) — accompanied by a non-nil error for handler-error,
-// strict-failure, or cancelled exits. Only an init/invariant failure before any
+// strict-failure, paused (see RunPaused), or cancelled exits. A non-nil error
+// therefore does not by itself mean the run failed; read State(). Only an
+// init/invariant failure before any
 // terminal result yields (nil, err).
 func (m *ManagedRun) Result() (*Result, error) {
 	m.mu.Lock()
@@ -84,6 +105,19 @@ func (m *ManagedRun) RunID() string {
 		return m.result.RunID
 	}
 	return ""
+}
+
+// ResumeRunID returns the tracker run id to resume from when the run stopped in
+// a recoverable paused state (State() == RunPaused), else "". Pass it as
+// Config.ResumeRunID (with the same Config.CheckpointDir and this run's WorkDir)
+// to continue from the paused node. Capture it before Forget() drops the run.
+func (m *ManagedRun) ResumeRunID() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.state != RunPaused || m.result == nil {
+		return ""
+	}
+	return m.result.RunID
 }
 
 // RunManager owns multiple concurrent pipeline runs keyed by an external id.
@@ -216,18 +250,32 @@ func (rm *RunManager) execute(ctx context.Context, m *ManagedRun, source string,
 
 	m.mu.Lock()
 	m.result, m.err = res, err
+	m.state = m.classifyFinalState(ctx, res, err)
+	m.mu.Unlock()
+}
+
+// classifyFinalState maps a finished Run's (result, error) onto a terminal
+// lifecycle state. Caller must hold m.mu (it reads m.canceled).
+func (m *ManagedRun) classifyFinalState(ctx context.Context, res *Result, err error) RunState {
 	switch {
 	case err == nil && res != nil && pipeline.TerminalStatus(res.Status).IsSuccess():
 		// A genuine success wins even if the context was cancelled in the
 		// completion window — the result is a real success, so State() must not
 		// disagree with a successful Result().
-		m.state = RunSucceeded
+		return RunSucceeded
+	case res != nil && res.Status == string(pipeline.OutcomePausedBilling):
+		// Same reasoning as success: the engine reached an authoritative
+		// terminal, so it outranks a cancellation observed in the completion
+		// window. paused_billing arrives WITH a non-nil error (the billing
+		// error rides out on Run's error return), so it must be classified from
+		// the status — not from err == nil — or it lands in RunFailed and the
+		// embedder loses the resume affordance.
+		return RunPaused
 	case m.canceled || ctx.Err() != nil:
-		m.state = RunCanceled
+		return RunCanceled
 	default:
-		m.state = RunFailed
+		return RunFailed
 	}
-	m.mu.Unlock()
 }
 
 func (m *ManagedRun) setState(s RunState) {

--- a/tracker_runmanager_test.go
+++ b/tracker_runmanager_test.go
@@ -3,11 +3,14 @@ package tracker
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/2389-research/tracker/pipeline"
 )
 
 // quickDip is a passthrough pipeline that completes immediately.
@@ -158,6 +161,73 @@ func TestRunManager_CapacityAndKeyGuards(t *testing.T) {
 	waitDone(t, m2, 10*time.Second)
 	if m2.State() != RunSucceeded {
 		t.Fatalf("reused run state=%s", m2.State())
+	}
+}
+
+// TestRunManager_PausedBillingIsResumable asserts a run whose engine stops in
+// the recoverable paused_billing terminal (#487) is reported as RunPaused — NOT
+// RunFailed — and exposes a resume id a control plane can feed back as
+// Config.ResumeRunID. Reporting it as failed would tell an embedder the run is
+// dead when in fact "add credit and resume" recovers it.
+func TestRunManager_PausedBillingIsResumable(t *testing.T) {
+	rm := NewRunManager(WithWorkDirBase(t.TempDir()))
+
+	m, err := rm.Start(context.Background(), "brokerun", costDip, Config{
+		Format:      "dip",
+		LLMClient:   &failingCompleter{err: errors.New("your credit balance is too low")},
+		RetryPolicy: "none",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitDone(t, m, 10*time.Second)
+
+	res, _ := m.Result()
+	if res == nil || res.Status != string(pipeline.OutcomePausedBilling) {
+		t.Fatalf("engine status = %v, want %q", res, pipeline.OutcomePausedBilling)
+	}
+	if got := m.State(); got != RunPaused {
+		t.Fatalf("state = %s, want %s", got, RunPaused)
+	}
+	if !m.State().Terminal() {
+		t.Fatal("RunPaused must be Terminal() — it is finished-but-resumable")
+	}
+	resumeID := m.ResumeRunID()
+	if resumeID == "" {
+		t.Fatal("ResumeRunID() empty for a paused run — a caller cannot resume it")
+	}
+	if resumeID != res.RunID {
+		t.Fatalf("ResumeRunID() = %q, want run id %q", resumeID, res.RunID)
+	}
+
+	// A paused run is finished, so the active-key guard lets the caller start the
+	// resume attempt under the same key (a non-Terminal paused state would strand
+	// it here with ErrRunKeyActive). Wait for the second run so no goroutine
+	// outlives the test's temp dir; its own outcome is not what's under test.
+	resumed, err := rm.Start(context.Background(), "brokerun", quickDip, Config{
+		Format: "dip", LLMClient: successStub(), ResumeRunID: resumeID,
+	})
+	if err != nil {
+		t.Fatalf("restart under a paused key: %v", err)
+	}
+	waitDone(t, resumed, 10*time.Second)
+}
+
+// TestManagedRun_ResumeRunIDOnlyWhenPaused asserts the resume handle is empty
+// for non-paused states, so a caller cannot mistake a succeeded/failed run's id
+// for a resumable one.
+func TestManagedRun_ResumeRunIDOnlyWhenPaused(t *testing.T) {
+	rm := NewRunManager(WithWorkDirBase(t.TempDir()))
+	m, err := rm.Start(context.Background(), "ok", quickDip, Config{Format: "dip", LLMClient: successStub()})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	waitDone(t, m, 10*time.Second)
+	if m.State() != RunSucceeded {
+		t.Fatalf("state = %s, want %s", m.State(), RunSucceeded)
+	}
+	if got := m.ResumeRunID(); got != "" {
+		t.Fatalf("ResumeRunID() = %q for a succeeded run, want \"\"", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`pipeline.OutcomePausedBilling` (`paused_billing`) is a **recoverable, resumable** terminal introduced by #487: the run checkpoints, preserves in-flight work, and continues with `tracker -r` / `Config.ResumeRunID` once credits are topped up. The embedding surface did not know it existed:

- `RunManager.execute` classified *anything* non-success as `RunFailed`, so a credit-exhausted run was reported to an embedder as **failed**.
- The `Result.Status` doc comment in `tracker.go` listed only four statuses (so did `pipeline.TerminalStatus`'s own known-values comment).
- `docs/architecture/embedding.md` §4 listed the same four.

Net effect: a control plane driving N runs could not distinguish "this run is dead" from "add credits and resume" — the entire point of #487.

## Design

- **New state `RunPaused RunState = "paused"`**, mapped from a `paused_billing` engine status.
- Classification extracted to `(*ManagedRun).classifyFinalState(ctx, res, err)` (also keeps `execute` under the complexity gate). The paused case is matched on `Result.Status`, **not** on `err == nil`: `paused_billing` exits `Run` *with* the billing error attached, so an error-based test drops it into `RunFailed`. It is ordered right after the success case and before the cancel case, for the same reason success is: the engine reached an authoritative terminal, which outranks a cancellation observed in the completion window.
- **New `func (m *ManagedRun) ResumeRunID() string`** — returns the run id to feed back as `Config.ResumeRunID` when `State() == RunPaused`, else `""` (so a caller can't mistake a succeeded/failed run's id for a resumable one). A paused state a caller can't resume from would be useless.

### The `Terminal()` decision: `RunPaused` **is** terminal

It is *finished-but-resumable*, which is neither "running" nor "failed" — but finishedness and resumability are separate axes. The run's goroutine has exited, `Done()` is closed, and `Result()` is populated, so:

- a non-terminal paused state would **contradict a closed `Done()` channel** (callers block on `Done()`, then ask `State()`);
- `claim()`'s active-key guard would keep the key locked forever, so the caller could never `Start` the **resume** under the same key — literally stranding the paused run;
- `Forget()` would refuse the run forever, leaking manager state.

Resumability is surfaced by `State() == RunPaused` + `ResumeRunID()`, not by `Terminal()`.

**Blast radius — every `Terminal()` caller (grepped; there are exactly two, both in `tracker_runmanager.go`):**

| Caller | Behavior with paused ⇒ Terminal | Verdict |
|---|---|---|
| `claim()` — active-key guard | a paused key is reusable, so the resume `Start` is admitted | desired; covered by the new test |
| `Forget()` — refuses non-terminal runs | a paused run can be dropped once the caller has captured `ResumeRunID()` (documented on the method) | correct |

No other package reads `RunState`/`Terminal()` (`cmd/trackerbot` uses `RunManager` but not its states), so there is no external behavior change beyond a state that used to be reported as `failed` now being reported as `paused`. That is the intended fix, and it is why this is called out in CHANGELOG.

### Docs
`Result.Status`, `embedding.md` §4 (plus a new bullet on what "resumable" concretely means for an embedder), `transport-boundary.md` §3 (terminal event) and its RunManager section now list `paused_billing`/`paused` and state explicitly that **both** the terminal-status set and `RunState` are **open enums** — do not switch exhaustively. `pipeline/terminal_status.go`'s known-values doc comment was missing `paused_billing` too; fixed (comment only, no code).

## Verification (actually run)

- `go build ./...` — clean
- `go test ./... -short -count=1` — all packages pass
- `make complexity` — `complexity gate OK (212 grandfathered, 0 new)`
- Pre-commit gates: format, vet, build, tests (22 packages), complexity, dippin lint — all green
- New tests (TDD — written first, watched fail to compile/`RunFailed`):
  - `TestRunManager_PausedBillingIsResumable` — a run whose completer returns a credit-balance error lands in `RunPaused` (not `RunFailed`), is `Terminal()`, exposes `ResumeRunID() == Result.RunID`, and its key is immediately reusable for the resume `Start`.
  - `TestManagedRun_ResumeRunIDOnlyWhenPaused` — `ResumeRunID()` is `""` for a succeeded run.

## Out of scope

`RunWaiting` (blocked-on-human-gate) is deliberately **not** added — it needs gate lifecycle events landing in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuhYJxVgQPsfuHZpAYbeed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787860347&installation_model_id=21126&pr_number=511&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F511&signature=5c696da90892d6ddf7df7679b131c0529c5fcc9d8d889979572a3646dfef386c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resumable runs paused due to billing limits.
  * Paused runs are now clearly distinguished from failed runs.
  * Added access to the resume identifier needed to continue a paused run.

* **Documentation**
  * Documented the new `paused_billing` status and paused run behavior.
  * Clarified that status values may expand and should be evaluated using success classification rather than exhaustive status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->