### PR TITLE
Run capture: store the executed spec and every provider request, plus a run.json manifest

### DIFF
--- a/agent/events.go
+++ b/agent/events.go
@@ -3,6 +3,7 @@
 package agent
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/2389-research/tracker/llm"
@@ -80,6 +81,16 @@ type Event struct {
 	Usage              llm.Usage
 	Metrics            *TurnMetrics
 	ToolDuration       time.Duration
+	// CallID groups every event belonging to one LLM request. Carried from
+	// llm.TraceEvent because the session re-emits every trace event as an
+	// agent llm_* event, and in a normal run that re-emission is the only
+	// path the activity log sees — the client-level writer skips
+	// session-owned events. Without the field here the id is dropped
+	// exactly where it matters.
+	CallID string
+	// RequestRaw is the verbatim wire body, set on the request-start event.
+	// Carried for the same reason as CallID.
+	RequestRaw json.RawMessage
 }
 
 // EventHandler receives events emitted by the agent session.

--- a/agent/session.go
+++ b/agent/session.go
@@ -601,6 +601,8 @@ func (s *Session) emitLLMTraceEvent(turn int, traceEvt llm.TraceEvent) {
 		ProviderEvent: traceEvt.ProviderEvent,
 		FinishReason:  traceEvt.FinishReason,
 		Usage:         traceEvt.Usage,
+		CallID:        traceEvt.CallID,
+		RequestRaw:    traceEvt.RequestRaw,
 	}
 
 	switch traceEvt.Kind {

--- a/agent/session.go
+++ b/agent/session.go
@@ -369,7 +369,7 @@ func (s *Session) handleToolCalls(ctx context.Context, toolCalls []llm.ToolCallD
 		return true, false
 	}
 
-	hadErrors, terminate := s.executeToolCalls(ctx, toolCalls, result)
+	hadErrors, terminate := s.executeToolCalls(ctx, toolCalls, result, turn)
 	s.maybeInjectReflection(hadErrors, ts)
 	s.emitTurnMetrics(turn, turnStart, resp, tracker, prevCacheHits, prevCacheMisses, result)
 	s.emit(Event{Type: EventTurnEnd, SessionID: s.id, Turn: turn})
@@ -531,7 +531,11 @@ func (s *Session) runRepairTurn(ctx context.Context, result *SessionResult) erro
 		return nil // LLM responded with text only (e.g. "I fixed it")
 	}
 
