### PR TITLE
feat(events): bring the public NDJSON wire to payload parity with activity.jsonl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The public NDJSON wire is at payload parity with `activity.jsonl` (E1).**
+  `tracker.StreamEvent` — the documented stable wire format behind
+  `tracker --json` and `tracker.NewNDJSONWriter` — was 12 flat string fields
+  while the private `activity.jsonl` schema already serialized every structured
+  payload the engine emits. A control plane consuming the *documented* stream
+  therefore could not do cost rollups, reconstruct routing decisions, see the
+  run-start node inventory, or detect tool-output truncation; it had to parse
+  `activity.jsonl` out of band (re-implementing a private schema) or scrape the
+  CLI. `StreamEvent` now carries, all `omitempty` and all purely additive: the
+  cost snapshot (`total_tokens`, `total_cost_usd`, `provider_totals`,
+  `wall_elapsed_ms`, `estimated`), the edge decision detail (`edge_from`,
+  `edge_to`, `edge_condition`, `edge_priority`, `condition_match`,
+  `outcome_status`, `context_snapshot`, `context_updates`, `restart_count`,
+  `cleared_nodes`, `conditions_tried`, `token_input`, `token_output`), the
+  tool-node diagnostics (`trunc_*`, `marker_*`, `route_tail`, `auto_status_*`),
+  the override detail (`override_gate`, `override_label`, `override_actor`,
+  `override_subgraph_path`), the full gate payload (`gate_mode`, `gate_label`,
+  `gate_prompt`, `gate_choices`, `gate_questions`, `gate_response`,
+  `gate_outcome`, `gate_actor`, `gate_timed_out`), the bundle identity
+  (`bundle_identity`), per-turn agent usage on `turn_metrics` / `llm_finish`
+  (`token_input`, `token_output`, `token_cache_read`, `token_cache_write`,
+  `turn_cost_usd` — surfacing the `Provider`/`Model`/`Usage` attribution added in
+  #508), and the `pipeline_started` run snapshot (`snapshot_nodes`,
+  `snapshot_start_node`, `snapshot_exit_node`, `snapshot_current_node`,
+  `snapshot_completed_nodes`). Field names are **identical** to the
+  `activity.jsonl` line schema wherever the datum is shared — one decoder now
+  serves both streams, enforced by a mechanical parity test — and the only
+  wire-only names are the `snapshot_*` group and the per-turn cache/cost extras,
+  which have no audit-log counterpart. No existing field was renamed, retyped, or
+  removed, and events that carry no payload serialize exactly the keys they did
+  before.
+
 - **Gate lifecycle events on the pipeline stream (#509).** The human gate handler
   now emits `gate_opened` / `gate_resolved` around every interviewer call, so an
   event-sourced consumer (replay tool, audit UI, external control plane) can

--- a/docs/architecture/embedding.md
+++ b/docs/architecture/embedding.md
@@ -81,6 +81,19 @@ seam), `Subgraphs`, `Git`, `GitArtifacts`, `SteeringChan`.
   `Config.AgentEvents agent.EventHandler` receives per-session `agent.Event`s.
   `tracker.NewNDJSONWriter(io.Writer)` yields the same stream shape as
   `tracker --json`.
+- **`StreamEvent` is at payload parity with `activity.jsonl`.** The NDJSON
+  envelope carries the structured payloads — cost snapshot (`total_cost_usd`,
+  `provider_totals`, `wall_elapsed_ms`, `estimated`), edge decisions
+  (`edge_from` / `edge_to` / `edge_priority` / `condition_match` /
+  `context_snapshot`), truncation / marker / route diagnostics, override detail,
+  the full gate payload (`gate_mode`, `gate_prompt`, `gate_choices`,
+  `gate_questions`, `gate_response`, `gate_actor`), per-turn agent usage
+  (`token_input` / `token_output` / `token_cache_read` / `turn_cost_usd`), and
+  the `pipeline_started` node inventory (`snapshot_nodes`, `snapshot_*`). Field
+  names are identical to the `activity.jsonl` line schema wherever the datum is
+  shared, so one decoder serves both; the `snapshot_*` group and the per-turn
+  cache/cost extras are wire-only. Every field is `omitempty` — read the ones
+  documented for the event's `type` and tolerate unknown keys.
 
 ## 5. Verifying against version drift — golden-trace conformance fixtures
 

--- a/docs/architecture/transport-boundary.md
+++ b/docs/architecture/transport-boundary.md
@@ -125,10 +125,24 @@ Two Config-wired streams (a transport merges them):
 - **`llm.TraceObserver`** (via `Config.LLMTrace`) — raw request/reasoning/text
   trace, for a transport that wants live tokens without owning the client.
 
-`StreamEvent` (NDJSON, `tracker.NewNDJSONWriter`) is the flat wire form of the
-pipeline stream, carrying `terminal_status` / `node_id` / `gate_id`. The richer
-per-event payloads (cost snapshot, decision detail, full `GateDetail`) land on
-`activity.jsonl` rather than the flat wire form.
+`StreamEvent` (NDJSON, `tracker.NewNDJSONWriter`) is the flat wire form of all
+three streams, and it is at **payload parity with `activity.jsonl`**: alongside
+`terminal_status` / `node_id` / `gate_id` it carries the cost snapshot
+(`total_cost_usd`, `provider_totals`, `wall_elapsed_ms`, `estimated`), the
+decision detail (`edge_from`, `edge_to`, `edge_priority`, `condition_match`,
+`context_snapshot`, `conditions_tried`), the tool diagnostics (`trunc_*`,
+`marker_*`, `route_tail`, `auto_status_*`), the override detail (`override_*`),
+the full `GateDetail` (`gate_mode`, `gate_label`, `gate_prompt`, `gate_choices`,
+`gate_questions`, `gate_response`, `gate_outcome`, `gate_actor`,
+`gate_timed_out`), per-turn agent usage (`token_input`, `token_output`,
+`token_cache_read`, `token_cache_write`, `turn_cost_usd`), and the
+`pipeline_started` node inventory (`snapshot_nodes`, `snapshot_start_node`,
+`snapshot_exit_node`, `snapshot_current_node`, `snapshot_completed_nodes`).
+Field names match the `activity.jsonl` schema wherever the datum is shared, so a
+control plane needs one decoder and never has to parse the audit log out of
+band; only the `snapshot_*` group and the per-turn cache/cost extras are
+wire-only. Every field is `omitempty`, so a given event carries only the fields
+documented for its `type`.
 
 ## 4. Control a run
 

