### PR TITLE
fix: EscalateMilestone 'accept' must route forward (ClearStaleReviews), not loop back into CheckMilestoneOutputs (tracker-runner#730)

### DIFF
--- a/examples/build_product.dip
+++ b/examples/build_product.dip
@@ -3293,22 +3293,26 @@ workflow BuildProduct
     # Milestone escalation — human decides per-milestone
     EscalateMilestone -> MarkMilestoneDone  label: "mark done"
     EscalateMilestone -> Implement  label: "retry"  restart: true
-    # #392: "accept" means "stop building more milestones, ship what exists" —
-    # but it must NOT ship UNVERIFIED. The pre-#392 edge jumped straight to
-    # Cleanup -> FinalCommit -> Done, bypassing the entire cross-review +
-    # FinalBuild (whole-tree `go test ./...`) + FinalSpecCheck subgraph, so a
-    # run could exit Done over a red suite with no compliance report. Route it
-    # instead to CheckMilestoneOutputs — the SAME entry the normal all-done
-    # path uses — so accepting still earns the structural gate, the three-way
-    # cross-review, the final build/test, and the spec-compliance check before
-    # Cleanup. CheckMilestoneOutputs's own fallback routes BACK to
-    # EscalateMilestone, so `restart: true` breaks what would otherwise be an
-    # unconditional EscalateMilestone -> CheckMilestoneOutputs ->
-    # EscalateMilestone cycle (DIP005) — the same mechanism the
-    # CheckReviewFixBudget -> CheckMilestoneOutputs re-review edge uses. accept
-    # is a forward transition out of the per-milestone loop into the review
-    # phase, so restart-on-entry semantics are correct.
-    EscalateMilestone -> CheckMilestoneOutputs  label: "accept"  restart: true
+    # #392/#730: "accept" means "operator has decided to ship what exists,
+    # stop building more milestones" — but it must NOT ship UNVERIFIED. The
+    # pre-#392 edge jumped straight to Cleanup -> FinalCommit -> Done, bypassing
+    # the entire cross-review + FinalBuild (whole-tree `go test ./...`) +
+    # FinalSpecCheck subgraph, so a run could exit Done over a red suite with no
+    # compliance report. #392 then routed accept BACK into CheckMilestoneOutputs
+    # — but that is the very check the operator is overriding, so when the
+    # structural gate flags (a false positive on a green tree, OR a true
+    # positive the operator has chosen to accept anyway) accept deterministically
+    # re-enters the failing check -> outputs-missing -> EscalateMilestone, an
+    # inescapable loop where only "abandon" (discard the whole run) exits. That
+    # is the #730 trap. Route accept FORWARD into the ship/review path at
+    # ClearStaleReviews instead: it still earns the three-way cross-review, the
+    # final whole-tree build/test, and the spec-compliance check before Cleanup
+    # (satisfying #392), but it does NOT pass back through the structural gate the
+    # operator is explicitly overriding — so accept is always a real forward exit
+    # that can ship a green (or operator-accepted) tree. restart: true resets the
+    # restart budget as accept leaves the per-milestone loop for the review phase
+    # (mirrors MarkMilestoneDone -> PickNextMilestone).
+    EscalateMilestone -> ClearStaleReviews  label: "accept"  restart: true
     EscalateMilestone -> Done  label: "abandon"
 
     # Cross-review

--- a/pipeline/build_product_milestone_gate_test.go
+++ b/pipeline/build_product_milestone_gate_test.go
@@ -30,30 +30,36 @@ func labeledEdgeAttr(g *Graph, from, to, label, key string) string {
 	return ""
 }
 
-// TestBuildProductIssue392AcceptDoesNotBypassVerification pins T2 of #392: the
-// EscalateMilestone "accept" option must route into CheckMilestoneOutputs — the
-// SAME entry the normal all-done path uses — NOT straight to Cleanup. The
-// pre-#392 edge (accept -> Cleanup -> FinalCommit -> Done) let a run exit Done
-// over a red suite, skipping the cross-review + FinalBuild (whole-tree test) +
-// FinalSpecCheck subgraph entirely. Routing through CheckMilestoneOutputs makes
-// "stop building more milestones" still ship verified work.
+// TestBuildProductIssue392AcceptDoesNotBypassVerification pins T2 of #392 as
+// amended by #730: the EscalateMilestone "accept" option must route FORWARD into
+// the ship/review path (ClearStaleReviews) — NOT straight to Cleanup (which
+// would skip verification, the pre-#392 bug) and NOT back into
+// CheckMilestoneOutputs (the #730 trap: accept re-enters the very structural
+// check the operator is overriding -> outputs-missing -> EscalateMilestone, an
+// inescapable loop where only "abandon" exits). Routing to ClearStaleReviews
+// still earns the three-way cross-review + FinalBuild (whole-tree test) +
+// FinalSpecCheck subgraph, so "stop building more milestones" ships verified
+// work AND always has a real forward exit.
 func TestBuildProductIssue392AcceptDoesNotBypassVerification(t *testing.T) {
 	g := loadBuildProduct(t)
 
 	if _, ok := g.Nodes["EscalateMilestone"]; !ok {
 		t.Fatal("EscalateMilestone node missing from build_product.dip (issue #392)")
 	}
-	if !hasLabeledEdge(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept") {
-		t.Error("EscalateMilestone `accept` must route to CheckMilestoneOutputs so it still earns cross-review + final build + spec check (issue #392)")
+	if !hasLabeledEdge(g, "EscalateMilestone", "ClearStaleReviews", "accept") {
+		t.Error("EscalateMilestone `accept` must route forward to ClearStaleReviews so it still earns cross-review + final build + spec check while escaping the CheckMilestoneOutputs loop (issues #392, #730)")
 	}
 	if hasLabeledEdge(g, "EscalateMilestone", "Cleanup", "accept") {
 		t.Error("EscalateMilestone `accept` still routes directly to Cleanup — that bypasses all verification (issue #392 regression)")
 	}
-	// accept re-enters CheckMilestoneOutputs, whose own fallback loops back to
-	// EscalateMilestone; the edge must carry restart:true to break the DIP005
-	// cycle (same mechanism as the CheckReviewFixBudget re-review edge).
-	if got := labeledEdgeAttr(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept", "restart"); got != "true" {
-		t.Errorf("EscalateMilestone accept -> CheckMilestoneOutputs restart = %q, want \"true\" (DIP005 cycle break, issue #392)", got)
+	if hasLabeledEdge(g, "EscalateMilestone", "CheckMilestoneOutputs", "accept") {
+		t.Error("EscalateMilestone `accept` still routes back into CheckMilestoneOutputs — accept can never override that gate, so a flagged tree loops forever (issue #730 regression)")
+	}
+	// accept is a forward transition out of the per-milestone loop into the
+	// review phase; the edge carries restart:true to reset the restart budget
+	// (mirrors MarkMilestoneDone -> PickNextMilestone).
+	if got := labeledEdgeAttr(g, "EscalateMilestone", "ClearStaleReviews", "accept", "restart"); got != "true" {
+		t.Errorf("EscalateMilestone accept -> ClearStaleReviews restart = %q, want \"true\" (issue #730)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem
In `examples/build_product.dip`, `CheckMilestoneOutputs` can emit `outputs-missing` and route to the `EscalateMilestone` human gate — but **every** gate choice loops back through the same check:
- `mark done` → MarkMilestoneDone → PickNextMilestone (all-done) → **CheckMilestoneOutputs** → outputs-missing → EscalateMilestone
- `retry` → Implement → … → **CheckMilestoneOutputs** → outputs-missing → EscalateMilestone
- `accept` → **CheckMilestoneOutputs** (restart:true) → outputs-missing → EscalateMilestone
- `abandon` → Done (kills the run — the only exit)

So a build — **including a green one** — has no forward exit except discarding the work. Observed live in a downstream tracker-runner run (tracker-runner#730): an operator hit the gate repeatedly and every choice returned it.

## Fix
Reroute `EscalateMilestone -> ClearStaleReviews label:"accept"` (was `-> CheckMilestoneOutputs`). `ClearStaleReviews` is exactly the node the normal `outputs-present` edge targets, so `accept` still earns the three-way cross-review + `FinalBuild` + `FinalSpecCheck` before `Cleanup` (#392 intent preserved) while always escaping the loop — a guaranteed non-`abandon` forward exit, independent of why the gate flagged.

## Review
Two independent adversarial reviewers confirmed the reroute is the robust, load-bearing fix (green build reaches completion; real failures still flag via `MISSING_DIRS`/`BUILD_FAIL`; `accept` lands on a valid ship/review path, no verification skipped). Tests: `dippin gate lint` passes (29 files); `go test ./pipeline/` passes incl. the amended `TestBuildProductIssue392AcceptDoesNotBypassVerification`.

An earlier offline `go build` pin was **dropped**: `verify.sh` runs an identical *bare* build earlier in the same sandbox and passes, so the false `outputs-missing` is **not** a blocked-GOPROXY artifact. The real cause of the false-positive is unconfirmed and needs the gate's captured stdout — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/2389-research/codesmith/tracker/pr/632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791134006&installation_model_id=21126&pr_number=632&repository=2389-research%2Ftracker&return_to=https%3A%2F%2Fgithub.com%2F2389-research%2Ftracker%2Fpull%2F632&signature=ccf9b8d64bf963c63122a3c51080b07cda53a2df70fb9d6f8619e069f2d035a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed milestone acceptance getting stuck in a repeat loop.
  * Accepted milestones now continue through review, build, test, and specification checks before cleanup.
  * Preserved restart handling when leaving the milestone review loop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->