-	_, _ = s.executeToolCalls(ctx, toolCalls, result)
+	// -1 matches the doLLMCall call above: repair turns sit outside the
+	// MaxTurns budget, so they have no ordinal, and a negative turn marks
+	// their events as repair-turn work rather than folding them into a
+	// numbered turn.
+	_, _ = s.executeToolCalls(ctx, toolCalls, result, -1)
 	return nil
 }
 

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -345,7 +345,10 @@ func (s *Session) computeToolSignature(toolCalls []llm.ToolCallData) string {
 // either redundant or could perform unwanted side-effects after the "final
 // step" (e.g., a model emitting `[dispatch_sprints, write_summary_doc]`
 // shouldn't run write_summary_doc once dispatch_sprints succeeded).
-func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult) (hadErrors, terminate bool) {
+// turn is stamped onto every event this dispatch emits so a post-hoc reader
+// can attribute a tool call to the turn that issued it; repair turns pass -1,
+// matching doLLMCall's convention.
+func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCallData, result *SessionResult, turn int) (hadErrors, terminate bool) {
 	// tool_access enforcement (issue #258): when restricted, the LLM was
 	// instructed via ToolChoice=none not to emit tool calls. If it did
 	// anyway (mock, retry of stale state, provider that ignored the
@@ -356,13 +359,14 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 		s.emit(Event{
 			Type:      EventError,
 			SessionID: s.id,
+			Turn:      turn,
 			Err:       fmt.Errorf("tool_access restricted: dropped %d tool call(s) emitted by the LLM despite ToolChoice=none", len(toolCalls)),
 		})
 		return false, false
 	}
 	var toolResults []llm.ContentPart
 	for _, call := range toolCalls {
-		toolResult, toolDuration := s.executeSingleTool(ctx, call)
+		toolResult, toolDuration := s.executeSingleTool(ctx, call, turn)
 		result.ToolCalls[call.Name]++
 		if toolResult.IsError {
 			hadErrors = true
@@ -383,7 +387,9 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 		s.emit(Event{
 			Type:         EventToolCallEnd,
 			SessionID:    s.id,
+			Turn:         turn,
 			ToolName:     call.Name,
+			ToolInput:    string(call.Arguments),
 			ToolOutput:   toolResult.Content,
 			ToolError:    boolToErrStr(toolResult.IsError),
 			ToolDuration: toolDuration,
@@ -407,17 +413,18 @@ func (s *Session) executeToolCalls(ctx context.Context, toolCalls []llm.ToolCall
 }
 
 // executeSingleTool runs a single tool call, handling caching.
-func (s *Session) executeSingleTool(ctx context.Context, call llm.ToolCallData) (llm.ToolResultData, time.Duration) {
+func (s *Session) executeSingleTool(ctx context.Context, call llm.ToolCallData, turn int) (llm.ToolResultData, time.Duration) {
 	s.emit(Event{
 		Type:      EventToolCallStart,
 		SessionID: s.id,
+		Turn:      turn,
 		ToolName:  call.Name,
 		ToolInput: string(call.Arguments),
 	})
 
 	policy := s.toolCachePolicy(call.Name)
 
-	if result, hit := s.tryToolCache(call, policy); hit {
+	if result, hit := s.tryToolCache(call, policy, turn); hit {
 		return result, 0
 	}
 
@@ -434,7 +441,7 @@ func (s *Session) toolCachePolicy(name string) tools.CachePolicy {
 }
 
 // tryToolCache checks the cache for a previous result. Returns the cached result and true on hit.
-func (s *Session) tryToolCache(call llm.ToolCallData, policy tools.CachePolicy) (llm.ToolResultData, bool) {
+func (s *Session) tryToolCache(call llm.ToolCallData, policy tools.CachePolicy, turn int) (llm.ToolResultData, bool) {
 	if s.cache == nil || policy != tools.CachePolicyCacheable {
 		return llm.ToolResultData{}, false
 	}
@@ -445,6 +452,7 @@ func (s *Session) tryToolCache(call llm.ToolCallData, policy tools.CachePolicy) 
 	s.emit(Event{
 		Type:      EventToolCacheHit,
 		SessionID: s.id,
+		Turn:      turn,
 		ToolName:  call.Name,
 		ToolInput: string(call.Arguments),
 	})

--- a/agent/session_run.go
+++ b/agent/session_run.go
@@ -303,7 +303,7 @@ func (s *Session) handleNoToolCalls(resp *llm.Response, turn int, turnStart time
 	if resp.FinishReason.Reason == "length" || resp.FinishReason.Reason == "max_tokens" {
 		text := resp.Text()
 		if text != "" {
-			s.emit(Event{Type: EventTextDelta, SessionID: s.id, Text: text})
+			s.emit(Event{Type: EventTextDelta, SessionID: s.id, Turn: turn, Text: text})
 		}
 		s.messages = append(s.messages, llm.UserMessage(
 			"Your previous response was truncated due to length. Continue where you left off. "+
@@ -317,7 +317,7 @@ func (s *Session) handleNoToolCalls(resp *llm.Response, turn int, turnStart time
 	text := resp.Text()
 
 	if text != "" {
-		s.emit(Event{Type: EventTextDelta, SessionID: s.id, Text: text})
+		s.emit(Event{Type: EventTextDelta, SessionID: s.id, Turn: turn, Text: text})
 	}
 	s.emitTurnMetrics(turn, turnStart, resp, tracker, prevCacheHits, prevCacheMisses, result)
 	s.emit(Event{Type: EventTurnEnd, SessionID: s.id, Turn: turn})

--- a/agent/session_run_test.go
+++ b/agent/session_run_test.go
@@ -1,0 +1,97 @@
+// ABOUTME: Tests for tool dispatch inside a session turn.
+// ABOUTME: Covers turn attribution on tool events so a call can be traced to the turn that issued it.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/2389-research/tracker/llm"
+)
+
+// TestToolEventsCarryTurn pins that tool_call_start / tool_call_end / the
+// tool-result end of a dispatch are attributable to the turn that issued
+// them. executeSingleTool did not receive the turn counter, so tool events
+// reached the activity log with a session but no turn — which makes a tool
+// call unattributable once a run has more than one turn, and unorderable
+// once parallel branches interleave into one log.
+func TestToolEventsCarryTurn(t *testing.T) {
+	client := &mockCompleter{
+		responses: []*llm.Response{
+			{ // turn 1: ask for a tool
+				Message: llm.Message{
+					Role: llm.RoleAssistant,
+					Content: []llm.ContentPart{{
+						Kind: llm.KindToolCall,
+						ToolCall: &llm.ToolCallData{
+							ID:        "call_1",
+							Name:      "probe",
+							Arguments: json.RawMessage(`{"path":"x.txt"}`),
+						},
+					}},
+				},
+				FinishReason: llm.FinishReason{Reason: "tool_calls"},
+			},
+			{ // turn 2: plain text, ends the session
+				Message:      llm.AssistantMessage("done"),
+				FinishReason: llm.FinishReason{Reason: "stop"},
+			},
+		},
+	}
+
+	var events []Event
+	sess := mustNewSession(t, client, DefaultConfig(),
+		WithEventHandler(EventHandlerFunc(func(evt Event) {
+			events = append(events, evt)
+		})))
+	sess.registry.Register(&stubTool{name: "probe", output: "probed"})
+
+	if _, err := sess.Run(context.Background(), "go"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	var sawStart, sawEnd bool
+	for _, evt := range events {
+		switch evt.Type {
+		case EventToolCallStart:
+			sawStart = true
+			if evt.Turn != 1 {
+				t.Errorf("tool_call_start Turn = %d, want 1", evt.Turn)
+			}
+			if evt.ToolInput != `{"path":"x.txt"}` {
+				t.Errorf("tool_call_start ToolInput = %q, want the arguments", evt.ToolInput)
+			}
+		case EventToolCallEnd:
+			sawEnd = true
+			if evt.Turn != 1 {
+				t.Errorf("tool_call_end Turn = %d, want 1", evt.Turn)
+			}
+			// End carries the input too, so a reader holding only the end
+			// event can still tell what was asked for.
+			if evt.ToolInput != `{"path":"x.txt"}` {
+				t.Errorf("tool_call_end ToolInput = %q, want the arguments", evt.ToolInput)
+			}
+			if evt.ToolOutput != "probed" {
+				t.Errorf("tool_call_end ToolOutput = %q, want probed", evt.ToolOutput)
+			}
+		}
+		if evt.SessionID == "" && isSessionScoped(evt.Type) {
+			t.Errorf("%s carries no SessionID", evt.Type)
+		}
+	}
+	if !sawStart || !sawEnd {
+		t.Fatalf("missing tool events: start=%v end=%v", sawStart, sawEnd)
+	}
+}
+
+// isSessionScoped reports whether an event type is emitted from inside a
+// session and should therefore always carry a SessionID.
+func isSessionScoped(t EventType) bool {
+	switch t {
+	case EventSessionStart, EventSessionEnd, EventTurnStart, EventTurnEnd,
+		EventToolCallStart, EventToolCallEnd, EventToolCacheHit, EventTurnMetrics:
+		return true
+	}
+	return false
+}

--- a/cmd/tracker/capture.go
+++ b/cmd/tracker/capture.go
@@ -1,0 +1,76 @@
+// ABOUTME: Run-capture hooks — records the executed spec and writes run.json when a run ends.
+// ABOUTME: Runs after the engine returns, which is the first point the run ID exists.
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/2389-research/dippin-lang/ir"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// capturedSpec holds the specification the current process is executing,
+// recorded when the pipeline file is read.
+//
+// Package-level state, matching activeArtifactDir and activeExportBundle in
+// run.go: one process runs one pipeline, and the alternative is threading two
+// fields through the whole load-to-run call chain for telemetry's sake.
+//
+// Captured at load rather than re-read at the end on purpose. The run ID does
+// not exist until the engine returns, so the write has to happen late — but
+// re-reading the file then would record whatever it says at that moment, which
+// is the wrong document if anyone edited it mid-run. These are the bytes that
+// actually executed.
+var capturedSpec struct {
+	path     string
+	source   string
+	workflow *ir.Workflow
+	bundleID string
+}
+
+// recordExecutedSpec stores the spec for the run about to start.
+func recordExecutedSpec(path, source string, workflow *ir.Workflow) {
+	capturedSpec.path = path
+	capturedSpec.source = source
+	capturedSpec.workflow = workflow
+}
+
+// recordBundleIdentity stores the .dipx identity for a bundle run.
+func recordBundleIdentity(id string) {
+	capturedSpec.bundleID = id
+}
+
+// finalizeRunCapture writes the spec artifacts and run.json for a finished run.
+//
+// Called from the same place as maybeExportBundle — after the engine returns,
+// the first point at which the run ID is known. Failures warn and continue:
+// losing telemetry is not worth failing a run that already did its work, and a
+// run whose manifest is missing can be rebuilt later with `tracker run-json`.
+func finalizeRunCapture(artifactBase, runID string) {
+	if runID == "" {
+		return
+	}
+	runDir := filepath.Join(artifactBase, runID)
+	if _, err := os.Stat(runDir); err != nil {
+		// No run directory means the run never wrote artifacts (a validation
+		// failure before execution, say). Nothing to describe.
+		return
+	}
+
+	if capturedSpec.source != "" || capturedSpec.workflow != nil {
+		if _, err := pipeline.WriteSpecArtifacts(runDir, pipeline.SpecArtifacts{
+			SourcePath:     capturedSpec.path,
+			Source:         capturedSpec.source,
+			Workflow:       capturedSpec.workflow,
+			BundleIdentity: capturedSpec.bundleID,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: spec capture failed: %v\n", err)
+		}
+	}
+
+	if _, err := pipeline.WriteRunManifest(runDir, runID); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: run manifest failed: %v\n", err)
+	}
+}

--- a/cmd/tracker/commands.go
+++ b/cmd/tracker/commands.go
@@ -74,6 +74,8 @@ func dispatchInfoCommands(cfg runConfig, deps commandDeps) (error, bool) {
 		return executeUpdate(), true
 	case modeStatus:
 		return executeStatus(cfg), true
+	case modeRunJSON:
+		return executeRunJSON(cfg), true
 	}
 	return nil, false
 }

--- a/cmd/tracker/flags.go
+++ b/cmd/tracker/flags.go
@@ -43,6 +43,7 @@ var subcommandMap = map[string]commandMode{
 	string(modeUpdate):      modeUpdate,
 	string(modeVerifyTests): modeVerifyTests,
 	string(modeStatus):      modeStatus,
+	string(modeRunJSON):     modeRunJSON,
 }
 
 // parseSubcommand checks if the second argument is a known subcommand and
@@ -70,7 +71,7 @@ func parseFlagsForMode(mode commandMode, args []string, cfg *runConfig) (runConf
 			cfg.pipelineFile = args[2]
 		}
 		return *cfg, nil
-	case modeAudit, modeDiagnose, modeStatus:
+	case modeAudit, modeDiagnose, modeStatus, modeRunJSON:
 		return parseAuditFlags(args, cfg)
 	default:
 		return *cfg, nil

--- a/cmd/tracker/loading.go
+++ b/cmd/tracker/loading.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/2389-research/dippin-lang/parser"
 	tracker "github.com/2389-research/tracker"
 	"github.com/2389-research/tracker/pipeline"
 )
@@ -220,6 +221,19 @@ func loadEmbeddedPipeline(info WorkflowInfo) (*pipeline.Graph, error) {
 // Graph representation. Validation errors are fatal; lint warnings are
 // printed to stderr but do not block execution.
 func loadDippinPipeline(source, filename string) (*pipeline.Graph, error) {
+	// Record the IR for run capture. dippin expands subgraphs at compile time,
+	// so the expanded graph is the only form that explains the run's events —
+	// the authored source alone does not. Parse failures are ignored here and
+	// left to LoadDippinWorkflow below, which owns error reporting; capture
+	// simply records nothing in that case.
+	if workflow, perr := parser.NewParser(source, filename).Parse(); perr == nil {
+		// Mirrors LoadDippinWorkflow: parser entry points do not resolve file
+		// directives, and tracker is a CLI entry point.
+		if rerr := parser.ResolveFileDirectives(workflow, filepath.Dir(filename)); rerr == nil {
+			recordExecutedSpec(filename, source, workflow)
+		}
+	}
+
 	graph, diags, err := pipeline.LoadDippinWorkflow(source, filename)
 	// Log validation errors and lint warnings before returning so users
 	// see the specific diagnostics even on fatal failures.

--- a/cmd/tracker/main.go
+++ b/cmd/tracker/main.go
@@ -84,6 +84,7 @@ const (
 	modeUpdate      commandMode = "update"
 	modeVerifyTests commandMode = "verify-tests"
 	modeStatus      commandMode = "status"
+	modeRunJSON     commandMode = "run-json"
 )
 
 var errUsage = errors.New("usage")

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -362,17 +362,12 @@ func emitForcedBundleMismatch(activityLog *pipeline.JSONLEventHandler, info resu
 }
 
 // llmTraceLogObserver returns the client-level trace → activity log writer.
-// Session-owned events are skipped: the agent session re-emits those as
-// llm_* agent events which reach the log via WriteAgentEvent, so writing
-// them here would log the same stream twice (#354). Non-session calls
-// (e.g. the autopilot interviewer) have no agent path and are kept.
+//
+// Delegates to the handler so embedders wiring capture themselves get the same
+// session-owned de-duplication rule (#354) rather than having to know it. Kept
+// as a named function because the CLI wires it from two places.
 func llmTraceLogObserver(activityLog *pipeline.JSONLEventHandler) llm.TraceObserverFunc {
-	return func(evt llm.TraceEvent) {
-		if evt.SessionOwned {
-			return
-		}
-		activityLog.WriteLLMEvent(evt)
-	}
+	return activityLog.LLMTraceObserver()
 }
 
 // interpretRunResult converts a raw engine run result into a pipeline-level

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -295,6 +295,7 @@ func finishRun(result *pipeline.EngineResult, runErr error, pipelineFile, artifa
 	pipelineErr := interpretRunResult(result, runErr, &runConfig{failOnOverride: activeFailOnOverride})
 	printRunSummary(result, pipelineErr, pipelineFile)
 	if result != nil && result.RunID != "" {
+		finalizeRunCapture(artifactDir, result.RunID)
 		maybeExportBundle(artifactDir, result.RunID)
 	}
 	return pipelineErr
@@ -643,6 +644,7 @@ func finishTUIRun(outcome pipelineOutcome, pipelineName, pipelineFile, artifactD
 	printRunSummary(outcome.result, outcome.err, pipelineFile)
 	notifyPipelineComplete(pipelineName, outcome.err)
 	if outcome.result != nil && outcome.result.RunID != "" {
+		finalizeRunCapture(artifactDir, outcome.result.RunID)
 		maybeExportBundle(artifactDir, outcome.result.RunID)
 	}
 	return outcome.err

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -430,11 +430,7 @@ func buildConsoleEventHandlers(
 ) (agent.EventHandler, pipeline.PipelineEventHandler, llm.TraceObserver) {
 	// Agent event handler that always logs to activity log.
 	logAgentEvent := func(evt agent.Event) {
-		errMsg := ""
-		if evt.Err != nil {
-			errMsg = evt.Err.Error()
-		}
-		activityLog.WriteAgentEvent(string(evt.Type), evt.NodeID, evt.ToolName, evt.ToolOutput, evt.ToolError, evt.Text, errMsg, evt.Provider, evt.Model)
+		activityLog.WriteAgentEvent(evt)
 	}
 	activityTrace := llmTraceLogObserver(activityLog)
 
@@ -785,11 +781,7 @@ func buildTUIAgentHandler(prog *tea.Program, activityLog *pipeline.JSONLEventHan
 		if msg := tui.AdaptAgentEvent(evt, evt.NodeID); msg != nil {
 			prog.Send(msg)
 		}
-		errMsg := ""
-		if evt.Err != nil {
-			errMsg = evt.Err.Error()
-		}
-		activityLog.WriteAgentEvent(string(evt.Type), evt.NodeID, evt.ToolName, evt.ToolOutput, evt.ToolError, evt.Text, errMsg, evt.Provider, evt.Model)
+		activityLog.WriteAgentEvent(evt)
 	})
 }
 

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -341,6 +341,10 @@ func setupActivityLog(artifactDir string, verbose bool, bundleIdentity string) *
 	// registry's BundleIdentityStamper). Empty identity is a no-op for
 	// plain .dip runs.
 	activityLog.SetBundleIdentity(bundleIdentity)
+	// Record it for the spec manifest as well. Without this the identity
+	// reached run.json only via the checkpoint, and SpecManifest.BundleIdentity
+	// was always empty at write time.
+	recordBundleIdentity(bundleIdentity)
 	// If this resume only proceeded because --force-bundle-mismatch was
 	// passed, record the override in activity.jsonl now — the engine
 	// hasn't fired yet, so without this the audit trail would lack the
@@ -586,6 +590,7 @@ func runTUI(pipelineFile, workdir, checkpoint, format, backend string, verbose b
 	// registry's BundleIdentityStamper). Empty identity is a no-op for
 	// plain .dip runs. Then record any forced bundle-mismatch resume.
 	activityLog.SetBundleIdentity(bundleInfo.Identity)
+	recordBundleIdentity(bundleInfo.Identity)
 	emitForcedBundleMismatch(activityLog, activeResumeInfo)
 
 	sendFn := tui.SendFunc(func(msg tea.Msg) { prog.Send(msg) })

--- a/cmd/tracker/run.go
+++ b/cmd/tracker/run.go
@@ -370,7 +370,7 @@ func llmTraceLogObserver(activityLog *pipeline.JSONLEventHandler) llm.TraceObser
 		if evt.SessionOwned {
 			return
 		}
-		activityLog.WriteLLMEvent(string(evt.Kind), evt.Provider, evt.Model, evt.ToolName, evt.Preview)
+		activityLog.WriteLLMEvent(evt)
 	}
 }
 

--- a/cmd/tracker/runjson_cmd.go
+++ b/cmd/tracker/runjson_cmd.go
@@ -1,0 +1,61 @@
+// ABOUTME: `tracker run-json [runID]` — assembles run.json for a run directory.
+// ABOUTME: Works after the fact, so SIGKILLed runs and runs archived before the manifest existed both get one.
+package main
+
+import (
+	"fmt"
+
+	"github.com/2389-research/tracker"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// executeRunJSON writes run.json for the named run (or the most recent one).
+//
+// Deliberately a separate command rather than only a run-completion hook: a run
+// killed with SIGKILL runs no in-process finalizer, and every run archived
+// before the manifest existed has none either. Being able to assemble one from
+// whatever the run directory holds is what makes those runs analyzable at all,
+// and it also means the manifest can be regenerated after the schema changes
+// instead of being frozen at whatever shape was current when the run happened.
+func executeRunJSON(cfg runConfig) error {
+	runID := cfg.resumeID
+	if runID == "" {
+		id, err := tracker.MostRecentRunID(cfg.workdir)
+		if err != nil {
+			return fmt.Errorf("no runs found: %w", err)
+		}
+		runID = id
+	}
+	runDir, err := tracker.ResolveRunDir(cfg.workdir, runID)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := pipeline.WriteRunManifest(runDir, runID)
+	if err != nil {
+		return fmt.Errorf("assemble run manifest: %w", err)
+	}
+	printRunManifestSummary(runDir, manifest)
+	return nil
+}
+
+// printRunManifestSummary reports what landed. Terminal status is printed even
+// when empty — an unset status means the process died before emitting a terminal
+// event, which is a real finding about the run and not a gap to hide.
+func printRunManifestSummary(runDir string, m pipeline.RunManifest) {
+	status := m.TerminalStatus
+	if status == "" {
+		status = "(none recorded — run did not emit a terminal event)"
+	}
+	fmt.Printf("wrote %s/%s\n", runDir, pipeline.RunManifestFile)
+	fmt.Printf("  run:      %s\n", m.RunID)
+	fmt.Printf("  status:   %s\n", status)
+	fmt.Printf("  nodes:    %d\n", len(m.Nodes))
+	if m.Totals.LLMCalls > 0 {
+		fmt.Printf("  llm:      %d calls, %d in / %d out tokens\n",
+			m.Totals.LLMCalls, m.Totals.InputTokens, m.Totals.OutputTokens)
+	}
+	if m.Human.Gates > 0 || m.Human.Steering > 0 {
+		fmt.Printf("  human:    %d gate events, %d steering\n", m.Human.Gates, m.Human.Steering)
+	}
+}

--- a/llm/anthropic/adapter.go
+++ b/llm/anthropic/adapter.go
@@ -142,7 +142,7 @@ func logEmptyResponseIfNeeded(resp *llm.Response, httpResp *http.Response, respB
 // Stream sends a streaming request and returns a channel of events.
 func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.StreamEvent {
 	ch := make(chan llm.StreamEvent, 64)
-	emitProviderEvents := shouldEmitProviderEvents(req)
+	emitProviderEvents := llm.RequestIsTraced(req)
 	go func() {
 		defer close(ch)
 		a.streamRequest(ctx, req, ch, emitProviderEvents)
@@ -157,6 +157,8 @@ func (a *Adapter) streamRequest(ctx context.Context, req *llm.Request, ch chan<-
 		ch <- llm.StreamEvent{Type: llm.EventError, Err: err}
 		return
 	}
+
+	llm.EmitRequestSent(ch, body, emitProviderEvents)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+messagesPath, bytes.NewReader(body))
 	if err != nil {
@@ -273,14 +275,6 @@ func resolveSSEEventType(headerType, data string) string {
 // are expected during normal shutdown and should not surface as SSE errors.
 func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-func shouldEmitProviderEvents(req *llm.Request) bool {
-	if req == nil || req.ProviderOptions == nil {
-		return false
-	}
-	enabled, _ := req.ProviderOptions["tracker_emit_provider_events"].(bool)
-	return enabled
 }
 
 // sseMessageStart is the top-level message_start event.

--- a/llm/anthropic/adapter_test.go
+++ b/llm/anthropic/adapter_test.go
@@ -1356,3 +1356,79 @@ func TestAdapterStreamErrorEvent(t *testing.T) {
 		})
 	}
 }
+
+// TestStreamEmitsRequestSentOnlyWhenTracing pins the gate on EventRequestSent.
+// The wire body is telemetry, so it is emitted only for a traced request; an
+// untraced caller driving the adapter directly must see the provider event
+// sequence unchanged, since a leading synthetic event would shift every
+// position-indexed assertion downstream.
+func TestStreamEmitsRequestSentOnlyWhenTracing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatal("expected flusher")
+		}
+		for _, evt := range []string{
+			`event: message_start` + "\n" + `data: {"type":"message_start","message":{"id":"m","model":"claude-opus-4-6","role":"assistant","content":[],"usage":{"input_tokens":1,"output_tokens":0}}}`,
+			`event: message_stop` + "\n" + `data: {"type":"message_stop"}`,
+		} {
+			fmt.Fprintf(w, "%s\n\n", evt)
+			flusher.Flush()
+		}
+	}))
+	defer server.Close()
+
+	adapter := New("test-key", WithBaseURL(server.URL))
+
+	collect := func(req *llm.Request) (requestRaw []byte, firstType llm.StreamEventType) {
+		for evt := range adapter.Stream(context.Background(), req) {
+			if firstType == "" {
+				firstType = evt.Type
+			}
+			if evt.Type == llm.EventRequestSent {
+				requestRaw = evt.RequestRaw
+			}
+		}
+		return requestRaw, firstType
+	}
+
+	t.Run("traced request carries the wire body", func(t *testing.T) {
+		raw, first := collect(&llm.Request{
+			Model:           "claude-opus-4-6",
+			Messages:        []llm.Message{llm.UserMessage("hi")},
+			ProviderOptions: map[string]any{"tracker_emit_provider_events": true},
+		})
+		if len(raw) == 0 {
+			t.Fatal("expected EventRequestSent to carry the wire body")
+		}
+		// The body must be what actually went out, including the stream flag
+		// the adapter injects -- not just the normalized request.
+		var parsed map[string]any
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			t.Fatalf("body is not valid JSON: %v", err)
+		}
+		if parsed["stream"] != true {
+			t.Errorf("body missing stream:true, got %v", parsed["stream"])
+		}
+		if parsed["model"] != "claude-opus-4-6" {
+			t.Errorf("body model = %v, want claude-opus-4-6", parsed["model"])
+		}
+		if first != llm.EventRequestSent {
+			t.Errorf("first event = %v, want request_sent (emitted before the HTTP call)", first)
+		}
+	})
+
+	t.Run("untraced request leaves the sequence unchanged", func(t *testing.T) {
+		raw, first := collect(&llm.Request{
+			Model:    "claude-opus-4-6",
+			Messages: []llm.Message{llm.UserMessage("hi")},
+		})
+		if len(raw) != 0 {
+			t.Errorf("untraced request emitted a body of %d bytes, want none", len(raw))
+		}
+		if first != llm.EventStreamStart {
+			t.Errorf("first event = %v, want stream_start", first)
+		}
+	})
+}

--- a/llm/catalog.go
+++ b/llm/catalog.go
@@ -15,6 +15,14 @@ type ModelInfo struct {
 	InputCostPerM     float64  `json:"input_cost_per_m"`
 	OutputCostPerM    float64  `json:"output_cost_per_m"`
 	Aliases           []string `json:"aliases,omitempty"`
+	// CacheReadMultiplier and CacheWriteMultiplier price cached prompt tokens
+	// as a fraction of InputCostPerM. They live per model because the discount
+	// is not a provider-wide convention: cached reads are 0.1x on Anthropic,
+	// Gemini, and the GPT-5 family, 0.25x on GPT-4.1, and 0.5x on gpt-4o-mini.
+	// Zero means "use the default" — see defaultCacheReadMultiplier — so a new
+	// catalog entry prices cache traffic sanely without having to state both.
+	CacheReadMultiplier  float64 `json:"cache_read_multiplier,omitempty"`
+	CacheWriteMultiplier float64 `json:"cache_write_multiplier,omitempty"`
 }
 
 // defaultCatalog is the built-in registry of known models.
@@ -178,6 +186,8 @@ var defaultCatalog = []ModelInfo{
 		InputCostPerM:     2.00,
 		OutputCostPerM:    8.00,
 		Aliases:           []string{"gpt4.1"},
+		// GPT-4.1 family: cached input is $0.50 vs $2.00 base.
+		CacheReadMultiplier: 0.25,
 	},
 	{
 		ID:                "gpt-4.1-mini",
@@ -191,6 +201,8 @@ var defaultCatalog = []ModelInfo{
 		InputCostPerM:     0.40,
 		OutputCostPerM:    1.60,
 		Aliases:           []string{"gpt4.1-mini"},
+		// GPT-4.1 family: cached input is $0.10 vs $0.40 base.
+		CacheReadMultiplier: 0.25,
 	},
 	{
 		ID:                "gpt-4.1-nano",
@@ -204,6 +216,8 @@ var defaultCatalog = []ModelInfo{
 		InputCostPerM:     0.10,
 		OutputCostPerM:    0.40,
 		Aliases:           []string{"gpt4.1-nano"},
+		// GPT-4.1 family: cached input is $0.025 vs $0.10 base.
+		CacheReadMultiplier: 0.25,
 	},
 	{
 		ID:                "o3",
@@ -244,6 +258,8 @@ var defaultCatalog = []ModelInfo{
 		InputCostPerM:     2.50,
 		OutputCostPerM:    10.00,
 		Aliases:           []string{"4o"},
+		// GPT-4o family: cached input is $1.25 vs $2.50 base.
+		CacheReadMultiplier: 0.5,
 	},
 	{
 		ID:                "gpt-4o-mini",
@@ -257,6 +273,8 @@ var defaultCatalog = []ModelInfo{
 		InputCostPerM:     0.15,
 		OutputCostPerM:    0.60,
 		Aliases:           []string{"4o-mini"},
+		// GPT-4o family: cached input is $0.075 vs $0.15 base.
+		CacheReadMultiplier: 0.5,
 	},
 	// ── Gemini ───────────────────────────────────────────────
 	// GA models first, then previews.
@@ -287,6 +305,11 @@ var defaultCatalog = []ModelInfo{
 		Aliases:           []string{"gemini-flash"},
 	},
 	{
+		// Closed to new API keys as of mid-2026: a request 404s with "no
+		// longer available to new users", though the models list still
+		// advertises it and existing keys may still work. Kept because runs
+		// that used it still need a price when their manifests are rebuilt —
+		// removing the entry would silently zero their cost.
 		ID:                "gemini-2.5-flash-lite",
 		Provider:          "gemini",
 		DisplayName:       "Gemini 2.5 Flash Lite",

--- a/llm/client.go
+++ b/llm/client.go
@@ -270,6 +270,7 @@ func (c *Client) completeWithTrace(ctx context.Context, req *Request, adapter Pr
 		Provider: adapter.Name(),
 		Model:    req.Model,
 		Verbose:  true,
+		CallID:   NewCallID(),
 	})
 	acc := NewStreamAccumulator()
 

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -321,15 +321,16 @@ func (a *Adapter) processCandidate(candidate geminiCandidate, chunk *geminiRespo
 // usageFromMeta builds the unified Usage struct from Gemini's usageMetadata
 // shape. Returns nil for nil input so callers can pass through without a
 // guard.
+//
+// Delegates to extractUsage so the streaming and non-streaming paths cannot
+// drift: they previously held the same conversion twice, and the copy here is
+// what let thinking tokens go unpriced on streamed calls.
 func usageFromMeta(meta *geminiUsageMeta) *llm.Usage {
 	if meta == nil {
 		return nil
 	}
-	return &llm.Usage{
-		InputTokens:  meta.PromptTokenCount,
-		OutputTokens: meta.CandidatesTokenCount,
-		TotalTokens:  meta.TotalTokenCount,
-	}
+	u := extractUsage(meta)
+	return &u
 }
 
 // processGeminiPart emits stream events for a single content part.

--- a/llm/google/adapter.go
+++ b/llm/google/adapter.go
@@ -126,7 +126,7 @@ func (a *Adapter) Complete(ctx context.Context, req *llm.Request) (*llm.Response
 // Stream sends a streaming request and returns a channel of events.
 func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.StreamEvent {
 	ch := make(chan llm.StreamEvent, 64)
-	emitProviderEvents := shouldEmitProviderEvents(req)
+	emitProviderEvents := llm.RequestIsTraced(req)
 
 	go func() {
 		defer close(ch)
@@ -136,6 +136,8 @@ func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.Strea
 			ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("google: translate request: %w", err)}
 			return
 		}
+
+		llm.EmitRequestSent(ch, body, emitProviderEvents)
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.streamGenerateContentURL(req.Model), bytes.NewReader(body))
 		if err != nil {
@@ -370,14 +372,6 @@ func (a *Adapter) processGeminiPart(part geminiPart, ch chan<- llm.StreamEvent, 
 // are expected during normal shutdown and should not surface as SSE errors.
 func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-func shouldEmitProviderEvents(req *llm.Request) bool {
-	if req == nil || req.ProviderOptions == nil {
-		return false
-	}
-	enabled, _ := req.ProviderOptions["tracker_emit_provider_events"].(bool)
-	return enabled
 }
 
 func hasToolCallParts(parts []geminiPart) bool {

--- a/llm/google/translate.go
+++ b/llm/google/translate.go
@@ -411,12 +411,6 @@ type geminiCandidate struct {
 	FinishReason string        `json:"finishReason,omitempty"`
 }
 
-type geminiUsageMeta struct {
-	PromptTokenCount     int `json:"promptTokenCount"`
-	CandidatesTokenCount int `json:"candidatesTokenCount"`
-	TotalTokenCount      int `json:"totalTokenCount"`
-}
-
 // translateResponse converts Gemini API JSON to a unified llm.Response.
 func translateResponse(raw []byte) (*llm.Response, error) {
 	var gr geminiResponse
@@ -484,18 +478,6 @@ func candidateContentParts(part geminiPart) ([]llm.ContentPart, error) {
 		})
 	}
 	return parts, nil
-}
-
-// extractUsage converts Gemini usage metadata to the unified Usage struct.
-func extractUsage(meta *geminiUsageMeta) llm.Usage {
-	if meta == nil {
-		return llm.Usage{}
-	}
-	return llm.Usage{
-		InputTokens:  meta.PromptTokenCount,
-		OutputTokens: meta.CandidatesTokenCount,
-		TotalTokens:  meta.TotalTokenCount,
-	}
 }
 
 func hasToolCalls(parts []llm.ContentPart) bool {

--- a/llm/google/usage.go
+++ b/llm/google/usage.go
@@ -1,0 +1,42 @@
+// ABOUTME: Translates Gemini usageMetadata into the unified llm.Usage shape.
+// ABOUTME: Thinking sits outside the candidate count; cached content sits inside the prompt count.
+package google
+
+import "github.com/2389-research/tracker/llm"
+
+type geminiUsageMeta struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+	TotalTokenCount      int `json:"totalTokenCount"`
+	// Billed at the output rate but NOT inside CandidatesTokenCount —
+	// totalTokenCount = prompt + candidates + thoughts. Dropping it understated
+	// the bill by however much the model thought.
+	ThoughtsTokenCount int `json:"thoughtsTokenCount"`
+	// The cached slice of the prompt, already counted inside PromptTokenCount.
+	CachedContentTokenCount int `json:"cachedContentTokenCount"`
+}
+
+// extractUsage converts Gemini usage metadata to the unified Usage struct,
+// normalizing onto the llm.Usage invariants: thinking folds into OutputTokens
+// (Gemini bills it there but omits it from candidatesTokenCount), and the cached
+// prompt slice lifts out of PromptTokenCount into its own bucket so pricing can
+// discount it without counting those tokens twice.
+func extractUsage(meta *geminiUsageMeta) llm.Usage {
+	if meta == nil {
+		return llm.Usage{}
+	}
+	u := llm.Usage{
+		InputTokens:  meta.PromptTokenCount - meta.CachedContentTokenCount,
+		OutputTokens: meta.CandidatesTokenCount + meta.ThoughtsTokenCount,
+		TotalTokens:  meta.TotalTokenCount,
+	}
+	if meta.ThoughtsTokenCount > 0 {
+		v := meta.ThoughtsTokenCount
+		u.ReasoningTokens = &v
+	}
+	if meta.CachedContentTokenCount > 0 {
+		v := meta.CachedContentTokenCount
+		u.CacheReadTokens = &v
+	}
+	return u
+}

--- a/llm/google/usage_test.go
+++ b/llm/google/usage_test.go
@@ -1,0 +1,101 @@
+// ABOUTME: Tests that Gemini usage metadata normalizes onto the llm.Usage invariants.
+// ABOUTME: Thinking tokens are billed but excluded from the candidate count; cached prompt tokens are nested inside it.
+package google
+
+import "testing"
+
+// TestExtractUsageFoldsThinkingIntoOutput pins the arithmetic that a live run
+// exposed: Gemini reports totalTokenCount = prompt + candidates + thoughts, so
+// thinking tokens are billed at the output rate while sitting outside
+// candidatesTokenCount. Dropping them understated the bill by however much the
+// model thought — on a reasoning-heavy call that is nearly all of the output.
+func TestExtractUsageFoldsThinkingIntoOutput(t *testing.T) {
+	// Shape taken from a real gemini-3-flash-preview response.
+	u := extractUsage(&geminiUsageMeta{
+		PromptTokenCount:     2,
+		CandidatesTokenCount: 1,
+		ThoughtsTokenCount:   44,
+		TotalTokenCount:      47,
+	})
+
+	if u.OutputTokens != 45 {
+		t.Errorf("OutputTokens = %d, want 45 (1 candidate + 44 thinking)", u.OutputTokens)
+	}
+	if u.InputTokens != 2 {
+		t.Errorf("InputTokens = %d, want 2", u.InputTokens)
+	}
+	if u.ReasoningTokens == nil || *u.ReasoningTokens != 44 {
+		t.Errorf("ReasoningTokens = %v, want 44 recorded for visibility", u.ReasoningTokens)
+	}
+	// The invariant that makes cost right: nothing Gemini billed is unaccounted.
+	if got := u.InputTokens + u.OutputTokens; got != u.TotalTokens {
+		t.Errorf("input+output = %d but Gemini reported total %d; the difference is billed and unpriced",
+			got, u.TotalTokens)
+	}
+}
+
+// TestExtractUsageLiftsCachedPromptOut covers the opposite nesting: the cached
+// slice is already inside promptTokenCount, and pricing sums the buckets, so it
+// has to be subtracted on the way into CacheReadTokens or the prompt is counted
+// twice.
+func TestExtractUsageLiftsCachedPromptOut(t *testing.T) {
+	u := extractUsage(&geminiUsageMeta{
+		PromptTokenCount:        1000, // includes the 600 cached
+		CachedContentTokenCount: 600,
+		CandidatesTokenCount:    50,
+		TotalTokenCount:         1050,
+	})
+
+	if u.InputTokens != 400 {
+		t.Errorf("InputTokens = %d, want 400 (1000 prompt - 600 cached)", u.InputTokens)
+	}
+	if u.CacheReadTokens == nil || *u.CacheReadTokens != 600 {
+		t.Errorf("CacheReadTokens = %v, want 600", u.CacheReadTokens)
+	}
+	// Buckets must reconstitute the prompt exactly.
+	if got := u.InputTokens + *u.CacheReadTokens; got != 1000 {
+		t.Errorf("input+cacheRead = %d, want the 1000 tokens Gemini reported", got)
+	}
+}
+
+// TestUsageFromMetaMatchesExtractUsage guards the streaming and non-streaming
+// paths against drifting apart. They held duplicate conversions, and the copy
+// in the adapter is what let thinking tokens go unpriced on streamed calls —
+// which is every call an agent session makes.
+func TestUsageFromMetaMatchesExtractUsage(t *testing.T) {
+	meta := &geminiUsageMeta{
+		PromptTokenCount:        900,
+		CachedContentTokenCount: 100,
+		CandidatesTokenCount:    20,
+		ThoughtsTokenCount:      30,
+		TotalTokenCount:         950,
+	}
+	streamed, direct := usageFromMeta(meta), extractUsage(meta)
+	if streamed == nil {
+		t.Fatal("usageFromMeta returned nil for non-nil metadata")
+	}
+	// Compared field by field: Usage holds pointers for the optional buckets,
+	// so struct equality would compare addresses and never match.
+	if streamed.InputTokens != direct.InputTokens ||
+		streamed.OutputTokens != direct.OutputTokens ||
+		streamed.TotalTokens != direct.TotalTokens {
+		t.Errorf("token counts differ: streaming %s, non-streaming %s", streamed, direct)
+	}
+	for _, c := range []struct {
+		name             string
+		streamed, direct *int
+	}{
+		{"ReasoningTokens", streamed.ReasoningTokens, direct.ReasoningTokens},
+		{"CacheReadTokens", streamed.CacheReadTokens, direct.CacheReadTokens},
+	} {
+		switch {
+		case (c.streamed == nil) != (c.direct == nil):
+			t.Errorf("%s: streaming %v, non-streaming %v", c.name, c.streamed, c.direct)
+		case c.streamed != nil && *c.streamed != *c.direct:
+			t.Errorf("%s: streaming %d, non-streaming %d", c.name, *c.streamed, *c.direct)
+		}
+	}
+	if usageFromMeta(nil) != nil {
+		t.Error("usageFromMeta(nil) should stay nil so callers need no guard")
+	}
+}

--- a/llm/openai/adapter.go
+++ b/llm/openai/adapter.go
@@ -127,7 +127,7 @@ func (a *Adapter) Complete(ctx context.Context, req *llm.Request) (*llm.Response
 // Stream sends a streaming request and returns a channel of events.
 func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.StreamEvent {
 	ch := make(chan llm.StreamEvent, 64)
-	emitProviderEvents := shouldEmitProviderEvents(req)
+	emitProviderEvents := llm.RequestIsTraced(req)
 	go func() {
 		defer close(ch)
 		a.streamRequest(ctx, req, ch, emitProviderEvents)
@@ -142,6 +142,8 @@ func (a *Adapter) streamRequest(ctx context.Context, req *llm.Request, ch chan<-
 		ch <- llm.StreamEvent{Type: llm.EventError, Err: err}
 		return
 	}
+
+	llm.EmitRequestSent(ch, body, emitProviderEvents)
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+responsesPath, bytes.NewReader(body))
 	if err != nil {
@@ -248,12 +250,4 @@ func resolveSSEEventType(headerType, data string) string {
 // are expected during normal shutdown and should not surface as SSE errors.
 func isContextError(err error) bool {
 	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
-}
-
-func shouldEmitProviderEvents(req *llm.Request) bool {
-	if req == nil || req.ProviderOptions == nil {
-		return false
-	}
-	enabled, _ := req.ProviderOptions["tracker_emit_provider_events"].(bool)
-	return enabled
 }

--- a/llm/openai/translate.go
+++ b/llm/openai/translate.go
@@ -408,17 +408,6 @@ type openaiSummaryBlock struct {
 	Text string `json:"text,omitempty"`
 }
 
-type openaiUsage struct {
-	InputTokens  int              `json:"input_tokens"`
-	OutputTokens int              `json:"output_tokens"`
-	TotalTokens  int              `json:"total_tokens"`
-	OutputDetail *openaiOutDetail `json:"output_tokens_details,omitempty"`
-}
-
-type openaiOutDetail struct {
-	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
-}
-
 type incompleteDetails struct {
 	Reason string `json:"reason"`
 }
@@ -507,20 +496,6 @@ func translateReasoningItem(summary []openaiSummaryBlock) (llm.ContentPart, bool
 		Kind:     llm.KindThinking,
 		Thinking: &llm.ThinkingData{Text: strings.Join(texts, "")},
 	}, true
-}
-
-// translateUsage converts OpenAI usage to unified format.
-func translateUsage(u openaiUsage) llm.Usage {
-	usage := llm.Usage{
-		InputTokens:  u.InputTokens,
-		OutputTokens: u.OutputTokens,
-		TotalTokens:  u.TotalTokens,
-	}
-	if u.OutputDetail != nil && u.OutputDetail.ReasoningTokens > 0 {
-		v := u.OutputDetail.ReasoningTokens
-		usage.ReasoningTokens = &v
-	}
-	return usage
 }
 
 // translateFinishReason maps OpenAI Responses API status to the unified finish reason format.

--- a/llm/openai/usage.go
+++ b/llm/openai/usage.go
@@ -1,0 +1,55 @@
+// ABOUTME: Translates OpenAI Responses API usage into the unified llm.Usage shape.
+// ABOUTME: Both cache classes and reasoning arrive nested inside the top-level counts.
+package openai
+
+import "github.com/2389-research/tracker/llm"
+
+type openaiUsage struct {
+	InputTokens  int              `json:"input_tokens"`
+	OutputTokens int              `json:"output_tokens"`
+	TotalTokens  int              `json:"total_tokens"`
+	OutputDetail *openaiOutDetail `json:"output_tokens_details,omitempty"`
+	InputDetail  *openaiInDetail  `json:"input_tokens_details,omitempty"`
+}
+
+type openaiOutDetail struct {
+	// Already counted inside OutputTokens.
+	ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+}
+
+// openaiInDetail breaks down InputTokens. Both fields are nested *inside* it and
+// billed at their own rate, so both are lifted out — see translateUsage.
+type openaiInDetail struct {
+	CachedTokens     int `json:"cached_tokens,omitempty"`
+	CacheWriteTokens int `json:"cache_write_tokens,omitempty"`
+}
+
+// translateUsage converts OpenAI usage to unified format.
+//
+// OutputTokens already includes reasoning — the llm.Usage invariant — so it
+// passes through untouched. The cache buckets arrive nested inside InputTokens
+// and are lifted out: pricing sums the buckets, so leaving them in charges the
+// full rate for discounted tokens, while moving them without subtracting counts
+// the prompt twice.
+func translateUsage(u openaiUsage) llm.Usage {
+	usage := llm.Usage{
+		InputTokens:  u.InputTokens,
+		OutputTokens: u.OutputTokens,
+		TotalTokens:  u.TotalTokens,
+	}
+	if u.OutputDetail != nil && u.OutputDetail.ReasoningTokens > 0 {
+		v := u.OutputDetail.ReasoningTokens
+		usage.ReasoningTokens = &v
+	}
+	if u.InputDetail != nil && u.InputDetail.CachedTokens > 0 {
+		v := u.InputDetail.CachedTokens
+		usage.InputTokens -= v
+		usage.CacheReadTokens = &v
+	}
+	if u.InputDetail != nil && u.InputDetail.CacheWriteTokens > 0 {
+		v := u.InputDetail.CacheWriteTokens
+		usage.InputTokens -= v
+		usage.CacheWriteTokens = &v
+	}
+	return usage
+}

--- a/llm/openai/usage_test.go
+++ b/llm/openai/usage_test.go
@@ -1,0 +1,62 @@
+// ABOUTME: Tests that OpenAI usage normalizes onto the llm.Usage invariants.
+// ABOUTME: Reasoning is already inside output_tokens; cached tokens are already inside input_tokens.
+package openai
+
+import "testing"
+
+// TestTranslateUsageLiftsCachedTokensOut covers the nesting that makes this
+// provider's fix asymmetric with Anthropic's. OpenAI reports cached tokens
+// *inside* input_tokens, and pricing sums the buckets — so the cached count has
+// to be subtracted on the way out. Copying Anthropic's mapping, where cache
+// reads arrive as a separate bucket already, would count the prompt twice.
+func TestTranslateUsageLiftsCachedTokensOut(t *testing.T) {
+	u := translateUsage(openaiUsage{
+		InputTokens:  1000, // includes the 800 cached
+		OutputTokens: 50,
+		TotalTokens:  1050,
+		InputDetail:  &openaiInDetail{CachedTokens: 800},
+	})
+
+	if u.InputTokens != 200 {
+		t.Errorf("InputTokens = %d, want 200 (1000 - 800 cached)", u.InputTokens)
+	}
+	if u.CacheReadTokens == nil || *u.CacheReadTokens != 800 {
+		t.Errorf("CacheReadTokens = %v, want 800", u.CacheReadTokens)
+	}
+	if got := u.InputTokens + *u.CacheReadTokens; got != 1000 {
+		t.Errorf("input+cacheRead = %d, want the 1000 tokens OpenAI reported", got)
+	}
+}
+
+// TestTranslateUsageLeavesReasoningInsideOutput is the guard against the
+// tempting symmetric change. Reasoning tokens are already counted in
+// output_tokens, so adding them again — or pricing them separately — bills them
+// twice. ReasoningTokens is reported for visibility only.
+func TestTranslateUsageLeavesReasoningInsideOutput(t *testing.T) {
+	u := translateUsage(openaiUsage{
+		InputTokens:  10,
+		OutputTokens: 500, // already contains the 450 reasoning tokens
+		TotalTokens:  510,
+		OutputDetail: &openaiOutDetail{ReasoningTokens: 450},
+	})
+
+	if u.OutputTokens != 500 {
+		t.Errorf("OutputTokens = %d, want 500 unchanged — reasoning is already inside it", u.OutputTokens)
+	}
+	if u.ReasoningTokens == nil || *u.ReasoningTokens != 450 {
+		t.Errorf("ReasoningTokens = %v, want 450 recorded as an informational subset", u.ReasoningTokens)
+	}
+}
+
+// TestTranslateUsageWithoutDetails covers the common case: no caching, no
+// reasoning. Both optional buckets stay nil rather than reporting a hollow zero.
+func TestTranslateUsageWithoutDetails(t *testing.T) {
+	u := translateUsage(openaiUsage{InputTokens: 100, OutputTokens: 20, TotalTokens: 120})
+	if u.InputTokens != 100 || u.OutputTokens != 20 {
+		t.Errorf("got %d/%d, want 100/20 passed through", u.InputTokens, u.OutputTokens)
+	}
+	if u.CacheReadTokens != nil || u.ReasoningTokens != nil {
+		t.Errorf("optional buckets should stay nil, got cache=%v reasoning=%v",
+			u.CacheReadTokens, u.ReasoningTokens)
+	}
+}

--- a/llm/openaicompat/adapter.go
+++ b/llm/openaicompat/adapter.go
@@ -126,6 +126,7 @@ func (a *Adapter) Complete(ctx context.Context, req *llm.Request) (*llm.Response
 // Stream sends a streaming request and returns a channel of events.
 func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.StreamEvent {
 	ch := make(chan llm.StreamEvent, 64)
+	emitProviderEvents := llm.RequestIsTraced(req)
 
 	go func() {
 		defer close(ch)
@@ -135,6 +136,8 @@ func (a *Adapter) Stream(ctx context.Context, req *llm.Request) <-chan llm.Strea
 			ch <- llm.StreamEvent{Type: llm.EventError, Err: fmt.Errorf("openai-compat: translate request: %w", err)}
 			return
 		}
+
+		llm.EmitRequestSent(ch, body, emitProviderEvents)
 
 		httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+chatCompletePath, bytes.NewReader(body))
 		if err != nil {

--- a/llm/pricing.go
+++ b/llm/pricing.go
@@ -68,7 +68,7 @@ func cacheCost(info *ModelInfo, usage Usage) float64 {
 // is actually something to price — a zero-usage call (e.g. a probe) shouldn't
 // produce a log line.
 func warnUnknownModel(model string, usage Usage) {
-	if usage.TotalTokens == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 {
+	if !usage.anyTokens() {
 		return
 	}
 	if _, already := unknownModelWarned.LoadOrStore(model, struct{}{}); already {

--- a/llm/pricing.go
+++ b/llm/pricing.go
@@ -13,35 +13,66 @@ import (
 // common for subscription-auth backends (claude-code, ACP bridges).
 var unknownModelWarned sync.Map
 
+// Cache multipliers used when a catalog entry states none. Both are the
+// published Anthropic rates, which the GPT-5 family also matches on reads.
+//
+// The write default is a *premium*, not a discount: a 5-minute cache write is
+// 1.25x base input. 1-hour writes are 2x, which this cannot express because
+// llm.Usage carries no TTL — a 1-hour-TTL run prices ~38% low, and threading
+// TTL through the adapters is the fix if that matters. The previous value here
+// was 0.25, reading "+25% premium" as "0.25x rate", which understated the
+// cache-write cost of every cached Anthropic run by 5x.
+const (
+	defaultCacheReadMultiplier  = 0.1
+	defaultCacheWriteMultiplier = 1.25
+)
+
 // EstimateCost returns the estimated dollar cost for the given model and token
 // usage. Looks up pricing from the model catalog (supports ID and aliases).
 // Returns 0 for unknown models, logging a single warning per unknown name so
 // operators notice that their --max-cost ceiling will not apply to usage
-// priced at an unknown rate. Cache read tokens are priced at 10% of input
-// rate; cache write tokens at 25% of input rate (Anthropic pricing
-// convention, applied uniformly since other providers use similar discounts).
+// priced at an unknown rate.
+//
+// Cached prompt tokens are priced from the model's own multipliers, since the
+// discount varies by model rather than by provider — see ModelInfo. Assumes
+// InputTokens excludes the cache buckets, the llm.Usage invariant every adapter
+// normalizes to.
 func EstimateCost(model string, usage Usage) float64 {
 	info := GetModelInfo(model)
 	if info == nil {
-		// Only warn when there's actually something to price — a zero-usage
-		// call (e.g. a probe) shouldn't produce a log line.
-		if usage.TotalTokens > 0 || usage.InputTokens > 0 || usage.OutputTokens > 0 {
-			if _, already := unknownModelWarned.LoadOrStore(model, struct{}{}); !already {
-				log.Printf("[llm] EstimateCost: unknown model %q (no catalog entry); returning $0 — budget --max-cost ceiling will not apply to usage priced under this model", model)
-			}
-		}
+		warnUnknownModel(model, usage)
 		return 0
 	}
 	input := float64(usage.InputTokens) / 1_000_000 * info.InputCostPerM
 	output := float64(usage.OutputTokens) / 1_000_000 * info.OutputCostPerM
+	return input + output + cacheCost(info, usage)
+}
 
-	var cacheRead, cacheWrite float64
-	if usage.CacheReadTokens != nil {
-		cacheRead = float64(*usage.CacheReadTokens) / 1_000_000 * info.InputCostPerM * 0.1
+// cacheCost prices the cache buckets, falling back to the package defaults for
+// a model that states no multiplier of its own.
+func cacheCost(info *ModelInfo, usage Usage) float64 {
+	perM := func(tokens *int, mult, fallback float64) float64 {
+		if tokens == nil {
+			return 0
+		}
+		if mult == 0 {
+			mult = fallback
+		}
+		return float64(*tokens) / 1_000_000 * info.InputCostPerM * mult
 	}
-	if usage.CacheWriteTokens != nil {
-		cacheWrite = float64(*usage.CacheWriteTokens) / 1_000_000 * info.InputCostPerM * 0.25
-	}
+	return perM(usage.CacheReadTokens, info.CacheReadMultiplier, defaultCacheReadMultiplier) +
+		perM(usage.CacheWriteTokens, info.CacheWriteMultiplier, defaultCacheWriteMultiplier)
+}
 
-	return input + output + cacheRead + cacheWrite
+// warnUnknownModel logs once per unrecognized model name. Only warns when there
+// is actually something to price — a zero-usage call (e.g. a probe) shouldn't
+// produce a log line.
+func warnUnknownModel(model string, usage Usage) {
+	if usage.TotalTokens == 0 && usage.InputTokens == 0 && usage.OutputTokens == 0 {
+		return
+	}
+	if _, already := unknownModelWarned.LoadOrStore(model, struct{}{}); already {
+		return
+	}
+	log.Printf("[llm] EstimateCost: unknown model %q (no catalog entry); returning $0 — budget --max-cost ceiling will not apply to usage priced under this model", model)
 }

--- a/llm/pricing_cache_test.go
+++ b/llm/pricing_cache_test.go
@@ -1,0 +1,131 @@
+// ABOUTME: Pins cached-token pricing multipliers against each provider's published rates.
+// ABOUTME: A wrong multiplier produces correct token counts at the wrong price, which no behavioral test can catch.
+package llm
+
+import (
+	"math"
+	"testing"
+)
+
+// TestCacheMultipliersMatchPublishedRates is the guard for a class of bug that
+// is invisible to every other check we have: the token counts are right and the
+// arithmetic is self-consistent, so the manifest agrees with the CLI and the
+// ladder's token-fidelity assertion passes — only the rate is wrong.
+//
+// The regression it exists for priced cache writes at 0.25x the input rate,
+// reading Anthropic's "+25% premium" as "0.25x rate". Real multiplier is 1.25x,
+// so every cached Anthropic run understated its cache-write cost by 5x — about
+// a third of the bill on a caching-heavy run.
+//
+// Each row is a published price, not a derived one. When a provider changes its
+// pricing this test should fail; re-check the pricing page rather than adjusting
+// the expectation to match the code.
+func TestCacheMultipliersMatchPublishedRates(t *testing.T) {
+	cases := []struct {
+		model string
+		// Published per-million prices. cachedIn of 0 means the provider does
+		// not publish a separate cached-input price for this model.
+		baseIn, cachedIn float64
+		source           string
+	}{
+		// Anthropic publishes multipliers rather than per-model cached prices:
+		// reads 0.1x, 5-minute writes 1.25x, 1-hour writes 2x.
+		{"claude-sonnet-4-6", 3.0, 0.30, "0.1x published multiplier"},
+		{"claude-haiku-4-5", 1.0, 0.10, "0.1x published multiplier"},
+		// OpenAI publishes explicit cached-input prices, and they are not one
+		// ratio across the lineup — this is why the multiplier is per model.
+		{"gpt-5.4", 2.50, 0.25, "developers.openai.com/api/docs/pricing"},
+		{"gpt-5.4-mini", 0.75, 0.075, "developers.openai.com/api/docs/pricing"},
+		{"gpt-5.4-nano", 0.20, 0.02, "developers.openai.com/api/docs/pricing"},
+		{"gpt-4.1", 2.00, 0.50, "developers.openai.com/api/docs/pricing"},
+		{"gpt-4.1-mini", 0.40, 0.10, "developers.openai.com/api/docs/pricing"},
+		{"gpt-4.1-nano", 0.10, 0.025, "developers.openai.com/api/docs/pricing"},
+		{"gpt-4o", 2.50, 1.25, "developers.openai.com/api/docs/pricing"},
+		{"gpt-4o-mini", 0.15, 0.075, "developers.openai.com/api/docs/pricing"},
+		// Gemini context caching is 10% of standard input (ai.google.dev
+		// pricing). The separate hourly storage fee is not token-derived and is
+		// therefore not modeled here — see the note in the pricing docs.
+		{"gemini-3-flash-preview", 0, 0, "0.1x published; base rate not asserted"},
+	}
+
+	for _, c := range cases {
+		info := GetModelInfo(c.model)
+		if info == nil {
+			t.Errorf("%s: no catalog entry", c.model)
+			continue
+		}
+		if c.baseIn > 0 && !closeEnough(info.InputCostPerM, c.baseIn) {
+			t.Errorf("%s: InputCostPerM = %v, published %v (%s)",
+				c.model, info.InputCostPerM, c.baseIn, c.source)
+		}
+		if c.cachedIn == 0 {
+			continue
+		}
+		want := c.cachedIn / c.baseIn
+		got := info.CacheReadMultiplier
+		if got == 0 {
+			got = defaultCacheReadMultiplier
+		}
+		if !closeEnough(got, want) {
+			t.Errorf("%s: cache read multiplier = %v, published cached/base = %v/%v = %v (%s)",
+				c.model, got, c.cachedIn, c.baseIn, want, c.source)
+		}
+	}
+}
+
+// TestCacheWriteIsAPremiumNotADiscount states the invariant the original bug
+// violated. A write multiplier below 1 means cached writes are cheaper than
+// uncached input, which is true of no provider we price — writes cost *more*
+// because the cache has to be populated.
+func TestCacheWriteIsAPremiumNotADiscount(t *testing.T) {
+	if defaultCacheWriteMultiplier < 1 {
+		t.Errorf("default cache write multiplier = %v; a write is a premium over base input, not a discount",
+			defaultCacheWriteMultiplier)
+	}
+	// Anthropic's published 5-minute rate.
+	if !closeEnough(defaultCacheWriteMultiplier, 1.25) {
+		t.Errorf("default cache write multiplier = %v, want 1.25 (Anthropic 5-minute published rate)",
+			defaultCacheWriteMultiplier)
+	}
+}
+
+// TestEstimateCostPricesCacheBucketsAdditively checks the arithmetic end to end
+// against a hand-computed figure, on the llm.Usage invariant that InputTokens
+// excludes the cache buckets.
+func TestEstimateCostPricesCacheBucketsAdditively(t *testing.T) {
+	read, write := 100_000, 10_000
+	got := EstimateCost("claude-sonnet-4-6", Usage{
+		InputTokens:      1_000,
+		OutputTokens:     2_000,
+		CacheReadTokens:  &read,
+		CacheWriteTokens: &write,
+	})
+
+	// sonnet-4-6: $3/M in, $15/M out; reads 0.1x, writes 1.25x.
+	want := 1_000/1e6*3.0 + 2_000/1e6*15.0 + 100_000/1e6*3.0*0.1 + 10_000/1e6*3.0*1.25
+	if !closeEnough(got, want) {
+		t.Errorf("EstimateCost = %v, want %v", got, want)
+	}
+
+	// The old 0.25x write multiplier would land here — assert we moved off it,
+	// since both figures are plausible-looking totals.
+	old := 1_000/1e6*3.0 + 2_000/1e6*15.0 + 100_000/1e6*3.0*0.1 + 10_000/1e6*3.0*0.25
+	if closeEnough(got, old) {
+		t.Errorf("EstimateCost still matches the 0.25x cache-write price (%v)", old)
+	}
+}
+
+// TestPerModelMultiplierBeatsTheDefault proves the catalog override is actually
+// consulted — a field that is read nowhere would leave every model on 0.1x and
+// silently underprice the GPT-4.1 and GPT-4o families.
+func TestPerModelMultiplierBeatsTheDefault(t *testing.T) {
+	read := 1_000_000
+	// gpt-4o-mini: $0.15/M in, cached at 0.5x — not the 0.1x default.
+	got := EstimateCost("gpt-4o-mini", Usage{CacheReadTokens: &read})
+	if want := 0.15 * 0.5; !closeEnough(got, want) {
+		t.Errorf("gpt-4o-mini cached-read cost = %v, want %v (0.5x, not the %v default)",
+			got, want, defaultCacheReadMultiplier)
+	}
+}
+
+func closeEnough(a, b float64) bool { return math.Abs(a-b) < 1e-9 }

--- a/llm/pricing_test.go
+++ b/llm/pricing_test.go
@@ -57,10 +57,16 @@ func TestEstimateCost_CacheTokensPriced(t *testing.T) {
 	// 100K input: 100_000 / 1_000_000 * 3.00 = 0.30
 	// 50K output: 50_000 / 1_000_000 * 15.00 = 0.75
 	// 500K cache read: 500_000 / 1_000_000 * 3.00 * 0.1 = 0.15
-	// 200K cache write: 200_000 / 1_000_000 * 3.00 * 0.25 = 0.15
-	// Total: 0.30 + 0.75 + 0.15 + 0.15 = 1.35
+	// 200K cache write: 200_000 / 1_000_000 * 3.00 * 1.25 = 0.75
+	// Total: 0.30 + 0.75 + 0.15 + 0.75 = 1.95
+	//
+	// This line previously read 0.25 and expected a 1.35 total, which locked in
+	// the mispricing rather than catching it: Anthropic bills a 5-minute cache
+	// write at 1.25x base input, not 0.25x. Published rates are now asserted
+	// directly in pricing_cache_test.go, so a stale multiplier fails against
+	// the pricing page instead of against a hand-computed constant.
 	got := EstimateCost("claude-sonnet-4-5", usage)
-	want := 1.35
+	want := 1.95
 	if math.Abs(got-want) > 0.001 {
 		t.Errorf("EstimateCost(with cache tokens) = %f, want %f", got, want)
 	}

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -48,11 +48,12 @@ type StreamEvent struct {
 	FullResponse       *Response       `json:"full_response,omitempty"`
 	Err                error           `json:"-"`
 	Raw                json.RawMessage `json:"raw,omitempty"`
-	// RequestRaw is the verbatim wire body the adapter sent, set only on the
-	// EventStreamStart event. The normalized Request records what tracker
-	// asked for; this records what actually went out after provider-specific
-	// translation and ProviderOptions merging — which is what a post-hoc
-	// reader needs in order to reproduce the call.
+	// RequestRaw is the verbatim wire body the adapter sent, carried on the
+	// EventRequestSent event that EmitRequestSent emits below. EventStreamStart
+	// only ever sees it via TraceBuilder's fallback, never set by an adapter.
+	// The normalized Request records what tracker asked for; this records what
+	// actually went out after provider-specific translation and ProviderOptions
+	// merging — which is what a post-hoc reader needs to reproduce the call.
 	RequestRaw json.RawMessage `json:"request_raw,omitempty"`
 }
 

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -26,6 +26,13 @@ const (
 	EventFinish             StreamEventType = "finish"
 	EventError              StreamEventType = "error"
 	EventProviderEvent      StreamEventType = "provider_event"
+	// EventRequestSent carries the verbatim wire body in RequestRaw. Adapters
+	// emit it once, immediately after building the body and before the HTTP
+	// call, because that is the only place the body is in scope — the
+	// provider's own stream-start arrives several layers deeper, inside SSE
+	// parsing. TraceBuilder folds it into the TraceRequestStart it emits, and
+	// StreamAccumulator ignores it, so it adds no event to either output.
+	EventRequestSent StreamEventType = "request_sent"
 )
 
 // StreamEvent represents a single event in a streaming response.
@@ -47,6 +54,36 @@ type StreamEvent struct {
 	// translation and ProviderOptions merging — which is what a post-hoc
 	// reader needs in order to reproduce the call.
 	RequestRaw json.RawMessage `json:"request_raw,omitempty"`
+}
+
+// RequestIsTraced reports whether the client is tracing this request. The
+// client sets the flag on every request it routes through the streaming trace
+// path; adapters use it to gate telemetry-only emissions (provider events and
+// the wire body) so an untraced caller sees neither.
+func RequestIsTraced(req *Request) bool {
+	if req == nil || req.ProviderOptions == nil {
+		return false
+	}
+	enabled, _ := req.ProviderOptions["tracker_emit_provider_events"].(bool)
+	return enabled
+}
+
+// EmitRequestSent records the verbatim wire body on the event stream. Adapters
+// call it immediately after building the body and before the HTTP call, because
+// that is the only place the body is in scope — the provider's own stream-start
+// arrives several layers deeper, inside SSE parsing.
+//
+// tracing gates the emit: the body is telemetry, so an untraced caller driving
+// an adapter directly sees the provider event sequence unchanged. A leading
+// synthetic event would otherwise shift every position-indexed assertion in
+// adapter tests and in any embedder reading Stream() by index. Adapters pass
+// the same per-request flag that gates provider events, which the client sets
+// on every request it traces.
+func EmitRequestSent(ch chan<- StreamEvent, body []byte, tracing bool) {
+	if !tracing {
+		return
+	}
+	ch <- StreamEvent{Type: EventRequestSent, RequestRaw: body}
 }
 
 // StreamAccumulator collects streaming events into a complete Response.

--- a/llm/stream.go
+++ b/llm/stream.go
@@ -41,6 +41,12 @@ type StreamEvent struct {
 	FullResponse       *Response       `json:"full_response,omitempty"`
 	Err                error           `json:"-"`
 	Raw                json.RawMessage `json:"raw,omitempty"`
+	// RequestRaw is the verbatim wire body the adapter sent, set only on the
+	// EventStreamStart event. The normalized Request records what tracker
+	// asked for; this records what actually went out after provider-specific
+	// translation and ProviderOptions merging — which is what a post-hoc
+	// reader needs in order to reproduce the call.
+	RequestRaw json.RawMessage `json:"request_raw,omitempty"`
 }
 
 // StreamAccumulator collects streaming events into a complete Response.

--- a/llm/trace.go
+++ b/llm/trace.go
@@ -116,6 +116,10 @@ func (f TraceObserverFunc) HandleTraceEvent(evt TraceEvent) {
 type TraceBuilder struct {
 	opts   TraceOptions
 	events []TraceEvent
+	// requestRaw holds the wire body from EventRequestSent until the
+	// provider's stream-start arrives, so both land on one trace event
+	// instead of the log carrying two request-start lines.
+	requestRaw json.RawMessage
 }
 
 // NewTraceBuilder creates a trace builder for one request.
@@ -132,10 +136,14 @@ func (b *TraceBuilder) Process(evt StreamEvent) {
 	}
 
 	switch evt.Type {
+	case EventRequestSent:
+		// Stash only — the trace event is emitted when the provider's
+		// stream-start arrives, so there is exactly one request_start.
+		b.requestRaw = evt.RequestRaw
 	case EventStreamStart:
 		start := base
 		start.Kind = TraceRequestStart
-		start.RequestRaw = evt.RequestRaw
+		start.RequestRaw = firstRaw(evt.RequestRaw, b.requestRaw)
 		b.events = append(b.events, start)
 	case EventReasoningDelta:
 		b.processReasoningDelta(evt, base)
@@ -328,6 +336,18 @@ func previewText(text string) string {
 // or flattens structured output when chunks are coalesced.
 func preserveSpacingText(text string) string {
 	return text
+}
+
+// firstRaw returns the first non-empty payload. Lets a stream-start event
+// carry the body directly if an adapter ever sets it there, while falling
+// back to the stashed EventRequestSent value.
+func firstRaw(candidates ...json.RawMessage) json.RawMessage {
+	for _, c := range candidates {
+		if len(c) > 0 {
+			return c
+		}
+	}
+	return nil
 }
 
 func previewJSON(raw json.RawMessage) string {

--- a/llm/trace.go
+++ b/llm/trace.go
@@ -2,12 +2,30 @@
 package llm
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strings"
 )
 
 const tracePreviewLimit = 80
+
+// NewCallID returns an identifier for one LLM request. Callers stamp it into
+// TraceOptions so every trace event from that request shares it; see
+// TraceEvent.CallID for why grouping matters.
+//
+// Locally generated rather than taken from Response.ID: the provider's ID only
+// exists once the response arrives, so events emitted before then — including
+// the request-start that carries the wire body — would have nothing to group
+// on. Collision resistance only has to hold within one run's log.
+func NewCallID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	return hex.EncodeToString(b)
+}
 
 // TraceKind identifies a normalized LLM trace event.
 type TraceKind string
@@ -22,6 +40,13 @@ const (
 )
 
 // TraceEvent is a normalized event for rendering live LLM activity.
+//
+// Preview and RawPreview are display fields: previewText collapses newlines
+// and clips to tracePreviewLimit (80 chars) so a TUI line stays a TUI line.
+// The Raw* / Arguments fields alongside them carry the same content
+// untruncated, for the activity log. Text and reasoning deltas are not
+// clipped in either place — preserveSpacingText keeps them whole because
+// coalescing clipped deltas would corrupt the reconstructed text.
 type TraceEvent struct {
 	Kind          TraceKind
 	Provider      string
@@ -32,6 +57,25 @@ type TraceEvent struct {
 	RawPreview    string
 	FinishReason  string
 	Usage         Usage
+	// CallID groups every event belonging to one LLM request. Two log paths
+	// record LLM activity — the agent session re-emits trace events as agent
+	// llm_* events, and the client-level writer catches calls no session sees
+	// (the autopilot interviewer, for one) — so one call can legitimately
+	// appear twice. Both paths are kept because their coverage differs; this
+	// is what lets a reader collapse the overlap rather than double-count
+	// usage when aggregating.
+	CallID string
+	// RequestRaw is the verbatim wire body, set on TraceRequestStart. The
+	// normalized Request says what tracker asked for; this says what actually
+	// went out after provider translation and ProviderOptions merging.
+	RequestRaw json.RawMessage
+	// ToolArguments is the untruncated tool-call arguments, set on
+	// TraceToolPrepare. Preview holds the same value clipped to 80 chars,
+	// which is enough to render but not enough to reconstruct the call.
+	ToolArguments json.RawMessage
+	// ProviderRaw is the untruncated provider chunk, set on TraceProviderRaw
+	// (verbose only). RawPreview holds the clipped form.
+	ProviderRaw json.RawMessage
 	// SessionOwned is true when the originating request carried
 	// request-level TraceObservers — in tracker only the agent session
 	// registers those, and it re-emits every trace event as an agent
@@ -48,6 +92,11 @@ type TraceOptions struct {
 	Provider string
 	Model    string
 	Verbose  bool
+	// CallID identifies the one request this builder traces. It is stamped
+	// onto every event the builder emits so a reader can group them, and —
+	// more importantly — collapse the overlap between the two log paths that
+	// both record LLM activity (see TraceEvent.CallID).
+	CallID string
 }
 
 // TraceObserver receives normalized LLM trace events.
@@ -79,11 +128,15 @@ func (b *TraceBuilder) Process(evt StreamEvent) {
 	base := TraceEvent{
 		Provider: b.opts.Provider,
 		Model:    b.opts.Model,
+		CallID:   b.opts.CallID,
 	}
 
 	switch evt.Type {
 	case EventStreamStart:
-		b.events = append(b.events, TraceEvent{Kind: TraceRequestStart, Provider: base.Provider, Model: base.Model})
+		start := base
+		start.Kind = TraceRequestStart
+		start.RequestRaw = evt.RequestRaw
+		b.events = append(b.events, start)
 	case EventReasoningDelta:
 		b.processReasoningDelta(evt, base)
 	case EventTextDelta:
@@ -103,7 +156,10 @@ func (b *TraceBuilder) processReasoningDelta(evt StreamEvent, base TraceEvent) {
 	if preview == "" {
 		return
 	}
-	b.events = append(b.events, TraceEvent{Kind: TraceReasoning, Provider: base.Provider, Model: base.Model, Preview: preview})
+	evtOut := base
+	evtOut.Kind = TraceReasoning
+	evtOut.Preview = preview
+	b.events = append(b.events, evtOut)
 }
 
 // processTextDelta emits a TraceText event for a text delta.
@@ -112,7 +168,10 @@ func (b *TraceBuilder) processTextDelta(evt StreamEvent, base TraceEvent) {
 	if preview == "" {
 		return
 	}
-	b.events = append(b.events, TraceEvent{Kind: TraceText, Provider: base.Provider, Model: base.Model, Preview: preview})
+	evtOut := base
+	evtOut.Kind = TraceText
+	evtOut.Preview = preview
+	b.events = append(b.events, evtOut)
 }
 
 // processToolCallStart emits a TraceToolPrepare event for a tool call start.
@@ -120,13 +179,12 @@ func (b *TraceBuilder) processToolCallStart(evt StreamEvent, base TraceEvent) {
 	if evt.ToolCall == nil {
 		return
 	}
-	b.events = append(b.events, TraceEvent{
-		Kind:     TraceToolPrepare,
-		Provider: base.Provider,
-		Model:    base.Model,
-		ToolName: evt.ToolCall.Name,
-		Preview:  previewJSON(evt.ToolCall.Arguments),
-	})
+	evtOut := base
+	evtOut.Kind = TraceToolPrepare
+	evtOut.ToolName = evt.ToolCall.Name
+	evtOut.Preview = previewJSON(evt.ToolCall.Arguments)
+	evtOut.ToolArguments = evt.ToolCall.Arguments
+	b.events = append(b.events, evtOut)
 }
 
 // processFinish emits a TraceFinish event with reason and usage.
@@ -139,13 +197,11 @@ func (b *TraceBuilder) processFinish(evt StreamEvent, base TraceEvent) {
 	if evt.Usage != nil {
 		usage = *evt.Usage
 	}
-	b.events = append(b.events, TraceEvent{
-		Kind:         TraceFinish,
-		Provider:     base.Provider,
-		Model:        base.Model,
-		FinishReason: finishReason,
-		Usage:        usage,
-	})
+	evtOut := base
+	evtOut.Kind = TraceFinish
+	evtOut.FinishReason = finishReason
+	evtOut.Usage = usage
+	b.events = append(b.events, evtOut)
 }
 
 // processProviderEvent emits a TraceProviderRaw event when verbose tracing is enabled.
@@ -153,13 +209,12 @@ func (b *TraceBuilder) processProviderEvent(evt StreamEvent, base TraceEvent) {
 	if !b.opts.Verbose {
 		return
 	}
-	b.events = append(b.events, TraceEvent{
-		Kind:          TraceProviderRaw,
-		Provider:      base.Provider,
-		Model:         base.Model,
-		ProviderEvent: inferProviderEvent(evt.Raw),
-		RawPreview:    previewJSON(evt.Raw),
-	})
+	evtOut := base
+	evtOut.Kind = TraceProviderRaw
+	evtOut.ProviderEvent = inferProviderEvent(evt.Raw)
+	evtOut.RawPreview = previewJSON(evt.Raw)
+	evtOut.ProviderRaw = evt.Raw
+	b.events = append(b.events, evtOut)
 }
 
 // Events returns the trace events emitted so far.

--- a/llm/trace_test.go
+++ b/llm/trace_test.go
@@ -200,3 +200,56 @@ func TestNewCallIDIsUnique(t *testing.T) {
 		seen[id] = true
 	}
 }
+
+// TestTraceBuilderFoldsRequestSentIntoStreamStart pins that the adapter's
+// EventRequestSent produces no trace event of its own: it is stashed and folded
+// into the single request_start, so the log does not gain a second
+// request-start line for every call.
+func TestTraceBuilderFoldsRequestSentIntoStreamStart(t *testing.T) {
+	body := []byte(`{"model":"m","stream":true}`)
+	b := NewTraceBuilder(TraceOptions{Provider: "anthropic", Model: "m"})
+
+	b.Process(StreamEvent{Type: EventRequestSent, RequestRaw: body})
+	if got := len(b.Events()); got != 0 {
+		t.Fatalf("EventRequestSent emitted %d trace events, want 0", got)
+	}
+
+	b.Process(StreamEvent{Type: EventStreamStart, Raw: []byte(`{"type":"message_start"}`)})
+	events := b.Events()
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1 request_start", len(events))
+	}
+	if events[0].Kind != TraceRequestStart {
+		t.Fatalf("Kind = %q, want %q", events[0].Kind, TraceRequestStart)
+	}
+	if string(events[0].RequestRaw) != string(body) {
+		t.Errorf("RequestRaw = %q, want the stashed wire body", events[0].RequestRaw)
+	}
+}
+
+// TestStreamAccumulatorIgnoresRequestSent guards the other half of the
+// contract: the new event type must not disturb response assembly.
+func TestStreamAccumulatorIgnoresRequestSent(t *testing.T) {
+	acc := NewStreamAccumulator()
+	acc.Process(StreamEvent{Type: EventRequestSent, RequestRaw: []byte(`{"model":"m"}`)})
+	acc.Process(StreamEvent{Type: EventTextDelta, Delta: "hi"})
+	acc.Process(StreamEvent{Type: EventFinish, FinishReason: &FinishReason{Reason: "stop"}})
+
+	resp := acc.Response()
+	if got := resp.Text(); got != "hi" {
+		t.Errorf("Text() = %q, want hi", got)
+	}
+}
+
+// TestFirstRaw covers the fallback ordering.
+func TestFirstRaw(t *testing.T) {
+	if got := firstRaw(nil, []byte("b")); string(got) != "b" {
+		t.Errorf("firstRaw(nil, b) = %q, want b", got)
+	}
+	if got := firstRaw([]byte("a"), []byte("b")); string(got) != "a" {
+		t.Errorf("firstRaw(a, b) = %q, want a (first non-empty wins)", got)
+	}
+	if got := firstRaw(nil, nil); got != nil {
+		t.Errorf("firstRaw(nil, nil) = %q, want nil", got)
+	}
+}

--- a/llm/trace_test.go
+++ b/llm/trace_test.go
@@ -3,7 +3,9 @@ package llm
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestTraceBuilderEmitsNormalizedEvents(t *testing.T) {
@@ -98,5 +100,103 @@ func TestTraceBuilderEmitsProviderRawOnlyInVerboseMode(t *testing.T) {
 	}
 	if events[0].RawPreview == "" {
 		t.Fatal("expected raw preview to be populated")
+	}
+}
+
+// TestTraceBuilderStampsCallID pins that every event from one request shares a
+// call id. Two log paths record LLM activity (the agent session re-emits trace
+// events; the client-level writer catches calls no session sees), so without a
+// shared id a reader cannot tell one call seen twice from two calls.
+func TestTraceBuilderStampsCallID(t *testing.T) {
+	b := NewTraceBuilder(TraceOptions{Provider: "anthropic", Model: "m", Verbose: true, CallID: "call-1"})
+	b.Process(StreamEvent{Type: EventStreamStart})
+	b.Process(StreamEvent{Type: EventTextDelta, Delta: "hi"})
+	b.Process(StreamEvent{Type: EventReasoningDelta, ReasoningDelta: "think"})
+	b.Process(StreamEvent{Type: EventToolCallStart, ToolCall: &ToolCallData{Name: "bash", Arguments: []byte(`{"command":"ls"}`)}})
+	b.Process(StreamEvent{Type: EventProviderEvent, Raw: []byte(`{"type":"x"}`)})
+	b.Process(StreamEvent{Type: EventFinish, FinishReason: &FinishReason{Reason: "stop"}})
+
+	events := b.Events()
+	if len(events) != 6 {
+		t.Fatalf("got %d events, want 6", len(events))
+	}
+	for _, evt := range events {
+		if evt.CallID != "call-1" {
+			t.Errorf("%s CallID = %q, want call-1", evt.Kind, evt.CallID)
+		}
+	}
+}
+
+// TestTraceBuilderCarriesRequestRaw pins that the wire body reaches the trace
+// event. The normalized Request records what tracker asked for; only the body
+// records what went out after provider translation.
+func TestTraceBuilderCarriesRequestRaw(t *testing.T) {
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	b := NewTraceBuilder(TraceOptions{Provider: "anthropic", Model: "m"})
+	b.Process(StreamEvent{Type: EventStreamStart, RequestRaw: body})
+
+	events := b.Events()
+	if len(events) != 1 || events[0].Kind != TraceRequestStart {
+		t.Fatalf("got %+v, want one request_start", events)
+	}
+	if string(events[0].RequestRaw) != string(body) {
+		t.Errorf("RequestRaw = %q, want the wire body", events[0].RequestRaw)
+	}
+}
+
+// TestTraceBuilderKeepsFullToolArguments pins the split between the display
+// field and the log field: Preview is clipped to tracePreviewLimit so a TUI
+// line stays one line, while ToolArguments stays whole. Before the split, an
+// argument list longer than 80 chars reached disk truncated with no marker
+// that anything was missing.
+func TestTraceBuilderKeepsFullToolArguments(t *testing.T) {
+	args := []byte(`{"command":"` + strings.Repeat("x", 200) + `"}`)
+	b := NewTraceBuilder(TraceOptions{Provider: "anthropic", Model: "m"})
+	b.Process(StreamEvent{Type: EventToolCallStart, ToolCall: &ToolCallData{Name: "bash", Arguments: args}})
+
+	evt := b.Events()[0]
+	if string(evt.ToolArguments) != string(args) {
+		t.Errorf("ToolArguments length = %d, want %d (untruncated)", len(evt.ToolArguments), len(args))
+	}
+	// Count runes, not bytes: previewText clips to tracePreviewLimit
+	// characters and appends a 3-byte ellipsis, so the byte length exceeds
+	// the limit while the display width does not.
+	if n := utf8.RuneCountInString(evt.Preview); n > tracePreviewLimit {
+		t.Errorf("Preview = %d runes, want <= %d (clipped for display)", n, tracePreviewLimit)
+	}
+	if string(evt.Preview) == string(args) {
+		t.Error("Preview should be the clipped form, not the full arguments")
+	}
+}
+
+// TestTraceBuilderKeepsFullProviderRaw is the provider-chunk equivalent of the
+// tool-argument split above.
+func TestTraceBuilderKeepsFullProviderRaw(t *testing.T) {
+	raw := []byte(`{"type":"content_block_delta","delta":{"text":"` + strings.Repeat("y", 200) + `"}}`)
+	b := NewTraceBuilder(TraceOptions{Provider: "anthropic", Model: "m", Verbose: true})
+	b.Process(StreamEvent{Type: EventProviderEvent, Raw: raw})
+
+	evt := b.Events()[0]
+	if string(evt.ProviderRaw) != string(raw) {
+		t.Errorf("ProviderRaw length = %d, want %d (untruncated)", len(evt.ProviderRaw), len(raw))
+	}
+	if n := utf8.RuneCountInString(evt.RawPreview); n > tracePreviewLimit {
+		t.Errorf("RawPreview = %d runes, want <= %d (clipped)", n, tracePreviewLimit)
+	}
+}
+
+// TestNewCallIDIsUnique guards the only property the id needs: distinctness
+// within one run's log.
+func TestNewCallIDIsUnique(t *testing.T) {
+	seen := make(map[string]bool, 100)
+	for i := 0; i < 100; i++ {
+		id := NewCallID()
+		if id == "" {
+			t.Fatal("NewCallID returned empty")
+		}
+		if seen[id] {
+			t.Fatalf("duplicate call id %q after %d draws", id, i)
+		}
+		seen[id] = true
 	}
 }

--- a/llm/types.go
+++ b/llm/types.go
@@ -213,6 +213,24 @@ type FinishReason struct {
 }
 
 // Usage tracks token consumption.
+//
+// The field names read as provider-neutral but the accounting rules are not
+// obvious, and providers disagree about what nests inside what. Adapters are
+// responsible for normalizing into the two invariants below; EstimateCost
+// depends on them, so getting one wrong misprices every run on that provider.
+//
+//	InputTokens EXCLUDES cached tokens. CacheReadTokens and CacheWriteTokens
+//	are separate additive buckets, so InputTokens + CacheReadTokens +
+//	CacheWriteTokens is the full prompt. Anthropic reports this shape natively.
+//	OpenAI and Gemini do not — their prompt counts INCLUDE the cached portion,
+//	so those adapters must subtract it out. Wiring their cached count straight
+//	into CacheReadTokens double-counts the prompt.
+//
+//	OutputTokens INCLUDES reasoning tokens. ReasoningTokens is an informational
+//	subset, never priced separately — pricing reasoning on top of OutputTokens
+//	would bill it twice. OpenAI reports this shape natively. Gemini does not:
+//	its candidate count excludes thinking tokens that it nonetheless bills, so
+//	that adapter must add them in.
 type Usage struct {
 	InputTokens      int     `json:"input_tokens"`
 	OutputTokens     int     `json:"output_tokens"`

--- a/llm/types.go
+++ b/llm/types.go
@@ -242,6 +242,19 @@ type Usage struct {
 	Raw              any     `json:"raw,omitempty"`
 }
 
+// anyTokens reports whether this Usage records consumption of any kind. Cache
+// buckets count: a fully-cached prefix call can carry nothing but cache reads,
+// and it still costs money and still prices at $0 on an unknown model.
+func (u Usage) anyTokens() bool {
+	if u.TotalTokens > 0 || u.InputTokens > 0 || u.OutputTokens > 0 {
+		return true
+	}
+	return nonZero(u.CacheReadTokens) || nonZero(u.CacheWriteTokens)
+}
+
+// nonZero reports whether an optional token count is present and positive.
+func nonZero(v *int) bool { return v != nil && *v > 0 }
+
 // Add combines two Usage values.
 func (u Usage) Add(other Usage) Usage {
 	result := Usage{

--- a/pipeline/engine_run.go
+++ b/pipeline/engine_run.go
@@ -561,6 +561,8 @@ func (e *Engine) executeNode(ctx context.Context, s *runState, currentNodeID str
 		Timestamp: time.Now(),
 		RunID:     s.runID,
 		NodeID:    currentNodeID,
+		NodeKind:  execNode.Handler,
+		AttemptNo: s.cp.RetryCount(currentNodeID) + 1,
 		Message:   fmt.Sprintf("executing node %q", currentNodeID),
 	})
 
@@ -868,6 +870,8 @@ func (e *Engine) handleRetryWithinBudget(ctx context.Context, s *runState, curre
 		Timestamp: time.Now(),
 		RunID:     s.runID,
 		NodeID:    currentNodeID,
+		NodeKind:  execNode.Handler,
+		AttemptNo: s.cp.RetryCount(currentNodeID),
 		Message:   fmt.Sprintf("retrying node %q (attempt %d/%d, policy=%s)", currentNodeID, s.cp.RetryCount(currentNodeID), policy.MaxRetries, policy.Name),
 	})
 
@@ -1008,6 +1012,8 @@ func (e *Engine) handleGoalGateRetry(s *runState, currentNodeID, target, gateNod
 		Timestamp: time.Now(),
 		RunID:     s.runID,
 		NodeID:    gateNodeID,
+		NodeKind:  gateNode.Handler,
+		AttemptNo: s.cp.RetryCount(gateNodeID),
 		Message:   msg,
 	})
 	traceEntry.EdgeTo = target

--- a/pipeline/events.go
+++ b/pipeline/events.go
@@ -258,6 +258,17 @@ type PipelineEvent struct {
 	// gate, label, actor, and subgraph_path of the traversed override edge.
 	Override *OverrideDetail
 
+	// NodeKind is the node's handler ("codergen", "tool", "human", …), set on
+	// node-scoped events. Recorded rather than inferred from which artifact
+	// files a node produced: artifact directories are sparse in large runs,
+	// so file-based inference loses the kind for most nodes.
+	NodeKind string
+	// AttemptNo is 1 for a node's first execution and increments per retry.
+	// The checkpoint's RetryCounts gives a final tally; this says which
+	// attempt an individual event belongs to, which is what separates the
+	// events of a retry storm from each other.
+	AttemptNo int
+
 	// TerminalStatus is the run's terminal status, set only on the single
 	// terminal event of a run — EventPipelineCompleted, EventPipelineFailed,
 	// or EventBudgetExceeded. One of "success", "validation_overridden",

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -152,6 +152,9 @@ func buildLogEntry(evt PipelineEvent) jsonlLogEntry {
 		NodeID:         evt.NodeID,
 		Message:        evt.Message,
 		BundleIdentity: evt.BundleIdentity,
+		NodeKind:       evt.NodeKind,
+		AttemptNo:      evt.AttemptNo,
+		TerminalStatus: evt.TerminalStatus,
 	}
 	if evt.Err != nil {
 		entry.Error = evt.Err.Error()

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/internal/bundleid"
+	"github.com/2389-research/tracker/llm"
 )
 
 // JSONLEventHandler appends every pipeline event as a JSON line to a
@@ -268,26 +269,37 @@ func (h *JSONLEventHandler) WriteAgentEvent(evt agent.Event) {
 }
 
 // WriteLLMEvent logs an LLM trace event to the activity log.
-func (h *JSONLEventHandler) WriteLLMEvent(kind, provider, model, toolName, preview string) {
+//
+// Takes the whole llm.TraceEvent rather than a clipped preview string: the
+// old signature's `preview` was previewText output, capped at 80 characters,
+// so a tool call's arguments and a raw provider chunk reached disk truncated
+// with no marker. Content now carries the untruncated payload where the trace
+// event has one, and the display-oriented Preview is used only when it is the
+// only form available (text and reasoning deltas, which are never clipped).
+func (h *JSONLEventHandler) WriteLLMEvent(evt llm.TraceEvent) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	if h.file == nil {
 		return
 	}
+	kind := string(evt.Kind)
 	if isRawLLMEventType(kind) && !h.captureRawLLM {
 		return
 	}
 
 	entry := jsonlLogEntry{
-		Timestamp: time.Now().Format("2006-01-02T15:04:05.000Z07:00"),
-		Source:    "llm",
-		Type:      kind,
-		Provider:  provider,
-		Model:     model,
-		ToolName:  toolName,
-		Content:   preview,
+		Timestamp:    time.Now().Format("2006-01-02T15:04:05.000Z07:00"),
+		Source:       "llm",
+		Type:         kind,
+		Provider:     evt.Provider,
+		Model:        evt.Model,
+		ToolName:     evt.ToolName,
+		Content:      llmTraceContent(evt),
+		CallID:       evt.CallID,
+		FinishReason: evt.FinishReason,
 	}
+	applyUsageFields(&entry, evt.Usage)
 	// Stamp .dipx bundle identity unless the caller already set one. Mirrors
 	// Engine.emit and the registry's BundleIdentityStamper — these writes
 	// bypass both chokepoints, so the stamping has to happen here for

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -271,6 +271,28 @@ func (h *JSONLEventHandler) WriteAgentEvent(evt agent.Event) {
 	h.writeEntry(entry)
 }
 
+// LLMTraceObserver returns the observer to pass as Config.LLMTrace so raw LLM
+// trace events reach this log.
+//
+// Prefer this over wiring WriteLLMEvent directly: it carries the rule that
+// keeps the two log paths from disagreeing. An agent session re-emits its own
+// trace events as llm_* agent events, which arrive via WriteAgentEvent, so
+// writing session-owned events here as well would record every session call
+// twice. Calls with no agent path — the autopilot interviewer, for one — have no
+// re-emission and are kept.
+//
+// Full capture needs three seams wired to the same handler: EventHandler,
+// AgentEvents, and this one. Only this one carries a non-obvious rule, which is
+// why it belongs with the writer rather than being restated by each caller.
+func (h *JSONLEventHandler) LLMTraceObserver() llm.TraceObserverFunc {
+	return func(evt llm.TraceEvent) {
+		if evt.SessionOwned {
+			return
+		}
+		h.WriteLLMEvent(evt)
+	}
+}
+
 // WriteLLMEvent logs an LLM trace event to the activity log.
 //
 // Takes the whole llm.TraceEvent rather than a clipped preview string: the

--- a/pipeline/events_jsonl.go
+++ b/pipeline/events_jsonl.go
@@ -13,94 +13,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/2389-research/tracker/agent"
 	"github.com/2389-research/tracker/internal/bundleid"
 )
-
-// jsonlLogEntry is the on-disk format for one activity log line.
-type jsonlLogEntry struct {
-	Timestamp      string `json:"ts"`
-	Source         string `json:"source"` // "pipeline" (engine emissions) | "agent" (LLM session) | "llm" (raw provider events) | "cli" (CLI-level audit, e.g. bundle_mismatch_forced)
-	Type           string `json:"type"`
-	RunID          string `json:"run_id,omitempty"`
-	NodeID         string `json:"node_id,omitempty"`
-	Message        string `json:"message,omitempty"`
-	Error          string `json:"error,omitempty"`
-	Provider       string `json:"provider,omitempty"`
-	Model          string `json:"model,omitempty"`
-	ToolName       string `json:"tool_name,omitempty"`
-	Content        string `json:"content,omitempty"`
-	BundleIdentity string `json:"bundle_identity,omitempty"`
-
-	// Decision audit trail fields.
-	EdgeFrom        string            `json:"edge_from,omitempty"`
-	EdgeTo          string            `json:"edge_to,omitempty"`
-	EdgeCondition   string            `json:"edge_condition,omitempty"`
-	EdgePriority    string            `json:"edge_priority,omitempty"`
-	ConditionMatch  *bool             `json:"condition_match,omitempty"`
-	OutcomeStatus   string            `json:"outcome_status,omitempty"`
-	ContextSnapshot map[string]string `json:"context_snapshot,omitempty"`
-	ContextUpdates  map[string]string `json:"context_updates,omitempty"`
-	RestartCount    *int              `json:"restart_count,omitempty"`
-	ClearedNodes    []string          `json:"cleared_nodes,omitempty"`
-	TokenInput      int               `json:"token_input,omitempty"`
-	TokenOutput     int               `json:"token_output,omitempty"`
-
-	// Cost snapshot fields — non-zero for cost_updated and budget_exceeded events.
-	TotalTokens    int                      `json:"total_tokens,omitempty"`
-	TotalCostUSD   float64                  `json:"total_cost_usd,omitempty"`
-	ProviderTotals map[string]ProviderUsage `json:"provider_totals,omitempty"`
-	WallElapsedMs  int64                    `json:"wall_elapsed_ms,omitempty"`
-	// Estimated is true when any session contributing to this cost snapshot
-	// was heuristic-derived (currently: ACP rune-count estimator). External
-	// NDJSON consumers read this to distinguish metered from estimated
-	// spend — see cmd/tracker/summary.go for the equivalent CLI surface.
-	Estimated bool `json:"estimated,omitempty"`
-
-	// Truncation fields — populated for tool_output_truncated events.
-	// Stream is "stdout" or "stderr"; CapturedBytes / DroppedBytes /
-	// TotalBytes record the per-stream byte accounting at the time of
-	// truncation. Issue #208.
-	TruncStream   string `json:"trunc_stream,omitempty"`
-	TruncLimit    int    `json:"trunc_limit,omitempty"`
-	TruncCaptured int    `json:"trunc_captured_bytes,omitempty"`
-	TruncDropped  int    `json:"trunc_dropped_bytes,omitempty"`
-	TruncTotal    int    `json:"trunc_total_bytes,omitempty"`
-
-	// Conditional-fallthrough fields — populated for
-	// conditional_fallthrough events. Lists routing intents that
-	// evaluated false on the way to a fallback selection.
-	ConditionsTried []ConditionEval `json:"conditions_tried,omitempty"`
-
-	// Marker fields — populated for tool_marker_missing events
-	// (issue #210). Pattern is the configured marker_grep regex;
-	// MarkerTail is up to 256 bytes from end of captured stdout for
-	// diagnosis; MarkerError is the regex-compile error when the
-	// failure was a bad regex rather than a missing match.
-	MarkerPattern string `json:"marker_pattern,omitempty"`
-	MarkerTail    string `json:"marker_tail,omitempty"`
-	MarkerError   string `json:"marker_error,omitempty"`
-
-	// Route fields — populated for tool_route_missing events (#212).
-	// The matcher is built-in so there is no Pattern field; just the
-	// captured stdout tail for diagnosis.
-	RouteTail string `json:"route_tail,omitempty"`
-
-	// Auto-status fields — populated for auto_status_missing events
-	// (#346). Tail is up to 256 bytes from the end of the agent's
-	// response text (where the STATUS line was expected); FailClosed is
-	// true when the missing line failed a goal gate closed.
-	AutoStatusTail       string `json:"auto_status_tail,omitempty"`
-	AutoStatusFailClosed bool   `json:"auto_status_fail_closed,omitempty"`
-
-	// Override fields — populated for validation_overridden events.
-	// Identify the gate that produced the override, the edge label that
-	// selected it, who acted, and the subgraph_path when the override
-	// was propagated up from a child run.
-	OverrideGate         string   `json:"override_gate,omitempty"`
-	OverrideLabel        string   `json:"override_label,omitempty"`
-	OverrideActor        Actor    `json:"override_actor,omitempty"`
-	OverrideSubgraphPath []string `json:"override_subgraph_path,omitempty"`
-}
 
 // JSONLEventHandler appends every pipeline event as a JSON line to a
 // file. The runtime writes to an integrity-protected path outside any
@@ -304,46 +219,44 @@ func applyDecisionFields(entry *jsonlLogEntry, d *DecisionDetail) {
 	entry.ConditionsTried = d.ConditionsTried
 }
 
-// WriteAgentEvent logs an agent event to the activity log.
-// The caller is responsible for passing the event; the handler writes
-// it to the same JSONL file as pipeline events. The nodeID identifies
-// which pipeline node (branch) produced this event.
-func (h *JSONLEventHandler) WriteAgentEvent(evtType, nodeID, toolName, toolOutput, toolError, text, errMsg, provider, model string) {
+// WriteAgentEvent logs an agent event to the activity log, writing to the
+// same JSONL file as pipeline events. The event carries its own NodeID
+// (which pipeline branch produced it) alongside the session/turn identity
+// and per-turn metrics that let a post-hoc reader rebuild the run as a
+// tree rather than a flat sequence — see applyAgentEventFields.
+//
+// Takes the whole agent.Event rather than unpacked strings: the fields
+// worth logging outgrew a parameter list, and passing the struct means a
+// newly-populated field reaches disk without another signature change.
+func (h *JSONLEventHandler) WriteAgentEvent(evt agent.Event) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	if h.file == nil {
 		return
 	}
+	evtType := string(evt.Type)
 	if isRawLLMEventType(evtType) && !h.captureRawLLM {
 		return
 	}
 
-	content := toolOutput
+	content := evt.ToolOutput
 	if content == "" {
-		content = text
+		content = evt.Text
 	}
 
 	entry := jsonlLogEntry{
 		Timestamp: time.Now().Format("2006-01-02T15:04:05.000Z07:00"),
 		Source:    "agent",
 		Type:      evtType,
-		NodeID:    nodeID,
-		ToolName:  toolName,
+		NodeID:    evt.NodeID,
+		ToolName:  evt.ToolName,
 		Content:   content,
-		Provider:  provider,
-		Model:     model,
+		Provider:  evt.Provider,
+		Model:     evt.Model,
+		Error:     joinAgentErrors(evt),
 	}
-	if toolError != "" {
-		entry.Error = toolError
-	}
-	if errMsg != "" {
-		if entry.Error != "" {
-			entry.Error += ": " + errMsg
-		} else {
-			entry.Error = errMsg
-		}
-	}
+	applyAgentEventFields(&entry, evt)
 	// Stamp .dipx bundle identity unless the caller already set one. Mirrors
 	// Engine.emit and the registry's BundleIdentityStamper — these writes
 	// bypass both chokepoints, so the stamping has to happen here for

--- a/pipeline/events_jsonl_entry.go
+++ b/pipeline/events_jsonl_entry.go
@@ -101,10 +101,18 @@ type jsonlLogEntry struct {
 	// disk so a run can be rebuilt as a tree rather than a flat sequence.
 	//
 	// SessionID is set on every agent-source line. TurnNo is set on
-	// turn-scoped lines. Without both, events from concurrently-executing
-	// `parallel` branches — which interleave into one file — cannot be
-	// separated, and `spawn_agent` children are indistinguishable from
-	// their parent.
+	// turn-scoped lines, 1-indexed, or -1 for a repair turn (which runs
+	// outside the MaxTurns budget and so has no ordinal). Without both,
+	// events from concurrently-executing `parallel` branches — which
+	// interleave into one file — cannot be separated.
+	//
+	// ParentSessionID is unset by stock tracker: the only thing that
+	// creates a child session is the spawn_agent tool, and its
+	// tools.SessionRunner has no in-tree implementation — it is an
+	// injection seam for embedders (agent.WithSessionRunner), and the tool
+	// is registered only when one is supplied. The field is here so an
+	// embedder that does spawn children can attribute their events; nothing
+	// in this repo populates it.
 	SessionID       string `json:"session_id,omitempty"`
 	ParentSessionID string `json:"parent_session_id,omitempty"`
 	TurnNo          int    `json:"turn_no,omitempty"`

--- a/pipeline/events_jsonl_entry.go
+++ b/pipeline/events_jsonl_entry.go
@@ -179,6 +179,12 @@ func applyAgentEventFields(entry *jsonlLogEntry, evt agent.Event) {
 	entry.FinishReason = evt.FinishReason
 	entry.ToolDurationMs = evt.ToolDuration.Milliseconds()
 	entry.ContextUtilization = evt.ContextUtilization
+	entry.CallID = evt.CallID
+	// The request body is the highest-fidelity content this event carries, so
+	// it wins over the display preview the generic content path would use.
+	if len(evt.RequestRaw) > 0 {
+		entry.Content = string(evt.RequestRaw)
+	}
 	applyUsageFields(entry, evt.Usage)
 	applyTurnMetricsFields(entry, evt.Metrics)
 }

--- a/pipeline/events_jsonl_entry.go
+++ b/pipeline/events_jsonl_entry.go
@@ -1,0 +1,216 @@
+// ABOUTME: On-disk schema for one activity-log line, plus the field-copy helpers
+// ABOUTME: that populate it from agent events. Split from events_jsonl.go, which owns the writer.
+package pipeline
+
+import (
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
+)
+
+// jsonlLogEntry is the on-disk format for one activity log line.
+type jsonlLogEntry struct {
+	Timestamp      string `json:"ts"`
+	Source         string `json:"source"` // "pipeline" (engine emissions) | "agent" (LLM session) | "llm" (raw provider events) | "cli" (CLI-level audit, e.g. bundle_mismatch_forced)
+	Type           string `json:"type"`
+	RunID          string `json:"run_id,omitempty"`
+	NodeID         string `json:"node_id,omitempty"`
+	Message        string `json:"message,omitempty"`
+	Error          string `json:"error,omitempty"`
+	Provider       string `json:"provider,omitempty"`
+	Model          string `json:"model,omitempty"`
+	ToolName       string `json:"tool_name,omitempty"`
+	Content        string `json:"content,omitempty"`
+	BundleIdentity string `json:"bundle_identity,omitempty"`
+
+	// Decision audit trail fields.
+	EdgeFrom        string            `json:"edge_from,omitempty"`
+	EdgeTo          string            `json:"edge_to,omitempty"`
+	EdgeCondition   string            `json:"edge_condition,omitempty"`
+	EdgePriority    string            `json:"edge_priority,omitempty"`
+	ConditionMatch  *bool             `json:"condition_match,omitempty"`
+	OutcomeStatus   string            `json:"outcome_status,omitempty"`
+	ContextSnapshot map[string]string `json:"context_snapshot,omitempty"`
+	ContextUpdates  map[string]string `json:"context_updates,omitempty"`
+	RestartCount    *int              `json:"restart_count,omitempty"`
+	ClearedNodes    []string          `json:"cleared_nodes,omitempty"`
+	TokenInput      int               `json:"token_input,omitempty"`
+	TokenOutput     int               `json:"token_output,omitempty"`
+
+	// Cost snapshot fields — non-zero for cost_updated and budget_exceeded events.
+	TotalTokens    int                      `json:"total_tokens,omitempty"`
+	TotalCostUSD   float64                  `json:"total_cost_usd,omitempty"`
+	ProviderTotals map[string]ProviderUsage `json:"provider_totals,omitempty"`
+	WallElapsedMs  int64                    `json:"wall_elapsed_ms,omitempty"`
+	// Estimated is true when any session contributing to this cost snapshot
+	// was heuristic-derived (currently: ACP rune-count estimator). External
+	// NDJSON consumers read this to distinguish metered from estimated
+	// spend — see cmd/tracker/summary.go for the equivalent CLI surface.
+	Estimated bool `json:"estimated,omitempty"`
+
+	// Truncation fields — populated for tool_output_truncated events.
+	// Stream is "stdout" or "stderr"; CapturedBytes / DroppedBytes /
+	// TotalBytes record the per-stream byte accounting at the time of
+	// truncation. Issue #208.
+	TruncStream   string `json:"trunc_stream,omitempty"`
+	TruncLimit    int    `json:"trunc_limit,omitempty"`
+	TruncCaptured int    `json:"trunc_captured_bytes,omitempty"`
+	TruncDropped  int    `json:"trunc_dropped_bytes,omitempty"`
+	TruncTotal    int    `json:"trunc_total_bytes,omitempty"`
+
+	// Conditional-fallthrough fields — populated for
+	// conditional_fallthrough events. Lists routing intents that
+	// evaluated false on the way to a fallback selection.
+	ConditionsTried []ConditionEval `json:"conditions_tried,omitempty"`
+
+	// Marker fields — populated for tool_marker_missing events
+	// (issue #210). Pattern is the configured marker_grep regex;
+	// MarkerTail is up to 256 bytes from end of captured stdout for
+	// diagnosis; MarkerError is the regex-compile error when the
+	// failure was a bad regex rather than a missing match.
+	MarkerPattern string `json:"marker_pattern,omitempty"`
+	MarkerTail    string `json:"marker_tail,omitempty"`
+	MarkerError   string `json:"marker_error,omitempty"`
+
+	// Route fields — populated for tool_route_missing events (#212).
+	// The matcher is built-in so there is no Pattern field; just the
+	// captured stdout tail for diagnosis.
+	RouteTail string `json:"route_tail,omitempty"`
+
+	// Auto-status fields — populated for auto_status_missing events
+	// (#346). Tail is up to 256 bytes from the end of the agent's
+	// response text (where the STATUS line was expected); FailClosed is
+	// true when the missing line failed a goal gate closed.
+	AutoStatusTail       string `json:"auto_status_tail,omitempty"`
+	AutoStatusFailClosed bool   `json:"auto_status_fail_closed,omitempty"`
+
+	// Override fields — populated for validation_overridden events.
+	// Identify the gate that produced the override, the edge label that
+	// selected it, who acted, and the subgraph_path when the override
+	// was propagated up from a child run.
+	OverrideGate         string   `json:"override_gate,omitempty"`
+	OverrideLabel        string   `json:"override_label,omitempty"`
+	OverrideActor        Actor    `json:"override_actor,omitempty"`
+	OverrideSubgraphPath []string `json:"override_subgraph_path,omitempty"`
+
+	// --- Run-reconstruction fields ---
+	//
+	// The agent package emits a nested span tree (session → turn → tool
+	// call) but the log used to flatten it: a post-hoc reader could see
+	// that `bash` ran and what it returned, never which turn issued it or
+	// what command was asked for. These fields carry that structure onto
+	// disk so a run can be rebuilt as a tree rather than a flat sequence.
+	//
+	// SessionID is set on every agent-source line. TurnNo is set on
+	// turn-scoped lines. Without both, events from concurrently-executing
+	// `parallel` branches — which interleave into one file — cannot be
+	// separated, and `spawn_agent` children are indistinguishable from
+	// their parent.
+	SessionID       string `json:"session_id,omitempty"`
+	ParentSessionID string `json:"parent_session_id,omitempty"`
+	TurnNo          int    `json:"turn_no,omitempty"`
+	// AttemptNo separates retry attempts of the same node. RetryCounts in
+	// the checkpoint gives a final tally; this says which attempt a given
+	// event belongs to.
+	AttemptNo int `json:"attempt_no,omitempty"`
+	// NodeKind ("agent" | "tool" | "human" | …) comes from engine state.
+	// It is deliberately not inferred from which artifact files exist:
+	// directories are sparse in large runs (a 39-node run leaves only a
+	// handful), so file-based inference loses kind for most nodes.
+	NodeKind string `json:"node_kind,omitempty"`
+
+	// ToolInput is the tool call's arguments as the model produced them.
+	// Content holds the tool's *output*; before this field existed the log
+	// recorded that a tool ran and what came back, but never what was
+	// asked — which makes repeated re-acquisition of the same state
+	// invisible.
+	ToolInput      string `json:"tool_input,omitempty"`
+	ToolDurationMs int64  `json:"tool_duration_ms,omitempty"`
+
+	// Per-turn economics. The engine already computes all of this per turn
+	// (agent.TurnMetrics); run-level cost snapshots can't attribute spend
+	// to a step. TokenInput/TokenOutput above carry the per-turn counts.
+	CacheReadTokens    int     `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens   int     `json:"cache_write_tokens,omitempty"`
+	ReasoningTokens    int     `json:"reasoning_tokens,omitempty"`
+	EstimatedCost      float64 `json:"estimated_cost,omitempty"`
+	ContextUtilization float64 `json:"context_utilization,omitempty"`
+	ToolCacheHits      int     `json:"tool_cache_hits,omitempty"`
+	ToolCacheMisses    int     `json:"tool_cache_misses,omitempty"`
+	TurnDurationMs     int64   `json:"turn_duration_ms,omitempty"`
+
+	// CallID groups every line belonging to one LLM call. Two log paths
+	// write LLM activity — the agent session re-emits trace events, and
+	// the client-level writer catches calls the session never sees (the
+	// autopilot interviewer, for one) — so the same call can legitimately
+	// appear twice. Both paths are kept because their coverage differs;
+	// this field is what lets a reader collapse the overlap instead, so
+	// aggregating usage doesn't double-count.
+	CallID string `json:"call_id,omitempty"`
+	// FinishReason distinguishes a completed turn from one that hit max
+	// turns or stopped on a tool — different failure classes that were
+	// previously indistinguishable.
+	FinishReason string `json:"finish_reason,omitempty"`
+}
+
+// applyAgentEventFields copies the run-reconstruction fields off an agent
+// event. Kept out of WriteAgentEvent so that adding a field here doesn't
+// raise that function's complexity.
+func applyAgentEventFields(entry *jsonlLogEntry, evt agent.Event) {
+	entry.SessionID = evt.SessionID
+	entry.TurnNo = evt.Turn
+	entry.ToolInput = evt.ToolInput
+	entry.FinishReason = evt.FinishReason
+	entry.ToolDurationMs = evt.ToolDuration.Milliseconds()
+	entry.ContextUtilization = evt.ContextUtilization
+	applyUsageFields(entry, evt.Usage)
+	applyTurnMetricsFields(entry, evt.Metrics)
+}
+
+// joinAgentErrors merges the two error channels on an agent event. A tool
+// can fail (ToolError) and the session can also error (Err) on the same
+// event, so both are preserved rather than one overwriting the other.
+func joinAgentErrors(evt agent.Event) string {
+	msg := evt.ToolError
+	if evt.Err == nil {
+		return msg
+	}
+	if msg == "" {
+		return evt.Err.Error()
+	}
+	return msg + ": " + evt.Err.Error()
+}
+
+// applyUsageFields copies provider-reported token usage. The optional
+// pointers are nil for providers that don't report that dimension, so a
+// zero in the log means "not reported" rather than "reported as zero".
+func applyUsageFields(entry *jsonlLogEntry, usage llm.Usage) {
+	entry.TokenInput = usage.InputTokens
+	entry.TokenOutput = usage.OutputTokens
+	entry.EstimatedCost = usage.EstimatedCost
+	if usage.ReasoningTokens != nil {
+		entry.ReasoningTokens = *usage.ReasoningTokens
+	}
+	if usage.CacheReadTokens != nil {
+		entry.CacheReadTokens = *usage.CacheReadTokens
+	}
+	if usage.CacheWriteTokens != nil {
+		entry.CacheWriteTokens = *usage.CacheWriteTokens
+	}
+}
+
+// applyTurnMetricsFields copies the per-turn metrics block. Metrics is nil
+// on every event except turn_metrics.
+func applyTurnMetricsFields(entry *jsonlLogEntry, m *agent.TurnMetrics) {
+	if m == nil {
+		return
+	}
+	entry.TokenInput = m.InputTokens
+	entry.TokenOutput = m.OutputTokens
+	entry.CacheReadTokens = m.CacheReadTokens
+	entry.CacheWriteTokens = m.CacheWriteTokens
+	entry.ContextUtilization = m.ContextUtilization
+	entry.ToolCacheHits = m.ToolCacheHits
+	entry.ToolCacheMisses = m.ToolCacheMisses
+	entry.TurnDurationMs = m.TurnDuration.Milliseconds()
+	entry.EstimatedCost = m.EstimatedCost
+}

--- a/pipeline/events_jsonl_entry.go
+++ b/pipeline/events_jsonl_entry.go
@@ -158,6 +158,15 @@ type jsonlLogEntry struct {
 	// turns or stopped on a tool — different failure classes that were
 	// previously indistinguishable.
 	FinishReason string `json:"finish_reason,omitempty"`
+
+	// TerminalStatus is the run's authoritative outcome, set on exactly one
+	// event per run ("success", "validation_overridden", "fail",
+	// "budget_exceeded"). The engine already guarantees the contract — see
+	// Engine.emitTerminalBackstop, which fires even on a panic or an invariant
+	// error — but the log dropped the field, so the one value a post-hoc
+	// reader needs in order to say how a run ended was reconstructible only
+	// by inferring from event types.
+	TerminalStatus string `json:"terminal_status,omitempty"`
 }
 
 // applyAgentEventFields copies the run-reconstruction fields off an agent

--- a/pipeline/events_jsonl_entry.go
+++ b/pipeline/events_jsonl_entry.go
@@ -174,6 +174,25 @@ func applyAgentEventFields(entry *jsonlLogEntry, evt agent.Event) {
 	applyTurnMetricsFields(entry, evt.Metrics)
 }
 
+// llmTraceContent picks the highest-fidelity payload the trace event carries.
+// The Raw* fields are untruncated; Preview is clipped to 80 chars for display
+// and is only the best available form for text and reasoning deltas, which
+// carry no raw counterpart because they are never clipped in the first place.
+func llmTraceContent(evt llm.TraceEvent) string {
+	switch {
+	case len(evt.RequestRaw) > 0:
+		return string(evt.RequestRaw)
+	case len(evt.ToolArguments) > 0:
+		return string(evt.ToolArguments)
+	case len(evt.ProviderRaw) > 0:
+		return string(evt.ProviderRaw)
+	case evt.Preview != "":
+		return evt.Preview
+	default:
+		return evt.RawPreview
+	}
+}
+
 // joinAgentErrors merges the two error channels on an agent event. A tool
 // can fail (ToolError) and the session can also error (Err) on the same
 // event, so both are preserved rather than one overwriting the other.

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -1244,3 +1244,59 @@ func lastEntryOfSource(t *testing.T, dir, runID, source string) jsonlLogEntry {
 	t.Fatalf("no %s-source entry in %d lines", source, len(lines))
 	return jsonlLogEntry{}
 }
+
+// TestBuildLogEntryPersistsTerminalStatus pins the field the engine already
+// guarantees but the log used to drop. Engine.emitTerminalBackstop exists to
+// make sure exactly one event per run carries TerminalStatus -- it fires even
+// on a panic or an invariant error -- yet buildLogEntry never copied it, so a
+// post-hoc reader had to infer how a run ended from event types alone.
+func TestBuildLogEntryPersistsTerminalStatus(t *testing.T) {
+	entry := buildLogEntry(PipelineEvent{
+		Type:           EventPipelineFailed,
+		Timestamp:      time.Now(),
+		RunID:          "r1",
+		TerminalStatus: "fail",
+	})
+	if entry.TerminalStatus != "fail" {
+		t.Errorf("terminal_status = %q, want fail", entry.TerminalStatus)
+	}
+}
+
+// TestBuildLogEntryPersistsNodeKindAndAttempt pins node identity that cannot be
+// recovered from the filesystem: artifact directories are sparse in large runs,
+// so a reader inferring kind from which files exist loses it for most nodes.
+func TestBuildLogEntryPersistsNodeKindAndAttempt(t *testing.T) {
+	entry := buildLogEntry(PipelineEvent{
+		Type:      EventStageStarted,
+		Timestamp: time.Now(),
+		RunID:     "r1",
+		NodeID:    "Generate",
+		NodeKind:  "codergen",
+		AttemptNo: 3,
+	})
+	if entry.NodeKind != "codergen" {
+		t.Errorf("node_kind = %q, want codergen", entry.NodeKind)
+	}
+	if entry.AttemptNo != 3 {
+		t.Errorf("attempt_no = %d, want 3", entry.AttemptNo)
+	}
+}
+
+// TestTerminalStatusOmittedOnNonTerminalEvents guards the other half of the
+// contract: the field must be absent on ordinary events, so "any line with a
+// terminal_status" stays a reliable way to find the run's outcome.
+func TestTerminalStatusOmittedOnNonTerminalEvents(t *testing.T) {
+	entry := buildLogEntry(PipelineEvent{
+		Type:      EventStageStarted,
+		Timestamp: time.Now(),
+		RunID:     "r1",
+		NodeID:    "A",
+	})
+	encoded, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(encoded), "terminal_status") {
+		t.Errorf("non-terminal event carries terminal_status: %s", encoded)
+	}
+}

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -4,12 +4,16 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
 )
 
 func TestJSONLEventHandlerWritesEvents(t *testing.T) {
@@ -154,7 +158,7 @@ func TestJSONLEventHandlerWritesAgentEvents(t *testing.T) {
 		RunID:     "agent123",
 	})
 
-	h.WriteAgentEvent("tool_call_end", "gen_code", "execute_command", "output here", "", "", "", "anthropic", "claude-sonnet-4-6")
+	h.WriteAgentEvent(agent.Event{Type: "tool_call_end", NodeID: "gen_code", ToolName: "execute_command", ToolOutput: "output here", Provider: "anthropic", Model: "claude-sonnet-4-6"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "agent123", "activity.jsonl"))
@@ -239,7 +243,7 @@ func TestJSONLEventHandlerAgentErrorCombining(t *testing.T) {
 		RunID:     "err123",
 	})
 
-	h.WriteAgentEvent("tool_call_end", "", "cmd", "", "exit code 1", "", "process killed", "", "")
+	h.WriteAgentEvent(agent.Event{Type: "tool_call_end", ToolName: "cmd", ToolError: "exit code 1", Err: errors.New("process killed")})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "err123", "activity.jsonl"))
@@ -378,7 +382,7 @@ func TestJSONLEventHandler_WriteAgentEvent_StampsBundleIdentity(t *testing.T) {
 		RunID:     "bundle-agent",
 	})
 
-	h.WriteAgentEvent("tool_call_end", "gen_code", "execute_command", "ok", "", "", "", "anthropic", "claude-sonnet-4-6")
+	h.WriteAgentEvent(agent.Event{Type: "tool_call_end", NodeID: "gen_code", ToolName: "execute_command", ToolOutput: "ok", Provider: "anthropic", Model: "claude-sonnet-4-6"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "bundle-agent", "activity.jsonl"))
@@ -451,7 +455,7 @@ func TestJSONLEventHandler_NoStampingWhenIdentityEmpty(t *testing.T) {
 		Timestamp: time.Now(),
 		RunID:     "no-bundle",
 	})
-	h.WriteAgentEvent("tool_call_end", "n1", "cmd", "out", "", "", "", "", "")
+	h.WriteAgentEvent(agent.Event{Type: "tool_call_end", NodeID: "n1", ToolName: "cmd", ToolOutput: "out"})
 	h.WriteLLMEvent("request_start", "anthropic", "claude-sonnet-4-6", "", "hi")
 	h.Close()
 
@@ -733,7 +737,7 @@ func TestJSONLEventHandler_SnapshotHandlesLargeLines(t *testing.T) {
 	// Build a >1 MiB content payload to push the snapshot reader past
 	// the old Scanner ceiling.
 	big := strings.Repeat("A", 1_200_000)
-	h.WriteAgentEvent("agent_response", "node1", "", "", "", big, "", "anthropic", "claude")
+	h.WriteAgentEvent(agent.Event{Type: "agent_response", NodeID: "node1", Text: big, Provider: "anthropic", Model: "claude"})
 	// Trigger openFile via a pipeline event with a runID; the agent
 	// write above doesn't carry one.
 	h.HandlePipelineEvent(PipelineEvent{
@@ -742,7 +746,7 @@ func TestJSONLEventHandler_SnapshotHandlesLargeLines(t *testing.T) {
 		RunID:     "big-line-test",
 	})
 	// Re-emit the agent event now that the file is open.
-	h.WriteAgentEvent("agent_response", "node1", "", "", "", big, "", "anthropic", "claude")
+	h.WriteAgentEvent(agent.Event{Type: "agent_response", NodeID: "node1", Text: big, Provider: "anthropic", Model: "claude"})
 
 	if err := h.Close(); err != nil {
 		t.Fatalf("Close: %v", err)
@@ -882,10 +886,10 @@ func TestJSONLEventHandler_DropsRawLLMEventsByDefault(t *testing.T) {
 
 	// Raw provider chunks are debugging payload (#354): both spellings
 	// are dropped unless raw capture is enabled.
-	h.WriteAgentEvent("llm_provider_raw", "gen_code", "", "", "", "chunk", "", "anthropic", "m")
+	h.WriteAgentEvent(agent.Event{Type: "llm_provider_raw", NodeID: "gen_code", Text: "chunk", Provider: "anthropic", Model: "m"})
 	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
 	// Non-raw events still land.
-	h.WriteAgentEvent("llm_text", "gen_code", "", "", "", "hello", "", "anthropic", "m")
+	h.WriteAgentEvent(agent.Event{Type: "llm_text", NodeID: "gen_code", Text: "hello", Provider: "anthropic", Model: "m"})
 	h.WriteLLMEvent("text", "anthropic", "m", "", "hello")
 	h.Close()
 
@@ -920,7 +924,7 @@ func TestJSONLEventHandler_WritesRawLLMEventsWhenEnabled(t *testing.T) {
 		RunID:     "raw456",
 	})
 
-	h.WriteAgentEvent("llm_provider_raw", "gen_code", "", "", "", "chunk", "", "anthropic", "m")
+	h.WriteAgentEvent(agent.Event{Type: "llm_provider_raw", NodeID: "gen_code", Text: "chunk", Provider: "anthropic", Model: "m"})
 	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
 	h.Close()
 
@@ -932,4 +936,174 @@ func TestJSONLEventHandler_WritesRawLLMEventsWhenEnabled(t *testing.T) {
 	if len(lines) != 3 {
 		t.Fatalf("expected 3 lines (pipeline + 2 raw), got %d:\n%s", len(lines), data)
 	}
+}
+
+// TestWriteAgentEventCapturesReconstructionFields pins the fields that let a
+// post-hoc reader rebuild a run as a tree. Each of these was populated on
+// agent.Event but dropped at the log boundary, so a reader could see that a
+// tool ran without knowing which turn issued it or what was asked for.
+func TestWriteAgentEventCapturesReconstructionFields(t *testing.T) {
+	dir := t.TempDir()
+	isolateSecureLog(t)
+	h := NewJSONLEventHandler(dir)
+	h.HandlePipelineEvent(PipelineEvent{
+		Type:      EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "recon1",
+	})
+
+	reasoning, cacheRead, cacheWrite := 7, 11, 13
+	h.WriteAgentEvent(agent.Event{
+		Type:               "tool_call_start",
+		NodeID:             "Generate",
+		SessionID:          "sess-abc",
+		Turn:               3,
+		ToolName:           "bash",
+		ToolInput:          `{"command":"ls -la"}`,
+		ToolDuration:       250 * time.Millisecond,
+		FinishReason:       "tool_use",
+		ContextUtilization: 0.42,
+		Usage: llm.Usage{
+			InputTokens:      100,
+			OutputTokens:     50,
+			ReasoningTokens:  &reasoning,
+			CacheReadTokens:  &cacheRead,
+			CacheWriteTokens: &cacheWrite,
+			EstimatedCost:    0.0125,
+		},
+	})
+	h.Close()
+
+	entry := lastAgentEntry(t, dir, "recon1")
+
+	if entry.SessionID != "sess-abc" {
+		t.Errorf("session_id = %q, want sess-abc", entry.SessionID)
+	}
+	if entry.TurnNo != 3 {
+		t.Errorf("turn_no = %d, want 3", entry.TurnNo)
+	}
+	// The whole point of the field: the command, not just the tool name.
+	if entry.ToolInput != `{"command":"ls -la"}` {
+		t.Errorf("tool_input = %q, want the arguments JSON", entry.ToolInput)
+	}
+	if entry.ToolDurationMs != 250 {
+		t.Errorf("tool_duration_ms = %d, want 250", entry.ToolDurationMs)
+	}
+	if entry.FinishReason != "tool_use" {
+		t.Errorf("finish_reason = %q, want tool_use", entry.FinishReason)
+	}
+	if entry.ContextUtilization != 0.42 {
+		t.Errorf("context_utilization = %v, want 0.42", entry.ContextUtilization)
+	}
+	if entry.TokenInput != 100 || entry.TokenOutput != 50 {
+		t.Errorf("tokens = %d/%d, want 100/50", entry.TokenInput, entry.TokenOutput)
+	}
+	if entry.ReasoningTokens != 7 || entry.CacheReadTokens != 11 || entry.CacheWriteTokens != 13 {
+		t.Errorf("reasoning/cacheRead/cacheWrite = %d/%d/%d, want 7/11/13",
+			entry.ReasoningTokens, entry.CacheReadTokens, entry.CacheWriteTokens)
+	}
+	if entry.EstimatedCost != 0.0125 {
+		t.Errorf("estimated_cost = %v, want 0.0125", entry.EstimatedCost)
+	}
+}
+
+// TestWriteAgentEventTurnMetrics covers the turn_metrics event, whose per-turn
+// economics arrive in a separate Metrics block rather than on Usage.
+func TestWriteAgentEventTurnMetrics(t *testing.T) {
+	dir := t.TempDir()
+	isolateSecureLog(t)
+	h := NewJSONLEventHandler(dir)
+	h.HandlePipelineEvent(PipelineEvent{
+		Type:      EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "recon2",
+	})
+
+	h.WriteAgentEvent(agent.Event{
+		Type:      "turn_metrics",
+		NodeID:    "Generate",
+		SessionID: "sess-xyz",
+		Turn:      2,
+		Metrics: &agent.TurnMetrics{
+			InputTokens:        900,
+			OutputTokens:       120,
+			CacheReadTokens:    800,
+			CacheWriteTokens:   64,
+			ContextUtilization: 0.71,
+			ToolCacheHits:      4,
+			ToolCacheMisses:    1,
+			TurnDuration:       2 * time.Second,
+			EstimatedCost:      0.031,
+		},
+	})
+	h.Close()
+
+	entry := lastAgentEntry(t, dir, "recon2")
+
+	if entry.SessionID != "sess-xyz" || entry.TurnNo != 2 {
+		t.Errorf("identity = %q/%d, want sess-xyz/2", entry.SessionID, entry.TurnNo)
+	}
+	if entry.TokenInput != 900 || entry.TokenOutput != 120 {
+		t.Errorf("tokens = %d/%d, want 900/120", entry.TokenInput, entry.TokenOutput)
+	}
+	if entry.CacheReadTokens != 800 || entry.CacheWriteTokens != 64 {
+		t.Errorf("cache r/w = %d/%d, want 800/64", entry.CacheReadTokens, entry.CacheWriteTokens)
+	}
+	if entry.ToolCacheHits != 4 || entry.ToolCacheMisses != 1 {
+		t.Errorf("tool cache h/m = %d/%d, want 4/1", entry.ToolCacheHits, entry.ToolCacheMisses)
+	}
+	if entry.TurnDurationMs != 2000 {
+		t.Errorf("turn_duration_ms = %d, want 2000", entry.TurnDurationMs)
+	}
+	if entry.ContextUtilization != 0.71 {
+		t.Errorf("context_utilization = %v, want 0.71", entry.ContextUtilization)
+	}
+	if entry.EstimatedCost != 0.031 {
+		t.Errorf("estimated_cost = %v, want 0.031", entry.EstimatedCost)
+	}
+}
+
+// TestJoinAgentErrors pins the merge of the two error channels: a tool can
+// fail and the session can error on the same event, and neither should
+// silently overwrite the other.
+func TestJoinAgentErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		evt  agent.Event
+		want string
+	}{
+		{"neither", agent.Event{}, ""},
+		{"tool only", agent.Event{ToolError: "exit 1"}, "exit 1"},
+		{"session only", agent.Event{Err: errors.New("killed")}, "killed"},
+		{"both", agent.Event{ToolError: "exit 1", Err: errors.New("killed")}, "exit 1: killed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := joinAgentErrors(tt.evt); got != tt.want {
+				t.Errorf("joinAgentErrors() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// lastAgentEntry reads the run's activity log and returns the final
+// agent-source entry.
+func lastAgentEntry(t *testing.T, dir, runID string) jsonlLogEntry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, runID, "activity.jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		var entry jsonlLogEntry
+		if err := json.Unmarshal([]byte(lines[i]), &entry); err != nil {
+			t.Fatalf("unmarshal line %d: %v", i, err)
+		}
+		if entry.Source == "agent" {
+			return entry
+		}
+	}
+	t.Fatalf("no agent-source entry in %d lines", len(lines))
+	return jsonlLogEntry{}
 }

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -1300,3 +1300,28 @@ func TestTerminalStatusOmittedOnNonTerminalEvents(t *testing.T) {
 		t.Errorf("non-terminal event carries terminal_status: %s", encoded)
 	}
 }
+
+// TestApplyAgentEventFieldsCarriesCallIDAndRequestRaw pins the boundary a live
+// run exposed. CallID and RequestRaw were added to llm.TraceEvent, but in a
+// normal run every LLM event reaches the log via the agent session's
+// re-emission — the client-level writer skips session-owned events — so both
+// were dropped exactly where they mattered.
+func TestApplyAgentEventFieldsCarriesCallIDAndRequestRaw(t *testing.T) {
+	body := []byte(`{"model":"m","messages":[{"role":"user","content":"hi"}]}`)
+	var entry jsonlLogEntry
+	applyAgentEventFields(&entry, agent.Event{
+		Type:       "llm_request_start",
+		SessionID:  "s1",
+		Turn:       1,
+		CallID:     "call-9",
+		RequestRaw: body,
+	})
+	if entry.CallID != "call-9" {
+		t.Errorf("call_id = %q, want call-9", entry.CallID)
+	}
+	// The wire body is the highest-fidelity content the event carries, so it
+	// must win over the display preview the generic path would use.
+	if entry.Content != string(body) {
+		t.Errorf("content = %q, want the wire body", entry.Content)
+	}
+}

--- a/pipeline/events_jsonl_test.go
+++ b/pipeline/events_jsonl_test.go
@@ -202,7 +202,7 @@ func TestJSONLEventHandlerWritesLLMEvents(t *testing.T) {
 		RunID:     "llm123",
 	})
 
-	h.WriteLLMEvent("request_start", "anthropic", "claude-sonnet-4-6", "", "hello world")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "request_start", Provider: "anthropic", Model: "claude-sonnet-4-6", Preview: "hello world"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "llm123", "activity.jsonl"))
@@ -418,7 +418,7 @@ func TestJSONLEventHandler_WriteLLMEvent_StampsBundleIdentity(t *testing.T) {
 		RunID:     "bundle-llm",
 	})
 
-	h.WriteLLMEvent("request_start", "anthropic", "claude-sonnet-4-6", "", "hi")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "request_start", Provider: "anthropic", Model: "claude-sonnet-4-6", Preview: "hi"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "bundle-llm", "activity.jsonl"))
@@ -456,7 +456,7 @@ func TestJSONLEventHandler_NoStampingWhenIdentityEmpty(t *testing.T) {
 		RunID:     "no-bundle",
 	})
 	h.WriteAgentEvent(agent.Event{Type: "tool_call_end", NodeID: "n1", ToolName: "cmd", ToolOutput: "out"})
-	h.WriteLLMEvent("request_start", "anthropic", "claude-sonnet-4-6", "", "hi")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "request_start", Provider: "anthropic", Model: "claude-sonnet-4-6", Preview: "hi"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "no-bundle", "activity.jsonl"))
@@ -887,10 +887,10 @@ func TestJSONLEventHandler_DropsRawLLMEventsByDefault(t *testing.T) {
 	// Raw provider chunks are debugging payload (#354): both spellings
 	// are dropped unless raw capture is enabled.
 	h.WriteAgentEvent(agent.Event{Type: "llm_provider_raw", NodeID: "gen_code", Text: "chunk", Provider: "anthropic", Model: "m"})
-	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "provider_raw", Provider: "anthropic", Model: "m", Preview: "chunk"})
 	// Non-raw events still land.
 	h.WriteAgentEvent(agent.Event{Type: "llm_text", NodeID: "gen_code", Text: "hello", Provider: "anthropic", Model: "m"})
-	h.WriteLLMEvent("text", "anthropic", "m", "", "hello")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "text", Provider: "anthropic", Model: "m", Preview: "hello"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "raw123", "activity.jsonl"))
@@ -925,7 +925,7 @@ func TestJSONLEventHandler_WritesRawLLMEventsWhenEnabled(t *testing.T) {
 	})
 
 	h.WriteAgentEvent(agent.Event{Type: "llm_provider_raw", NodeID: "gen_code", Text: "chunk", Provider: "anthropic", Model: "m"})
-	h.WriteLLMEvent("provider_raw", "anthropic", "m", "", "chunk")
+	h.WriteLLMEvent(llm.TraceEvent{Kind: "provider_raw", Provider: "anthropic", Model: "m", Preview: "chunk"})
 	h.Close()
 
 	data, err := os.ReadFile(filepath.Join(dir, "raw456", "activity.jsonl"))
@@ -1105,5 +1105,142 @@ func lastAgentEntry(t *testing.T, dir, runID string) jsonlLogEntry {
 		}
 	}
 	t.Fatalf("no agent-source entry in %d lines", len(lines))
+	return jsonlLogEntry{}
+}
+
+// TestWriteLLMEventKeepsFullPayload pins that the activity log records the
+// untruncated payload. The old signature took previewText output, capped at 80
+// characters, so a long tool-argument list or provider chunk reached disk
+// clipped with nothing to indicate content was missing.
+func TestWriteLLMEventKeepsFullPayload(t *testing.T) {
+	longArgs := `{"command":"` + strings.Repeat("x", 300) + `"}`
+
+	tests := []struct {
+		name string
+		evt  llm.TraceEvent
+		want string
+	}{
+		{
+			name: "request body wins over preview",
+			evt: llm.TraceEvent{
+				Kind:       "request_start",
+				RequestRaw: []byte(`{"model":"m","messages":[]}`),
+				Preview:    "clipped…",
+			},
+			want: `{"model":"m","messages":[]}`,
+		},
+		{
+			name: "full tool arguments, not the clipped preview",
+			evt: llm.TraceEvent{
+				Kind:          "tool_prepare",
+				ToolName:      "bash",
+				ToolArguments: []byte(longArgs),
+				Preview:       "clipped…",
+			},
+			want: longArgs,
+		},
+		{
+			name: "full provider chunk",
+			evt: llm.TraceEvent{
+				Kind:        "provider_raw",
+				ProviderRaw: []byte(`{"type":"delta"}`),
+				RawPreview:  "clipped…",
+			},
+			want: `{"type":"delta"}`,
+		},
+		{
+			name: "text deltas fall back to Preview, which is never clipped",
+			evt:  llm.TraceEvent{Kind: "text", Preview: "hello world"},
+			want: "hello world",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			isolateSecureLog(t)
+			h := NewJSONLEventHandler(dir)
+			h.SetCaptureRawLLM(true) // provider_raw is gated off by default
+			h.HandlePipelineEvent(PipelineEvent{
+				Type:      EventPipelineStarted,
+				Timestamp: time.Now(),
+				RunID:     "llmfull",
+			})
+			evt := tt.evt
+			evt.CallID = "call-42"
+			h.WriteLLMEvent(evt)
+			h.Close()
+
+			entry := lastEntryOfSource(t, dir, "llmfull", "llm")
+			if entry.Content != tt.want {
+				t.Errorf("content = %q (len %d), want %q (len %d)",
+					entry.Content, len(entry.Content), tt.want, len(tt.want))
+			}
+			if entry.CallID != "call-42" {
+				t.Errorf("call_id = %q, want call-42", entry.CallID)
+			}
+		})
+	}
+}
+
+// TestWriteLLMEventRecordsUsage pins that per-call token usage reaches the log,
+// so cost can be attributed to a call rather than only to the run.
+func TestWriteLLMEventRecordsUsage(t *testing.T) {
+	dir := t.TempDir()
+	isolateSecureLog(t)
+	h := NewJSONLEventHandler(dir)
+	h.HandlePipelineEvent(PipelineEvent{
+		Type:      EventPipelineStarted,
+		Timestamp: time.Now(),
+		RunID:     "llmusage",
+	})
+
+	cacheRead := 512
+	h.WriteLLMEvent(llm.TraceEvent{
+		Kind:         "finish",
+		CallID:       "call-7",
+		FinishReason: "tool_calls",
+		Usage: llm.Usage{
+			InputTokens:     600,
+			OutputTokens:    40,
+			CacheReadTokens: &cacheRead,
+			EstimatedCost:   0.0042,
+		},
+	})
+	h.Close()
+
+	entry := lastEntryOfSource(t, dir, "llmusage", "llm")
+	if entry.TokenInput != 600 || entry.TokenOutput != 40 {
+		t.Errorf("tokens = %d/%d, want 600/40", entry.TokenInput, entry.TokenOutput)
+	}
+	if entry.CacheReadTokens != 512 {
+		t.Errorf("cache_read_tokens = %d, want 512", entry.CacheReadTokens)
+	}
+	if entry.EstimatedCost != 0.0042 {
+		t.Errorf("estimated_cost = %v, want 0.0042", entry.EstimatedCost)
+	}
+	if entry.FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", entry.FinishReason)
+	}
+}
+
+// lastEntryOfSource returns the final activity-log entry with the given source.
+func lastEntryOfSource(t *testing.T, dir, runID, source string) jsonlLogEntry {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, runID, "activity.jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		var entry jsonlLogEntry
+		if err := json.Unmarshal([]byte(lines[i]), &entry); err != nil {
+			t.Fatalf("unmarshal line %d: %v", i, err)
+		}
+		if entry.Source == source {
+			return entry
+		}
+	}
+	t.Fatalf("no %s-source entry in %d lines", source, len(lines))
 	return jsonlLogEntry{}
 }

--- a/pipeline/handlers/parallel.go
+++ b/pipeline/handlers/parallel.go
@@ -413,9 +413,9 @@ func (h *ParallelHandler) runBranch(ctx context.Context, idx int, tn *pipeline.N
 	}
 
 	defer h.recoverBranch(idx, tn, resultsCh)
-
 	h.eventHandler.HandlePipelineEvent(pipeline.PipelineEvent{
 		Type: pipeline.EventStageStarted, Timestamp: time.Now(), NodeID: tn.ID,
+		NodeKind: tn.Handler, AttemptNo: 1,
 		Message: fmt.Sprintf("parallel branch %q started", tn.ID),
 	})
 

--- a/pipeline/runmanifest.go
+++ b/pipeline/runmanifest.go
@@ -90,14 +90,19 @@ type NodeSummary struct {
 	// separately from Outcome because a node can fail an attempt and then
 	// succeed on retry.
 	Failed bool `json:"failed,omitempty"`
+	// Usage is this node's share of the run's economics, attributed from the
+	// same tier the run totals use so the nodes sum to the run. Nil for nodes
+	// that consumed nothing, such as tool and human nodes.
+	Usage *RunTotals `json:"usage,omitempty"`
 }
 
 // RunTotals is the run's aggregate economics.
 //
-// Derived by summing per-call usage grouped by call_id rather than by reading
-// the cost_updated snapshots: those snapshots turned out to be absent from the
-// overwhelming majority of archived runs, and both log paths record the same
-// LLM call, so an ungrouped sum double-counts.
+// Derived from the activity log rather than the cost_updated snapshots, which
+// turned out to be absent from the overwhelming majority of archived runs. The
+// log reports the same consumption at several granularities, so the figures are
+// taken from the most direct one present rather than summed across all of them
+// — see usageTier in runusage.go for why an ungrouped sum triple-counts.
 type RunTotals struct {
 	InputTokens      int     `json:"input_tokens,omitempty"`
 	OutputTokens     int     `json:"output_tokens,omitempty"`
@@ -228,7 +233,7 @@ func readActivityEntries(path string) ([]jsonlLogEntry, error) {
 type manifestAccumulator struct {
 	nodes       map[string]*NodeSummary
 	nodeOrder   []string
-	calls       map[string]RunTotals
+	usage       *usageLedger
 	toolCalls   map[string]int
 	eventCounts map[string]int
 	firstTS     string
@@ -242,7 +247,7 @@ type manifestAccumulator struct {
 func newManifestAccumulator() *manifestAccumulator {
 	return &manifestAccumulator{
 		nodes:       map[string]*NodeSummary{},
-		calls:       map[string]RunTotals{},
+		usage:       newUsageLedger(),
 		toolCalls:   map[string]int{},
 		eventCounts: map[string]int{},
 	}
@@ -264,7 +269,7 @@ func (a *manifestAccumulator) add(e jsonlLogEntry) {
 		a.estimated = true
 	}
 	a.addNode(e)
-	a.addUsage(e)
+	a.usage.add(e)
 	a.addHuman(e)
 }
 
@@ -308,31 +313,6 @@ func (a *manifestAccumulator) addNodeByType(e jsonlLogEntry, n *NodeSummary) {
 	}
 }
 
-// addUsage records per-call usage keyed by call_id, so the two log paths that
-// both report one call collapse instead of summing twice. Entries with no
-// call_id are keyed by their own identity and still counted once.
-func (a *manifestAccumulator) addUsage(e jsonlLogEntry) {
-	if e.TokenInput == 0 && e.TokenOutput == 0 && e.EstimatedCost == 0 {
-		return
-	}
-	key := e.CallID
-	if key == "" {
-		// No call id: fall back to a per-line key so pre-call-id logs still
-		// aggregate, accepting that an overlapping pair counts twice there.
-		key = e.Timestamp + "|" + e.Type + "|" + e.NodeID
-	}
-	// Last write wins for a given call: a finish event carries the
-	// authoritative totals for that call, superseding partial figures.
-	a.calls[key] = RunTotals{
-		InputTokens:      e.TokenInput,
-		OutputTokens:     e.TokenOutput,
-		CacheReadTokens:  e.CacheReadTokens,
-		CacheWriteTokens: e.CacheWriteTokens,
-		ReasoningTokens:  e.ReasoningTokens,
-		CostUSD:          e.EstimatedCost,
-	}
-}
-
 // addHuman counts human intervention points.
 func (a *manifestAccumulator) addHuman(e jsonlLogEntry) {
 	switch e.Type {
@@ -356,21 +336,15 @@ func (a *manifestAccumulator) finish(m *RunManifest) {
 		m.ToolCalls = nil
 	}
 
+	perNode := a.usage.nodeTotals()
 	m.Nodes = make([]NodeSummary, 0, len(a.nodeOrder))
 	for _, id := range a.nodeOrder {
-		m.Nodes = append(m.Nodes, *a.nodes[id])
+		n := *a.nodes[id]
+		n.Usage = perNode[id]
+		m.Nodes = append(m.Nodes, n)
 	}
 
-	totals := RunTotals{Estimated: a.estimated, LLMCalls: len(a.calls)}
-	for _, c := range a.calls {
-		totals.InputTokens += c.InputTokens
-		totals.OutputTokens += c.OutputTokens
-		totals.CacheReadTokens += c.CacheReadTokens
-		totals.CacheWriteTokens += c.CacheWriteTokens
-		totals.ReasoningTokens += c.ReasoningTokens
-		totals.CostUSD += c.CostUSD
-	}
-	m.Totals = totals
+	m.Totals = a.usage.runTotals(a.estimated)
 }
 
 // applyCheckpointToManifest folds in facts the checkpoint states directly

--- a/pipeline/runmanifest.go
+++ b/pipeline/runmanifest.go
@@ -430,6 +430,30 @@ func applySpecToManifest(m *RunManifest, runDir string) {
 	if m.Spec.BundleIdentity == "" {
 		m.Spec.BundleIdentity = m.BundleIdentity
 	}
+	if m.Goal == "" {
+		m.Goal = goalFromIR(runDir)
+	}
+}
+
+// goalFromIR reads the workflow goal out of the stored IR.
+//
+// The checkpoint is the other source, but it is a side effect of node
+// transitions: a single-node run never writes one, so a goal read only from
+// there goes missing on exactly the smallest pipelines. The spec declares the
+// goal outright, which makes the IR the more reliable source and the checkpoint
+// the fallback.
+func goalFromIR(runDir string) string {
+	data, err := os.ReadFile(filepath.Join(runDir, SpecIRFile)) //nolint:gosec // composed from a validated run dir
+	if err != nil {
+		return ""
+	}
+	var ir struct {
+		Goal string `json:"goal"`
+	}
+	if err := json.Unmarshal(data, &ir); err != nil {
+		return ""
+	}
+	return ir.Goal
 }
 
 // readSpecInputs lists stored input documents by digest.

--- a/pipeline/runmanifest.go
+++ b/pipeline/runmanifest.go
@@ -1,0 +1,441 @@
+// ABOUTME: Assembles run.json — a single self-describing record of one run, derived from the activity log and checkpoint.
+// ABOUTME: Runnable after the fact so a run that died without finalizing still gets one, and archived runs can be backfilled.
+package pipeline
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// RunManifestFile is the manifest's name inside the run directory.
+const RunManifestFile = "run.json"
+
+// RunManifestSchemaVersion is bumped when the manifest's shape changes in a way
+// a reader must notice. Readers should check it before trusting field
+// semantics.
+const RunManifestSchemaVersion = 1
+
+// RunManifest is one run, described in a single readable document.
+//
+// Everything here is derivable from the run directory, which is the point: the
+// assembler can run after the fact, so a run killed before it could finalize
+// still gets a manifest, and runs archived before this existed can be
+// backfilled. The alternative — deriving these facts at read time — means every
+// consumer re-parses an activity log that can reach millions of lines to answer
+// questions as basic as "did this finish".
+type RunManifest struct {
+	SchemaVersion int    `json:"schema_version"`
+	RunID         string `json:"run_id"`
+
+	// Goal is the workflow's stated intent, read from the checkpoint's
+	// context ("graph.goal"). Declared by the spec, so it needs no inference.
+	Goal string `json:"goal,omitempty"`
+
+	// Spec records the specification that executed. Populated from the
+	// manifest WriteSpecArtifacts returns, or read back from disk on backfill.
+	Spec SpecManifest `json:"spec,omitempty"`
+
+	StartedAt  string `json:"started_at,omitempty"`
+	FinishedAt string `json:"finished_at,omitempty"`
+
+	// TerminalStatus is how the run ended: "success",
+	// "validation_overridden", "fail", "budget_exceeded", or empty when the
+	// log carries no terminal event at all — which means the process died
+	// before it could emit one, and is itself worth recording rather than
+	// papering over.
+	TerminalStatus string `json:"terminal_status,omitempty"`
+	// ReachedNode is the last node the checkpoint recorded as current. Read
+	// alongside the spec's configured exit node, this is what distinguishes a
+	// run that finished from one that stopped early.
+	ReachedNode string `json:"reached_node,omitempty"`
+	// CompletedNodes is the checkpoint's completed set.
+	CompletedNodes []string `json:"completed_nodes,omitempty"`
+	RestartCount   int      `json:"restart_count,omitempty"`
+
+	// Nodes is one entry per node the run actually started, keyed off
+	// stage_started events rather than off which artifact directories exist —
+	// directories are sparse in large runs, so enumerating by filesystem
+	// silently drops nodes.
+	Nodes []NodeSummary `json:"nodes,omitempty"`
+
+	Totals    RunTotals      `json:"totals"`
+	Human     HumanSummary   `json:"human"`
+	ToolCalls map[string]int `json:"tool_calls,omitempty"`
+
+	// EventCounts is every event type seen, with its count — a cheap shape
+	// summary that answers "was there a retry storm" without a second pass.
+	EventCounts map[string]int `json:"event_counts,omitempty"`
+
+	// BundleIdentity is the .dipx identity, empty for a plain .dip run.
+	BundleIdentity string `json:"bundle_identity,omitempty"`
+}
+
+// NodeSummary is what the log says about one node.
+type NodeSummary struct {
+	ID   string `json:"id"`
+	Kind string `json:"kind,omitempty"`
+	// Attempts is the highest attempt number observed, so a node that
+	// succeeded first try reads 1.
+	Attempts int    `json:"attempts"`
+	Outcome  string `json:"outcome,omitempty"`
+	// Turns counts turn_start events attributed to this node; 0 for tool and
+	// human nodes, which run no agent turns.
+	Turns int `json:"turns,omitempty"`
+	// Failed is true when any stage_failed event named this node — recorded
+	// separately from Outcome because a node can fail an attempt and then
+	// succeed on retry.
+	Failed bool `json:"failed,omitempty"`
+}
+
+// RunTotals is the run's aggregate economics.
+//
+// Derived by summing per-call usage grouped by call_id rather than by reading
+// the cost_updated snapshots: those snapshots turned out to be absent from the
+// overwhelming majority of archived runs, and both log paths record the same
+// LLM call, so an ungrouped sum double-counts.
+type RunTotals struct {
+	InputTokens      int     `json:"input_tokens,omitempty"`
+	OutputTokens     int     `json:"output_tokens,omitempty"`
+	CacheReadTokens  int     `json:"cache_read_tokens,omitempty"`
+	CacheWriteTokens int     `json:"cache_write_tokens,omitempty"`
+	ReasoningTokens  int     `json:"reasoning_tokens,omitempty"`
+	CostUSD          float64 `json:"cost_usd,omitempty"`
+	// LLMCalls is the number of distinct call_ids seen.
+	LLMCalls int `json:"llm_calls,omitempty"`
+	// Estimated is true when any contributing figure was heuristic-derived
+	// rather than metered (the ACP backend estimates from rune counts), so a
+	// reader knows not to treat the cost as authoritative.
+	Estimated bool `json:"estimated,omitempty"`
+}
+
+// HumanSummary counts the points where a person had to intervene. A run that
+// needed steering did not run autonomously, which is worth knowing separately
+// from whether it succeeded.
+type HumanSummary struct {
+	Gates    int `json:"gates,omitempty"`
+	Steering int `json:"steering,omitempty"`
+}
+
+// AssembleRunManifest builds a manifest for the run in runDir by reading
+// activity.jsonl, checkpoint.json, and any spec artifacts present.
+//
+// Tolerant by design: a missing checkpoint, an unparseable line, or a truncated
+// log yields a partial manifest rather than an error, because the runs most
+// worth describing are the ones that ended badly. A missing activity log is the
+// one hard failure — without it there is nothing to describe.
+func AssembleRunManifest(runDir, runID string) (RunManifest, error) {
+	m := RunManifest{
+		SchemaVersion: RunManifestSchemaVersion,
+		RunID:         runID,
+		ToolCalls:     map[string]int{},
+		EventCounts:   map[string]int{},
+	}
+
+	entries, err := readActivityEntries(filepath.Join(runDir, "activity.jsonl"))
+	if err != nil {
+		return m, err
+	}
+	acc := newManifestAccumulator()
+	for _, e := range entries {
+		acc.add(e)
+	}
+	acc.finish(&m)
+
+	applyCheckpointToManifest(&m, runDir)
+	applySpecToManifest(&m, runDir)
+	return m, nil
+}
+
+// WriteRunManifest assembles and writes run.json into runDir.
+func WriteRunManifest(runDir, runID string) (RunManifest, error) {
+	m, err := AssembleRunManifest(runDir, runID)
+	if err != nil {
+		return m, err
+	}
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return m, fmt.Errorf("marshal manifest: %w", err)
+	}
+	path := filepath.Join(runDir, RunManifestFile)
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return m, fmt.Errorf("write %s: %w", RunManifestFile, err)
+	}
+	return m, nil
+}
+
+// readActivityEntries decodes every parseable line of an activity log.
+//
+// Unparseable lines are skipped rather than fatal: a run killed mid-write
+// leaves a partial final line, and that run is precisely the one a manifest is
+// most useful for. Lines carry ActivityLogSentinel in the secure log and not in
+// the artifact-dir snapshot, so the prefix is stripped when present.
+func readActivityEntries(path string) ([]jsonlLogEntry, error) {
+	f, err := os.Open(path) //nolint:gosec // path is composed from a validated run dir
+	if err != nil {
+		return nil, fmt.Errorf("open activity log: %w", err)
+	}
+	defer f.Close()
+
+	var out []jsonlLogEntry
+	sc := bufio.NewScanner(f)
+	// Tool output and raw provider payloads make individual lines large; the
+	// default 64KB token limit would truncate them into parse failures.
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimPrefix(sc.Text(), ActivityLogSentinel)
+		if line == "" {
+			continue
+		}
+		var entry jsonlLogEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		out = append(out, entry)
+	}
+	// A scan error (an over-long line) still leaves everything read so far
+	// usable, so it is not surfaced as a failure.
+	return out, nil
+}
+
+// manifestAccumulator folds activity entries into manifest state.
+type manifestAccumulator struct {
+	nodes       map[string]*NodeSummary
+	nodeOrder   []string
+	calls       map[string]RunTotals
+	toolCalls   map[string]int
+	eventCounts map[string]int
+	firstTS     string
+	lastTS      string
+	terminal    string
+	gates       int
+	steering    int
+	estimated   bool
+}
+
+func newManifestAccumulator() *manifestAccumulator {
+	return &manifestAccumulator{
+		nodes:       map[string]*NodeSummary{},
+		calls:       map[string]RunTotals{},
+		toolCalls:   map[string]int{},
+		eventCounts: map[string]int{},
+	}
+}
+
+// add folds one entry in.
+func (a *manifestAccumulator) add(e jsonlLogEntry) {
+	if e.Timestamp != "" {
+		if a.firstTS == "" {
+			a.firstTS = e.Timestamp
+		}
+		a.lastTS = e.Timestamp
+	}
+	a.eventCounts[e.Type]++
+	if e.TerminalStatus != "" {
+		a.terminal = e.TerminalStatus
+	}
+	if e.Estimated {
+		a.estimated = true
+	}
+	a.addNode(e)
+	a.addUsage(e)
+	a.addHuman(e)
+}
+
+// addNode records per-node facts. Node identity comes from any event that
+// names one, so a node reaches the manifest even when it produced no artifact
+// directory.
+func (a *manifestAccumulator) addNode(e jsonlLogEntry) {
+	if e.NodeID == "" {
+		return
+	}
+	n, ok := a.nodes[e.NodeID]
+	if !ok {
+		n = &NodeSummary{ID: e.NodeID, Attempts: 1}
+		a.nodes[e.NodeID] = n
+		a.nodeOrder = append(a.nodeOrder, e.NodeID)
+	}
+	if e.NodeKind != "" {
+		n.Kind = e.NodeKind
+	}
+	if e.AttemptNo > n.Attempts {
+		n.Attempts = e.AttemptNo
+	}
+	if e.OutcomeStatus != "" {
+		n.Outcome = e.OutcomeStatus
+	}
+	a.addNodeByType(e, n)
+}
+
+// addNodeByType applies the per-event-type node updates. Split from addNode to
+// keep each within the complexity ceiling.
+func (a *manifestAccumulator) addNodeByType(e jsonlLogEntry, n *NodeSummary) {
+	switch e.Type {
+	case "turn_start":
+		n.Turns++
+	case "stage_failed":
+		n.Failed = true
+	case "tool_call_start":
+		if e.ToolName != "" {
+			a.toolCalls[e.ToolName]++
+		}
+	}
+}
+
+// addUsage records per-call usage keyed by call_id, so the two log paths that
+// both report one call collapse instead of summing twice. Entries with no
+// call_id are keyed by their own identity and still counted once.
+func (a *manifestAccumulator) addUsage(e jsonlLogEntry) {
+	if e.TokenInput == 0 && e.TokenOutput == 0 && e.EstimatedCost == 0 {
+		return
+	}
+	key := e.CallID
+	if key == "" {
+		// No call id: fall back to a per-line key so pre-call-id logs still
+		// aggregate, accepting that an overlapping pair counts twice there.
+		key = e.Timestamp + "|" + e.Type + "|" + e.NodeID
+	}
+	// Last write wins for a given call: a finish event carries the
+	// authoritative totals for that call, superseding partial figures.
+	a.calls[key] = RunTotals{
+		InputTokens:      e.TokenInput,
+		OutputTokens:     e.TokenOutput,
+		CacheReadTokens:  e.CacheReadTokens,
+		CacheWriteTokens: e.CacheWriteTokens,
+		ReasoningTokens:  e.ReasoningTokens,
+		CostUSD:          e.EstimatedCost,
+	}
+}
+
+// addHuman counts human intervention points.
+func (a *manifestAccumulator) addHuman(e jsonlLogEntry) {
+	switch e.Type {
+	case "human_gate_opened", "human_gate_resolved":
+		a.gates++
+	case "steering_injected":
+		a.steering++
+	}
+}
+
+// finish writes accumulated state onto the manifest.
+func (a *manifestAccumulator) finish(m *RunManifest) {
+	m.StartedAt = a.firstTS
+	m.FinishedAt = a.lastTS
+	m.TerminalStatus = a.terminal
+	m.Human = HumanSummary{Gates: a.gates, Steering: a.steering}
+	m.EventCounts = a.eventCounts
+	if len(a.toolCalls) > 0 {
+		m.ToolCalls = a.toolCalls
+	} else {
+		m.ToolCalls = nil
+	}
+
+	m.Nodes = make([]NodeSummary, 0, len(a.nodeOrder))
+	for _, id := range a.nodeOrder {
+		m.Nodes = append(m.Nodes, *a.nodes[id])
+	}
+
+	totals := RunTotals{Estimated: a.estimated, LLMCalls: len(a.calls)}
+	for _, c := range a.calls {
+		totals.InputTokens += c.InputTokens
+		totals.OutputTokens += c.OutputTokens
+		totals.CacheReadTokens += c.CacheReadTokens
+		totals.CacheWriteTokens += c.CacheWriteTokens
+		totals.ReasoningTokens += c.ReasoningTokens
+		totals.CostUSD += c.CostUSD
+	}
+	m.Totals = totals
+}
+
+// applyCheckpointToManifest folds in facts the checkpoint states directly
+// rather than facts the log implies. Absent or unreadable checkpoints are
+// skipped: an interrupted run may have none, and the rest of the manifest is
+// still worth having.
+func applyCheckpointToManifest(m *RunManifest, runDir string) {
+	cp, err := LoadCheckpoint(filepath.Join(runDir, "checkpoint.json"))
+	if err != nil || cp == nil {
+		return
+	}
+	m.ReachedNode = cp.CurrentNode
+	m.CompletedNodes = cp.CompletedNodes
+	m.RestartCount = cp.RestartCount
+	if cp.BundleIdentity != "" {
+		m.BundleIdentity = cp.BundleIdentity
+	}
+	if goal := cp.Context["graph.goal"]; goal != "" {
+		m.Goal = goal
+	}
+	// Nodes the checkpoint completed but that left no log line still belong in
+	// the node table.
+	m.Nodes = mergeCheckpointNodes(m.Nodes, cp.CompletedNodes)
+}
+
+// mergeCheckpointNodes appends completed nodes absent from the log-derived
+// table. Enumerating from one source alone loses nodes: the log misses any node
+// whose events were lost, and the artifact directory misses most nodes in a
+// large run.
+func mergeCheckpointNodes(nodes []NodeSummary, completed []string) []NodeSummary {
+	seen := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		seen[n.ID] = true
+	}
+	for _, id := range completed {
+		if !seen[id] {
+			nodes = append(nodes, NodeSummary{ID: id, Attempts: 1, Outcome: "success"})
+			seen[id] = true
+		}
+	}
+	return nodes
+}
+
+// applySpecToManifest reads back spec artifacts written by WriteSpecArtifacts.
+// Only the digest and filenames are recorded — the manifest references the spec
+// rather than inlining it, so it stays readable.
+func applySpecToManifest(m *RunManifest, runDir string) {
+	source, err := os.ReadFile(filepath.Join(runDir, SpecSourceFile)) //nolint:gosec // composed from a validated run dir
+	if err == nil {
+		m.Spec.SourceFile = SpecSourceFile
+		m.Spec.SourceSHA256 = digest(source)
+	}
+	if _, err := os.Stat(filepath.Join(runDir, SpecIRFile)); err == nil {
+		m.Spec.IRFile = SpecIRFile
+	}
+	m.Spec.Inputs = readSpecInputs(runDir)
+	if m.Spec.BundleIdentity == "" {
+		m.Spec.BundleIdentity = m.BundleIdentity
+	}
+}
+
+// readSpecInputs lists stored input documents by digest.
+func readSpecInputs(runDir string) []SpecInput {
+	entries, err := os.ReadDir(filepath.Join(runDir, SpecInputsDir))
+	if err != nil {
+		return nil
+	}
+	out := make([]SpecInput, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		ext := filepath.Ext(name)
+		in := SpecInput{
+			Name:   name,
+			SHA256: strings.TrimSuffix(name, ext),
+			Ext:    ext,
+		}
+		if info, err := e.Info(); err == nil {
+			in.Size = int(info.Size())
+		}
+		out = append(out, in)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SHA256 < out[j].SHA256 })
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/pipeline/runmanifest.go
+++ b/pipeline/runmanifest.go
@@ -136,7 +136,7 @@ func AssembleRunManifest(runDir, runID string) (RunManifest, error) {
 		EventCounts:   map[string]int{},
 	}
 
-	entries, err := readActivityEntries(filepath.Join(runDir, "activity.jsonl"))
+	entries, err := readActivityEntries(activityLogForRun(runDir, runID))
 	if err != nil {
 		return m, err
 	}
@@ -166,6 +166,28 @@ func WriteRunManifest(runDir, runID string) (RunManifest, error) {
 		return m, fmt.Errorf("write %s: %w", RunManifestFile, err)
 	}
 	return m, nil
+}
+
+// activityLogForRun picks which copy of the log to read.
+//
+// The run directory holds a sentinel-stripped snapshot, but it is written at
+// Close and is documented as best-effort — so it can be absent while the run is
+// still open, or if the mirror failed. The secure path is the live log and the
+// authoritative copy, so fall back to it. Both are handled by the reader, which
+// strips the sentinel when present.
+func activityLogForRun(runDir, runID string) string {
+	snapshot := filepath.Join(runDir, "activity.jsonl")
+	if _, err := os.Stat(snapshot); err == nil {
+		return snapshot
+	}
+	if secure, err := SecureActivityLogPath(runID); err == nil {
+		if _, err := os.Stat(secure); err == nil {
+			return secure
+		}
+	}
+	// Neither exists: return the snapshot path so the error names the location
+	// a reader would expect to find it.
+	return snapshot
 }
 
 // readActivityEntries decodes every parseable line of an activity log.

--- a/pipeline/runmanifest_test.go
+++ b/pipeline/runmanifest_test.go
@@ -1,0 +1,284 @@
+// ABOUTME: Tests for run.json assembly from a run directory.
+// ABOUTME: Covers node enumeration from two sources, call-id-grouped usage, tolerance of damaged logs, and backfill.
+package pipeline
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeLog writes lines as an activity log in runDir.
+func writeLog(t *testing.T, runDir string, lines ...string) {
+	t.Helper()
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := strings.Join(lines, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(runDir, "activity.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAssembleRunManifestSummarizesNodes(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r1")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:00.000Z","source":"pipeline","type":"pipeline_started","run_id":"r1"}`,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"stage_started","node_id":"Gen","node_kind":"codergen","attempt_no":1}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"agent","type":"turn_start","node_id":"Gen","session_id":"s1","turn_no":1}`,
+		`{"ts":"2026-01-01T00:00:03.000Z","source":"agent","type":"tool_call_start","node_id":"Gen","tool_name":"bash","tool_input":"{\"command\":\"ls\"}","session_id":"s1","turn_no":1}`,
+		`{"ts":"2026-01-01T00:00:04.000Z","source":"pipeline","type":"stage_failed","node_id":"Gen"}`,
+		`{"ts":"2026-01-01T00:00:05.000Z","source":"pipeline","type":"stage_retrying","node_id":"Gen","node_kind":"codergen","attempt_no":2}`,
+		`{"ts":"2026-01-01T00:00:06.000Z","source":"pipeline","type":"decision_outcome","node_id":"Gen","outcome_status":"success"}`,
+		`{"ts":"2026-01-01T00:00:07.000Z","source":"pipeline","type":"pipeline_completed","terminal_status":"success"}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r1")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+
+	if m.SchemaVersion != RunManifestSchemaVersion {
+		t.Errorf("schema_version = %d, want %d", m.SchemaVersion, RunManifestSchemaVersion)
+	}
+	if m.TerminalStatus != "success" {
+		t.Errorf("terminal_status = %q, want success", m.TerminalStatus)
+	}
+	if m.StartedAt != "2026-01-01T00:00:00.000Z" || m.FinishedAt != "2026-01-01T00:00:07.000Z" {
+		t.Errorf("window = %s..%s, want first..last event timestamp", m.StartedAt, m.FinishedAt)
+	}
+	if len(m.Nodes) != 1 {
+		t.Fatalf("got %d nodes, want 1", len(m.Nodes))
+	}
+
+	n := m.Nodes[0]
+	if n.Kind != "codergen" {
+		t.Errorf("kind = %q, want codergen", n.Kind)
+	}
+	// Attempts tracks the highest attempt seen, so a retried node reads 2.
+	if n.Attempts != 2 {
+		t.Errorf("attempts = %d, want 2", n.Attempts)
+	}
+	if n.Turns != 1 {
+		t.Errorf("turns = %d, want 1", n.Turns)
+	}
+	// Failed and Outcome are independent: this node failed an attempt and then
+	// succeeded, and collapsing them would hide the retry.
+	if !n.Failed {
+		t.Error("failed = false, want true (a stage_failed named this node)")
+	}
+	if n.Outcome != "success" {
+		t.Errorf("outcome = %q, want success", n.Outcome)
+	}
+	if m.ToolCalls["bash"] != 1 {
+		t.Errorf("tool_calls[bash] = %d, want 1", m.ToolCalls["bash"])
+	}
+}
+
+func TestAssembleRunManifestGroupsUsageByCallID(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r2")
+	// The same call reported twice — once by the agent session re-emitting the
+	// trace event, once by the client-level writer. Both paths are kept because
+	// their coverage differs, so an ungrouped sum would double the usage.
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"llm","type":"finish","call_id":"c1","token_input":100,"token_output":20,"estimated_cost":0.01}`,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"agent","type":"llm_finish","call_id":"c1","token_input":100,"token_output":20,"estimated_cost":0.01}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"llm","type":"finish","call_id":"c2","token_input":50,"token_output":10,"estimated_cost":0.005}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r2")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+	if m.Totals.LLMCalls != 2 {
+		t.Errorf("llm_calls = %d, want 2 (one call reported twice is still one call)", m.Totals.LLMCalls)
+	}
+	if m.Totals.InputTokens != 150 {
+		t.Errorf("input_tokens = %d, want 150 (not 250 — the duplicate must collapse)", m.Totals.InputTokens)
+	}
+	if m.Totals.OutputTokens != 30 {
+		t.Errorf("output_tokens = %d, want 30", m.Totals.OutputTokens)
+	}
+	if m.Totals.CostUSD != 0.015 {
+		t.Errorf("cost_usd = %v, want 0.015", m.Totals.CostUSD)
+	}
+}
+
+func TestAssembleRunManifestMergesCheckpointNodes(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r3")
+	// A node the checkpoint completed but whose events are absent from the log.
+	// Enumerating from either source alone loses nodes, which is why both are
+	// consulted.
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"stage_started","node_id":"Gen","node_kind":"codergen","attempt_no":1}`,
+	)
+	cp := &Checkpoint{
+		RunID:          "r3",
+		CurrentNode:    "Done",
+		CompletedNodes: []string{"Setup", "Gen"},
+		RestartCount:   2,
+		Context:        map[string]string{"graph.goal": "ship the thing"},
+	}
+	if err := SaveCheckpoint(cp, filepath.Join(runDir, "checkpoint.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	m, err := AssembleRunManifest(runDir, "r3")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+	if m.Goal != "ship the thing" {
+		t.Errorf("goal = %q, want the checkpoint's graph.goal", m.Goal)
+	}
+	if m.ReachedNode != "Done" {
+		t.Errorf("reached_node = %q, want Done", m.ReachedNode)
+	}
+	if m.RestartCount != 2 {
+		t.Errorf("restart_count = %d, want 2", m.RestartCount)
+	}
+
+	ids := map[string]bool{}
+	for _, n := range m.Nodes {
+		ids[n.ID] = true
+	}
+	if !ids["Setup"] {
+		t.Error("Setup missing: a node the checkpoint completed but the log never mentioned")
+	}
+	if !ids["Gen"] {
+		t.Error("Gen missing from the node table")
+	}
+	if len(m.Nodes) != 2 {
+		t.Errorf("got %d nodes, want 2 with no duplicate for Gen", len(m.Nodes))
+	}
+}
+
+func TestAssembleRunManifestToleratesDamagedLog(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r4")
+	// A run killed mid-write leaves a truncated final line. That run is exactly
+	// the one a manifest is most useful for, so a bad line must not be fatal.
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"stage_started","node_id":"A","node_kind":"tool","attempt_no":1}`,
+		`not json at all`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"stage_completed","node_id":"A"`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r4")
+	if err != nil {
+		t.Fatalf("a damaged log should still yield a manifest, got: %v", err)
+	}
+	if len(m.Nodes) != 1 || m.Nodes[0].ID != "A" {
+		t.Errorf("nodes = %+v, want the one parseable node", m.Nodes)
+	}
+	// No terminal event survived, and that absence is reported rather than
+	// guessed at.
+	if m.TerminalStatus != "" {
+		t.Errorf("terminal_status = %q, want empty for a run with no terminal event", m.TerminalStatus)
+	}
+}
+
+func TestAssembleRunManifestStripsSentinel(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r5")
+	// The live secure log prefixes every line with the sentinel; the
+	// artifact-dir snapshot does not. The assembler must read either.
+	writeLog(t, runDir,
+		ActivityLogSentinel+`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"stage_started","node_id":"A","node_kind":"tool"}`,
+		ActivityLogSentinel+`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"pipeline_completed","terminal_status":"success"}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r5")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+	if m.TerminalStatus != "success" {
+		t.Errorf("terminal_status = %q — sentinel-prefixed lines were not parsed", m.TerminalStatus)
+	}
+	if len(m.Nodes) != 1 {
+		t.Errorf("got %d nodes, want 1", len(m.Nodes))
+	}
+}
+
+func TestAssembleRunManifestRequiresActivityLog(t *testing.T) {
+	// No log means nothing to describe — the one hard failure.
+	if _, err := AssembleRunManifest(t.TempDir(), "nope"); err == nil {
+		t.Error("expected an error when the activity log is missing")
+	}
+}
+
+func TestAssembleRunManifestCountsHumanIntervention(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r6")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"human_gate_opened","node_id":"Approve"}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"human_gate_resolved","node_id":"Approve"}`,
+		`{"ts":"2026-01-01T00:00:03.000Z","source":"agent","type":"steering_injected","node_id":"Gen"}`,
+	)
+	m, err := AssembleRunManifest(runDir, "r6")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+	if m.Human.Gates != 2 {
+		t.Errorf("gates = %d, want 2", m.Human.Gates)
+	}
+	if m.Human.Steering != 1 {
+		t.Errorf("steering = %d, want 1", m.Human.Steering)
+	}
+}
+
+func TestWriteRunManifestRoundTrips(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r7")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"stage_started","node_id":"A","node_kind":"tool","attempt_no":1}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"pipeline_completed","terminal_status":"success"}`,
+	)
+	// A spec on disk should be referenced by the manifest.
+	if _, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Source: "workflow X\n  goal: \"x\"\n",
+		Inputs: []SpecInput{{Name: "spec.md", Content: []byte("# spec")}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	written, err := WriteRunManifest(runDir, "r7")
+	if err != nil {
+		t.Fatalf("WriteRunManifest: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(runDir, RunManifestFile))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var loaded RunManifest
+	if err := json.Unmarshal(data, &loaded); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v", err)
+	}
+	if loaded.TerminalStatus != written.TerminalStatus || loaded.RunID != "r7" {
+		t.Errorf("round trip lost fields: %+v", loaded)
+	}
+	if loaded.Spec.SourceFile != SpecSourceFile || loaded.Spec.SourceSHA256 == "" {
+		t.Errorf("manifest does not reference the stored spec: %+v", loaded.Spec)
+	}
+	if len(loaded.Spec.Inputs) != 1 {
+		t.Errorf("manifest lists %d inputs, want 1", len(loaded.Spec.Inputs))
+	}
+}
+
+// TestAssembleRunManifestHandlesLargeLines guards the scanner buffer. Tool
+// output and raw provider payloads make individual lines large, and the default
+// 64KB token limit would turn them into parse failures.
+func TestAssembleRunManifestHandlesLargeLines(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r8")
+	big := strings.Repeat("x", 300_000)
+	writeLog(t, runDir,
+		fmt.Sprintf(`{"ts":"2026-01-01T00:00:01.000Z","source":"agent","type":"tool_call_end","node_id":"A","tool_name":"bash","content":%q}`, big),
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"pipeline_completed","terminal_status":"success"}`,
+	)
+	m, err := AssembleRunManifest(runDir, "r8")
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+	if m.TerminalStatus != "success" {
+		t.Errorf("terminal_status = %q — an oversized line broke the scan", m.TerminalStatus)
+	}
+}

--- a/pipeline/runspec.go
+++ b/pipeline/runspec.go
@@ -15,6 +15,10 @@ import (
 )
 
 // Filenames written into <artifactDir>/<runID>/ by WriteSpecArtifacts.
+// specFileMode is the mode for every stored spec artifact. Owner-only: the
+// files carry the run's --param values and any reference material it was given.
+const specFileMode = 0o600
+
 const (
 	SpecSourceFile = "workflow.dip"
 	SpecIRFile     = "workflow.ir.json"
@@ -149,10 +153,29 @@ func WriteSpecArtifacts(runDir string, spec SpecArtifacts) (SpecManifest, error)
 	return manifest, joinErrs(errs)
 }
 
+// writeTightened writes data at 0o600 and then forces that mode.
+//
+// os.WriteFile only applies its mode when it *creates* the file, so a run
+// directory that already holds a wider-mode artifact — a resumed run, a reused
+// dir, a race — would keep the old permissions and leave the spec (and any
+// params or reference material in it) readable by other local users. Same
+// force-tighten the activity-log writer does for the same reason.
+//
+// The chmod is best-effort: the write already succeeded, and failing the run
+// over a mode we could not narrow would trade a real artifact for a
+// defense-in-depth measure. Same-UID access is unaffected either way.
+func writeTightened(path string, data []byte) error {
+	if err := os.WriteFile(path, data, specFileMode); err != nil {
+		return err
+	}
+	_ = os.Chmod(path, specFileMode)
+	return nil
+}
+
 // writeSpecSource stores the .dip verbatim and records its digest.
 func writeSpecSource(runDir, source string, manifest *SpecManifest) error {
 	path := filepath.Join(runDir, SpecSourceFile)
-	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+	if err := writeTightened(path, []byte(source)); err != nil {
 		return fmt.Errorf("write %s: %w", SpecSourceFile, err)
 	}
 	manifest.SourceFile = SpecSourceFile
@@ -168,7 +191,7 @@ func writeSpecIR(runDir string, workflow *ir.Workflow, manifest *SpecManifest) e
 		return fmt.Errorf("marshal IR: %w", err)
 	}
 	path := filepath.Join(runDir, SpecIRFile)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
+	if err := writeTightened(path, data); err != nil {
 		return fmt.Errorf("write %s: %w", SpecIRFile, err)
 	}
 	manifest.IRFile = SpecIRFile
@@ -195,7 +218,7 @@ func writeSpecInputs(runDir string, inputs []SpecInput) ([]SpecInput, []error) {
 			in.Ext = filepath.Ext(in.Name)
 		}
 		path := filepath.Join(dir, in.SHA256+in.Ext)
-		if err := os.WriteFile(path, in.Content, 0o600); err != nil {
+		if err := writeTightened(path, in.Content); err != nil {
 			errs = append(errs, fmt.Errorf("write input %s: %w", in.Name, err))
 			continue
 		}

--- a/pipeline/runspec.go
+++ b/pipeline/runspec.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/2389-research/dippin-lang/ir"
 )
@@ -62,6 +63,39 @@ type SpecArtifacts struct {
 	BundleIdentity string
 }
 
+// secretParamKey matches param names that conventionally carry a credential.
+// Params are recorded because they change behavior and a spec without them does
+// not reproduce the run — but the manifest is durable and on-disk, so a value
+// under one of these names is replaced with a placeholder rather than persisted.
+// Matching is on the key, since values are opaque.
+var secretParamKey = regexp.MustCompile(`(?i)(token|secret|password|passwd|credential|api[_-]?key|access[_-]?key|private[_-]?key|auth)`)
+
+// redactedParamValue marks a param whose value was withheld. Deliberately not
+// an empty string: a reader has to be able to tell "no value" from "not shown".
+const redactedParamValue = "[redacted]"
+
+// redactSecretParams copies params, replacing secret-looking values. The keys
+// are kept — knowing *which* params a run was given is part of reproducing it,
+// and the name alone is not the secret.
+//
+// Key-name matching is a heuristic and will miss a credential passed under an
+// innocuous name. It is a floor, not a guarantee; the durable fix is to keep
+// secrets out of --param entirely.
+func redactSecretParams(params map[string]string) map[string]string {
+	if params == nil {
+		return nil
+	}
+	out := make(map[string]string, len(params))
+	for k, v := range params {
+		if v != "" && secretParamKey.MatchString(k) {
+			out[k] = redactedParamValue
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
 // SpecManifest is the record of what WriteSpecArtifacts stored, for embedding
 // in a run manifest. Paths are relative to the run directory.
 type SpecManifest struct {
@@ -90,7 +124,7 @@ type SpecManifest struct {
 func WriteSpecArtifacts(runDir string, spec SpecArtifacts) (SpecManifest, error) {
 	manifest := SpecManifest{
 		SourcePath:     spec.SourcePath,
-		Params:         spec.Params,
+		Params:         redactSecretParams(spec.Params),
 		BundleIdentity: spec.BundleIdentity,
 	}
 	if err := os.MkdirAll(runDir, 0o755); err != nil {
@@ -118,7 +152,7 @@ func WriteSpecArtifacts(runDir string, spec SpecArtifacts) (SpecManifest, error)
 // writeSpecSource stores the .dip verbatim and records its digest.
 func writeSpecSource(runDir, source string, manifest *SpecManifest) error {
 	path := filepath.Join(runDir, SpecSourceFile)
-	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", SpecSourceFile, err)
 	}
 	manifest.SourceFile = SpecSourceFile
@@ -134,7 +168,7 @@ func writeSpecIR(runDir string, workflow *ir.Workflow, manifest *SpecManifest) e
 		return fmt.Errorf("marshal IR: %w", err)
 	}
 	path := filepath.Join(runDir, SpecIRFile)
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		return fmt.Errorf("write %s: %w", SpecIRFile, err)
 	}
 	manifest.IRFile = SpecIRFile
@@ -161,7 +195,7 @@ func writeSpecInputs(runDir string, inputs []SpecInput) ([]SpecInput, []error) {
 			in.Ext = filepath.Ext(in.Name)
 		}
 		path := filepath.Join(dir, in.SHA256+in.Ext)
-		if err := os.WriteFile(path, in.Content, 0o644); err != nil {
+		if err := os.WriteFile(path, in.Content, 0o600); err != nil {
 			errs = append(errs, fmt.Errorf("write input %s: %w", in.Name, err))
 			continue
 		}

--- a/pipeline/runspec.go
+++ b/pipeline/runspec.go
@@ -1,0 +1,189 @@
+// ABOUTME: Writes the executed specification into the run directory — source .dip, expanded IR, and input documents.
+// ABOUTME: Makes a run's structure reconstructible from the spec instead of from whichever per-node artifact files happen to exist.
+package pipeline
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+// Filenames written into <artifactDir>/<runID>/ by WriteSpecArtifacts.
+const (
+	SpecSourceFile = "workflow.dip"
+	SpecIRFile     = "workflow.ir.json"
+	SpecInputsDir  = "inputs"
+)
+
+// SpecInput is one document supplied to a run — a spec, a sprint file, any
+// reference material a node reads. Stored content-addressed so two runs given
+// the same input share a name, and so a recorded digest can be checked against
+// the bytes on disk.
+type SpecInput struct {
+	// Name is the document's original filename, for display only.
+	Name string `json:"name"`
+	// Role describes what the run used it for ("spec", "sprint", …). Free
+	// text; nothing branches on it.
+	Role string `json:"role,omitempty"`
+	// SHA256 is the digest of Content, and the stored file's basename.
+	SHA256 string `json:"sha256"`
+	// Size is Content's length in bytes.
+	Size int `json:"size_bytes"`
+	// Ext is the stored file's extension, including the dot.
+	Ext string `json:"ext,omitempty"`
+
+	// Content is the document itself. Not serialized into the manifest — the
+	// bytes live in inputs/<sha256><ext> so the manifest stays small.
+	Content []byte `json:"-"`
+}
+
+// SpecArtifacts is everything about the specification a run executed.
+type SpecArtifacts struct {
+	// SourcePath is where the .dip was read from, for display.
+	SourcePath string
+	// Source is the .dip verbatim.
+	Source string
+	// Workflow is the parsed IR. Recorded because dippin expands subgraphs at
+	// compile time: the authored source and the graph that actually ran are
+	// not the same document, and only the expanded form explains the events.
+	Workflow *ir.Workflow
+	// Params are the --param values as passed. These change behavior, so a
+	// spec recorded without them does not reproduce the run.
+	Params map[string]string
+	// Inputs are the documents the run was given.
+	Inputs []SpecInput
+	// BundleIdentity is the .dipx identity ("sha256:<hex>"), empty for a
+	// plain .dip run.
+	BundleIdentity string
+}
+
+// SpecManifest is the record of what WriteSpecArtifacts stored, for embedding
+// in a run manifest. Paths are relative to the run directory.
+type SpecManifest struct {
+	SourcePath     string            `json:"source_path,omitempty"`
+	SourceFile     string            `json:"source_file,omitempty"`
+	SourceSHA256   string            `json:"source_sha256,omitempty"`
+	IRFile         string            `json:"ir_file,omitempty"`
+	Params         map[string]string `json:"params,omitempty"`
+	Inputs         []SpecInput       `json:"inputs,omitempty"`
+	BundleIdentity string            `json:"bundle_identity,omitempty"`
+}
+
+// WriteSpecArtifacts stores the spec in runDir and returns a manifest of what
+// it wrote.
+//
+// Without this, a run's own structure is only recoverable by inference. Node
+// kind, the configured exit node, per-node model choices, and the edge set all
+// live in the spec; a reader that instead infers them from which artifact
+// directories exist gets them wrong at scale, because directories are sparse —
+// a 39-node run leaves a handful. Recording the spec turns that inference into
+// a join.
+//
+// Best-effort per file: a failure to write one artifact does not prevent the
+// others, and the manifest reports only what actually landed. The run itself is
+// never failed by this — losing telemetry is not worth losing the run.
+func WriteSpecArtifacts(runDir string, spec SpecArtifacts) (SpecManifest, error) {
+	manifest := SpecManifest{
+		SourcePath:     spec.SourcePath,
+		Params:         spec.Params,
+		BundleIdentity: spec.BundleIdentity,
+	}
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return manifest, fmt.Errorf("create run dir: %w", err)
+	}
+
+	var errs []error
+	if spec.Source != "" {
+		if err := writeSpecSource(runDir, spec.Source, &manifest); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if spec.Workflow != nil {
+		if err := writeSpecIR(runDir, spec.Workflow, &manifest); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	inputs, inputErrs := writeSpecInputs(runDir, spec.Inputs)
+	manifest.Inputs = inputs
+	errs = append(errs, inputErrs...)
+
+	return manifest, joinErrs(errs)
+}
+
+// writeSpecSource stores the .dip verbatim and records its digest.
+func writeSpecSource(runDir, source string, manifest *SpecManifest) error {
+	path := filepath.Join(runDir, SpecSourceFile)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", SpecSourceFile, err)
+	}
+	manifest.SourceFile = SpecSourceFile
+	manifest.SourceSHA256 = digest([]byte(source))
+	return nil
+}
+
+// writeSpecIR stores the expanded graph as JSON. Marshaling the IR is what
+// `dippin parse` does, so the file is the same shape that tool emits.
+func writeSpecIR(runDir string, workflow *ir.Workflow, manifest *SpecManifest) error {
+	data, err := json.MarshalIndent(workflow, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal IR: %w", err)
+	}
+	path := filepath.Join(runDir, SpecIRFile)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", SpecIRFile, err)
+	}
+	manifest.IRFile = SpecIRFile
+	return nil
+}
+
+// writeSpecInputs stores each input content-addressed under inputs/. Returns
+// the manifest entries for the inputs that landed, plus one error per failure.
+func writeSpecInputs(runDir string, inputs []SpecInput) ([]SpecInput, []error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	dir := filepath.Join(runDir, SpecInputsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, []error{fmt.Errorf("create %s: %w", SpecInputsDir, err)}
+	}
+
+	stored := make([]SpecInput, 0, len(inputs))
+	var errs []error
+	for _, in := range inputs {
+		in.SHA256 = digest(in.Content)
+		in.Size = len(in.Content)
+		if in.Ext == "" {
+			in.Ext = filepath.Ext(in.Name)
+		}
+		path := filepath.Join(dir, in.SHA256+in.Ext)
+		if err := os.WriteFile(path, in.Content, 0o644); err != nil {
+			errs = append(errs, fmt.Errorf("write input %s: %w", in.Name, err))
+			continue
+		}
+		stored = append(stored, in)
+	}
+	return stored, errs
+}
+
+// digest returns the hex sha256 of b.
+func digest(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// joinErrs collapses a slice of errors into one, or nil when empty.
+func joinErrs(errs []error) error {
+	switch len(errs) {
+	case 0:
+		return nil
+	case 1:
+		return errs[0]
+	default:
+		return fmt.Errorf("%w (and %d more)", errs[0], len(errs)-1)
+	}
+}

--- a/pipeline/runspec_test.go
+++ b/pipeline/runspec_test.go
@@ -1,0 +1,217 @@
+// ABOUTME: Tests for spec-artifact capture into the run directory.
+// ABOUTME: Covers verbatim source, expanded IR, content-addressed inputs, and best-effort failure behavior.
+package pipeline
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/dippin-lang/ir"
+)
+
+func TestWriteSpecArtifactsStoresSourceAndIR(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run1")
+	source := "workflow Hello\n  goal: \"say hi\"\n  start: A\n  exit: A\n"
+	workflow := &ir.Workflow{
+		Name: "Hello",
+		Goal: "say hi",
+		Nodes: []*ir.Node{
+			{ID: "A", Kind: ir.NodeAgent},
+		},
+	}
+
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		SourcePath: "/tmp/hello.dip",
+		Source:     source,
+		Workflow:   workflow,
+		Params:     map[string]string{"model": "claude-haiku-4-5"},
+	})
+	if err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+
+	// The .dip must be byte-identical: a spec diff between two runs is the
+	// whole point, and a reformatted copy would show spurious changes.
+	got, err := os.ReadFile(filepath.Join(runDir, SpecSourceFile))
+	if err != nil {
+		t.Fatalf("read source: %v", err)
+	}
+	if string(got) != source {
+		t.Errorf("stored source = %q, want verbatim %q", got, source)
+	}
+	if manifest.SourceSHA256 == "" {
+		t.Error("manifest records no source digest")
+	}
+	if manifest.SourcePath != "/tmp/hello.dip" {
+		t.Errorf("manifest SourcePath = %q, want the original path", manifest.SourcePath)
+	}
+	if manifest.Params["model"] != "claude-haiku-4-5" {
+		t.Errorf("manifest Params = %v, want the passed params", manifest.Params)
+	}
+
+	// The IR is the graph that actually ran; dippin expands subgraphs at
+	// compile time, so it is a different document from the source.
+	irData, err := os.ReadFile(filepath.Join(runDir, SpecIRFile))
+	if err != nil {
+		t.Fatalf("read IR: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(irData, &parsed); err != nil {
+		t.Fatalf("IR is not valid JSON: %v", err)
+	}
+	if manifest.IRFile != SpecIRFile {
+		t.Errorf("manifest IRFile = %q, want %q", manifest.IRFile, SpecIRFile)
+	}
+}
+
+func TestWriteSpecArtifactsContentAddressesInputs(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run2")
+	body := []byte("# Sprint 001\nStand up the skeleton.\n")
+
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Source: "workflow X\n",
+		Inputs: []SpecInput{
+			{Name: "SPRINT-001.md", Role: "sprint", Content: body},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+	if len(manifest.Inputs) != 1 {
+		t.Fatalf("manifest has %d inputs, want 1", len(manifest.Inputs))
+	}
+
+	in := manifest.Inputs[0]
+	if in.SHA256 == "" {
+		t.Fatal("input has no digest")
+	}
+	if in.Size != len(body) {
+		t.Errorf("input Size = %d, want %d", in.Size, len(body))
+	}
+	if in.Ext != ".md" {
+		t.Errorf("input Ext = %q, want .md (inferred from the name)", in.Ext)
+	}
+
+	// Stored under its digest, so identical inputs across runs collide by
+	// design and a recorded digest can be checked against the bytes.
+	stored, err := os.ReadFile(filepath.Join(runDir, SpecInputsDir, in.SHA256+in.Ext))
+	if err != nil {
+		t.Fatalf("read stored input: %v", err)
+	}
+	if string(stored) != string(body) {
+		t.Errorf("stored input = %q, want %q", stored, body)
+	}
+
+	// The manifest must not inline the bytes — it stays small so a reader can
+	// load it without pulling every input into memory.
+	encoded, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if strings.Contains(string(encoded), "Stand up the skeleton") {
+		t.Error("manifest inlines input content; it should only reference the digest")
+	}
+}
+
+func TestWriteSpecArtifactsDedupesIdenticalInputs(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run3")
+	body := []byte("shared reference material")
+
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Inputs: []SpecInput{
+			{Name: "a.txt", Content: body},
+			{Name: "b.txt", Content: body},
+		},
+	})
+	if err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+	if len(manifest.Inputs) != 2 {
+		t.Fatalf("manifest has %d inputs, want both recorded", len(manifest.Inputs))
+	}
+	if manifest.Inputs[0].SHA256 != manifest.Inputs[1].SHA256 {
+		t.Error("identical content produced different digests")
+	}
+
+	// Both manifest entries survive (they had different names), but only one
+	// file is stored, because the name is the digest.
+	entries, err := os.ReadDir(filepath.Join(runDir, SpecInputsDir))
+	if err != nil {
+		t.Fatalf("read inputs dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("stored %d files, want 1 (content-addressed)", len(entries))
+	}
+}
+
+func TestWriteSpecArtifactsSkipsEmptyFields(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run4")
+
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{})
+	if err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+	// Nothing supplied, nothing written, and no phantom manifest entries
+	// pointing at files that don't exist.
+	if manifest.SourceFile != "" || manifest.IRFile != "" || len(manifest.Inputs) != 0 {
+		t.Errorf("manifest references artifacts that were never written: %+v", manifest)
+	}
+	for _, name := range []string{SpecSourceFile, SpecIRFile, SpecInputsDir} {
+		if _, err := os.Stat(filepath.Join(runDir, name)); !os.IsNotExist(err) {
+			t.Errorf("%s exists but nothing was supplied for it", name)
+		}
+	}
+}
+
+func TestWriteSpecArtifactsRecordsBundleIdentity(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run5")
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Source:         "workflow X\n",
+		BundleIdentity: "sha256:deadbeef",
+	})
+	if err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+	if manifest.BundleIdentity != "sha256:deadbeef" {
+		t.Errorf("BundleIdentity = %q, want it carried through", manifest.BundleIdentity)
+	}
+}
+
+func TestWriteSpecArtifactsIsBestEffortPerFile(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "run6")
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Occupy the inputs path with a regular file so MkdirAll under it fails,
+	// while the source write is unaffected.
+	if err := os.WriteFile(filepath.Join(runDir, SpecInputsDir), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	manifest, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Source: "workflow X\n",
+		Inputs: []SpecInput{{Name: "a.txt", Content: []byte("a")}},
+	})
+	if err == nil {
+		t.Error("expected an error for the input that could not be stored")
+	}
+	// The source still landed: one artifact failing must not cost the others.
+	if manifest.SourceFile == "" {
+		t.Error("source was not written despite being independent of the failure")
+	}
+	if len(manifest.Inputs) != 0 {
+		t.Error("manifest lists an input that was never stored")
+	}
+}
+
+func TestDigestIsStable(t *testing.T) {
+	if digest([]byte("abc")) != digest([]byte("abc")) {
+		t.Error("digest is not deterministic")
+	}
+	if digest([]byte("abc")) == digest([]byte("abd")) {
+		t.Error("digest collides on different content")
+	}
+}

--- a/pipeline/runspec_test.go
+++ b/pipeline/runspec_test.go
@@ -253,3 +253,49 @@ func TestSecretParamsAreRedacted(t *testing.T) {
 		t.Error("nil params should stay nil")
 	}
 }
+
+// TestSpecArtifactsAreNarrowedOnRewrite covers a CodeRabbit finding on #519:
+// os.WriteFile applies its mode only when it *creates* the file, so a run
+// directory that already held a world-readable artifact — a resumed run, a
+// reused dir — kept the wider permissions and left the spec (and any params or
+// reference material in it) readable by other local users.
+func TestSpecArtifactsAreNarrowedOnRewrite(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "reused")
+	inputsDir := filepath.Join(runDir, SpecInputsDir)
+	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte("reference material")
+	sha := digest(body)
+	// Pre-create every artifact wide open, as a prior run would have left them.
+	pre := map[string][]byte{
+		filepath.Join(runDir, SpecSourceFile): []byte("stale\n"),
+		filepath.Join(runDir, SpecIRFile):     []byte("{}\n"),
+		filepath.Join(inputsDir, sha+".md"):   []byte("stale\n"),
+	}
+	for path, data := range pre {
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := WriteSpecArtifacts(runDir, SpecArtifacts{
+		Source:   "workflow X\n",
+		Workflow: &ir.Workflow{Name: "X"},
+		Inputs:   []SpecInput{{Name: "ref.md", Content: body}},
+	}); err != nil {
+		t.Fatalf("WriteSpecArtifacts: %v", err)
+	}
+
+	for path := range pre {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if got := info.Mode().Perm(); got != specFileMode {
+			t.Errorf("%s mode = %#o, want %#o — a pre-existing wide file was not narrowed",
+				filepath.Base(path), got, specFileMode)
+		}
+	}
+}

--- a/pipeline/runspec_test.go
+++ b/pipeline/runspec_test.go
@@ -208,10 +208,48 @@ func TestWriteSpecArtifactsIsBestEffortPerFile(t *testing.T) {
 }
 
 func TestDigestIsStable(t *testing.T) {
-	if digest([]byte("abc")) != digest([]byte("abc")) {
+	// Bind the first call rather than comparing digest(x) != digest(x) inline:
+	// staticcheck flags identical operands (SA4000) even though determinism is
+	// exactly what this asserts.
+	abc := digest([]byte("abc"))
+	if abc != digest([]byte("abc")) {
 		t.Error("digest is not deterministic")
 	}
-	if digest([]byte("abc")) == digest([]byte("abd")) {
+	if abc == digest([]byte("abd")) {
 		t.Error("digest collides on different content")
+	}
+}
+
+// TestSecretParamsAreRedacted covers a CodeRabbit finding on #519: --param
+// values commonly carry credentials, and the manifest is durable on-disk, so a
+// secret-looking key must not persist its value. Keys are kept — knowing which
+// params a run was given is part of reproducing it, and the name is not secret.
+func TestSecretParamsAreRedacted(t *testing.T) {
+	got := redactSecretParams(map[string]string{
+		"api_key":     "sk-live-abc123",
+		"AUTH_TOKEN":  "bearer-xyz",
+		"db-password": "hunter2",
+		"model":       "claude-haiku-4-5",
+		"empty_token": "",
+	})
+
+	for _, k := range []string{"api_key", "AUTH_TOKEN", "db-password"} {
+		if got[k] != redactedParamValue {
+			t.Errorf("%s = %q, want %q", k, got[k], redactedParamValue)
+		}
+	}
+	if got["model"] != "claude-haiku-4-5" {
+		t.Errorf("non-secret param was altered: %q", got["model"])
+	}
+	// An empty value has nothing to hide; redacting it would imply a secret
+	// exists where none was passed.
+	if got["empty_token"] != "" {
+		t.Errorf("empty value became %q", got["empty_token"])
+	}
+	if len(got) != 5 {
+		t.Errorf("key set changed: %v", got)
+	}
+	if redactSecretParams(nil) != nil {
+		t.Error("nil params should stay nil")
 	}
 }

--- a/pipeline/runusage.go
+++ b/pipeline/runusage.go
@@ -1,0 +1,218 @@
+package pipeline
+
+import (
+	"strconv"
+)
+
+// usageTier ranks how directly a log line reports LLM consumption.
+//
+// The same call is reported at up to three granularities: the call itself
+// (llm_finish), the turn that issued it (turn_metrics), and the node that ran
+// the turn (decision_outcome). Summing across tiers multiplies the truth — a
+// six-turn node whose every call is restated at all three levels reports three
+// times its real token count. So totals come from the most direct tier the log
+// actually contains, and coarser restatements of the same calls are ignored.
+//
+// The tiers are ordered coarsest-first so that a higher value is more direct.
+type usageTier int
+
+const (
+	tierNodeRollup usageTier = iota // decision_outcome: one line per node
+	tierTurn                        // turn_metrics: one line per agent turn
+	tierCall                        // llm_finish: one line per LLM call
+)
+
+// usageTiers lists the tiers most-direct first, which is the order totals
+// prefer them in.
+var usageTiers = []usageTier{tierCall, tierTurn, tierNodeRollup}
+
+// usageRecord is one tier's report of consumption, tagged with the node it
+// belongs to so per-node attribution falls out of the same pass.
+type usageRecord struct {
+	nodeID string
+	totals RunTotals
+}
+
+// usageIdentity classifies a usage-bearing line and names the unit it
+// describes, so repeated reports of one unit collapse instead of summing.
+//
+// Only the call tier can repeat within itself, because both log paths report
+// the same call; call_id collapses that pair. The turn and node tiers emit once
+// per turn and once per node visit, so each of their lines is its own unit — a
+// retried or revisited node emits a separate rollup per visit, and keying those
+// by node id alone would silently discard every visit but the last.
+func usageIdentity(e jsonlLogEntry) (usageTier, string) {
+	perLine := e.Timestamp + "|" + e.Type + "|" + e.NodeID
+	switch e.Type {
+	case "decision_outcome":
+		return tierNodeRollup, perLine
+	case "turn_metrics":
+		return tierTurn, perLine + "|" + e.SessionID + "|" + strconv.Itoa(e.TurnNo)
+	default:
+		if e.CallID != "" {
+			return tierCall, e.CallID
+		}
+		return tierCall, perLine
+	}
+}
+
+// hasTokens and hasCost say which metric a record carries. Tokens and cost are
+// selected independently because no single tier carries both: llm_finish meters
+// tokens without pricing them, and turn_metrics prices a turn without
+// re-reporting per-call cache figures.
+func hasTokens(r RunTotals) bool { return r.InputTokens != 0 || r.OutputTokens != 0 }
+func hasCost(r RunTotals) bool   { return r.CostUSD != 0 }
+
+// isCompletion reports whether a line marks one LLM call finishing.
+//
+// Both log paths record the same call: the client writer emits "finish" for
+// every call, and an agent session re-emits its own subset as "llm_finish".
+// Counting either alone is wrong — in archived runs the agent subset was under
+// half the total — so both are counted and deduplicated by call identity.
+func isCompletion(e jsonlLogEntry) bool {
+	if e.Source != "llm" && e.Source != "agent" {
+		return false
+	}
+	return e.Type == "finish" || e.Type == "llm_finish"
+}
+
+// usageLedger folds usage-bearing log lines into per-tier buckets.
+type usageLedger struct {
+	tiers map[usageTier]map[string]usageRecord
+	// callIDs holds one entry per distinct call_id seen completing. Counted
+	// from completion events rather than from usage rows: the tier carrying
+	// usage is often coarser than a call, so its entry count is not a call
+	// count.
+	callIDs map[string]struct{}
+	// pathCompletions counts completions per log path, for logs written
+	// before call_id existed. Timestamps cannot substitute — the two paths
+	// record the same call microseconds apart, so pairing by timestamp
+	// matched barely a tenth of one archived run's calls and nearly doubled
+	// its total.
+	pathCompletions map[string]int
+}
+
+func newUsageLedger() *usageLedger {
+	return &usageLedger{
+		tiers:           map[usageTier]map[string]usageRecord{},
+		callIDs:         map[string]struct{}{},
+		pathCompletions: map[string]int{},
+	}
+}
+
+// llmCalls returns the number of distinct LLM calls.
+//
+// Each path independently tries to record every call, so the fuller path is
+// the better count and a union across paths would double-count. Where call_ids
+// are present they identify calls exactly and agree with the per-path counts;
+// where they are absent the per-path maximum carries it, which is a lower bound
+// if one path dropped events.
+func (l *usageLedger) llmCalls() int {
+	best := len(l.callIDs)
+	for _, n := range l.pathCompletions {
+		if n > best {
+			best = n
+		}
+	}
+	return best
+}
+
+// add records one line, replacing any earlier report of the same logical unit:
+// a finish event carries that unit's authoritative totals and supersedes
+// partial figures reported while it was still streaming.
+func (l *usageLedger) add(e jsonlLogEntry) {
+	if isCompletion(e) {
+		l.pathCompletions[e.Source]++
+		if e.CallID != "" {
+			l.callIDs[e.CallID] = struct{}{}
+		}
+	}
+	if e.TokenInput == 0 && e.TokenOutput == 0 && e.EstimatedCost == 0 {
+		return
+	}
+	tier, key := usageIdentity(e)
+	bucket, ok := l.tiers[tier]
+	if !ok {
+		bucket = map[string]usageRecord{}
+		l.tiers[tier] = bucket
+	}
+	bucket[key] = usageRecord{
+		nodeID: e.NodeID,
+		totals: RunTotals{
+			InputTokens:      e.TokenInput,
+			OutputTokens:     e.TokenOutput,
+			CacheReadTokens:  e.CacheReadTokens,
+			CacheWriteTokens: e.CacheWriteTokens,
+			ReasoningTokens:  e.ReasoningTokens,
+			CostUSD:          e.EstimatedCost,
+		},
+	}
+}
+
+// bestTier returns the most direct tier holding the given metric.
+func (l *usageLedger) bestTier(carries func(RunTotals) bool) (usageTier, bool) {
+	for _, t := range usageTiers {
+		for _, r := range l.tiers[t] {
+			if carries(r.totals) {
+				return t, true
+			}
+		}
+	}
+	return tierCall, false
+}
+
+// runTotals sums the run's consumption, taking tokens and cost each from the
+// most direct tier reporting them.
+func (l *usageLedger) runTotals(estimated bool) RunTotals {
+	out := RunTotals{Estimated: estimated, LLMCalls: l.llmCalls()}
+	if t, ok := l.bestTier(hasTokens); ok {
+		for _, r := range l.tiers[t] {
+			addTokens(&out, r.totals)
+		}
+	}
+	if t, ok := l.bestTier(hasCost); ok {
+		for _, r := range l.tiers[t] {
+			out.CostUSD += r.totals.CostUSD
+		}
+	}
+	return out
+}
+
+// nodeTotals attributes consumption to the node that incurred it, using the
+// same tier selection as the run totals so the parts sum to the whole.
+// Records with no node id are omitted: they cannot be attributed, and guessing
+// would silently misprice a node.
+func (l *usageLedger) nodeTotals() map[string]*RunTotals {
+	per := map[string]*RunTotals{}
+	if t, ok := l.bestTier(hasTokens); ok {
+		l.foldNode(per, t, func(dst *RunTotals, src RunTotals) { addTokens(dst, src) })
+	}
+	if t, ok := l.bestTier(hasCost); ok {
+		l.foldNode(per, t, func(dst *RunTotals, src RunTotals) { dst.CostUSD += src.CostUSD })
+	}
+	return per
+}
+
+// foldNode applies one tier's records to their nodes.
+func (l *usageLedger) foldNode(per map[string]*RunTotals, t usageTier, apply func(*RunTotals, RunTotals)) {
+	for _, r := range l.tiers[t] {
+		if r.nodeID == "" {
+			continue
+		}
+		dst, ok := per[r.nodeID]
+		if !ok {
+			dst = &RunTotals{}
+			per[r.nodeID] = dst
+		}
+		apply(dst, r.totals)
+	}
+}
+
+// addTokens accumulates every metered token figure, leaving cost alone.
+func addTokens(dst *RunTotals, src RunTotals) {
+	dst.InputTokens += src.InputTokens
+	dst.OutputTokens += src.OutputTokens
+	dst.CacheReadTokens += src.CacheReadTokens
+	dst.CacheWriteTokens += src.CacheWriteTokens
+	dst.ReasoningTokens += src.ReasoningTokens
+}

--- a/pipeline/runusage.go
+++ b/pipeline/runusage.go
@@ -136,7 +136,7 @@ func (l *usageLedger) add(e jsonlLogEntry) {
 		bucket = map[string]usageRecord{}
 		l.tiers[tier] = bucket
 	}
-	bucket[key] = usageRecord{
+	rec := usageRecord{
 		nodeID: e.NodeID,
 		totals: RunTotals{
 			InputTokens:      e.TokenInput,
@@ -147,6 +147,23 @@ func (l *usageLedger) add(e jsonlLogEntry) {
 			CostUSD:          e.EstimatedCost,
 		},
 	}
+	bucket[key] = keepKnownNode(rec, bucket[key])
+}
+
+// keepKnownNode carries a previously-recorded node id onto a replacement that
+// lacks one.
+//
+// Both log paths share a call_id, but the client-sourced "finish" line carries
+// no node_id while the agent-sourced "llm_finish" does. Plain last-writer-wins
+// therefore let a node-less duplicate erase the attribution, after which
+// nodeTotals drops the record: run totals stayed correct while the per-node
+// shares silently stopped summing to the whole — the one invariant this file
+// exists to hold.
+func keepKnownNode(rec, prev usageRecord) usageRecord {
+	if rec.nodeID == "" {
+		rec.nodeID = prev.nodeID
+	}
+	return rec
 }
 
 // bestTier returns the most direct tier holding the given metric.

--- a/pipeline/runusage_test.go
+++ b/pipeline/runusage_test.go
@@ -126,3 +126,37 @@ func TestNodeUsageSumsToRunTotals(t *testing.T) {
 		t.Errorf("node costs sum to %v, run total says %v", cost, m.Totals.CostUSD)
 	}
 }
+
+// TestNodeAttributionSurvivesANodelessDuplicate covers a CodeRabbit finding on
+// #519: both log paths share a call_id, but the client-sourced "finish" line
+// carries no node_id while the agent-sourced "llm_finish" does. Last-writer-wins
+// meant a node-less duplicate arriving second erased the attribution, so the run
+// totals stayed right while the per-node shares stopped summing to the whole —
+// the one invariant runusage.go exists to hold.
+func TestNodeAttributionSurvivesANodelessDuplicate(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r5")
+	writeLog(t, runDir,
+		// Agent path first, carrying the node.
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"agent","type":"llm_finish","node_id":"Gen","call_id":"c1","token_input":100,"token_output":10}`,
+		// Client path second, same call, no node_id.
+		`{"ts":"2026-01-01T00:00:01.001Z","source":"llm","type":"finish","call_id":"c1","token_input":100,"token_output":10}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Totals.InputTokens != 100 {
+		t.Errorf("input_tokens = %d, want 100 (one call, counted once)", m.Totals.InputTokens)
+	}
+	var attributed int
+	for _, n := range m.Nodes {
+		if n.Usage != nil {
+			attributed += n.Usage.InputTokens
+		}
+	}
+	if attributed != m.Totals.InputTokens {
+		t.Errorf("node usage sums to %d but run total is %d — the node-less duplicate erased the attribution",
+			attributed, m.Totals.InputTokens)
+	}
+}

--- a/pipeline/runusage_test.go
+++ b/pipeline/runusage_test.go
@@ -1,0 +1,128 @@
+// ABOUTME: Tests for how run totals are derived from a log that reports the same consumption at several granularities.
+// ABOUTME: Covers cross-tier de-duplication, per-visit node rollups, dual-path call counting, and per-node attribution.
+package pipeline
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestRunTotalsIgnoreCoarserRestatements is the regression test for a live
+// t6 codegen run reporting exactly three times its real token count. One call
+// is logged three ways — as the call, as the turn that issued it, and as the
+// node rollup — and summing all three tripled every figure.
+func TestRunTotalsIgnoreCoarserRestatements(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r1")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:00.000Z","source":"pipeline","type":"stage_started","node_id":"Gen","node_kind":"codergen","attempt_no":1}`,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"agent","type":"turn_start","node_id":"Gen","session_id":"s1","turn_no":1}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"agent","type":"llm_finish","node_id":"Gen","session_id":"s1","turn_no":1,"call_id":"c1","token_input":100,"token_output":40,"cache_read_tokens":7}`,
+		`{"ts":"2026-01-01T00:00:03.000Z","source":"agent","type":"turn_metrics","node_id":"Gen","session_id":"s1","turn_no":1,"token_input":100,"token_output":40,"cache_read_tokens":7,"estimated_cost":0.5}`,
+		`{"ts":"2026-01-01T00:00:04.000Z","source":"pipeline","type":"decision_outcome","node_id":"Gen","outcome_status":"success","token_input":100,"token_output":40}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Totals.InputTokens != 100 || m.Totals.OutputTokens != 40 {
+		t.Errorf("tokens counted %d/%d, want 100/40 (one call, not three restatements)",
+			m.Totals.InputTokens, m.Totals.OutputTokens)
+	}
+	if m.Totals.CacheReadTokens != 7 {
+		t.Errorf("cache read tokens = %d, want 7", m.Totals.CacheReadTokens)
+	}
+	// Cost is reported only by the turn tier, so it must survive tokens being
+	// taken from the call tier.
+	if m.Totals.CostUSD != 0.5 {
+		t.Errorf("cost = %v, want 0.5 (from the turn tier)", m.Totals.CostUSD)
+	}
+	if m.Totals.LLMCalls != 1 {
+		t.Errorf("llm_calls = %d, want 1", m.Totals.LLMCalls)
+	}
+}
+
+// TestRunTotalsSumEveryNodeVisit guards the opposite error: node rollups are
+// emitted once per visit, so a retried node reports twice and both visits are
+// real consumption. Keying them by node id alone kept only the last and
+// silently halved archived runs whose only usage figures came from that tier.
+func TestRunTotalsSumEveryNodeVisit(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r2")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"pipeline","type":"decision_outcome","node_id":"Gen","token_input":100,"token_output":10}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"pipeline","type":"decision_outcome","node_id":"Gen","token_input":300,"token_output":20}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Totals.InputTokens != 400 || m.Totals.OutputTokens != 30 {
+		t.Errorf("tokens = %d/%d, want 400/30 (both visits)",
+			m.Totals.InputTokens, m.Totals.OutputTokens)
+	}
+}
+
+// TestLLMCallsUsesTheFullerLogPath covers logs written before call_id existed.
+// Both paths record every call, and their timestamps differ by microseconds, so
+// pairing by timestamp double-counts while trusting the agent path alone
+// undercounts — one archived run recorded 253 calls on the client path and only
+// 84 on the agent path.
+func TestLLMCallsUsesTheFullerLogPath(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r3")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"llm","type":"finish","model":"m"}`,
+		`{"ts":"2026-01-01T00:00:01.001Z","source":"agent","type":"llm_finish","node_id":"Gen","model":"m"}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"llm","type":"finish","model":"m"}`,
+		`{"ts":"2026-01-01T00:00:03.000Z","source":"llm","type":"finish","model":"m"}`,
+		`{"ts":"2026-01-01T00:00:04.000Z","source":"pipeline","type":"decision_outcome","node_id":"Gen","token_input":5,"token_output":5}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Totals.LLMCalls != 3 {
+		t.Errorf("llm_calls = %d, want 3 (the fuller path, neither the union of 4 nor the agent subset of 1)",
+			m.Totals.LLMCalls)
+	}
+}
+
+// TestNodeUsageSumsToRunTotals is the invariant that makes per-node cost
+// trustworthy: attribute from the same tier the run totals use, so the parts
+// add up to the whole.
+func TestNodeUsageSumsToRunTotals(t *testing.T) {
+	runDir := filepath.Join(t.TempDir(), "r4")
+	writeLog(t, runDir,
+		`{"ts":"2026-01-01T00:00:01.000Z","source":"agent","type":"llm_finish","node_id":"A","call_id":"c1","token_input":100,"token_output":10}`,
+		`{"ts":"2026-01-01T00:00:02.000Z","source":"agent","type":"turn_metrics","node_id":"A","session_id":"s1","turn_no":1,"estimated_cost":0.25}`,
+		`{"ts":"2026-01-01T00:00:03.000Z","source":"agent","type":"llm_finish","node_id":"B","call_id":"c2","token_input":50,"token_output":5}`,
+		`{"ts":"2026-01-01T00:00:04.000Z","source":"agent","type":"turn_metrics","node_id":"B","session_id":"s2","turn_no":1,"estimated_cost":0.75}`,
+		`{"ts":"2026-01-01T00:00:05.000Z","source":"pipeline","type":"stage_started","node_id":"Tool","node_kind":"tool"}`,
+	)
+
+	m, err := AssembleRunManifest(runDir, "r4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var in, out int
+	var cost float64
+	for _, n := range m.Nodes {
+		if n.ID == "Tool" && n.Usage != nil {
+			t.Errorf("tool node carries usage %+v, want none", n.Usage)
+		}
+		if n.Usage == nil {
+			continue
+		}
+		in += n.Usage.InputTokens
+		out += n.Usage.OutputTokens
+		cost += n.Usage.CostUSD
+	}
+	if in != m.Totals.InputTokens || out != m.Totals.OutputTokens {
+		t.Errorf("node tokens sum to %d/%d, run totals say %d/%d",
+			in, out, m.Totals.InputTokens, m.Totals.OutputTokens)
+	}
+	if cost != m.Totals.CostUSD {
+		t.Errorf("node costs sum to %v, run total says %v", cost, m.Totals.CostUSD)
+	}
+}

--- a/tracker_capture_e2e_test.go
+++ b/tracker_capture_e2e_test.go
@@ -87,6 +87,7 @@ type logEntry struct {
 	ToolInput  string `json:"tool_input"`
 	CallID     string `json:"call_id"`
 	Terminal   string `json:"terminal_status"`
+	Content    string `json:"content"`
 	TokenIn    int    `json:"token_input"`
 	TokenOut   int    `json:"token_output"`
 	FinishWhy  string `json:"finish_reason"`
@@ -237,6 +238,42 @@ func TestRunCapture_ActivityLogCarriesReconstructionFields(t *testing.T) {
 		}
 		if statuses[0] != "success" {
 			t.Errorf("terminal_status = %q, want success", statuses[0])
+		}
+	})
+
+	t.Run("llm events carry a call id and the wire request body", func(t *testing.T) {
+		// Structurally out of reach here: a bare agent.Completer stub bypasses
+		// llm.Client, so completeWithTrace never runs, no CallID is minted, and
+		// no llm_* trace events exist to carry the wire body. Only a run through
+		// a real client and provider adapter exercises that path — which is
+		// exactly why a live Haiku run was the first thing to catch these being
+		// dropped at the agent re-emission boundary, and why asserting it here
+		// would test the harness rather than the code. Covered instead by
+		// pipeline.TestApplyAgentEventFieldsCarriesCallIDAndRequestRaw (the
+		// boundary itself) and by capture-tests/t2 (the whole path, live).
+		var sawLLM bool
+		for _, e := range entries {
+			if e.Type == "llm_request_start" || e.Type == "llm_finish" {
+				sawLLM = true
+			}
+		}
+		if !sawLLM {
+			t.Skip("no llm_* trace events: stub Completer bypasses llm.Client")
+		}
+		var sawCallID, sawBody bool
+		for _, e := range entries {
+			if e.CallID != "" {
+				sawCallID = true
+			}
+			if e.Type == "llm_request_start" && strings.HasPrefix(strings.TrimSpace(e.Content), "{") {
+				sawBody = true
+			}
+		}
+		if !sawCallID {
+			t.Error("no event carries a call_id — usage cannot be de-duplicated across log paths")
+		}
+		if !sawBody {
+			t.Error("no llm_request_start carries the wire request body")
 		}
 	})
 

--- a/tracker_capture_e2e_test.go
+++ b/tracker_capture_e2e_test.go
@@ -324,7 +324,7 @@ func TestRunCapture_ManifestAssemblesFromRealRun(t *testing.T) {
 	if m.TerminalStatus != "success" {
 		t.Errorf("terminal_status = %q, want success", m.TerminalStatus)
 	}
-	// quickDip has two agent nodes; both must appear, with their kind.
+	// captureDip has two agent nodes; both must appear, with their kind.
 	if len(m.Nodes) != 2 {
 		t.Fatalf("got %d nodes, want 2: %+v", len(m.Nodes), m.Nodes)
 	}

--- a/tracker_capture_e2e_test.go
+++ b/tracker_capture_e2e_test.go
@@ -1,0 +1,319 @@
+// ABOUTME: End-to-end tests that run a real pipeline and assert the activity log carries the run-reconstruction fields.
+// ABOUTME: Covers the whole path — agent session -> event -> JSONL -> run.json — which unit tests per layer cannot.
+package tracker
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// toolCallingStub asks for one tool call, then answers with text so the session
+// terminates. The shipped stubs never request a tool, which left tool_input,
+// multi-turn, and turn-on-tool-events testable only against a live provider.
+type toolCallingStub struct {
+	calls int
+}
+
+func (s *toolCallingStub) Complete(_ context.Context, _ *llm.Request) (*llm.Response, error) {
+	s.calls++
+	if s.calls == 1 {
+		return &llm.Response{
+			Message: llm.Message{
+				Role: llm.RoleAssistant,
+				Content: []llm.ContentPart{{
+					Kind: llm.KindToolCall,
+					ToolCall: &llm.ToolCallData{
+						ID:   "call_1",
+						Name: "definitely_not_a_registered_tool",
+						// Deliberately longer than the 80-char preview limit:
+						// a clipped copy reaching the log would be invisible
+						// without something long enough to notice.
+						Arguments: json.RawMessage(`{"path":"` + strings.Repeat("z", 120) + `"}`),
+					},
+				}},
+			},
+			FinishReason: llm.FinishReason{Reason: "tool_calls"},
+			Usage:        llm.Usage{InputTokens: 100, OutputTokens: 20, TotalTokens: 120},
+		}, nil
+	}
+	return &llm.Response{
+		Message:      llm.AssistantMessage("done"),
+		FinishReason: llm.FinishReason{Reason: "stop"},
+		Usage:        llm.Usage{InputTokens: 130, OutputTokens: 5, TotalTokens: 135},
+	}, nil
+}
+
+// captureDip has agent nodes with prompts. A prompt is required: codergen
+// skips the LLM entirely for a promptless agent node, so a pipeline without one
+// produces no agent session and therefore none of the events under test.
+const captureDip = `workflow capture
+  start: A
+  exit: B
+
+  agent A
+    label: A
+    prompt:
+      Do the first thing.
+
+  agent B
+    label: B
+    prompt:
+      Do the second thing.
+
+  edges
+    A -> B
+`
+
+// logEntry is the subset of the on-disk activity-log schema these tests read.
+// Declared here rather than reaching into pipeline's unexported type, so the
+// test asserts against the wire format a real consumer sees.
+type logEntry struct {
+	Source     string `json:"source"`
+	Type       string `json:"type"`
+	NodeID     string `json:"node_id"`
+	NodeKind   string `json:"node_kind"`
+	AttemptNo  int    `json:"attempt_no"`
+	SessionID  string `json:"session_id"`
+	TurnNo     int    `json:"turn_no"`
+	ToolName   string `json:"tool_name"`
+	ToolInput  string `json:"tool_input"`
+	CallID     string `json:"call_id"`
+	Terminal   string `json:"terminal_status"`
+	TokenIn    int    `json:"token_input"`
+	TokenOut   int    `json:"token_output"`
+	FinishWhy  string `json:"finish_reason"`
+	TurnMs     int64  `json:"turn_duration_ms"`
+	ToolCallMs int64  `json:"tool_duration_ms"`
+}
+
+// readRunLog returns the parsed activity log for the single run under workDir.
+func readRunLog(t *testing.T, workDir string) []logEntry {
+	t.Helper()
+	runsDir := filepath.Join(workDir, ".tracker", "runs")
+	dirs, err := os.ReadDir(runsDir)
+	if err != nil {
+		t.Fatalf("read runs dir: %v", err)
+	}
+	if len(dirs) != 1 {
+		t.Fatalf("expected exactly 1 run dir, got %d", len(dirs))
+	}
+	path := filepath.Join(runsDir, dirs[0].Name(), "activity.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read activity log: %v", err)
+	}
+	var out []logEntry
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		line = strings.TrimPrefix(line, pipeline.ActivityLogSentinel)
+		if line == "" {
+			continue
+		}
+		var e logEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Fatalf("unmarshal %q: %v", line, err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// TestRunCapture_ActivityLogCarriesReconstructionFields runs a real pipeline and
+// asserts the on-disk log carries everything needed to rebuild the run as a
+// tree. Each field here was populated in memory and dropped at the log
+// boundary; only an end-to-end run proves the whole chain.
+func TestRunCapture_ActivityLogCarriesReconstructionFields(t *testing.T) {
+	workDir := t.TempDir()
+	handler := pipeline.NewJSONLEventHandler(filepath.Join(workDir, ".tracker", "runs"))
+	stub := &toolCallingStub{}
+
+	_, err := Run(context.Background(), captureDip, Config{
+		Format:       "dip",
+		WorkingDir:   workDir,
+		LLMClient:    stub,
+		EventHandler: handler,
+		AgentEvents:  agent.EventHandlerFunc(handler.WriteAgentEvent),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := handler.Close(); err != nil {
+		t.Fatalf("close log: %v", err)
+	}
+
+	entries := readRunLog(t, workDir)
+
+	t.Run("every agent-source event carries a session id", func(t *testing.T) {
+		// Without this, events from concurrently-executing parallel branches
+		// cannot be separated: they interleave into one file.
+		checked := 0
+		for _, e := range entries {
+			if e.Source != "agent" || !sessionScopedType(e.Type) {
+				continue
+			}
+			checked++
+			if e.SessionID == "" {
+				t.Errorf("%s carries no session_id", e.Type)
+			}
+		}
+		if checked == 0 {
+			t.Fatal("no session-scoped agent events in the log")
+		}
+	})
+
+	t.Run("tool events carry the turn that issued them and the full input", func(t *testing.T) {
+		var found bool
+		for _, e := range entries {
+			if e.Type != "tool_call_start" {
+				continue
+			}
+			found = true
+			if e.TurnNo != 1 {
+				t.Errorf("tool_call_start turn_no = %d, want 1", e.TurnNo)
+			}
+			if e.ToolName == "" {
+				t.Error("tool_call_start carries no tool_name")
+			}
+			// The arguments are 120+ chars; a clipped copy would prove the
+			// preview path is still in play.
+			if !strings.Contains(e.ToolInput, strings.Repeat("z", 120)) {
+				t.Errorf("tool_input is truncated or absent: %q", e.ToolInput)
+			}
+		}
+		if !found {
+			t.Fatal("no tool_call_start event reached the log")
+		}
+	})
+
+	t.Run("the run reached a second turn", func(t *testing.T) {
+		// A tool call means the session loops; turn 2 is what proves the turn
+		// counter is real rather than hardcoded.
+		maxTurn := 0
+		for _, e := range entries {
+			if e.TurnNo > maxTurn {
+				maxTurn = e.TurnNo
+			}
+		}
+		if maxTurn < 2 {
+			t.Errorf("highest turn_no = %d, want >= 2", maxTurn)
+		}
+	})
+
+	t.Run("node events carry kind and attempt", func(t *testing.T) {
+		var found bool
+		for _, e := range entries {
+			if e.Type != "stage_started" {
+				continue
+			}
+			found = true
+			if e.NodeKind == "" {
+				t.Errorf("stage_started for %q carries no node_kind", e.NodeID)
+			}
+			if e.AttemptNo != 1 {
+				t.Errorf("stage_started for %q attempt_no = %d, want 1", e.NodeID, e.AttemptNo)
+			}
+		}
+		if !found {
+			t.Fatal("no stage_started event reached the log")
+		}
+	})
+
+	t.Run("exactly one event carries the terminal status", func(t *testing.T) {
+		var statuses []string
+		for _, e := range entries {
+			if e.Terminal != "" {
+				statuses = append(statuses, e.Terminal)
+			}
+		}
+		if len(statuses) != 1 {
+			t.Fatalf("terminal_status appears %d times %v, want exactly 1", len(statuses), statuses)
+		}
+		if statuses[0] != "success" {
+			t.Errorf("terminal_status = %q, want success", statuses[0])
+		}
+	})
+
+	t.Run("per-turn economics reach the log", func(t *testing.T) {
+		var found bool
+		for _, e := range entries {
+			if e.Type != "turn_metrics" {
+				continue
+			}
+			found = true
+			if e.TokenIn == 0 || e.TokenOut == 0 {
+				t.Errorf("turn_metrics has no token counts (in=%d out=%d)", e.TokenIn, e.TokenOut)
+			}
+		}
+		if !found {
+			t.Fatal("no turn_metrics event reached the log")
+		}
+	})
+}
+
+// TestRunCapture_ManifestAssemblesFromRealRun closes the loop: the manifest is
+// built from the log a real run produced, not from a synthetic one.
+func TestRunCapture_ManifestAssemblesFromRealRun(t *testing.T) {
+	workDir := t.TempDir()
+	runsDir := filepath.Join(workDir, ".tracker", "runs")
+	handler := pipeline.NewJSONLEventHandler(runsDir)
+
+	result, err := Run(context.Background(), captureDip, Config{
+		Format:       "dip",
+		WorkingDir:   workDir,
+		LLMClient:    &toolCallingStub{},
+		EventHandler: handler,
+		AgentEvents:  agent.EventHandlerFunc(handler.WriteAgentEvent),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := handler.Close(); err != nil {
+		t.Fatalf("close log: %v", err)
+	}
+
+	runDir := filepath.Join(runsDir, result.RunID)
+	m, err := pipeline.AssembleRunManifest(runDir, result.RunID)
+	if err != nil {
+		t.Fatalf("AssembleRunManifest: %v", err)
+	}
+
+	if m.TerminalStatus != "success" {
+		t.Errorf("terminal_status = %q, want success", m.TerminalStatus)
+	}
+	// quickDip has two agent nodes; both must appear, with their kind.
+	if len(m.Nodes) != 2 {
+		t.Fatalf("got %d nodes, want 2: %+v", len(m.Nodes), m.Nodes)
+	}
+	for _, n := range m.Nodes {
+		if n.Kind == "" {
+			t.Errorf("node %q has no kind", n.ID)
+		}
+		if n.Turns == 0 {
+			t.Errorf("node %q recorded no turns despite running an agent", n.ID)
+		}
+	}
+	if m.Totals.InputTokens == 0 {
+		t.Error("totals record no input tokens despite two agent nodes running")
+	}
+	if len(m.ToolCalls) == 0 {
+		t.Error("tool histogram is empty despite the stub requesting a tool")
+	}
+}
+
+// sessionScopedType reports whether an event type is emitted from inside an
+// agent session and must therefore carry a session id.
+func sessionScopedType(t string) bool {
+	switch t {
+	case "session_start", "session_end", "turn_start", "turn_end",
+		"tool_call_start", "tool_call_end", "turn_metrics":
+		return true
+	}
+	return false
+}

--- a/tracker_capture_totals_test.go
+++ b/tracker_capture_totals_test.go
@@ -66,9 +66,14 @@ func TestRunManifestTotalsMatchEngineUsage(t *testing.T) {
 		}
 		engine.InputTokens += e.Stats.InputTokens
 		engine.OutputTokens += e.Stats.OutputTokens
+		// Accumulate, don't assign: a node can contribute more than one
+		// Stats-bearing trace entry (a retry, a repair session). Overwriting
+		// kept only the last, so this subtest would have failed against a
+		// correct manifest — a false alarm rather than a caught bug.
+		prev := engineByNode[e.NodeID]
 		engineByNode[e.NodeID] = llm.Usage{
-			InputTokens:  e.Stats.InputTokens,
-			OutputTokens: e.Stats.OutputTokens,
+			InputTokens:  prev.InputTokens + e.Stats.InputTokens,
+			OutputTokens: prev.OutputTokens + e.Stats.OutputTokens,
 		}
 	}
 	if engine.InputTokens == 0 {

--- a/tracker_capture_totals_test.go
+++ b/tracker_capture_totals_test.go
@@ -1,0 +1,316 @@
+// ABOUTME: Cross-checks run.json's log-derived totals against the engine's own independently-derived usage.
+// ABOUTME: The manifest reads the activity log; the engine counts as it goes — when they disagree, the manifest is wrong.
+package tracker
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/2389-research/tracker/agent"
+	"github.com/2389-research/tracker/llm"
+	"github.com/2389-research/tracker/pipeline"
+)
+
+// TestRunManifestTotalsMatchEngineUsage is the deterministic regression test for
+// a live run reporting three times its real token usage.
+//
+// It works because the two figures come from genuinely independent places: the
+// engine accumulates usage from each Response as it runs, while the manifest
+// re-derives it by reading the activity log after the fact. The log states the
+// same consumption at three granularities (the call, the turn, the node), so a
+// manifest that sums across them inflates while the engine stays right.
+//
+// A third, fully independent oracle is the stub itself: it counts how many times
+// it was asked to complete, which is by definition the number of LLM calls.
+func TestRunManifestTotalsMatchEngineUsage(t *testing.T) {
+	workDir := t.TempDir()
+	handler := pipeline.NewJSONLEventHandler(filepath.Join(workDir, ".tracker", "runs"))
+	stub := &toolCallingStub{}
+
+	// All three capture seams, wired exactly as the CLI wires them. Omitting
+	// LLMTrace is what makes llm_calls unknowable: usage still reaches the log
+	// through turn and node events, but nothing records the individual calls.
+	result, err := Run(context.Background(), captureDip, Config{
+		Format:       "dip",
+		WorkingDir:   workDir,
+		LLMClient:    stub,
+		EventHandler: handler,
+		AgentEvents:  agent.EventHandlerFunc(handler.WriteAgentEvent),
+		LLMTrace:     handler.LLMTraceObserver(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := handler.Close(); err != nil {
+		t.Fatalf("close log: %v", err)
+	}
+
+	runDir := filepath.Join(workDir, ".tracker", "runs", result.RunID)
+	m, err := pipeline.AssembleRunManifest(runDir, result.RunID)
+	if err != nil {
+		t.Fatalf("assemble manifest: %v", err)
+	}
+
+	// What the engine counted, taken from the per-node session stats it
+	// accumulated while running. Per-provider totals are not usable here: they
+	// key on a provider name the stub never sets.
+	engineByNode := map[string]llm.Usage{}
+	var engine llm.Usage
+	for _, e := range result.Trace.Entries {
+		if e.Stats == nil {
+			continue
+		}
+		engine.InputTokens += e.Stats.InputTokens
+		engine.OutputTokens += e.Stats.OutputTokens
+		engineByNode[e.NodeID] = llm.Usage{
+			InputTokens:  e.Stats.InputTokens,
+			OutputTokens: e.Stats.OutputTokens,
+		}
+	}
+	if engine.InputTokens == 0 {
+		t.Fatal("engine recorded no usage; the test cannot compare anything")
+	}
+
+	t.Run("token totals agree with the engine", func(t *testing.T) {
+		if m.Totals.InputTokens != engine.InputTokens {
+			t.Errorf("manifest input_tokens = %d, engine counted %d (ratio %.2f — a whole-number ratio means a tier was summed twice)",
+				m.Totals.InputTokens, engine.InputTokens,
+				float64(m.Totals.InputTokens)/float64(engine.InputTokens))
+		}
+		if m.Totals.OutputTokens != engine.OutputTokens {
+			t.Errorf("manifest output_tokens = %d, engine counted %d",
+				m.Totals.OutputTokens, engine.OutputTokens)
+		}
+	})
+
+	t.Run("call count is unavailable without a tracing client", func(t *testing.T) {
+		// Documents a real limit rather than papering over it. Tracing lives in
+		// llm.Client; a bare agent.Completer emits no trace events, so nothing
+		// records individual calls and Config.LLMTrace has nothing to attach
+		// to. Usage still arrives via turn and node events, which is why the
+		// totals above are right while the call count is absent. Deriving one
+		// from turn count would be a guess: a turn can issue more than one call
+		// (repair, compaction). TestCaptureChainWithTracingClient covers the
+		// counted case.
+		if m.Totals.LLMCalls != 0 {
+			t.Errorf("llm_calls = %d, want 0 — a bare Completer logs no call events, so any number here is inferred",
+				m.Totals.LLMCalls)
+		}
+		if stub.calls == 0 {
+			t.Fatal("stub was never called; the rest of this test proves nothing")
+		}
+	})
+
+	t.Run("per-node usage sums to the run total", func(t *testing.T) {
+		// Attribution is only trustworthy if the parts add up to the whole.
+		var in, out int
+		attributed := 0
+		for _, n := range m.Nodes {
+			if n.Usage == nil {
+				continue
+			}
+			attributed++
+			in += n.Usage.InputTokens
+			out += n.Usage.OutputTokens
+		}
+		if attributed == 0 {
+			t.Fatal("no node carries usage, so nothing is attributable")
+		}
+		if in != m.Totals.InputTokens || out != m.Totals.OutputTokens {
+			t.Errorf("node usage sums to %d/%d, run totals say %d/%d",
+				in, out, m.Totals.InputTokens, m.Totals.OutputTokens)
+		}
+	})
+
+	t.Run("each node is charged what the engine charged it", func(t *testing.T) {
+		// Summing to the right total is not enough: the shares could be right
+		// in aggregate and attributed to the wrong nodes.
+		for _, n := range m.Nodes {
+			want, ok := engineByNode[n.ID]
+			if !ok || want.InputTokens == 0 {
+				continue
+			}
+			if n.Usage == nil {
+				t.Errorf("node %s consumed %d input tokens per the engine but carries no usage",
+					n.ID, want.InputTokens)
+				continue
+			}
+			if n.Usage.InputTokens != want.InputTokens || n.Usage.OutputTokens != want.OutputTokens {
+				t.Errorf("node %s charged %d/%d, engine charged it %d/%d",
+					n.ID, n.Usage.InputTokens, n.Usage.OutputTokens,
+					want.InputTokens, want.OutputTokens)
+			}
+		}
+	})
+}
+
+// tracingStubAdapter is a ProviderAdapter whose stream carries everything the
+// capture chain reads: the verbatim wire body, a tool call, and metered usage on
+// finish. Going through llm.Client rather than a bare Completer is what makes
+// the trace path real — TraceBuilder, call ids, and request_raw only exist
+// there, which is exactly the stretch a stub Completer silently skips.
+type tracingStubAdapter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (a *tracingStubAdapter) Name() string { return "anthropic" }
+func (a *tracingStubAdapter) Close() error { return nil }
+
+func (a *tracingStubAdapter) Complete(context.Context, *llm.Request) (*llm.Response, error) {
+	return &llm.Response{
+		Message:      llm.AssistantMessage("done"),
+		FinishReason: llm.FinishReason{Reason: "stop"},
+	}, nil
+}
+
+// wireBody is the fake request body the adapter reports sending. It is
+// recognizable on purpose: the test asserts this exact text reaches disk, so a
+// truncated or synthesized copy fails rather than passing on shape alone.
+const wireBody = `{"model":"stub-model","messages":[{"role":"user","content":"capture-chain-probe"}]}`
+
+func (a *tracingStubAdapter) Stream(_ context.Context, req *llm.Request) <-chan llm.StreamEvent {
+	a.mu.Lock()
+	a.calls++
+	n := a.calls
+	a.mu.Unlock()
+
+	ch := make(chan llm.StreamEvent, 8)
+	go func() {
+		defer close(ch)
+		// Same call the real adapters make, including the tracing gate.
+		llm.EmitRequestSent(ch, []byte(wireBody), llm.RequestIsTraced(req))
+		ch <- llm.StreamEvent{Type: llm.EventStreamStart}
+		if n == 1 {
+			// An unregistered tool fails fast, which still drives the session
+			// into a second turn — the cheapest way to get more than one call.
+			ch <- llm.StreamEvent{Type: llm.EventToolCallEnd, ToolCall: &llm.ToolCallData{
+				ID:        "call_1",
+				Name:      "definitely_not_a_registered_tool",
+				Arguments: json.RawMessage(`{"probe":"yes"}`),
+			}}
+			ch <- llm.StreamEvent{
+				Type:         llm.EventFinish,
+				FinishReason: &llm.FinishReason{Reason: "tool_calls"},
+				Usage:        &llm.Usage{InputTokens: 100, OutputTokens: 20, TotalTokens: 120},
+			}
+			return
+		}
+		ch <- llm.StreamEvent{Type: llm.EventTextDelta, Delta: "done"}
+		ch <- llm.StreamEvent{
+			Type:         llm.EventFinish,
+			FinishReason: &llm.FinishReason{Reason: "stop"},
+			Usage:        &llm.Usage{InputTokens: 130, OutputTokens: 5, TotalTokens: 135},
+		}
+	}()
+	return ch
+}
+
+// TestCaptureChainWithTracingClient exercises the capture chain end to end
+// through a real llm.Client, which is the configuration production runs in.
+//
+// This is the coverage the earlier stub e2e only appeared to have: it declared
+// call_id and request_raw as fields and asserted neither, so both were absent
+// from live runs while the test stayed green. Here the adapter counts its own
+// invocations and names the exact bytes it sent, giving two oracles the
+// manifest cannot fake.
+func TestCaptureChainWithTracingClient(t *testing.T) {
+	adapter := &tracingStubAdapter{}
+	client, err := llm.NewClient(
+		llm.WithProvider(adapter),
+		llm.WithDefaultProvider("anthropic"),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer client.Close()
+
+	workDir := t.TempDir()
+	handler := pipeline.NewJSONLEventHandler(filepath.Join(workDir, ".tracker", "runs"))
+
+	result, err := Run(context.Background(), captureDip, Config{
+		Format:       "dip",
+		WorkingDir:   workDir,
+		LLMClient:    client,
+		EventHandler: handler,
+		AgentEvents:  agent.EventHandlerFunc(handler.WriteAgentEvent),
+		LLMTrace:     handler.LLMTraceObserver(),
+		Model:        "stub-model",
+		Provider:     "anthropic",
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if err := handler.Close(); err != nil {
+		t.Fatalf("close log: %v", err)
+	}
+
+	entries := readRunLog(t, workDir)
+	runDir := filepath.Join(workDir, ".tracker", "runs", result.RunID)
+	m, err := pipeline.AssembleRunManifest(runDir, result.RunID)
+	if err != nil {
+		t.Fatalf("assemble manifest: %v", err)
+	}
+
+	t.Run("every call is counted exactly once", func(t *testing.T) {
+		// The adapter is ground truth. Counting the same call on both log paths
+		// would read high; trusting only the agent path would read low.
+		adapter.mu.Lock()
+		want := adapter.calls
+		adapter.mu.Unlock()
+		if m.Totals.LLMCalls != want {
+			t.Errorf("manifest llm_calls = %d, adapter streamed %d call(s)", m.Totals.LLMCalls, want)
+		}
+	})
+
+	t.Run("usage is not multiplied by the number of log paths", func(t *testing.T) {
+		var engine int
+		for _, e := range result.Trace.Entries {
+			if e.Stats != nil {
+				engine += e.Stats.InputTokens
+			}
+		}
+		if engine == 0 {
+			t.Fatal("engine recorded no usage")
+		}
+		if m.Totals.InputTokens != engine {
+			t.Errorf("manifest input_tokens = %d, engine counted %d", m.Totals.InputTokens, engine)
+		}
+	})
+
+	t.Run("the verbatim wire body reaches disk", func(t *testing.T) {
+		// The whole reconstruction claim rests on this: what the provider was
+		// actually sent, not a summary of it.
+		var found bool
+		for _, e := range entries {
+			if strings.Contains(e.Content, "capture-chain-probe") && e.Content == wireBody {
+				found = true
+			}
+		}
+		if !found {
+			t.Error("no log entry carries the exact wire body the adapter sent")
+		}
+	})
+
+	t.Run("calls carry an id that groups their events", func(t *testing.T) {
+		ids := map[string]int{}
+		for _, e := range entries {
+			if e.CallID != "" {
+				ids[e.CallID]++
+			}
+		}
+		if len(ids) == 0 {
+			t.Fatal("no log entry carries a call_id")
+		}
+		// A call id that appears on only one line groups nothing.
+		for id, n := range ids {
+			if n < 2 {
+				t.Errorf("call_id %s appears on %d line; it should group a call's events", id, n)
+			}
+		}
+	})
+}

--- a/tracker_doctor.go
+++ b/tracker_doctor.go
@@ -438,7 +438,7 @@ var knownProviders = []providerDef{
 	{
 		name:         "Gemini",
 		envVars:      []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"},
-		defaultModel: "gemini-2.0-flash",
+		defaultModel: "gemini-3-flash-preview", // 2.0-flash is retired; it 404s
 		buildAdapter: func(key string) (llm.ProviderAdapter, error) {
 			base, err := ResolveProviderBaseURLStrict("gemini")
 			if err != nil {


### PR DESCRIPTION
Makes a tracker run reconstructable after the fact: the executed spec, every request sent to a provider, per-call/turn/tool identity, and a `run.json` manifest that indexes it all. Then fixes the pricing and usage-decoding bugs that live provider runs exposed along the way.

Verified against **live Anthropic, OpenAI, and Gemini APIs** — not just stubs. `@clintecker` flagging you since you've been deepest in this; happy to split it if the review surface is too wide.

---

## Why

We want to learn from tracker runs after they finish — which spec phrasing led to which outcome. That needs three things a run didn't previously record: **the spec that actually executed**, **what each model was actually asked**, and **a cheap index** so you can find the runs worth opening without reading gigabytes of logs.

Concretely, before this branch: the activity log stored event summaries with 80-char previews, agent-session events carried no session/turn identity (so concurrent parallel branches were indistinguishable once interleaved into one file), tool arguments were truncated, and nothing recorded which `.dip` produced the run. Dippin expands subgraphs inline at compile time, so the authored source isn't the executed graph — storing only the `.dip` would have left you reconstructing against the wrong topology.

---

## What changed

**Capture (feat commits).** Session/turn identity, node kind, attempt number, and terminal status onto disk. Tool calls attributed to the turn that issued them, with untruncated inputs. LLM events grouped by a generated `call_id`, and payloads no longer clipped. Verbatim wire request bodies from all four adapters — what actually went out after provider translation and `ProviderOptions` merging, which is what you need to reproduce a call. Executed spec (`workflow.dip` + `workflow.ir.json` + input files) stored per run.

**`run.json`.** A manifest assembled from the log at run end: goal, terminal status, per-node kind/attempts/outcome/turns/usage, run totals, tool-call counts, event counts, spec identity. `tracker run-json -w <dir> <runID>` backfills it for archived runs. Measured: 742 MB of logs across 61 archived runs collapse to 134 KB of manifests; a 39-node/54 MB run assembles in 0.57s.

**Fixes found by running it live** (the interesting half — details below).

**Not included:** a run viewer built against these logs. It lives outside this repo; happy to contribute it separately if useful.

---

## The bugs live runs exposed

These are worth reviewing carefully because most produced *plausible* numbers, which is why they survived a green test suite.

**1. `run.json` reported 3x its real token usage.** The log states the same consumption at three granularities — `llm_finish` (the call), `turn_metrics` (the turn), `decision_outcome` (the node rollup) — and the accumulator summed all three. Its `call_id` grouping only collapsed the pair it was written for; in a real agent run only `llm_finish` carries a `call_id`, so 10 of 18 usage lines fell through to a per-line key and each counted again. t6 reported 6729 input tokens against a true 2243, and 18 LLM calls against 8. Tracker's own CLI summary printed the correct figure, which is what made the manifest obviously wrong.

Fixed by taking each metric from the most direct tier present rather than summing across tiers (`pipeline/runusage.go`). Tokens and cost select independently because no tier carries both: `llm_finish` meters tokens without pricing them, `turn_metrics` prices a turn without restating cache figures.

Two things that fix must not break, both found by checking rather than assuming: node rollups fire once per node *visit*, so a retried node reports twice and both are real (keying that tier by node id discarded every visit but the last, halving 15 archived runs); and `llm_calls` can't come from the usage tier at all, whose entries are coarser than calls — counting completion events by timestamp union inflated one archived run from 86 to 161, while trusting the agent path alone saw 84 of another run's 253.

**2. Cache writes priced at 0.25x input instead of 1.25x.** Someone read Anthropic's "+25% premium" as "0.25x rate". Every cached Anthropic run understated its cache-write cost by 5x — a third of the bill on t6 ($0.0608 reported against ~$0.078 actual).

Checking the pricing pages showed cached *reads* aren't a provider-wide convention either: 0.1x on Anthropic/Gemini/GPT-5, **0.25x on GPT-4.1**, **0.5x on GPT-4o**. So the multipliers moved onto `ModelInfo` with per-model overrides. Verifying mattered — a secondary source put Gemini's cached reads at 25%, but Google publishes 10%, so the existing read multiplier was already right there.

**3. Gemini dropped billed thinking tokens.** `geminiUsageMeta` decoded only prompt/candidates/total. Google's docs confirm `totalTokenCount = prompt + thoughts + candidates` and that `candidatesTokenCount` **excludes** thoughts — which Gemini bills at the output rate. Provable from t8's own arithmetic: per-call tokens summed to 2453 against a reported total of 2527, a 74-token gap. Only ~3% there, but a direct curl on the same model returned 1 candidate token against 44 thinking tokens, so on a reasoning-heavy call **98% of billed output can vanish**. That silently defeats `--max-cost`.

**4. OpenAI dropped cached input tokens**, charging cached tokens at the full rate. Also decodes `cache_write_tokens`, which the API reports and nothing read.

The nesting rules here are counterintuitive and worth a careful look, because getting one backwards swaps a missing charge for a double charge — Anthropic's `input_tokens` **excludes** the cache buckets, while OpenAI's and Gemini's prompt counts **include** them. Documented as invariants on `llm.Usage`; adapters normalize to them. I verified OpenAI's nesting empirically rather than trusting docs: two identical calls, `input_tokens: 2514` with `cached_tokens: 1792` and `total_tokens` unchanged at 2519.

**5. Three capture gaps only live runs found.** `call_id`/`request_raw` never reached the log (the stub e2e test *declared* both fields and asserted neither, so it looked like coverage); `goal` missing on single-node runs, which write no checkpoint; parallel branch nodes carried no `node_kind` because they bypass `Engine.executeNode`.

**6. `text_delta` carried no `turn_no`.** It holds the session's final assistant message — often the node's actual product, since every earlier turn is recoverable from the next request's echoed history but the last one is echoed nowhere. It was unattributable to a turn while the `turn_end` emit on the adjacent line carried one.

---

## Verification

**Live, all three providers.** Same probe task against `claude-haiku-4-5`, `gpt-5.4-nano`, and `gemini-3-flash-preview`; all pass every field. Each reconstructs its full exchange from the stored bodies despite three different request shapes (Anthropic `system`+`messages[].content[]` blocks, OpenAI `instructions`+flat `input[]`, Gemini `systemInstruction`+`contents[].parts[]`) — system prompt, the literal command the model chose, tool result, final message, and all 8 tool schemas.

**Deterministic tests, no API key** (`tracker_capture_totals_test.go`): `run.json`'s log-derived totals cross-checked against `result.Trace`, which the engine accumulates independently while running. That comparison reproduces the 3x bug with no provider. Two fixtures — a bare `agent.Completer` (proves tokens and per-node attribution, and pins that `llm_calls` is unavailable there since tracing lives in `llm.Client`) and a streaming adapter behind a real `llm.Client`, which is the stretch the earlier stub only appeared to cover. The adapter counts its own invocations and names the exact bytes it sent: two oracles the manifest can't fake.

**Pricing** (`llm/pricing_cache_test.go`): multipliers asserted against published prices with sources, since this bug class is invisible to everything else — token counts stay right and the arithmetic stays self-consistent, so the manifest agrees with the CLI and a token-conservation check passes. The pre-existing unit test had 0.25x baked into its expectation *and* its comment, locking the bug in rather than catching it; corrected to $1.95.

**Backfill:** all 61 archived runs under `~/Downloads` re-assemble with token totals byte-identical to before the usage fix, confirming the tier overlap was introduced by this branch (which added per-call usage) rather than latent in old logs. `terminal_status` comes back empty on all of them, correctly — the field didn't exist when they ran.

`make ci` green throughout: coverage 85.6%, complexity baseline untouched (212 grandfathered, 0 new), 4 core pipelines grade A, jailcheck clean.

---

## Things I'd like a second opinion on

1. **`Usage.TotalTokens` means different things per provider.** Anthropic computes `input + output` (cache excluded); OpenAI and Gemini pass the provider's own total (cache included). It isn't comparable across providers today, so anything aggregating it — budgets, dashboards — mixes units. Normalizing to "all billed tokens" changes `--max-cost` behavior for Anthropic, so I left it alone and filed #518.

2. **Cache TTL isn't modeled.** Anthropic bills a 1-hour-TTL write at 2x versus 1.25x at 5 minutes, and `llm.Usage` carries no TTL, so 1-hour runs price ~38% low. Documented at the constant; the fix is threading TTL from the adapter.

3. **Capture is CLI-only.** `pipeline.NewJSONLEventHandler`, the trace observer, and `finalizeRunCapture` are all wired in `cmd/tracker`. An embedder calling `tracker.Run` gets nothing unless it wires all three itself. I exported `JSONLEventHandler.LLMTraceObserver()` so the non-obvious rule (skip `SessionOwned` or every session call logs twice) ships with the writer, but if harvesting runs from embedders matters, a single `Config` option to enable capture is the change I'd make next.

4. **Log volume.** `request_raw` grows monotonically per turn (5137 → 17176 bytes across t6's six turns). I measured 43–70x zstd compression on this content, which is what makes storing it viable, but nothing compresses or caps it today.

5. **Permissions.** The live log is deliberately hardened — 0600 in a 0700 dir, `O_NOFOLLOW`, explicit chmod. The run-dir mirror and `run.json` are **0644 in a 0755 dir**, and now hold verbatim prompts and full tool results where they previously held truncated previews. No credentials leak (the key is an HTTP header, never in the body — I grepped to confirm), so this is content exposure, not key exposure. Related: `wip_preserve.go` runs `git add -A` on the failure path, which stages `.tracker/` into git objects unless it's gitignored, and `tracker doctor` only warns.

## Also fixed in passing

`tracker doctor` probed retired `gemini-2.0-flash` and reported a working Gemini key as a transport failure, advising key rotation. And `gemini-2.5-flash-lite` is in the catalog but 404s as "no longer available to new users" — annotated rather than removed, since archived runs that used it still need a price when their manifests are rebuilt.

## Not covered

Per-turn cost fidelity on `--backend claude-code` / `acp`. Those bypass the adapter layer entirely and estimate usage from rune counts (`ACPUsageMarker`), so there's no wire body or `call_id`, and usage is estimated rather than metered. `RunTotals.Estimated` exists to flag this; whether it propagates into `run.json` is unverified. Ollama is also untested — it should route through `openaicompat` with a base-URL override, and its cost would read $0, correct for local but indistinguishable from unpriced (#518).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787955543&installation_model_id=21126&pr_number=519&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F519&signature=1eb7e24efd2dcded5d244e6ae8d559b707f6ba557f093e180bdeaa384dcdcdb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `run-json` command to generate run summaries with status, node details, usage, costs, and human interventions.
  * Added persisted run specifications, expanded pipeline metadata, and richer activity logs and traces.
* **Bug Fixes**
  * Corrected cached-token pricing and improved model-specific pricing accuracy.
  * Updated the default Gemini model used for authentication checks.
* **Security/Improvements**
  * Redacted sensitive specification parameters and tightened permissions for saved artifacts.
  * Preserved complete request and tool payloads when tracing is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->