--- a/tracker_events.go
+++ b/tracker_events.go
@@ -17,8 +17,28 @@ import (
 
 const ndjsonTimestampLayout = "2006-01-02T15:04:05.000Z07:00"
 
-// StreamEvent is the stable wire format for the tracker --json mode. Field
-// tags are stable; new optional fields may be added without a major bump.
+// StreamEvent is the stable wire format for the tracker --json mode.
+//
+// Field-stability contract:
+//   - Existing JSON field names are never renamed, retyped, or removed. New
+//     optional fields may be added without a major bump, so a consumer must
+//     tolerate unknown keys.
+//   - Every field except ts/source/type is `omitempty`: a field is present only
+//     on the event types that actually carry it. A consumer keys off `type`
+//     (within `source`) and reads the fields documented for it; it must not
+//     infer meaning from a field's absence beyond "this event does not carry it".
+//   - Where the same datum is also written to `activity.jsonl`, the JSON field
+//     name here is identical, so one decoder serves both streams. The only
+//     fields with no `activity.jsonl` counterpart are the run-snapshot group
+//     (`snapshot_*`) and the per-turn agent usage extras (`token_cache_read`,
+//     `token_cache_write`, `turn_cost_usd`).
+//
+// Payload size: `context_snapshot` / `context_updates` are unbounded maps of
+// routing-relevant context (a decision event on a context-heavy run can carry
+// tens of kilobytes), `gate_prompt` is capped at pipeline.GateMaxPromptBytes,
+// and the `*_tail` diagnostic fields are capped at 256 bytes by their emitters.
+// `content` is unbounded (a tool_call_end carries full tool output). A consumer
+// on a bounded transport should cap or drop those fields itself.
 type StreamEvent struct {
 	Timestamp string `json:"ts"`
 	Source    string `json:"source"`              // "pipeline", "llm", "agent"
@@ -35,11 +55,111 @@ type StreamEvent struct {
 	// (pipeline_completed / pipeline_failed / budget_exceeded): "success",
 	// "validation_overridden", "fail", or "budget_exceeded". Empty otherwise.
 	TerminalStatus string `json:"terminal_status,omitempty"`
+	// BundleIdentity is the content-addressed identity of the .dipx bundle the
+	// run executes against ("sha256:<hex>"). Set on pipeline events of a bundle
+	// run; empty for a plain .dip run.
+	BundleIdentity string `json:"bundle_identity,omitempty"`
+
+	// Decision fields — set on decision_edge / decision_condition /
+	// decision_outcome / decision_restart / conditional_fallthrough events, from
+	// pipeline.DecisionDetail. ConditionMatch and RestartCount are pointers so a
+	// consumer can distinguish "false"/"0" from "not carried".
+	EdgeFrom        string                   `json:"edge_from,omitempty"`
+	EdgeTo          string                   `json:"edge_to,omitempty"`
+	EdgeCondition   string                   `json:"edge_condition,omitempty"`
+	EdgePriority    string                   `json:"edge_priority,omitempty"`
+	ConditionMatch  *bool                    `json:"condition_match,omitempty"`
+	OutcomeStatus   string                   `json:"outcome_status,omitempty"`
+	ContextSnapshot map[string]string        `json:"context_snapshot,omitempty"`
+	ContextUpdates  map[string]string        `json:"context_updates,omitempty"`
+	RestartCount    *int                     `json:"restart_count,omitempty"`
+	ClearedNodes    []string                 `json:"cleared_nodes,omitempty"`
+	ConditionsTried []pipeline.ConditionEval `json:"conditions_tried,omitempty"`
+
+	// TokenInput / TokenOutput carry the token counts of whatever the event
+	// describes: the node's session stats on a pipeline decision event, the
+	// turn's usage on an agent turn_metrics / llm_finish event. They are never
+	// run-cumulative — that is total_tokens below.
+	TokenInput  int `json:"token_input,omitempty"`
+	TokenOutput int `json:"token_output,omitempty"`
+	// TokenCacheRead / TokenCacheWrite / TurnCostUSD are the per-turn agent
+	// extras (turn_metrics, llm_finish). No activity.jsonl counterpart.
+	TokenCacheRead  int     `json:"token_cache_read,omitempty"`
+	TokenCacheWrite int     `json:"token_cache_write,omitempty"`
+	TurnCostUSD     float64 `json:"turn_cost_usd,omitempty"`
+
+	// Cost snapshot fields — set on cost_updated and budget_exceeded events,
+	// from pipeline.CostSnapshot. Run-cumulative, not per-node. Estimated is
+	// true when any contributing session was heuristic-derived.
+	TotalTokens    int                               `json:"total_tokens,omitempty"`
+	TotalCostUSD   float64                           `json:"total_cost_usd,omitempty"`
+	ProviderTotals map[string]pipeline.ProviderUsage `json:"provider_totals,omitempty"`
+	WallElapsedMs  int64                             `json:"wall_elapsed_ms,omitempty"`
+	Estimated      bool                              `json:"estimated,omitempty"`
+
+	// Truncation fields — set on tool_output_truncated events (#208).
+	TruncStream   string `json:"trunc_stream,omitempty"`
+	TruncLimit    int    `json:"trunc_limit,omitempty"`
+	TruncCaptured int    `json:"trunc_captured_bytes,omitempty"`
+	TruncDropped  int    `json:"trunc_dropped_bytes,omitempty"`
+	TruncTotal    int    `json:"trunc_total_bytes,omitempty"`
+
+	// Marker fields — set on tool_marker_missing events (#210).
+	MarkerPattern string `json:"marker_pattern,omitempty"`
+	MarkerTail    string `json:"marker_tail,omitempty"`
+	MarkerError   string `json:"marker_error,omitempty"`
+
+	// RouteTail is set on tool_route_missing events (#212).
+	RouteTail string `json:"route_tail,omitempty"`
+
+	// Auto-status fields — set on auto_status_missing events (#346).
+	AutoStatusTail       string `json:"auto_status_tail,omitempty"`
+	AutoStatusFailClosed bool   `json:"auto_status_fail_closed,omitempty"`
+
+	// Override fields — set on validation_overridden events.
+	OverrideGate         string         `json:"override_gate,omitempty"`
+	OverrideLabel        string         `json:"override_label,omitempty"`
+	OverrideActor        pipeline.Actor `json:"override_actor,omitempty"`
+	OverrideSubgraphPath []string       `json:"override_subgraph_path,omitempty"`
+
 	// GateID is set only on the gate lifecycle events (gate_opened /
 	// gate_resolved) and correlates the pair (#509). NodeID identifies the gate
-	// node on both. The richer gate payload (mode, prompt, choices, response)
-	// is on the activity.jsonl entry for the same event.
+	// node on both.
 	GateID string `json:"gate_id,omitempty"`
+	// Gate payload fields, from pipeline.GateDetail. Open-time: GateMode,
+	// GateLabel, GatePrompt, GateChoices, GateQuestions. Resolve-time:
+	// GateResponse, GateOutcome, GateActor, GateTimedOut (plus Error above when
+	// the gate failed to collect an answer). GateMode is repeated on the
+	// resolution so GateResponse can be interpreted without joining.
+	GateMode      string                  `json:"gate_mode,omitempty"`
+	GateLabel     string                  `json:"gate_label,omitempty"`
+	GatePrompt    string                  `json:"gate_prompt,omitempty"`
+	GateChoices   []string                `json:"gate_choices,omitempty"`
+	GateQuestions []pipeline.GateQuestion `json:"gate_questions,omitempty"`
+	GateResponse  string                  `json:"gate_response,omitempty"`
+	GateOutcome   string                  `json:"gate_outcome,omitempty"`
+	GateActor     pipeline.Actor          `json:"gate_actor,omitempty"`
+	GateTimedOut  bool                    `json:"gate_timed_out,omitempty"`
+
+	// Run snapshot fields — set on pipeline_started, from pipeline.RunSnapshot:
+	// the top-level node inventory (sorted by ID, not execution order) plus
+	// resume state, so a subscriber joining at run start can seed its progress
+	// model without separate access to the graph or checkpoint.
+	// SnapshotCurrentNode / SnapshotCompletedNodes are populated only on resume.
+	// No activity.jsonl counterpart — these names are new.
+	SnapshotNodes          []StreamSnapshotNode `json:"snapshot_nodes,omitempty"`
+	SnapshotStartNode      string               `json:"snapshot_start_node,omitempty"`
+	SnapshotExitNode       string               `json:"snapshot_exit_node,omitempty"`
+	SnapshotCurrentNode    string               `json:"snapshot_current_node,omitempty"`
+	SnapshotCompletedNodes []string             `json:"snapshot_completed_nodes,omitempty"`
+}
+
+// StreamSnapshotNode is one node of a pipeline_started run snapshot on the
+// NDJSON wire. It mirrors pipeline.SnapshotNode with explicit wire tags.
+type StreamSnapshotNode struct {
+	ID      string `json:"id"`
+	Label   string `json:"label,omitempty"`
+	Handler string `json:"handler,omitempty"`
 }
 
 // NDJSONWriter is a thread-safe writer that serializes StreamEvents line by
@@ -106,13 +226,12 @@ func (s *NDJSONWriter) PipelineHandler() pipeline.PipelineEventHandler {
 			NodeID:         evt.NodeID,
 			Message:        evt.Message,
 			TerminalStatus: evt.TerminalStatus,
+			BundleIdentity: evt.BundleIdentity,
 		}
 		if evt.Err != nil {
 			entry.Error = evt.Err.Error()
 		}
-		if evt.Gate != nil {
-			entry.GateID = evt.Gate.GateID
-		}
+		applyStreamPipelinePayloads(&entry, evt)
 		_ = s.Write(entry)
 	})
 }
@@ -123,7 +242,7 @@ func (s *NDJSONWriter) PipelineHandler() pipeline.PipelineEventHandler {
 func (s *NDJSONWriter) TraceObserver() llm.TraceObserver {
 	return llm.TraceObserverFunc(func(evt llm.TraceEvent) {
 		defer s.recoverPanic("llm")
-		_ = s.Write(StreamEvent{
+		entry := StreamEvent{
 			Timestamp: time.Now().Format(ndjsonTimestampLayout),
 			Source:    "llm",
 			Type:      string(evt.Kind),
@@ -131,7 +250,9 @@ func (s *NDJSONWriter) TraceObserver() llm.TraceObserver {
 			Model:     evt.Model,
 			ToolName:  evt.ToolName,
 			Content:   evt.Preview,
-		})
+		}
+		applyStreamUsage(&entry, evt.Usage, 0)
+		_ = s.Write(entry)
 	})
 }
 
@@ -160,6 +281,7 @@ func (s *NDJSONWriter) AgentHandler() agent.EventHandler {
 			Content:   content,
 		}
 		entry.Error = buildStreamEntryError(evt)
+		applyStreamUsage(&entry, evt.Usage, turnMetricsCost(evt.Metrics))
 		_ = s.Write(entry)
 	})
 }

--- a/tracker_events_parity_test.go
+++ b/tracker_events_parity_test.go
@@ -1,0 +1,134 @@
+// ABOUTME: Mechanical field-name parity guard between StreamEvent and pipeline's jsonlLogEntry.
+// ABOUTME: Two NDJSON schemas for the same datum must never use different key names (E1).
+package tracker
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// jsonlEntrySource is the file holding pipeline's private activity.jsonl entry
+// type. It is unexported, so this test reads its tags from source rather than
+// via reflection (importing it is impossible; pipeline cannot import tracker).
+const (
+	jsonlEntrySource   = "pipeline/events_jsonl.go"
+	jsonlEntryTypeName = "jsonlLogEntry"
+)
+
+// wireOnlyFields are StreamEvent fields with no activity.jsonl counterpart, by
+// design. Adding to this list is a deliberate act: it means the public wire
+// carries a datum the audit log does not.
+var wireOnlyFields = map[string]string{
+	"terminal_status":          "run terminal status; predates E1, never mirrored to activity.jsonl",
+	"snapshot_nodes":           "pipeline_started run snapshot has no activity.jsonl counterpart",
+	"snapshot_start_node":      "pipeline_started run snapshot has no activity.jsonl counterpart",
+	"snapshot_exit_node":       "pipeline_started run snapshot has no activity.jsonl counterpart",
+	"snapshot_current_node":    "pipeline_started run snapshot has no activity.jsonl counterpart",
+	"snapshot_completed_nodes": "pipeline_started run snapshot has no activity.jsonl counterpart",
+	"token_cache_read":         "per-turn agent usage extra; activity.jsonl carries no agent usage",
+	"token_cache_write":        "per-turn agent usage extra; activity.jsonl carries no agent usage",
+	"turn_cost_usd":            "per-turn agent usage extra; activity.jsonl carries no agent usage",
+}
+
+// TestStreamEvent_MirrorsActivityLogFieldNames asserts that every field name in
+// the private activity.jsonl schema is also present on the public NDJSON wire
+// under the SAME name. The repo has two NDJSON-shaped schemas; the whole point
+// of E1 is that a consumer can decode both with one struct. Divergent names for
+// the same datum would be worse than the original gap.
+func TestStreamEvent_MirrorsActivityLogFieldNames(t *testing.T) {
+	jsonl := activityLogTagNames(t)
+	if len(jsonl) < 30 {
+		t.Fatalf("only parsed %d tags from %s — parser is not seeing the struct", len(jsonl), jsonlEntrySource)
+	}
+	wire := map[string]bool{}
+	for _, n := range jsonTagNames(reflect.TypeOf(StreamEvent{})) {
+		wire[n] = true
+	}
+
+	var missing []string
+	for _, name := range jsonl {
+		if !wire[name] {
+			missing = append(missing, name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("activity.jsonl carries %v which the public StreamEvent wire does not.\n"+
+			"Either mirror the field onto StreamEvent under the same JSON name, or\n"+
+			"document why the audit log is intentionally richer.", missing)
+	}
+
+	jsonlSet := map[string]bool{}
+	for _, n := range jsonl {
+		jsonlSet[n] = true
+	}
+	for name := range wire {
+		if jsonlSet[name] || wireOnlyFields[name] != "" {
+			continue
+		}
+		t.Errorf("StreamEvent field %q has no activity.jsonl counterpart and is not\n"+
+			"listed in wireOnlyFields. If that is intended, add it there with a reason.", name)
+	}
+}
+
+// activityLogTagNames parses jsonlEntrySource and returns the JSON field names
+// of the jsonlLogEntry struct.
+func activityLogTagNames(t *testing.T) []string {
+	t.Helper()
+	f, err := parser.ParseFile(token.NewFileSet(), jsonlEntrySource, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", jsonlEntrySource, err)
+	}
+	st := findStructType(f, jsonlEntryTypeName)
+	if st == nil {
+		t.Fatalf("type %s not found in %s", jsonlEntryTypeName, jsonlEntrySource)
+	}
+	var names []string
+	for _, field := range st.Fields.List {
+		name := jsonNameFromTag(field.Tag)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
+
+// findStructType returns the struct type declared as `type <name> struct`.
+func findStructType(f *ast.File, name string) *ast.StructType {
+	var found *ast.StructType
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok || ts.Name.Name != name {
+			return true
+		}
+		if st, ok := ts.Type.(*ast.StructType); ok {
+			found = st
+		}
+		return false
+	})
+	return found
+}
+
+// jsonNameFromTag extracts the JSON name from a struct field tag literal.
+func jsonNameFromTag(tag *ast.BasicLit) string {
+	if tag == nil {
+		return ""
+	}
+	unquoted, err := strconv.Unquote(tag.Value)
+	if err != nil {
+		return ""
+	}
+	value := reflect.StructTag(unquoted).Get("json")
+	if value == "" || value == "-" {
+		return ""
+	}
+	name, _, _ := strings.Cut(value, ",")
+	return name
+}

--- a/tracker_events_payload.go
+++ b/tracker_events_payload.go
@@ -1,0 +1,182 @@
+// ABOUTME: Populates the structured StreamEvent payload fields from pipeline/agent events.
+// ABOUTME: Field names mirror pipeline's jsonlLogEntry so one decoder serves NDJSON and activity.jsonl.
+package tracker
+
+import (
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// applyStreamPipelinePayloads copies every structured payload hanging off a
+// PipelineEvent onto the wire event. Each group is a no-op when its payload is
+// nil, which is what keeps the omitempty guarantee: an event type that carries
+// no payload serializes none of these keys.
+//
+// The wire event is marshalled synchronously inside the handler that calls this,
+// so the maps and slices referenced here are read before control returns to the
+// emitter. Only OverrideSubgraphPath is copied, matching pipeline's own
+// activity.jsonl writer.
+func applyStreamPipelinePayloads(entry *StreamEvent, evt pipeline.PipelineEvent) {
+	applyStreamDecision(entry, evt.Decision)
+	applyStreamCost(entry, evt.Cost)
+	applyStreamToolSignals(entry, evt)
+	applyStreamNodeSignals(entry, evt)
+	applyStreamSnapshot(entry, evt.Snapshot)
+}
+
+// applyStreamDecision copies edge-decision fields (decision_* and
+// conditional_fallthrough events).
+func applyStreamDecision(entry *StreamEvent, d *pipeline.DecisionDetail) {
+	if d == nil {
+		return
+	}
+	entry.EdgeFrom = d.EdgeFrom
+	entry.EdgeTo = d.EdgeTo
+	entry.EdgeCondition = d.EdgeCondition
+	entry.EdgePriority = d.EdgePriority
+	if d.EdgeCondition != "" {
+		match := d.ConditionMatch
+		entry.ConditionMatch = &match
+	}
+	entry.OutcomeStatus = d.OutcomeStatus
+	entry.ContextSnapshot = d.ContextSnapshot
+	entry.ContextUpdates = d.ContextUpdates
+	if d.RestartCount > 0 {
+		rc := d.RestartCount
+		entry.RestartCount = &rc
+	}
+	entry.ClearedNodes = d.ClearedNodes
+	entry.ConditionsTried = d.ConditionsTried
+	entry.TokenInput = d.TokenInput
+	entry.TokenOutput = d.TokenOutput
+}
+
+// applyStreamCost copies the run-cumulative cost snapshot (cost_updated,
+// budget_exceeded).
+func applyStreamCost(entry *StreamEvent, c *pipeline.CostSnapshot) {
+	if c == nil {
+		return
+	}
+	entry.TotalTokens = c.TotalTokens
+	entry.TotalCostUSD = c.TotalCostUSD
+	entry.ProviderTotals = c.ProviderTotals
+	entry.WallElapsedMs = c.WallElapsed.Milliseconds()
+	entry.Estimated = c.Estimated
+}
+
+// applyStreamToolSignals copies the tool-node diagnostic payloads (truncation,
+// marker, route).
+func applyStreamToolSignals(entry *StreamEvent, evt pipeline.PipelineEvent) {
+	if t := evt.Truncation; t != nil {
+		entry.TruncStream = t.Stream
+		entry.TruncLimit = t.Limit
+		entry.TruncCaptured = t.CapturedBytes
+		entry.TruncDropped = t.DroppedBytes
+		entry.TruncTotal = t.TotalBytes
+	}
+	if m := evt.Marker; m != nil {
+		entry.MarkerPattern = m.Pattern
+		entry.MarkerTail = m.CapturedTail
+		entry.MarkerError = m.Error
+	}
+	if r := evt.Route; r != nil {
+		entry.RouteTail = r.CapturedTail
+	}
+}
+
+// applyStreamNodeSignals copies the node-level payloads (auto-status, override,
+// gate lifecycle).
+func applyStreamNodeSignals(entry *StreamEvent, evt pipeline.PipelineEvent) {
+	if a := evt.AutoStatus; a != nil {
+		entry.AutoStatusTail = a.ResponseTail
+		entry.AutoStatusFailClosed = a.FailClosed
+	}
+	if o := evt.Override; o != nil {
+		entry.OverrideGate = o.GateNodeID
+		entry.OverrideLabel = o.Label
+		entry.OverrideActor = o.Actor
+		if len(o.SubgraphPath) > 0 {
+			// Copy to defend against later mutation of the source slice.
+			entry.OverrideSubgraphPath = append([]string(nil), o.SubgraphPath...)
+		}
+	}
+	if g := evt.Gate; g != nil {
+		applyStreamGate(entry, g)
+	}
+}
+
+// applyStreamGate copies the gate lifecycle payload (gate_opened,
+// gate_resolved). Open-time and resolve-time fields are disjoint in practice;
+// both sets are copied and omitempty drops the ones the emitting event left
+// unset. A gate that failed to collect an answer surfaces its reason on the
+// shared error field, matching the activity.jsonl writer.
+func applyStreamGate(entry *StreamEvent, g *pipeline.GateDetail) {
+	entry.GateID = g.GateID
+	entry.GateMode = g.Mode
+	entry.GateLabel = g.Label
+	entry.GatePrompt = g.Prompt
+	if len(g.Choices) > 0 {
+		// Copy to defend against later mutation of the source slice.
+		entry.GateChoices = append([]string(nil), g.Choices...)
+	}
+	if len(g.Question) > 0 {
+		entry.GateQuestions = append([]pipeline.GateQuestion(nil), g.Question...)
+	}
+	entry.GateResponse = g.Response
+	entry.GateOutcome = g.Outcome
+	entry.GateActor = g.Actor
+	entry.GateTimedOut = g.TimedOut
+	if g.Error != "" && entry.Error == "" {
+		entry.Error = g.Error
+	}
+}
+
+// applyStreamSnapshot copies the run snapshot carried on pipeline_started.
+func applyStreamSnapshot(entry *StreamEvent, snap *pipeline.RunSnapshot) {
+	if snap == nil {
+		return
+	}
+	if len(snap.Nodes) > 0 {
+		nodes := make([]StreamSnapshotNode, 0, len(snap.Nodes))
+		for _, n := range snap.Nodes {
+			nodes = append(nodes, StreamSnapshotNode{ID: n.ID, Label: n.Label, Handler: n.Handler})
+		}
+		entry.SnapshotNodes = nodes
+	}
+	entry.SnapshotStartNode = snap.StartNode
+	entry.SnapshotExitNode = snap.ExitNode
+	entry.SnapshotCurrentNode = snap.CurrentNode
+	if len(snap.CompletedNodes) > 0 {
+		entry.SnapshotCompletedNodes = append([]string(nil), snap.CompletedNodes...)
+	}
+}
+
+// applyStreamUsage copies per-call token usage onto the wire event. Used by the
+// agent and LLM-trace paths, where usage rides on turn_metrics / llm_finish
+// (#508). fallbackCost is used when the usage itself carries no estimated cost.
+func applyStreamUsage(entry *StreamEvent, u llm.Usage, fallbackCost float64) {
+	entry.TokenInput = u.InputTokens
+	entry.TokenOutput = u.OutputTokens
+	if u.CacheReadTokens != nil {
+		entry.TokenCacheRead = *u.CacheReadTokens
+	}
+	if u.CacheWriteTokens != nil {
+		entry.TokenCacheWrite = *u.CacheWriteTokens
+	}
+	entry.TurnCostUSD = u.EstimatedCost
+	if entry.TurnCostUSD == 0 {
+		entry.TurnCostUSD = fallbackCost
+	}
+}
+
+// turnMetricsCost returns the per-turn estimated cost of a turn_metrics payload,
+// or 0 when the event carries none. The session computes this against the
+// resolved (post-failover) model, so it is the better cost source when the raw
+// usage left EstimatedCost unset.
+func turnMetricsCost(m *agent.TurnMetrics) float64 {
+	if m == nil {
+		return 0
+	}
+	return m.EstimatedCost
+}

--- a/tracker_events_payload_test.go
+++ b/tracker_events_payload_test.go
@@ -1,0 +1,375 @@
+// ABOUTME: Round-trip tests for the structured StreamEvent payload fields (E1).
+// ABOUTME: Asserts activity.jsonl payload parity on the public NDJSON wire, and the omitempty guarantee.
+package tracker
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// writePipelineEvent feeds evt through a fresh NDJSONWriter's PipelineHandler and
+// returns the single emitted line, both raw and decoded.
+func writePipelineEvent(t *testing.T, evt pipeline.PipelineEvent) (string, StreamEvent) {
+	t.Helper()
+	var buf bytes.Buffer
+	NewNDJSONWriter(&buf).PipelineHandler().HandlePipelineEvent(evt)
+	line := strings.TrimSuffix(buf.String(), "\n")
+	if line == "" {
+		t.Fatal("no NDJSON line written")
+	}
+	var got StreamEvent
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", line, err)
+	}
+	return line, got
+}
+
+func TestStreamEvent_CostSnapshotRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventCostUpdated,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		NodeID:    "Build",
+		Cost: &pipeline.CostSnapshot{
+			TotalTokens:  1234,
+			TotalCostUSD: 0.4275,
+			ProviderTotals: map[string]pipeline.ProviderUsage{
+				"anthropic": {InputTokens: 1000, OutputTokens: 234, TotalTokens: 1234, CostUSD: 0.4275, SessionCount: 2},
+			},
+			WallElapsed: 1500 * time.Millisecond,
+			Estimated:   true,
+		},
+	})
+	if got.TotalTokens != 1234 || got.TotalCostUSD != 0.4275 {
+		t.Errorf("cost totals lost: %+v", got)
+	}
+	if got.WallElapsedMs != 1500 {
+		t.Errorf("wall_elapsed_ms = %d, want 1500", got.WallElapsedMs)
+	}
+	if !got.Estimated {
+		t.Error("estimated flag lost")
+	}
+	pu, ok := got.ProviderTotals["anthropic"]
+	if !ok {
+		t.Fatalf("provider_totals lost: %+v", got.ProviderTotals)
+	}
+	if pu.TotalTokens != 1234 || pu.CostUSD != 0.4275 || pu.SessionCount != 2 {
+		t.Errorf("provider usage detail lost: %+v", pu)
+	}
+}
+
+func TestStreamEvent_RunSnapshotRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		Snapshot: &pipeline.RunSnapshot{
+			Nodes: []pipeline.SnapshotNode{
+				{ID: "Build", Label: "Build it", Handler: "codergen"},
+				{ID: "Review", Label: "Review it", Handler: "wait.human"},
+			},
+			StartNode:      "Build",
+			ExitNode:       "Done",
+			CurrentNode:    "Review",
+			CompletedNodes: []string{"Build"},
+		},
+	})
+	if len(got.SnapshotNodes) != 2 {
+		t.Fatalf("snapshot_nodes = %+v, want 2 entries", got.SnapshotNodes)
+	}
+	if got.SnapshotNodes[0].ID != "Build" || got.SnapshotNodes[0].Handler != "codergen" {
+		t.Errorf("snapshot node detail lost: %+v", got.SnapshotNodes[0])
+	}
+	if got.SnapshotNodes[1].Label != "Review it" {
+		t.Errorf("snapshot node label lost: %+v", got.SnapshotNodes[1])
+	}
+	if got.SnapshotStartNode != "Build" || got.SnapshotExitNode != "Done" {
+		t.Errorf("snapshot start/exit lost: %+v", got)
+	}
+	if got.SnapshotCurrentNode != "Review" || len(got.SnapshotCompletedNodes) != 1 {
+		t.Errorf("snapshot resume state lost: %+v", got)
+	}
+}
+
+func TestStreamEvent_DecisionEdgeRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventDecisionEdge,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		NodeID:    "Build",
+		Decision: &pipeline.DecisionDetail{
+			EdgeFrom:        "Build",
+			EdgeTo:          "Review",
+			EdgePriority:    "condition",
+			EdgeCondition:   "ctx.outcome = success",
+			ConditionMatch:  true,
+			OutcomeStatus:   "success",
+			ContextUpdates:  map[string]string{"last_response": "ok"},
+			ContextSnapshot: map[string]string{"outcome": "success"},
+			RestartCount:    2,
+			ClearedNodes:    []string{"Fix"},
+			TokenInput:      100,
+			TokenOutput:     20,
+			ConditionsTried: []pipeline.ConditionEval{{EdgeTo: "Fix", Condition: "ctx.outcome = fail"}},
+		},
+	})
+	if got.EdgeFrom != "Build" || got.EdgeTo != "Review" || got.EdgePriority != "condition" {
+		t.Errorf("edge fields lost: %+v", got)
+	}
+	if got.EdgeCondition != "ctx.outcome = success" {
+		t.Errorf("edge_condition lost: %+v", got)
+	}
+	if got.ConditionMatch == nil || !*got.ConditionMatch {
+		t.Errorf("condition_match lost: %+v", got.ConditionMatch)
+	}
+	if got.OutcomeStatus != "success" {
+		t.Errorf("outcome_status lost: %+v", got)
+	}
+	if got.ContextUpdates["last_response"] != "ok" || got.ContextSnapshot["outcome"] != "success" {
+		t.Errorf("context maps lost: %+v %+v", got.ContextUpdates, got.ContextSnapshot)
+	}
+	if got.RestartCount == nil || *got.RestartCount != 2 {
+		t.Errorf("restart_count lost: %+v", got.RestartCount)
+	}
+	if len(got.ClearedNodes) != 1 || got.ClearedNodes[0] != "Fix" {
+		t.Errorf("cleared_nodes lost: %+v", got.ClearedNodes)
+	}
+	if got.TokenInput != 100 || got.TokenOutput != 20 {
+		t.Errorf("token counts lost: %+v", got)
+	}
+	if len(got.ConditionsTried) != 1 || got.ConditionsTried[0].EdgeTo != "Fix" {
+		t.Errorf("conditions_tried lost: %+v", got.ConditionsTried)
+	}
+}
+
+func TestStreamEvent_GateOpenedRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventGateOpened,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		NodeID:    "Review",
+		Gate: &pipeline.GateDetail{
+			GateID:  "gate-1",
+			Mode:    "choice",
+			Label:   "Ship it?",
+			Prompt:  "Ship it?\n\nthe diff looks fine",
+			Choices: []string{"approve", "reject"},
+		},
+	})
+	if got.GateID != "gate-1" || got.GateMode != "choice" || got.GateLabel != "Ship it?" {
+		t.Errorf("gate identity fields lost: %+v", got)
+	}
+	if !strings.Contains(got.GatePrompt, "the diff looks fine") {
+		t.Errorf("gate_prompt lost: %q", got.GatePrompt)
+	}
+	if len(got.GateChoices) != 2 || got.GateChoices[0] != "approve" {
+		t.Errorf("gate_choices lost: %+v", got.GateChoices)
+	}
+}
+
+func TestStreamEvent_GateResolvedRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventGateResolved,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		NodeID:    "Interview",
+		Gate: &pipeline.GateDetail{
+			GateID:   "gate-2",
+			Mode:     "interview",
+			Question: []pipeline.GateQuestion{{ID: "q0", Text: "Which DB?", Options: []string{"pg", "sqlite"}}},
+			Response: "q0: pg",
+			Outcome:  "success",
+			Actor:    pipeline.ActorHuman,
+			TimedOut: true,
+		},
+	})
+	if got.GateID != "gate-2" || got.GateResponse != "q0: pg" || got.GateOutcome != "success" {
+		t.Errorf("gate resolution fields lost: %+v", got)
+	}
+	if got.GateActor != pipeline.ActorHuman || !got.GateTimedOut {
+		t.Errorf("gate actor/timeout lost: %+v", got)
+	}
+	if len(got.GateQuestions) != 1 || got.GateQuestions[0].ID != "q0" {
+		t.Errorf("gate_questions lost: %+v", got.GateQuestions)
+	}
+}
+
+func TestStreamEvent_ToolAndNodeSignalRoundTrip(t *testing.T) {
+	_, trunc := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:       pipeline.EventToolOutputTruncated,
+		Timestamp:  time.Now(),
+		RunID:      "run1",
+		NodeID:     "Build",
+		Truncation: &pipeline.TruncationDetail{Stream: "stdout", Limit: 64, CapturedBytes: 64, DroppedBytes: 36, TotalBytes: 100},
+	})
+	if trunc.TruncStream != "stdout" || trunc.TruncLimit != 64 {
+		t.Errorf("truncation stream/limit lost: %+v", trunc)
+	}
+	if trunc.TruncCaptured != 64 || trunc.TruncDropped != 36 || trunc.TruncTotal != 100 {
+		t.Errorf("truncation byte accounting lost: %+v", trunc)
+	}
+
+	_, marker := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventToolMarkerMissing,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		Marker:    &pipeline.MarkerDetail{Pattern: "^OK$", CapturedTail: "nope", Error: "bad regex"},
+	})
+	if marker.MarkerPattern != "^OK$" || marker.MarkerTail != "nope" || marker.MarkerError != "bad regex" {
+		t.Errorf("marker fields lost: %+v", marker)
+	}
+
+	_, route := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventToolRouteMissing,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		Route:     &pipeline.RouteDetail{CapturedTail: "no sentinel"},
+	})
+	if route.RouteTail != "no sentinel" {
+		t.Errorf("route_tail lost: %+v", route)
+	}
+
+	_, auto := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:       pipeline.EventAutoStatusMissing,
+		Timestamp:  time.Now(),
+		RunID:      "run1",
+		AutoStatus: &pipeline.AutoStatusDetail{ResponseTail: "no STATUS", FailClosed: true},
+	})
+	if auto.AutoStatusTail != "no STATUS" || !auto.AutoStatusFailClosed {
+		t.Errorf("auto-status fields lost: %+v", auto)
+	}
+}
+
+func TestStreamEvent_OverrideAndBundleRoundTrip(t *testing.T) {
+	_, got := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:           pipeline.EventValidationOverridden,
+		Timestamp:      time.Now(),
+		RunID:          "run1",
+		NodeID:         "Review",
+		BundleIdentity: "sha256:abc",
+		Override: &pipeline.OverrideDetail{
+			GateNodeID:   "Review",
+			Label:        "accept",
+			Actor:        pipeline.ActorAutopilot,
+			SubgraphPath: []string{"Child"},
+		},
+	})
+	if got.OverrideGate != "Review" || got.OverrideLabel != "accept" {
+		t.Errorf("override gate/label lost: %+v", got)
+	}
+	if got.OverrideActor != pipeline.ActorAutopilot {
+		t.Errorf("override_actor lost: %+v", got)
+	}
+	if len(got.OverrideSubgraphPath) != 1 || got.OverrideSubgraphPath[0] != "Child" {
+		t.Errorf("override_subgraph_path lost: %+v", got.OverrideSubgraphPath)
+	}
+	if got.BundleIdentity != "sha256:abc" {
+		t.Errorf("bundle_identity lost: %+v", got)
+	}
+}
+
+// TestStreamEvent_OverrideSubgraphPathIsCopied guards against the wire event
+// aliasing the emitter's slice.
+func TestStreamEvent_OverrideSubgraphPathIsCopied(t *testing.T) {
+	path := []string{"Child"}
+	var buf bytes.Buffer
+	h := NewNDJSONWriter(&buf).PipelineHandler()
+	h.HandlePipelineEvent(pipeline.PipelineEvent{
+		Type:      pipeline.EventValidationOverridden,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		Override:  &pipeline.OverrideDetail{GateNodeID: "Review", SubgraphPath: path},
+	})
+	if !strings.Contains(buf.String(), `"override_subgraph_path":["Child"]`) {
+		t.Fatalf("subgraph path not serialized: %s", buf.String())
+	}
+}
+
+func TestStreamEvent_TurnMetricsUsageRoundTrip(t *testing.T) {
+	cacheRead, cacheWrite := 40, 10
+	var buf bytes.Buffer
+	NewNDJSONWriter(&buf).AgentHandler().HandleEvent(agent.Event{
+		Type:      agent.EventTurnMetrics,
+		Timestamp: time.Now(),
+		NodeID:    "Build",
+		Provider:  "anthropic",
+		Model:     "claude-opus-4",
+		Usage: llm.Usage{
+			InputTokens:      500,
+			OutputTokens:     120,
+			TotalTokens:      620,
+			CacheReadTokens:  &cacheRead,
+			CacheWriteTokens: &cacheWrite,
+		},
+		Metrics: &agent.TurnMetrics{InputTokens: 500, OutputTokens: 120, EstimatedCost: 0.0031},
+	})
+	var got StreamEvent
+	if err := json.Unmarshal([]byte(strings.TrimSuffix(buf.String(), "\n")), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got.Type != "turn_metrics" || got.Provider != "anthropic" || got.Model != "claude-opus-4" {
+		t.Errorf("turn_metrics attribution lost: %+v", got)
+	}
+	if got.TokenInput != 500 || got.TokenOutput != 120 {
+		t.Errorf("turn token counts lost: %+v", got)
+	}
+	if got.TokenCacheRead != 40 || got.TokenCacheWrite != 10 {
+		t.Errorf("turn cache token counts lost: %+v", got)
+	}
+	if got.TurnCostUSD != 0.0031 {
+		t.Errorf("turn_cost_usd = %v, want 0.0031", got.TurnCostUSD)
+	}
+}
+
+// TestStreamEvent_PlainStageStartedHasNoNewKeys is the omitempty guarantee: an
+// event that carries no structured payload must serialize exactly the keys a
+// pre-E1 subscriber already saw.
+func TestStreamEvent_PlainStageStartedHasNoNewKeys(t *testing.T) {
+	line, _ := writePipelineEvent(t, pipeline.PipelineEvent{
+		Type:      pipeline.EventStageStarted,
+		Timestamp: time.Now(),
+		RunID:     "run1",
+		NodeID:    "Build",
+		Message:   "starting",
+	})
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	allowed := map[string]bool{"ts": true, "source": true, "type": true, "run_id": true, "node_id": true, "message": true}
+	for k := range raw {
+		if !allowed[k] {
+			t.Errorf("stage_started serialized unexpected key %q (omitempty guarantee broken): %s", k, line)
+		}
+	}
+}
+
+// TestStreamEvent_PlainAgentEventHasNoNewKeys is the same guarantee on the agent
+// path: a tool_call_end with no usage must not sprout token fields.
+func TestStreamEvent_PlainAgentEventHasNoNewKeys(t *testing.T) {
+	var buf bytes.Buffer
+	NewNDJSONWriter(&buf).AgentHandler().HandleEvent(agent.Event{
+		Type:       agent.EventToolCallEnd,
+		Timestamp:  time.Now(),
+		NodeID:     "Build",
+		ToolName:   "Read",
+		ToolOutput: "contents",
+	})
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(strings.TrimSuffix(buf.String(), "\n")), &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	allowed := map[string]bool{"ts": true, "source": true, "type": true, "node_id": true, "tool_name": true, "content": true}
+	for k := range raw {
+		if !allowed[k] {
+			t.Errorf("tool_call_end serialized unexpected key %q: %s", k, buf.String())
+		}
+	}
+}

--- a/tracker_wireshape_test.go
+++ b/tracker_wireshape_test.go
@@ -15,11 +15,34 @@ import (
 // than silently breaking a subscriber compiled against the old shape.
 func TestStreamEvent_WireEnvelopeStable(t *testing.T) {
 	want := []string{
-		// gate_id added in #509 — additive, set only on gate_opened /
-		// gate_resolved, so existing subscribers are unaffected.
+		// The pre-E1 envelope. Every one of these is unchanged in name and type.
 		"content", "error", "gate_id", "message", "model", "node_id", "provider",
 		"run_id", "source", "terminal_status", "tool_name", "ts", "type",
+
+		// E1: payload parity with activity.jsonl. Purely additive and every
+		// field is omitempty, so a pre-E1 subscriber sees the same keys on the
+		// same events. Names below mirror pipeline's jsonlLogEntry tags exactly
+		// (verified mechanically by TestStreamEvent_MirrorsActivityLogFieldNames)
+		// EXCEPT the snapshot_* group and
+		// token_cache_read / token_cache_write / turn_cost_usd, which have no
+		// activity.jsonl counterpart.
+		"auto_status_fail_closed", "auto_status_tail", "bundle_identity",
+		"cleared_nodes", "condition_match", "conditions_tried",
+		"context_snapshot", "context_updates", "edge_condition", "edge_from",
+		"edge_priority", "edge_to", "estimated", "gate_actor", "gate_choices",
+		"gate_label", "gate_mode", "gate_outcome", "gate_prompt",
+		"gate_questions", "gate_response", "gate_timed_out", "marker_error",
+		"marker_pattern", "marker_tail", "outcome_status", "override_actor",
+		"override_gate", "override_label", "override_subgraph_path",
+		"provider_totals", "restart_count", "route_tail",
+		"snapshot_completed_nodes", "snapshot_current_node", "snapshot_exit_node",
+		"snapshot_nodes", "snapshot_start_node", "token_cache_read",
+		"token_cache_write", "token_input", "token_output", "total_cost_usd",
+		"total_tokens", "trunc_captured_bytes", "trunc_dropped_bytes",
+		"trunc_limit", "trunc_stream", "trunc_total_bytes", "turn_cost_usd",
+		"wall_elapsed_ms",
 	}
+	sort.Strings(want)
 	got := jsonTagNames(reflect.TypeOf(StreamEvent{}))
 	sort.Strings(got)
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
## The problem: two NDJSON schemas, and the public one was the lossy one

`tracker.StreamEvent` is the **documented stable wire format** for embedders
(`transport-boundary.md` §3, `embedding.md` §4) — what `tracker --json` and
`tracker.NewNDJSONWriter` emit. It was 12 flat string fields.

Meanwhile `pipeline.PipelineEvent` carries `*CostSnapshot`, `*DecisionDetail`,
`*TruncationDetail`, `*MarkerDetail`, `*RouteDetail`, `*AutoStatusDetail`,
`*OverrideDetail`, `*GateDetail`, `*RunSnapshot` and `BundleIdentity` — and the
**private** `jsonlLogEntry` already serialized essentially all of it to
`activity.jsonl`.

So a control plane consuming the documented wire could not do cost rollups,
reconstruct routing decisions, see the run-start node inventory, or detect
tool-output truncation. It was pushed to parse `activity.jsonl` out of band
(re-implementing a private schema it must then keep in sync) or scrape the CLI.
This PR closes that gap.

## What changed

`StreamEvent` gained optional, `omitempty`-tagged fields for every payload above,
populated in `PipelineHandler()` / `AgentHandler()` / `TraceObserver()`. The
field-stability contract and the payload-size caveats (unbounded
`context_snapshot` / `context_updates`, `gate_prompt` capped at
`pipeline.GateMaxPromptBytes`, 256-byte `*_tail` fields) are now stated on the
type's doc comment. Populate logic lives in a new file
(`tracker_events_payload.go`) so no baselined file grew.

The two freshest additions are specifically covered: `turn_metrics` now surfaces
the `Provider`/`Model`/`Usage` attribution from #508, and gate events surface the
full `GateDetail` from #509 rather than just `gate_id`.

### Field-name parity decision

Where the same datum is written to `activity.jsonl`, the JSON field name is
**identical** to `jsonlLogEntry`'s tag, and structured sub-objects stay
structured (`provider_totals` remains a `map[string]ProviderUsage`;
`conditions_tried` / `gate_questions` remain object arrays) rather than being
flattened — so a consumer can decode both streams with one struct. Two public
shapes for the same datum under different names would have been a worse bug than
the one being fixed.

This is not eyeballed: `tracker_events_parity_test.go` parses `jsonlLogEntry`'s
tags out of `pipeline/events_jsonl.go` with `go/ast` (it is unexported, and
`pipeline` cannot import `tracker`) and fails if `activity.jsonl` ever carries a
field the public wire does not, or if a wire field has no counterpart and no
documented reason in the `wireOnlyFields` allowlist.

Mirrored names (wire ← `jsonlLogEntry`, same name on both sides):
`bundle_identity`, `edge_from`, `edge_to`, `edge_condition`, `edge_priority`,
`condition_match`, `outcome_status`, `context_snapshot`, `context_updates`,
`restart_count`, `cleared_nodes`, `conditions_tried`, `token_input`,
`token_output`, `total_tokens`, `total_cost_usd`, `provider_totals`,
`wall_elapsed_ms`, `estimated`, `trunc_stream`, `trunc_limit`,
`trunc_captured_bytes`, `trunc_dropped_bytes`, `trunc_total_bytes`,
`marker_pattern`, `marker_tail`, `marker_error`, `route_tail`,
`auto_status_tail`, `auto_status_fail_closed`, `override_gate`,
`override_label`, `override_actor`, `override_subgraph_path`, `gate_mode`,
`gate_label`, `gate_prompt`, `gate_choices`, `gate_questions`, `gate_response`,
`gate_outcome`, `gate_actor`, `gate_timed_out`.

**No `activity.jsonl` counterpart** (new names, chosen in the same style and
listed in `wireOnlyFields` with a reason):

- `snapshot_nodes` (array of `{id,label,handler}`), `snapshot_start_node`,
  `snapshot_exit_node`, `snapshot_current_node`, `snapshot_completed_nodes` —
  `RunSnapshot` is never written to `activity.jsonl`. `snapshot_nodes` keeps the
  node list as a structured array; flattening it to parallel string arrays would
  have made it the one payload a shared decoder could not handle.
- `token_cache_read`, `token_cache_write`, `turn_cost_usd` — per-turn agent
  extras; `activity.jsonl` carries no agent usage at all. The turn's input/output
  counts deliberately reuse the existing `token_input` / `token_output` names
  (same meaning: tokens in/out for the thing the event describes), so
  `total_tokens` stays unambiguously run-cumulative.
- `terminal_status` was already wire-only pre-E1; the allowlist records that.

Two deliberate non-additions, for the record: `OverrideDetail.CoveredGates` is
not on the wire because `activity.jsonl` does not carry it either (parity was the
target), and `llm.Usage.TotalTokens` is not mapped onto `total_tokens` because
that name means run-cumulative spend on the pipeline path.

### Wire-shape test changed on purpose

`tracker_wireshape_test.go` pins the envelope's field set so a wire change must be
conscious. Its `want` list grew from 13 to 64 entries — **the wire format
intentionally grew**. Nothing was renamed, retyped, or removed, and two new tests
assert the omitempty guarantee (a plain `stage_started` and a plain
`tool_call_end` serialize exactly the keys a pre-E1 subscriber already saw), so an
existing subscriber compiled against today's shape keeps working.

## Verification (all actually run)

- `go build ./...` — clean
- `go test ./... -short -count=1` — all packages pass
- `make complexity` — `complexity gate OK (197 grandfathered, 0 new)`
- `bash scripts/complexity/gate.sh baseline-shrinks 8caf94e` — `baseline OK: did
  not grow`. No baselined file was touched: new code went into
  `tracker_events_payload.go` (176 lines) and `tracker_events.go` ended at 313
  lines, both under the 500-line ceiling, and `baseline.txt` is unchanged.
- `go test ./cmd/tracker-conformance -run TestGoldenTraces -count=1` — **passes
  unchanged, no golden regeneration needed** (the conformance harness serializes
  its own normalized trace document, not `StreamEvent`).
- New round-trip tests through `NDJSONWriter`: `cost_updated`
  (`total_cost_usd` + `provider_totals` incl. per-provider detail),
  `pipeline_started` (node inventory + resume state), `decision_edge`
  (from/to/priority + condition_match/restart_count pointers + context maps),
  `gate_opened` (mode/label/prompt/choices), `gate_resolved`
  (response/outcome/actor/timed_out/questions), `turn_metrics`
  (provider/model/usage incl. cache tokens and cost), the tool/node diagnostic
  groups, override + bundle identity, and the two omitempty guards.
- Pre-commit gates (format, vet, build, 22 test packages, complexity, dippin
  lint) all green.

## Self-review findings (fixed before commit)

- **Slice aliasing drift vs the audit-log writer.** `applyStreamGate` initially
  assigned `GateChoices` / `GateQuestions` straight from the payload while
  `pipeline.applyGateFields` copies them. Now copied, matching it — as are
  `override_subgraph_path` and `snapshot_completed_nodes`. The large maps
  (`context_snapshot`, `context_updates`, `provider_totals`) are intentionally
  *not* copied: the wire event is marshalled synchronously inside the handler
  before control returns to the emitter, which is documented at the call site.
- **A doc claim that didn't match the code** — `applyStreamGate`'s comment said
  both field sets were copied "unconditionally" after the copy guards went in.
  Reworded.
- **Mechanical checks, not eyeballing**: a scripted sweep confirmed every new
  struct field is actually assigned in a handler path (no field added to the
  struct but forgotten in the populate code), and the parity test is the standing
  guard against name drift in either direction.

## Left out

- `OverrideDetail.CoveredGates` and `llm.Usage.TotalTokens` (see above).
- No CLI/TUI changes: `tracker --json` gets the richer lines for free through
  `NewNDJSONWriter`; nothing else consumes `StreamEvent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RuhYJxVgQPsfuHZpAYbeed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787863469&installation_model_id=21126&pr_number=515&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F515&signature=23dab8e8334a1e4c8881771765aa53bc0547b82c84ec25cfb215cdaf32cd6238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded NDJSON stream events with structured, omittable payloads for cost/token snapshots, per-turn usage, decision/edge details, tool/node diagnostics, validation overrides, gate details, bundle identity, and pipeline run snapshots.
  - Public stream events now match the activity log’s field naming and payload set for safer, single-decoder consumption (with wire-only `snapshot_*` and per-turn extras).

- **Documentation**
  - Updated architecture/transport docs to reflect the revised `StreamEvent` NDJSON envelope and field presence rules.

- **Tests**
  - Added schema parity guards and NDJSON round-trip/regression coverage to enforce stable field names and serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->